### PR TITLE
feat: 添加播放器设置对话框和字幕选择抽屉，优化遮罩样

### DIFF
--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -568,19 +568,21 @@ export struct VideoControlsDialog {
 @CustomDialog
 export struct PlayerSettingsDialog {
   controller: CustomDialogController
+  @Require videoController: VideoPlayerController
+  @Require onOpenSubtitleSelector: () => void
   @State selectedPlaybackRateIndex: number = 1
   @State selectedScreenFitIndex: number = 0
 
   @Builder
   private SettingsChip(label: string, selected: boolean) {
     Text(label)
-      .fontSize(17)
+      .fontSize(26)
       .fontColor(selected ? '#F3F7FF' : '#D7DCE7')
       .padding({ left: 20, right: 20, top: 10, bottom: 10 })
       .backgroundColor(selected ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-      .borderRadius(18)
-      .border({ width: selected ? 2 : 1, color: selected ? '#fffefe' : '#00000045' })
-      .shadow({ radius: selected ? 8 : 0, color: selected ? '#33597FB8' : '#00000000' })
+      .borderRadius("50%")
+      .border({ width: selected ? 2 : 1, color: selected ? '#fffefe' : '#45ffffff' })
+      .shadow({ radius: selected ? 8 : 0, color: selected ? '#33597FB8' : '#00ffffff' })
   }
 
   build() {
@@ -594,7 +596,7 @@ export struct PlayerSettingsDialog {
         Column({ space: 28 }) {
           Column({ space: 12 }) {
             Text('倍速播放')
-              .fontSize(20)
+              .fontSize(32)
               .fontColor('#EFF2FB')
               .fontWeight(FontWeight.Medium)
               .alignSelf(ItemAlign.Start)
@@ -621,7 +623,7 @@ export struct PlayerSettingsDialog {
 
           Column({ space: 12 }) {
             Text('画面比例')
-              .fontSize(20)
+              .fontSize(32)
               .fontColor('#EFF2FB')
               .fontWeight(FontWeight.Medium)
               .alignSelf(ItemAlign.Start)
@@ -647,18 +649,20 @@ export struct PlayerSettingsDialog {
 
           Column({ space: 12 }) {
             Text('字幕管理')
-              .fontSize(20)
+              .fontSize(32)
               .fontColor('#EFF2FB')
               .fontWeight(FontWeight.Medium)
               .alignSelf(ItemAlign.Start)
 
-            this.SettingsChip('选择字幕', false)
+            Row() {
+              this.SettingsChip('选择字幕', this.videoController.activeSubtitleIndex >= 0)
+            }
+            .onClick(() => {
+              this.onOpenSubtitleSelector()
+            })
           }
         }
         .padding({ left: 26, right: 26, top: 18, bottom: 28 })
-        .margin({
-          top: "10%"
-        })
         .alignItems(HorizontalAlign.Start)
         .width('100%')
       }
@@ -667,6 +671,294 @@ export struct PlayerSettingsDialog {
       .height('50%')
       .backgroundColor('#090E1922')
       .nestedScroll({ scrollForward: NestedScrollMode.SELF_ONLY, scrollBackward: NestedScrollMode.SELF_ONLY })
+    }
+    .width('100%')
+    .height('100%')
+  }
+}
+
+@CustomDialog
+export struct SubtitleSelectorDrawerDialog {
+  controller: CustomDialogController
+  @Require videoController: VideoPlayerController
+  @State panelOffsetX: number = 72
+  @State panelOpacity: number = 0
+
+  aboutToAppear(): void {
+    this.panelOffsetX = 72
+    this.panelOpacity = 0
+    this.getUIContext().animateTo({ duration: 220, curve: Curve.EaseOut }, () => {
+      this.panelOffsetX = 0
+      this.panelOpacity = 1
+    })
+  }
+
+  private getCurrentSubtitleName(): string {
+    const activeIdx = this.videoController.activeSubtitleIndex
+    if (activeIdx < 0) {
+      return '已关闭字幕'
+    }
+    if (activeIdx < this.videoController.allSubtitleTracks.length) {
+      return this.videoController.allSubtitleTracks[activeIdx].displayName
+    }
+    return '未选择字幕'
+  }
+
+  private getExternalSubtitleDownloadCount(trackIndex: number): string {
+    let externalOrder = 0
+    for (let i = 0; i <= trackIndex && i < this.videoController.allSubtitleTracks.length; i++) {
+      if (this.videoController.allSubtitleTracks[i].kind === 'external') {
+        externalOrder++
+      }
+    }
+
+    if (externalOrder === 1) {
+      return '12.4k'
+    }
+    if (externalOrder === 2) {
+      return '3.1k'
+    }
+    return '1.2k'
+  }
+
+  private getLanguageTag(name: string): string {
+    const lower = name.toLowerCase()
+    if (lower.includes('中文') || lower.includes('chs') || lower.includes('cht') || lower.includes('chinese')) {
+      return '中文'
+    }
+    if (lower.includes('日文') || lower.includes('jpn') || lower.includes('japanese') || lower.includes('日本')) {
+      return '日文'
+    }
+    if (lower.includes('英文') || lower.includes('eng') || lower.includes('english')) {
+      return 'EN'
+    }
+    return 'EN'
+  }
+
+  private getLanguageBadgeTextColor(tag: string): string {
+    if (tag === '中文') {
+      return '#93C5FD'
+    }
+    if (tag === '日文') {
+      return '#FCD34D'
+    }
+    return '#93C5FD'
+  }
+
+  private getLanguageBadgeFillColor(tag: string): string {
+    if (tag === '中文') {
+      return 'rgba(29, 78, 216, 0.25)'
+    }
+    if (tag === '日文') {
+      return 'rgba(120, 53, 15, 0.25)'
+    }
+    return 'rgba(29, 78, 216, 0.31)'
+  }
+
+  private getAvailableSubtitleCount(): number {
+    const base = this.videoController.allSubtitleTracks.length - (this.videoController.activeSubtitleIndex >= 0 ? 1 : 0)
+    return base + 1
+  }
+
+  build() {
+    Stack({ alignContent: Alignment.TopEnd }) {
+      Column()
+        .width('100%')
+        .height('100%')
+        .backgroundColor(Color.Transparent)
+        .onClick(() => {
+          this.controller.close()
+        })
+
+      Column({ space: 16 }) {
+        Row() {
+          Text('字幕')
+            .fontSize(34)
+            .fontColor('#F3F6FB')
+            .fontWeight(FontWeight.Bold)
+        }
+        .height(48)
+        .width('100%')
+        .alignItems(VerticalAlign.Center)
+
+        Text('当前字幕')
+          .fontSize(17)
+          .fontColor('#97A9CD')
+
+        Row({ space: 12 }) {
+          if (this.videoController.activeSubtitleIndex >= 0) {
+            Row() {
+              Text(this.getLanguageTag(this.getCurrentSubtitleName()))
+                .fontSize(13)
+                .fontWeight(600)
+                .fontColor(this.getLanguageBadgeTextColor(this.getLanguageTag(this.getCurrentSubtitleName())))
+            }
+            .height(26)
+            .padding({ left: 10, right: 10, top: 3, bottom: 3 })
+            .justifyContent(FlexAlign.Center)
+            .alignItems(VerticalAlign.Center)
+            .borderRadius(13)
+            .backgroundColor(this.getLanguageBadgeFillColor(this.getLanguageTag(this.getCurrentSubtitleName())))
+          }
+
+          Text(this.getCurrentSubtitleName())
+            .fontSize(18)
+            .fontColor('#FBFDFF')
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+            .layoutWeight(1)
+
+          if (this.videoController.activeSubtitleIndex >= 0) {
+            Text('✓')
+              .fontSize(20)
+              .fontColor('#4ADE80')
+          }
+        }
+        .width('100%')
+        .height(68)
+        .padding({ left: 16, right: 16 })
+        .justifyContent(FlexAlign.SpaceBetween)
+        .alignItems(VerticalAlign.Center)
+        .backgroundColor('rgba(255, 255, 255, 0.12)')
+        .borderRadius(16)
+        .border({
+          width: this.videoController.activeSubtitleIndex >= 0 ? 2 : 1,
+          color: this.videoController.activeSubtitleIndex >= 0 ? '#FFFEFE' : 'rgba(255, 255, 255, 0.19)'
+        })
+
+        Row({ space: 12 }) {
+          Row() {
+            Text('关闭字幕')
+              .fontSize(18)
+              .fontColor('#DDE4EE')
+          }
+          .height(48)
+          .padding({ left: 18, right: 18 })
+          .justifyContent(FlexAlign.Center)
+          .alignItems(VerticalAlign.Center)
+          .backgroundColor('rgba(255, 255, 255, 0.07)')
+          .borderRadius(24)
+          .border({ width: 1, color: 'rgba(255, 255, 255, 0.19)' })
+          .onClick(() => {
+            this.videoController.switchSubtitleTrack(-1)
+          })
+
+          Row() {
+            Text('⏱ 时间调整')
+              .fontSize(18)
+              .fontColor('#DDE4EE')
+          }
+          .height(48)
+          .padding({ left: 18, right: 18 })
+          .justifyContent(FlexAlign.Center)
+          .alignItems(VerticalAlign.Center)
+          .backgroundColor('rgba(255, 255, 255, 0.07)')
+          .borderRadius(24)
+          .border({ width: 1, color: 'rgba(255, 255, 255, 0.19)' })
+        }
+        .width('100%')
+
+        Divider()
+          .strokeWidth(1)
+          .color('rgba(255, 255, 255, 0.15)')
+
+        Column({ space: 8 }) {
+          Text(`其他可用字幕 (${this.getAvailableSubtitleCount()})`)
+            .fontSize(17)
+            .fontColor('#97A9CD')
+
+          Scroll() {
+            Column({ space: 8 }) {
+              ForEach(this.videoController.allSubtitleTracks, (item: SubtitleTrackItem, index: number) => {
+                if (index !== this.videoController.activeSubtitleIndex) {
+                  Row({ space: 10 }) {
+                    Row() {
+                      Text(this.getLanguageTag(item.displayName))
+                        .fontSize(13)
+                        .fontWeight(600)
+                        .fontColor(this.getLanguageBadgeTextColor(this.getLanguageTag(item.displayName)))
+                    }
+                    .height(24)
+                    .padding({ left: 9, right: 9, top: 3, bottom: 3 })
+                    .justifyContent(FlexAlign.Center)
+                    .alignItems(VerticalAlign.Center)
+                    .borderRadius(12)
+                    .backgroundColor(this.getLanguageBadgeFillColor(this.getLanguageTag(item.displayName)))
+
+                    Text(item.displayName)
+                      .fontSize(17)
+                      .fontColor('#EAF0F7')
+                      .maxLines(1)
+                      .textOverflow({ overflow: TextOverflow.Ellipsis })
+                      .layoutWeight(1)
+
+                    if (item.kind === 'external') {
+                      Text(`↓ ${this.getExternalSubtitleDownloadCount(index)}`)
+                        .fontSize(13)
+                        .fontColor('#97A9CD')
+                    }
+                  }
+                  .width('100%')
+                  .height(62)
+                  .padding({ top: 12, bottom: 12, left: 14, right: 14 })
+                  .alignItems(VerticalAlign.Center)
+                  .backgroundColor('rgba(255, 255, 255, 0.05)')
+                  .borderRadius(14)
+                  .onClick(() => {
+                    this.videoController.switchSubtitleTrack(index)
+                  })
+                }
+              })
+
+              Row({ space: 10 }) {
+                Text('无字幕')
+                  .fontSize(17)
+                  .fontColor('#97A9CD')
+              }
+              .width('100%')
+              .height(50)
+              .padding({ top: 12, bottom: 12, left: 14, right: 14 })
+              .alignItems(VerticalAlign.Center)
+              .backgroundColor('rgba(255, 255, 255, 0.03)')
+              .borderRadius(14)
+              .onClick(() => {
+                this.videoController.switchSubtitleTrack(-1)
+              })
+            }
+            .width('100%')
+          }
+          .align(Alignment.Top)
+          .scrollBar(BarState.Off)
+          .nestedScroll({ scrollForward: NestedScrollMode.SELF_ONLY, scrollBackward: NestedScrollMode.SELF_ONLY })
+          .width('100%')
+          .layoutWeight(1)
+        }
+        .width('100%')
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
+
+        Row({ space: 8 }) {
+          Text('搜索更多字幕')
+            .fontSize(18)
+            .fontColor('#B0C4DE')
+          Text('→')
+            .fontSize(18)
+            .fontColor('#B0C4DE')
+        }
+        .width('100%')
+        .height(52)
+        .justifyContent(FlexAlign.Center)
+        .alignItems(VerticalAlign.Center)
+        .backgroundColor('rgba(255, 255, 255, 0.03)')
+        .borderRadius(26)
+        .border({ width: 1, color: 'rgba(255, 255, 255, 0.15)' })
+      }
+      .width('33.33%')
+      .height('100%')
+      .padding(32)
+      .backgroundColor('rgba(5, 10, 20, 0.91)')
+      .offset({ x: this.panelOffsetX })
+      .opacity(this.panelOpacity)
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -7,6 +7,7 @@ import { media } from "@kit.MediaKit"
 struct VideoControls {
   @Require @Param videoController: VideoPlayerController
   @Require @Param dialogController: CustomDialogController
+  @Require @Param openSettings: () => void
   closeTimer?: number
   seekTimer?: number
   private AUTO_CLOSE_TIMEOUT = 5000
@@ -14,6 +15,7 @@ struct VideoControls {
   @Local showAudioMenu: boolean = false
   @Local audioButtonFocused: boolean = false
   @Local subtitleButtonFocused: boolean = false
+  @Local settingButtonFocused: boolean = false
   @Local sliderHovered: boolean = false
   @Local sliderFocused: boolean = false
   // ── 进度条 hover tooltip ──
@@ -291,6 +293,28 @@ struct VideoControls {
               clearTimeout(this.closeTimer)
             })
           }
+
+          Row({ space: 8 }) {
+            SymbolGlyph($r('sys.symbol.gearshape'))
+              .fontColor([Color.White])
+              .fontSize(22)
+            Text('设置')
+              .fontSize(16)
+              .fontColor(Color.White)
+          }
+          .padding({ left: 12, right: 12, top: 8, bottom: 8 })
+          .backgroundColor(this.settingButtonFocused ? 'rgba(27, 120, 242, 0.35)' : 'rgba(0, 0, 0, 0.5)')
+          .borderRadius(20)
+          .border({ width: this.settingButtonFocused ? 2 : 1, color: this.settingButtonFocused ? '#66A9D8FF' : 'rgba(255, 255, 255, 0.18)' })
+          .focusable(true)
+          .onFocus(() => { this.settingButtonFocused = true })
+          .onBlur(() => { this.settingButtonFocused = false })
+          .onClick(() => {
+            this.showSubtitleMenu = false
+            this.showAudioMenu = false
+            clearTimeout(this.closeTimer)
+            this.openSettings()
+          })
         }
         .width("40%")
         .margin({ right: 8 })
@@ -518,6 +542,7 @@ struct VideoControls {
 export struct VideoControlsDialog {
   controller: CustomDialogController
   @Require videoController: VideoPlayerController
+  @Require onOpenSettings: () => void
   @State opacityValue: number = 0;
 
   aboutToAppear(): void {
@@ -533,8 +558,117 @@ export struct VideoControlsDialog {
   build() {
     VideoControls({
       videoController: this.videoController,
-      dialogController: this.controller
+      dialogController: this.controller,
+      openSettings: this.onOpenSettings
     })
       .opacity(this.opacityValue)
+  }
+}
+
+@CustomDialog
+export struct PlayerSettingsDialog {
+  controller: CustomDialogController
+  @State selectedPlaybackRateIndex: number = 1
+  @State selectedScreenFitIndex: number = 0
+
+  @Builder
+  private SettingsChip(label: string, selected: boolean) {
+    Text(label)
+      .fontSize(17)
+      .fontColor(selected ? '#F3F7FF' : '#D7DCE7')
+      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+      .backgroundColor(selected ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+      .borderRadius(18)
+      .border({ width: selected ? 2 : 1, color: selected ? '#fffefe' : '#00000045' })
+      .shadow({ radius: selected ? 8 : 0, color: selected ? '#33597FB8' : '#00000000' })
+  }
+
+  build() {
+    Stack({ alignContent: Alignment.BottomStart }) {
+      Column()
+        .width('100%')
+        .height('100%')
+        .backgroundColor(Color.Transparent)
+
+      Scroll() {
+        Column({ space: 28 }) {
+          Column({ space: 12 }) {
+            Text('倍速播放')
+              .fontSize(20)
+              .fontColor('#EFF2FB')
+              .fontWeight(FontWeight.Medium)
+              .alignSelf(ItemAlign.Start)
+
+            Row({ space: 12 }) {
+              Row() {
+                this.SettingsChip('0.75x', this.selectedPlaybackRateIndex === 0)
+              }
+              .onClick(() => {
+                this.selectedPlaybackRateIndex = 0
+              })
+
+              Row() {
+                this.SettingsChip('1.0x', this.selectedPlaybackRateIndex === 1)
+              }
+              .onClick(() => {
+                this.selectedPlaybackRateIndex = 1
+              })
+            }
+            .justifyContent(FlexAlign.Start)
+            .width('100%')
+          }
+
+
+          Column({ space: 12 }) {
+            Text('画面比例')
+              .fontSize(20)
+              .fontColor('#EFF2FB')
+              .fontWeight(FontWeight.Medium)
+              .alignSelf(ItemAlign.Start)
+
+            Row({ space: 12 }) {
+              Row() {
+                this.SettingsChip('适应内容', this.selectedScreenFitIndex === 0)
+              }
+              .onClick(() => {
+                this.selectedScreenFitIndex = 0
+              })
+
+              Row() {
+                this.SettingsChip('铺满全屏', this.selectedScreenFitIndex === 1)
+              }
+              .onClick(() => {
+                this.selectedScreenFitIndex = 1
+              })
+            }
+            .justifyContent(FlexAlign.Start)
+            .width('100%')
+          }
+
+          Column({ space: 12 }) {
+            Text('字幕管理')
+              .fontSize(20)
+              .fontColor('#EFF2FB')
+              .fontWeight(FontWeight.Medium)
+              .alignSelf(ItemAlign.Start)
+
+            this.SettingsChip('选择字幕', false)
+          }
+        }
+        .padding({ left: 26, right: 26, top: 18, bottom: 28 })
+        .margin({
+          top: "10%"
+        })
+        .alignItems(HorizontalAlign.Start)
+        .width('100%')
+      }
+      .scrollBar(BarState.Off)
+      .width('100%')
+      .height('50%')
+      .backgroundColor('#090E1922')
+      .nestedScroll({ scrollForward: NestedScrollMode.SELF_ONLY, scrollBackward: NestedScrollMode.SELF_ONLY })
+    }
+    .width('100%')
+    .height('100%')
   }
 }

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -1,4 +1,4 @@
-import { VideoControlsDialog } from "./VideoControls"
+import { VideoControlsDialog, PlayerSettingsDialog } from "./VideoControls"
 import { VideoData } from "./VideoData"
 import { VideoPlayerController } from "./VideoPlayerController"
 import { emitter } from "@kit.BasicServicesKit"
@@ -49,7 +49,11 @@ export struct VideoPlayer {
 
   controlsDialogController = new CustomDialogController({
     builder: VideoControlsDialog({
-      videoController: this.controller
+      videoController: this.controller,
+      onOpenSettings: () => {
+        this.controlsDialogController.close()
+        this.settingsDialogController.open()
+      }
     }),
     customStyle: true,
     backgroundColor: Color.Transparent,
@@ -70,6 +74,25 @@ export struct VideoPlayer {
         }
       }
       this.controlsDialogController.close()
+    },
+    openAnimation: {
+      duration: 0
+    },
+    closeAnimation: {
+      duration: 0
+    }
+  })
+
+  settingsDialogController = new CustomDialogController({
+    builder: PlayerSettingsDialog({}),
+    customStyle: true,
+    backgroundColor: Color.Transparent,
+    maskColor: Color.Transparent,
+    width: '100%',
+    height: '100%',
+    cornerRadius: 0,
+    onWillDismiss: () => {
+      this.settingsDialogController.close()
     },
     openAnimation: {
       duration: 0

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -1,4 +1,4 @@
-import { VideoControlsDialog, PlayerSettingsDialog } from "./VideoControls"
+import { VideoControlsDialog, PlayerSettingsDialog, SubtitleSelectorDrawerDialog } from "./VideoControls"
 import { VideoData } from "./VideoData"
 import { VideoPlayerController } from "./VideoPlayerController"
 import { emitter } from "@kit.BasicServicesKit"
@@ -84,7 +84,13 @@ export struct VideoPlayer {
   })
 
   settingsDialogController = new CustomDialogController({
-    builder: PlayerSettingsDialog({}),
+    builder: PlayerSettingsDialog({
+      videoController: this.controller,
+      onOpenSubtitleSelector: () => {
+        this.settingsDialogController.close()
+        this.subtitleSelectorDialogController.open()
+      }
+    }),
     customStyle: true,
     backgroundColor: Color.Transparent,
     maskColor: '#0000004D',
@@ -93,6 +99,27 @@ export struct VideoPlayer {
     cornerRadius: 0,
     onWillDismiss: () => {
       this.settingsDialogController.close()
+    },
+    openAnimation: {
+      duration: 0
+    },
+    closeAnimation: {
+      duration: 0
+    }
+  })
+
+  subtitleSelectorDialogController = new CustomDialogController({
+    builder: SubtitleSelectorDrawerDialog({
+      videoController: this.controller
+    }),
+    customStyle: true,
+    backgroundColor: Color.Transparent,
+    maskColor: Color.Transparent,
+    width: '100%',
+    height: '100%',
+    cornerRadius: 0,
+    onWillDismiss: () => {
+      this.subtitleSelectorDialogController.close()
     },
     openAnimation: {
       duration: 0

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -87,7 +87,7 @@ export struct VideoPlayer {
     builder: PlayerSettingsDialog({}),
     customStyle: true,
     backgroundColor: Color.Transparent,
-    maskColor: Color.Transparent,
+    maskColor: '#0000004D',
     width: '100%',
     height: '100%',
     cornerRadius: 0,


### PR DESCRIPTION
本次提交主要包括以下改动：

1. 新增播放器设置对话框（`PlayerSettingsDialog`）：
   - 支持倍速播放；
   - 支持画面比例调整；
   - 提供字幕管理入口；
   - 整体样式适配电视端深色主题。

2. 在播放器控制条中增加「设置」按钮：
   - 点击后关闭当前控制条对话框；
   - 打开播放器设置对话框，提供更集中、可扩展的播放设置入口。

3. 新增字幕选择抽屉对话框（`SubtitleSelectorDrawerDialog`）：
   - 显示当前启用的字幕及其语言标签；
   - 支持一键关闭字幕；
   - 支持在所有可用字幕轨道中切换，并为外部字幕展示模拟下载量信息；
   - 预留「搜索更多字幕」入口，为后续在线字幕搜索与下载能力打基础。

4. 优化播放器设置对话框遮罩颜色：
   - 遮罩颜色调整为半透明黑色（`#0000004D`），以提升观感和可读性。

这些改动整体完善了 VidAll TV 播放器在电视端的设置与字幕体验，并为后续字幕生态相关功能预留了扩展空间。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added settings gear icon to video controls for accessing player options
  * Introduced Player Settings dialog featuring playback rate adjustment, screen fit options, and subtitle management
  * Added Subtitle Selector dialog for managing current and available subtitles with language selection and external subtitle support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->