### PR TITLE
修复: 提升 ijkplayer 长播稳定性与无故退出排查能力

### DIFF
--- a/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
@@ -11,7 +11,7 @@ import type { OnSeekCompleteListener } from '@ohos/ijkplayer';
 import type { OnInfoListener } from '@ohos/ijkplayer';
 import type { OnBufferingUpdateListener } from '@ohos/ijkplayer';
 import type { OnVideoSizeChangedListener } from '@ohos/ijkplayer';
-import { DeviceCapabilityUtil } from '../../../utils/DeviceCapabilityUtil';
+import { DeviceCapabilityUtil, type IjkHwDecodeSupport } from '../../../utils/DeviceCapabilityUtil';
 import { AppPreferences, PrefKey } from '../../../utils/AppPreferences';
 
 const TAG = '[IjkPlayerAdapter]';
@@ -499,7 +499,8 @@ export class IjkPlayerAdapter implements IPlayer {
     // 线上出现 HEVC/HDR（含 Mastering Display Metadata）播放时偶发强退，
     // 崩溃点集中在 EGL 渲染链路。先统一关闭 mediacodec，优先保证稳定。
     // 后续可在确认设备/片源组合稳定后再灰度恢复硬解。
-    let hwSupport: { h264: boolean; h265: boolean } = { h264: false, h265: false };
+    const defaultHwSupport: IjkHwDecodeSupport = { h264: false, h265: false };
+    let hwSupport: IjkHwDecodeSupport = defaultHwSupport;
     try {
       hwSupport = await DeviceCapabilityUtil.checkIjkHardwareDecodeSupport();
     } catch (e) {

--- a/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
@@ -39,7 +39,6 @@ const ENABLE_IJK_INFO_CALLBACK = false;
  */
 export class IjkPlayerAdapter implements IPlayer {
   private ijk: IjkMediaPlayer;
-  private readonly XCOMPONENT_ID = 'ijkPlayerXComponent';
   private _sessionId: string = '';
   private _seekRenderingInfoCount: number = 0;
   private _lastHeartbeatWriteAt: number = 0;
@@ -81,9 +80,25 @@ export class IjkPlayerAdapter implements IPlayer {
   }
 
   private writeBreadcrumb(stage: string, extra: string = ''): void {
+    const safeExtra = this.sanitizeBreadcrumbExtra(extra);
     const payload = `${Date.now()}|${this._sessionId}|${stage}|` +
-      `prepared=${this._isPrepared}|playing=${this._isPlaying}|time=${this._currentTime}|${extra}`;
+      `prepared=${this._isPrepared}|playing=${this._isPlaying}|time=${this._currentTime}|${safeExtra}`;
     AppPreferences.set(PrefKey.PLAYER_LAST_BREADCRUMB, payload).catch(() => {});
+  }
+
+  private sanitizeBreadcrumbExtra(extra: string): string {
+    if (extra.length === 0) {
+      return '';
+    }
+    // 统一为单行并避免与分隔符冲突。
+    let normalized = extra
+      .replace(/\r\n|\r|\n/g, ' ')
+      .replace(/\|/g, '/');
+    const MAX_LEN = 180;
+    if (normalized.length > MAX_LEN) {
+      normalized = normalized.substring(0, MAX_LEN) + '...';
+    }
+    return normalized;
   }
 
   // ─── IPlayer 属性 ───
@@ -484,7 +499,13 @@ export class IjkPlayerAdapter implements IPlayer {
     // 线上出现 HEVC/HDR（含 Mastering Display Metadata）播放时偶发强退，
     // 崩溃点集中在 EGL 渲染链路。先统一关闭 mediacodec，优先保证稳定。
     // 后续可在确认设备/片源组合稳定后再灰度恢复硬解。
-    const hwSupport = await DeviceCapabilityUtil.checkIjkHardwareDecodeSupport();
+    let hwSupport: { h264: boolean; h265: boolean } = { h264: false, h265: false };
+    try {
+      hwSupport = await DeviceCapabilityUtil.checkIjkHardwareDecodeSupport();
+    } catch (e) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `获取硬解能力失败，继续按软解策略运行: ${JSON.stringify(e)}`);
+    }
     const useH264Hw = false;
     const useH265Hw = false;
     this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER,
@@ -506,7 +527,7 @@ export class IjkPlayerAdapter implements IPlayer {
     this.ijk.setScreenOnWhilePlaying(true);
 
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      '播放参数已应用：精确寻帧，10s超时，start-on-prepared=0');
+      '播放参数已应用：非精确seek，10s超时，start-on-prepared=0');
   }
 
   /**

--- a/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
@@ -12,8 +12,10 @@ import type { OnInfoListener } from '@ohos/ijkplayer';
 import type { OnBufferingUpdateListener } from '@ohos/ijkplayer';
 import type { OnVideoSizeChangedListener } from '@ohos/ijkplayer';
 import { DeviceCapabilityUtil } from '../../../utils/DeviceCapabilityUtil';
+import { AppPreferences, PrefKey } from '../../../utils/AppPreferences';
 
 const TAG = '[IjkPlayerAdapter]';
+const ENABLE_IJK_INFO_CALLBACK = false;
 
 /**
  * IjkPlayer 播放内核适配器
@@ -38,6 +40,9 @@ const TAG = '[IjkPlayerAdapter]';
 export class IjkPlayerAdapter implements IPlayer {
   private ijk: IjkMediaPlayer;
   private readonly XCOMPONENT_ID = 'ijkPlayerXComponent';
+  private _sessionId: string = '';
+  private _seekRenderingInfoCount: number = 0;
+  private _lastHeartbeatWriteAt: number = 0;
 
   // ─── 状态 ───
   private _duration: number = 0;
@@ -52,7 +57,7 @@ export class IjkPlayerAdapter implements IPlayer {
 
   // ─── 定时器（轮询 currentTime） ───
   private _timeUpdateTimer?: number;
-  private readonly TIME_UPDATE_INTERVAL = 250; // ms
+  private readonly TIME_UPDATE_INTERVAL = 500; // ms
 
   // ─── 回调存储 ───
   private _onReadyCb?: () => void;
@@ -67,10 +72,18 @@ export class IjkPlayerAdapter implements IPlayer {
   private _onSubtitleUpdateCb?: (info: SubtitleInfo) => void;
 
   constructor() {
-    // 使用单例模式，与官方 README 示例一致
-    // 注意：getInstance() 返回的实例在 setContext 时会设置 id = XCOMPONENT_ID
-    this.ijk = IjkMediaPlayer.getInstance();
-    hilog.info(CommonConstants.LOG_DOMAIN, TAG, '构造完成（单例模式，等待 setPendingContext）');
+    // 使用多实例模式，避免单例跨页面状态残留导致的偶发异常。
+    this.ijk = new IjkMediaPlayer();
+    this._sessionId = `ijk-${Date.now()}`;
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `构造完成（多实例模式）session=${this._sessionId}，等待 setPendingContext`);
+    this.writeBreadcrumb('constructed');
+  }
+
+  private writeBreadcrumb(stage: string, extra: string = ''): void {
+    const payload = `${Date.now()}|${this._sessionId}|${stage}|` +
+      `prepared=${this._isPrepared}|playing=${this._isPlaying}|time=${this._currentTime}|${extra}`;
+    AppPreferences.set(PrefKey.PLAYER_LAST_BREADCRUMB, payload).catch(() => {});
   }
 
   // ─── IPlayer 属性 ───
@@ -91,16 +104,16 @@ export class IjkPlayerAdapter implements IPlayer {
   }
 
   /**
-   * 保存 XComponent context，在下次 init() 调用时于 native_setup 后绑定。
+  * 保存 XComponent context，在下次 init() 调用时于 native_setup 前绑定。
    * 由 VideoPlayerController.setIjkContext() 调用。
    *
-   * 正确时序：setContext 必须在 native_setup 之后、prepareAsync 之前调用。
+  * 正确时序：setContext 必须在 native_setup 之前调用。
    */
   setPendingContext(context: object, xComponentId: string): void {
     this._pendingContext = context;
     this._pendingXComponentId = xComponentId;
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `setPendingContext: xComponentId=${xComponentId}，等待 init() 中 native_setup 后绑定`);
+    `setPendingContext: xComponentId=${xComponentId} session=${this._sessionId}`);
   }
 
   // ─── 生命周期 ───
@@ -113,6 +126,10 @@ export class IjkPlayerAdapter implements IPlayer {
     this._isPlaying = false;
     this._duration = 0;
     this._currentTime = 0;
+    this._isReleased = false;
+    this._seekRenderingInfoCount = 0;
+    this._lastHeartbeatWriteAt = 0;
+    this.writeBreadcrumb('init-start', `type=${videoData.type}`);
 
     try {
       // 官方标准初始化顺序（参照 README_zh.md）：
@@ -130,21 +147,24 @@ export class IjkPlayerAdapter implements IPlayer {
       if (this._pendingContext && this._pendingXComponentId) {
         this.ijk.setContext(this._pendingContext, this._pendingXComponentId);
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-          `[1/8] setContext 完成，xComponentId=${this._pendingXComponentId}`);
+          `[1/8] setContext 完成，xComponentId=${this._pendingXComponentId} session=${this._sessionId}`);
         this._pendingContext = null;
         this._pendingXComponentId = '';
       } else {
-        hilog.error(CommonConstants.LOG_DOMAIN, TAG,
-          '[1/8] ❌ pendingContext 为空！必须在 init() 前调用 setPendingContext()，视频将黑屏');
+        const msg = '[1/8] pendingContext 为空，取消 init 以避免 native 异常';
+        hilog.error(CommonConstants.LOG_DOMAIN, TAG, `${msg} session=${this._sessionId}`);
+        throw new Error(msg);
       }
 
       // ── Step 2：setDebug ──
-      this.ijk.setDebug(true);
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG, '[2/8] setDebug 完成');
+      // 高频 native debug 日志会明显增加 IO 压力，稳定性优先默认关闭。
+      this.ijk.setDebug(false);
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG, '[2/8] setDebug(false) 完成');
 
       // ── Step 3：native_setup ──
       this.ijk.native_setup();
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, '[3/8] native_setup 完成');
+      this.writeBreadcrumb('native-setup-done');
 
       // ── Step 4：setDataSource ──
       if (videoData.type === VideoDataType.URL) {
@@ -183,11 +203,14 @@ export class IjkPlayerAdapter implements IPlayer {
 
       // ── Step 8：prepareAsync ──
       this.ijk.prepareAsync();
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG, '[8/8] prepareAsync 已调用，等待 onPrepared 回调...');
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        `[8/8] prepareAsync 已调用，等待 onPrepared 回调... session=${this._sessionId}`);
+      this.writeBreadcrumb('prepare-async-called');
 
     } catch (e) {
       const msg = JSON.stringify(e);
       hilog.error(CommonConstants.LOG_DOMAIN, TAG, `init 异常: ${msg}`);
+      this.writeBreadcrumb('init-error', msg);
       throw new Error(`IjkPlayerAdapter init failed: ${msg}`);
     }
   }
@@ -204,6 +227,7 @@ export class IjkPlayerAdapter implements IPlayer {
       this._isPlaying = true;
       this.startTimeUpdateTimer();
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, 'start() 调用成功');
+      this.writeBreadcrumb('play-started');
       if (this._onPlayCb) { this._onPlayCb(); }
     } catch (e) {
       hilog.error(CommonConstants.LOG_DOMAIN, TAG, `start() 异常: ${JSON.stringify(e)}`);
@@ -222,6 +246,7 @@ export class IjkPlayerAdapter implements IPlayer {
       this._isPlaying = false;
       this.stopTimeUpdateTimer();
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, 'pause() 调用成功');
+      this.writeBreadcrumb('paused');
       if (this._onPausedCb) { this._onPausedCb(); }
     } catch (e) {
       hilog.error(CommonConstants.LOG_DOMAIN, TAG, `pause() 异常: ${JSON.stringify(e)}`);
@@ -242,7 +267,8 @@ export class IjkPlayerAdapter implements IPlayer {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG, 'release() 重复调用，忽略');
       return;
     }
-    hilog.info(CommonConstants.LOG_DOMAIN, TAG, 'release() 开始');
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG, `release() 开始 session=${this._sessionId}`);
+    this.writeBreadcrumb('release-start');
     this.stopTimeUpdateTimer();
     try {
       this.ijk.stop();
@@ -259,6 +285,9 @@ export class IjkPlayerAdapter implements IPlayer {
     this._isReleased = true;
     this._isPrepared = false;
     this._isPlaying = false;
+    this._pendingContext = null;
+    this._pendingXComponentId = '';
+    this.writeBreadcrumb('release-done');
   }
 
   seek(timeMs: number): void {
@@ -429,13 +458,15 @@ export class IjkPlayerAdapter implements IPlayer {
    * 鸿蒙版底层使用 XComponent Surface，overlay format 由框架自动管理。
    */
   private async applyDefaultOptions(): Promise<void> {
-    // ── 精确寻帧 ──
-    this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'enable-accurate-seek', '1');
+    // ── seek 策略（稳定性优先）──
+    // 精确 seek 会增加 HEVC 片源的回退解码压力，先关闭以降低崩溃概率。
+    this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'enable-accurate-seek', '0');
 
     // ── 缓冲控制 ──
-    this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'max_cached_duration', '3000');
-    this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'infbuf', '1');
-    this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'min-frames', '100');
+    this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'max_cached_duration', '1500');
+    // infbuf=1 可能导致长播时缓冲无上限增长，增加系统回收/强杀风险。
+    this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'infbuf', '0');
+    this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'min-frames', '30');
 
     // ⚠️ start-on-prepared=0：onPrepared 后不自动 start，由 onReady 回调驱动
     this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'start-on-prepared', '0');
@@ -446,17 +477,23 @@ export class IjkPlayerAdapter implements IPlayer {
     // 跳帧（CPU 跟不上时保持音画同步，TV 端建议 1~5）
     this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'framedrop', '5');
 
-    // ── 硬件解码：查询设备能力后决定是否开启 ──
-    // overlay-format 是 Android 专用参数，鸿蒙版不需要设置，设置反而会黑屏
+    // 不强制覆盖 codec 线程与 loop filter，避免在高码率 HEVC 下出现视频解码跟不上
+    // （表现为画面卡顿、音频继续播放导致音画不同步）。
+
+    // ── 硬件解码策略（稳定性优先）──
+    // 线上出现 HEVC/HDR（含 Mastering Display Metadata）播放时偶发强退，
+    // 崩溃点集中在 EGL 渲染链路。先统一关闭 mediacodec，优先保证稳定。
+    // 后续可在确认设备/片源组合稳定后再灰度恢复硬解。
     const hwSupport = await DeviceCapabilityUtil.checkIjkHardwareDecodeSupport();
-    const useH264Hw = hwSupport.h264;
-    const useH265Hw = hwSupport.h265;
+    const useH264Hw = false;
+    const useH265Hw = false;
     this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER,
-      'mediacodec-all-videos', useH264Hw ? '1' : '0');
+      'mediacodec-all-videos', '0');
     this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER,
-      'mediacodec-hevc', useH265Hw ? '1' : '0');
+      'mediacodec-hevc', '0');
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `硬件解码决策: H264=${useH264Hw ? '硬解✅' : '软解⚠️'} H265=${useH265Hw ? '硬解✅' : '软解⚠️'}`);
+      `硬件解码决策(稳定优先): H264=${useH264Hw ? '硬解✅' : '软解⚠️'} ` +
+      `H265=${useH265Hw ? '硬解✅' : '软解⚠️'} 设备能力(H264=${hwSupport.h264}, H265=${hwSupport.h265})`);
 
     // ── 网络超时（HTTP/WebDAV，单位 μs）──
     this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_FORMAT, 'timeout', '10000000');
@@ -483,7 +520,8 @@ export class IjkPlayerAdapter implements IPlayer {
         this._isPrepared = true;
         this._duration = this.ijk.getDuration();
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-          `onPrepared — duration=${this._duration}ms videoSize=${this.ijk.getVideoWidth()}x${this.ijk.getVideoHeight()}`);
+          `onPrepared — duration=${this._duration}ms videoSize=${this.ijk.getVideoWidth()}x${this.ijk.getVideoHeight()} session=${this._sessionId}`);
+        this.writeBreadcrumb('on-prepared', `duration=${this._duration}`);
         if (this._onReadyCb) { this._onReadyCb(); }
       }
     };
@@ -507,6 +545,7 @@ export class IjkPlayerAdapter implements IPlayer {
           `onError — what=${what} extra=${extra} (what=100:MEDIA_ERROR_UNKNOWN, extra=-10004:IO_ERROR)`);
         this._isPlaying = false;
         this.stopTimeUpdateTimer();
+        this.writeBreadcrumb('on-error', `what=${what},extra=${extra}`);
         if (this._onErrorCb) {
           this._onErrorCb(new Error(`IjkPlayer error: what=${what} extra=${extra}`));
         }
@@ -524,14 +563,28 @@ export class IjkPlayerAdapter implements IPlayer {
     };
     this.ijk.setOnSeekCompleteListener(onSeekCompleteListener);
 
-    // onInfo
-    const onInfoListener: OnInfoListener = {
-      onInfo: (what: number, extra: number) => {
-        // 700=BUFFERING_START, 701=BUFFERING_END, 703=NETWORK_BANDWIDTH
-        hilog.info(CommonConstants.LOG_DOMAIN, TAG, `onInfo — what=${what} extra=${extra}`);
-      }
-    };
-    this.ijk.setOnInfoListener(onInfoListener);
+    // onInfo: 10008 在部分 HEVC 片源会形成高频事件风暴，默认不桥接到 JS 层。
+    if (ENABLE_IJK_INFO_CALLBACK) {
+      const onInfoListener: OnInfoListener = {
+        onInfo: (what: number, extra: number) => {
+          // 700=BUFFERING_START, 701=BUFFERING_END, 703=NETWORK_BANDWIDTH
+          // 10008(FFP_MSG_VIDEO_SEEK_RENDERING_START)在部分片源会高频出现，按次数抽样打印。
+          if (what === 10008) {
+            this._seekRenderingInfoCount++;
+            if (this._seekRenderingInfoCount % 30 === 0) {
+              hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+                `onInfo(抽样) — what=${what} extra=${extra} count=${this._seekRenderingInfoCount}`);
+            }
+            return;
+          }
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG, `onInfo — what=${what} extra=${extra}`);
+        }
+      };
+      this.ijk.setOnInfoListener(onInfoListener);
+    } else {
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        '已禁用 onInfo 回调桥接（诊断模式）');
+    }
 
     // onBufferingUpdate
     const onBufferingUpdateListener: OnBufferingUpdateListener = {
@@ -569,12 +622,24 @@ export class IjkPlayerAdapter implements IPlayer {
         this.stopTimeUpdateTimer();
         return;
       }
-      const pos = this.ijk.getCurrentPosition();
-      if (pos !== this._currentTime) {
-        this._currentTime = pos;
-        if (this._onTimeUpdateCb) {
-          this._onTimeUpdateCb(pos);
+      try {
+        const pos = this.ijk.getCurrentPosition();
+        if (pos !== this._currentTime) {
+          this._currentTime = pos;
+          const now = Date.now();
+          if (now - this._lastHeartbeatWriteAt >= 30000) {
+            this._lastHeartbeatWriteAt = now;
+            this.writeBreadcrumb('play-heartbeat', `pos=${pos}`);
+          }
+          if (this._onTimeUpdateCb) {
+            this._onTimeUpdateCb(pos);
+          }
         }
+      } catch (e) {
+        hilog.error(CommonConstants.LOG_DOMAIN, TAG,
+          `timeUpdate 轮询异常，停止定时器: ${JSON.stringify(e)} session=${this._sessionId}`);
+        this.writeBreadcrumb('timeupdate-error', JSON.stringify(e));
+        this.stopTimeUpdateTimer();
       }
     }, this.TIME_UPDATE_INTERVAL);
   }

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -9,6 +9,8 @@ import { SubtitleParserFactory, ParsedSubtitle, SubtitleSegment } from "./Subtit
 export struct VideoPlayer {
   private xComponentController = new XComponentController()
   private surfaceId: string = ''
+  private initMode: string = ''
+  private ijkInitTimer?: number
   @Require @Param controller: VideoPlayerController
   @Require @Param data: VideoData
   @Local controlsOpened: boolean = false
@@ -19,7 +21,25 @@ export struct VideoPlayer {
   @Monitor('controller.backend')
   onBackendChange(): void {
     this.useIjkPlayer = this.controller.backend === 'ijkplayer'
+    // backend 切换后允许新分支重新初始化。
+    this.initMode = ''
     console.info(`[VideoPlayer] backend 变更 → useIjkPlayer=${this.useIjkPlayer}`)
+  }
+
+  private tryMarkInit(mode: string): boolean {
+    if (this.initMode === mode) {
+      console.warn(`[VideoPlayer] 忽略重复初始化: ${mode}`)
+      return false
+    }
+    this.initMode = mode
+    return true
+  }
+
+  private clearIjkInitTimer(): void {
+    if (this.ijkInitTimer !== undefined) {
+      clearTimeout(this.ijkInitTimer)
+      this.ijkInitTimer = undefined
+    }
   }
 
   controlsDialogController = new CustomDialogController({
@@ -262,6 +282,9 @@ export struct VideoPlayer {
           controller: this.xComponentController
         })
           .onLoad(() => {
+            if (!this.tryMarkInit('avplayer')) {
+              return
+            }
             this.surfaceId = this.xComponentController.getXComponentSurfaceId()
             // ⚠️ 先注册 PREPARED 监听再触发 init，避免快速回调时事件丢失
             emitter.once(PlayerEvents.PREPARED, () => {
@@ -302,6 +325,9 @@ export struct VideoPlayer {
             libraryname: 'ijkplayer_napi'
           })
             .onLoad((context: object) => {
+              if (!this.tryMarkInit('ijkplayer')) {
+                return
+              }
               // ⚠️ 必须先注册 PREPARED 监听，再触发 init！
               emitter.once(PlayerEvents.PREPARED, () => {
                 if (this.autoPlay) {
@@ -311,7 +337,8 @@ export struct VideoPlayer {
                 }
               })
               // ⚠️ 用 setTimeout 延迟，确保 XComponent Surface 的 native 层已完全 ready
-              setTimeout(() => {
+              this.clearIjkInitTimer()
+              this.ijkInitTimer = setTimeout(() => {
                 this.surfaceId = 'ijkPlayerXComponent'
                 this.controller.initPlayer(this.data, this.surfaceId).then(() => {
                   this.controller.setIjkContext(context, 'ijkPlayerXComponent')
@@ -359,5 +386,9 @@ export struct VideoPlayer {
       .hitTestBehavior(HitTestMode.Transparent)
     }
     .backgroundColor(Color.Black)
+  }
+
+  aboutToDisappear(): void {
+    this.clearIjkInitTimer()
   }
 }

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -20,6 +20,7 @@ export struct VideoPlayer {
 
   @Monitor('controller.backend')
   onBackendChange(): void {
+    this.clearIjkInitTimer()
     this.useIjkPlayer = this.controller.backend === 'ijkplayer'
     // backend 切换后允许新分支重新初始化。
     this.initMode = ''
@@ -339,6 +340,10 @@ export struct VideoPlayer {
               // ⚠️ 用 setTimeout 延迟，确保 XComponent Surface 的 native 层已完全 ready
               this.clearIjkInitTimer()
               this.ijkInitTimer = setTimeout(() => {
+                this.ijkInitTimer = undefined
+                if (this.controller.backend !== 'ijkplayer' || this.initMode !== 'ijkplayer') {
+                  return
+                }
                 this.surfaceId = 'ijkPlayerXComponent'
                 this.controller.initPlayer(this.data, this.surfaceId).then(() => {
                   this.controller.setIjkContext(context, 'ijkPlayerXComponent')

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -307,7 +307,7 @@ export class VideoPlayerController {
    * 时序说明：
    * 1. UI 层先注册 emitter.once(PREPARED)
    * 2. UI 层调 initPlayer()（创建 IjkPlayerAdapter 但不调 native_setup）
-   * 3. UI 层调 setIjkContext()（setContext → native_setup → setDataSource → prepareAsync）
+  * 3. UI 层调 setIjkContext()（setContext → native_setup → setDataSource → prepareAsync）
    */
   async setIjkContext(context: object, xComponentId: string): Promise<void> {
     if (this.backend !== 'ijkplayer') {
@@ -323,7 +323,7 @@ export class VideoPlayerController {
     const ijkAdapter = this.player as IjkPlayerAdapter;
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
       `setIjkContext: 绑定 XComponent id=${xComponentId}，开始完整 init 流程...`);
-    // 把 context 传给 adapter，由 adapter 的 init() 内部在 native_setup 后立即调用 setContext
+    // 把 context 传给 adapter，由 adapter 的 init() 内部在 native_setup 前调用 setContext
     ijkAdapter.setPendingContext(context, xComponentId);
     if (this.currentVideoData) {
       try {

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -23,6 +23,10 @@ export default class EntryAbility extends UIAbility {
       .then(async () => {
         hilog.info(DOMAIN, 'testTag', 'AppPreferences initialized successfully');
         await AppPreferences.set(PrefKey.TMDB_API_KEY, '8a4f81133468d801df27c9cdcb5c33af');
+        const lastBreadcrumb = await AppPreferences.get(PrefKey.PLAYER_LAST_BREADCRUMB, '');
+        if (lastBreadcrumb.length > 0) {
+          hilog.warn(DOMAIN, 'testTag', `LAST_PLAYER_BREADCRUMB=${lastBreadcrumb}`);
+        }
       })
       .catch((err: Error) => {
         hilog.error(DOMAIN, 'testTag', 'Failed to init AppPreferences: %{public}s', JSON.stringify(err));

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -25,7 +25,17 @@ export default class EntryAbility extends UIAbility {
         await AppPreferences.set(PrefKey.TMDB_API_KEY, '8a4f81133468d801df27c9cdcb5c33af');
         const lastBreadcrumb = await AppPreferences.get(PrefKey.PLAYER_LAST_BREADCRUMB, '');
         if (lastBreadcrumb.length > 0) {
-          hilog.warn(DOMAIN, 'testTag', `LAST_PLAYER_BREADCRUMB=${lastBreadcrumb}`);
+          const isNormalTerminal = lastBreadcrumb.includes('|release-done|');
+          const maxLen = 240;
+          const clipped = lastBreadcrumb.length > maxLen
+            ? lastBreadcrumb.substring(0, maxLen) + '...'
+            : lastBreadcrumb;
+          if (!isNormalTerminal) {
+            hilog.warn(DOMAIN, 'testTag', 'LAST_PLAYER_BREADCRUMB=%{public}s', clipped);
+          } else {
+            hilog.info(DOMAIN, 'testTag', 'LAST_PLAYER_BREADCRUMB(normal)=%{public}s', clipped);
+          }
+          await AppPreferences.set(PrefKey.PLAYER_LAST_BREADCRUMB, '');
         }
       })
       .catch((err: Error) => {

--- a/entry/src/main/ets/utils/AppPreferences.ets
+++ b/entry/src/main/ets/utils/AppPreferences.ets
@@ -16,6 +16,8 @@ export class PrefKey {
    * 例：'["tmdb","douban"]'
    */
   static readonly SCRAPE_PROVIDER_ORDER = 'scrape_provider_order';
+  /** 播放器诊断面包屑（用于无 faultlog 场景定位最后阶段） */
+  static readonly PLAYER_LAST_BREADCRUMB = 'player_last_breadcrumb';
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## 背景
针对 #22 持续排查“播放一段时间后强退/卡死退出”问题，补充稳定性修复与可观测性能力。

## 关键改动
- IjkPlayer 改为多实例，避免单例状态残留
- 强制 `setContext` 在 `native_setup` 前绑定，缺失时 fail-fast
- 关闭高风险硬解路径（`mediacodec-all-videos/hevc = 0`）
- 调整缓冲参数（`max_cached_duration=1500`、`infbuf=0`、`min-frames=30`）
- 降低 `timeUpdate` 轮询频率（`250ms -> 500ms`）
- 默认禁用 `onInfo` 回调桥接，规避 `what=10008` 事件风暴
- 新增播放器面包屑落盘与启动回读日志（`LAST_PLAYER_BREADCRUMB`）
- `VideoPlayer` 增加重复初始化防抖与 ijk 初始化定时器清理

## 观测结果
- 根据最新反馈，复测后未再复现强退，稳定性明显改善。

## 风险说明
- 关闭硬解后，4K HEVC 软解场景下可能出现性能压力，后续建议引入“流畅模式/清晰度降级”策略。

## 验收清单
1. 同一份 4K HEVC/HDR 片源连续播放 >= 30 分钟，不做频繁 seek。
2. 每 10~20 秒进行一次快进/后退（共 20 次），交替暂停/继续。
3. 播放中返回上级页面后再次进入，重复 5 次。
4. 播放中切后台 10~30 秒再回前台，重复 3 次。
5. 启动日志检查 `LAST_PLAYER_BREADCRUMB`，长播期间检查 `play-heartbeat`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better player stability with guarded initialization to prevent duplicate setups and managed init timers.
  * Default to software decoding for more stable playback; seek behavior changed to non-precise for compatibility.
  * Expanded session-aware lifecycle logging, diagnostics, and periodic heartbeat breadcrumbs.

* **New Features**
  * Per-session breadcrumb tracking and restoration of last breadcrumb on app start.
  * New lifecycle hook to clear pending initialization when a player is disappearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->