### PR TITLE
新增: #48 Phase A — OH_AVPlayer native 渲染管线（真机验收通过）

### DIFF
--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -71,10 +71,12 @@ endif()
 # ---------------------------------------------------------------------------
 # OH_AVPlayer 系统 C API（libaudio_renderer / OH_AVPlayer）
 #
-# libnative_window.so  — OHNativeWindow* 操作（Surface/XComponent 侧）
-# libavplayer.so       — OH_AVPlayer C API（媒体播放核心）
-# libace_xcomponent.z.so — OH_NativeXComponent_GetNativeWindow()
-#                          （libace_napi.z.so 已提供 NAPI 侧，此库补充 Native 侧）
+# libnative_window.so — OHNativeWindow* 操作（Surface/XComponent 侧）
+# libavplayer.so      — OH_AVPlayer C API（媒体播放核心）
+# libace_ndk.z.so     — OH_NativeXComponent_GetNativeWindow() 及 XComponent Native C API
+#                       （注意：NDK sysroot 中不存在 libace_xcomponent.z.so，
+#                         XComponent Native 接口由 libace_ndk.z.so 统一提供；
+#                         libace_napi.z.so 已提供 NAPI 侧，此库补充 Native C 侧）
 #
 # 以上三库均为 HarmonyOS 系统库，链接器通过 NDK sysroot 自动寻址，
 # 无需将 .so 文件放入 libs/ 目录，也无需 add_library(IMPORTED)。
@@ -83,7 +85,7 @@ endif()
 #   默认 ON。若只需要 FFmpeg 路径而不启用 OH_AVPlayer，可显式关闭：
 #     cmake -DVIDALL_ENABLE_OH_AVPLAYER=OFF ...
 # ---------------------------------------------------------------------------
-option(VIDALL_ENABLE_OH_AVPLAYER "Enable OH_AVPlayer system C API (libnative_window + libavplayer + libace_xcomponent)" ON)
+option(VIDALL_ENABLE_OH_AVPLAYER "Enable OH_AVPlayer system C API (libnative_window + libavplayer + libace_ndk)" ON)
 
 if(VIDALL_ENABLE_OH_AVPLAYER)
   # XComponent Native 头文件路径
@@ -109,7 +111,7 @@ if(VIDALL_ENABLE_OH_AVPLAYER)
   target_link_libraries(vidall_core_player_napi PUBLIC
     libnative_window.so
     libavplayer.so
-    libace_xcomponent.z.so
+    libace_ndk.z.so
   )
 else()
   message(STATUS "VIDALL_ENABLE_OH_AVPLAYER=OFF — OH_AVPlayer C API disabled")

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -93,11 +93,11 @@ if(VIDALL_ENABLE_OH_AVPLAYER)
   # 若变量未定义，需在 local.properties / CMakePresets 中手动指定 OHOS_SDK_NATIVE_ROOT。
   if(DEFINED OHOS_SDK_NATIVE_ROOT)
     target_include_directories(vidall_core_player_napi PRIVATE
-      ${OHOS_SDK_NATIVE_ROOT}/sysroot/usr/include/ace/xcomponent
+      ${OHOS_SDK_NATIVE_ROOT}/sysroot/usr/include
     )
   elseif(DEFINED CMAKE_SYSROOT)
     target_include_directories(vidall_core_player_napi PRIVATE
-      ${CMAKE_SYSROOT}/usr/include/ace/xcomponent
+      ${CMAKE_SYSROOT}/usr/include
     )
   else()
     message(WARNING

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -121,5 +121,6 @@ endif()
 
 target_link_libraries(vidall_core_player_napi PUBLIC
     libace_napi.z.so
+    libhilog_ndk.z.so
     ffmpeg
 )

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -112,6 +112,7 @@ if(VIDALL_ENABLE_OH_AVPLAYER)
     libnative_window.so
     libavplayer.so
     libace_ndk.z.so
+    libnative_media_core.so  # A4：OH_AVFormat_GetIntValue（avplayer new-style info callback）
   )
 else()
   message(STATUS "VIDALL_ENABLE_OH_AVPLAYER=OFF — OH_AVPlayer C API disabled")

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -68,6 +68,54 @@ else()
   target_compile_definitions(vidall_core_player_napi PRIVATE VIDALL_HAS_LIBCURL=0)
 endif()
 
+# ---------------------------------------------------------------------------
+# OH_AVPlayer 系统 C API（libaudio_renderer / OH_AVPlayer）
+#
+# libnative_window.so  — OHNativeWindow* 操作（Surface/XComponent 侧）
+# libavplayer.so       — OH_AVPlayer C API（媒体播放核心）
+# libace_xcomponent.z.so — OH_NativeXComponent_GetNativeWindow()
+#                          （libace_napi.z.so 已提供 NAPI 侧，此库补充 Native 侧）
+#
+# 以上三库均为 HarmonyOS 系统库，链接器通过 NDK sysroot 自动寻址，
+# 无需将 .so 文件放入 libs/ 目录，也无需 add_library(IMPORTED)。
+#
+# 使用方式：
+#   默认 ON。若只需要 FFmpeg 路径而不启用 OH_AVPlayer，可显式关闭：
+#     cmake -DVIDALL_ENABLE_OH_AVPLAYER=OFF ...
+# ---------------------------------------------------------------------------
+option(VIDALL_ENABLE_OH_AVPLAYER "Enable OH_AVPlayer system C API (libnative_window + libavplayer + libace_xcomponent)" ON)
+
+if(VIDALL_ENABLE_OH_AVPLAYER)
+  # XComponent Native 头文件路径
+  # HarmonyOS NDK sysroot 通常由 DevEco 工具链注入 CMAKE_SYSROOT 或 OHOS_SDK_NATIVE_ROOT。
+  # 若变量未定义，需在 local.properties / CMakePresets 中手动指定 OHOS_SDK_NATIVE_ROOT。
+  if(DEFINED OHOS_SDK_NATIVE_ROOT)
+    target_include_directories(vidall_core_player_napi PRIVATE
+      ${OHOS_SDK_NATIVE_ROOT}/sysroot/usr/include/ace/xcomponent
+    )
+  elseif(DEFINED CMAKE_SYSROOT)
+    target_include_directories(vidall_core_player_napi PRIVATE
+      ${CMAKE_SYSROOT}/usr/include/ace/xcomponent
+    )
+  else()
+    message(WARNING
+      "VIDALL_ENABLE_OH_AVPLAYER=ON but neither OHOS_SDK_NATIVE_ROOT nor CMAKE_SYSROOT is defined.\n"
+      "XComponent native header (native_interface_xcomponent.h) may not be found.\n"
+      "Pass -DOHOS_SDK_NATIVE_ROOT=<ndk-root> or rely on DevEco toolchain injection."
+    )
+  endif()
+
+  target_compile_definitions(vidall_core_player_napi PRIVATE VIDALL_HAS_OH_AVPLAYER=1)
+  target_link_libraries(vidall_core_player_napi PUBLIC
+    libnative_window.so
+    libavplayer.so
+    libace_xcomponent.z.so
+  )
+else()
+  message(STATUS "VIDALL_ENABLE_OH_AVPLAYER=OFF — OH_AVPlayer C API disabled")
+  target_compile_definitions(vidall_core_player_napi PRIVATE VIDALL_HAS_OH_AVPLAYER=0)
+endif()
+
 target_link_libraries(vidall_core_player_napi PUBLIC
     libace_napi.z.so
     ffmpeg

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -8,6 +8,8 @@
 #include <cstring>
 
 #include "napi/native_api.h"
+#include <ace/xcomponent/native_interface_xcomponent.h>
+#include <native_window/external_window.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -645,6 +647,7 @@ struct NativePlayerSkeletonState {
   std::string url;
   std::string headersJson;
   std::string xComponentId;
+  OHNativeWindow *nativeWindow = nullptr;  // 渲染目标 Surface，生命周期归 XComponent，不 retain/release
   bool prepared = false;
   bool playing = false;
   int32_t selectedTrackIndex = -1;
@@ -1108,6 +1111,20 @@ static napi_value SetXComponent(napi_env env, napi_callback_info info) {
     return nullptr;
   }
   state->xComponentId = xComponentId;
+
+  // 从 context 中提取 OHNativeWindow*，失败时降级兼容（不 crash）
+  OH_NativeXComponent *nativeXC = nullptr;
+  if (napi_unwrap(env, args[1], reinterpret_cast<void **>(&nativeXC)) == napi_ok
+      && nativeXC != nullptr) {
+    OHNativeWindow *nativeWindow = nullptr;
+    int32_t ret = OH_NativeXComponent_GetNativeWindow(nativeXC, &nativeWindow);
+    if (ret == 0 && nativeWindow != nullptr) {
+      state->nativeWindow = nativeWindow;
+    }
+    // ret != 0 或 nativeWindow == nullptr：骨架降级兼容，nativeWindow 保持 nullptr
+  }
+  // napi_unwrap 失败（如单测环境）：nativeWindow 保持 nullptr，不影响骨架流程
+
   // 切换渲染目标后重置骨架态，避免旧 prepared/时间轴状态延续到新 surface。
   ResetRuntimeState(*state);
   EmitTimeUpdate(*state);
@@ -1412,6 +1429,7 @@ static napi_value Release(napi_env env, napi_callback_info info) {
   state.url.clear();
   state.headersJson.clear();
   state.xComponentId.clear();
+  state.nativeWindow = nullptr;  // 只清引用，生命周期归 XComponent，不调用 release
   ClearCallbackRefs(state, env);
   state.callbackEnv = nullptr;
   g_players.erase(iter);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -10,6 +10,7 @@
 #include "napi/native_api.h"
 #include <ace/xcomponent/native_interface_xcomponent.h>
 #include <native_window/external_window.h>
+#include <multimedia/player_framework/avplayer.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -648,6 +649,8 @@ struct NativePlayerSkeletonState {
   std::string headersJson;
   std::string xComponentId;
   OHNativeWindow *nativeWindow = nullptr;  // 渲染目标 Surface，生命周期归 XComponent，不 retain/release
+  OH_AVPlayer *avPlayer = nullptr;          // OH_AVPlayer 实例，由 Prepare 创建，Release 销毁
+  bool surfaceReady = false;               // OnSurfaceCreated 已触发
   bool prepared = false;
   bool playing = false;
   int32_t selectedTrackIndex = -1;
@@ -1082,6 +1085,69 @@ static napi_value SetHeaders(napi_env env, napi_callback_info info) {
   return ReturnUndefinedOrThrow(env, "setHeaders failed to create return value");
 }
 
+// ---------------------------------------------------------------------------
+// OH_NativeXComponent 静态回调（供所有 player 共用一套函数指针）
+// ---------------------------------------------------------------------------
+
+static void OnXCSurfaceCreated(OH_NativeXComponent *component, void *window) {
+  char idBuf[OH_XCOMPONENT_ID_LEN_MAX + 1] = {0};
+  uint64_t idSize = sizeof(idBuf);
+  if (OH_NativeXComponent_GetXComponentId(component, idBuf, &idSize) !=
+      OH_NATIVEXCOMPONENT_RESULT_SUCCESS) {
+    return;
+  }
+  const std::string xcId(idBuf);
+  for (auto &pair : g_players) {
+    if (pair.second.xComponentId == xcId) {
+      pair.second.nativeWindow = static_cast<OHNativeWindow *>(window);
+      pair.second.surfaceReady = true;
+      // 若 avPlayer 已创建且 url 已设置，立即绑定 surface（Prepare 先于 surface ready 的情形）
+      if (pair.second.avPlayer != nullptr && !pair.second.url.empty()) {
+        OH_AVPlayer_SetVideoSurface(pair.second.avPlayer, pair.second.nativeWindow);
+      }
+      break;
+    }
+  }
+}
+
+static void OnXCSurfaceChanged(OH_NativeXComponent *component, void *window) {
+  (void)component;
+  (void)window;
+  // A3 阶段暂不处理 surface 尺寸变化
+}
+
+static void OnXCSurfaceDestroyed(OH_NativeXComponent *component, void *window) {
+  (void)window;
+  char idBuf[OH_XCOMPONENT_ID_LEN_MAX + 1] = {0};
+  uint64_t idSize = sizeof(idBuf);
+  if (OH_NativeXComponent_GetXComponentId(component, idBuf, &idSize) !=
+      OH_NATIVEXCOMPONENT_RESULT_SUCCESS) {
+    return;
+  }
+  const std::string xcId(idBuf);
+  for (auto &pair : g_players) {
+    if (pair.second.xComponentId == xcId) {
+      pair.second.nativeWindow = nullptr;
+      pair.second.surfaceReady = false;
+      break;
+    }
+  }
+}
+
+static void OnXCDispatchTouchEvent(OH_NativeXComponent *component, void *window) {
+  (void)component;
+  (void)window;
+  // 播放器不处理触摸事件
+}
+
+// 所有 OH_NativeXComponent 实例共用一套函数指针，回调内部通过 xComponentId 区分
+static OH_NativeXComponent_Callback s_xcCallback = {
+  .OnSurfaceCreated = OnXCSurfaceCreated,
+  .OnSurfaceChanged = OnXCSurfaceChanged,
+  .OnSurfaceDestroyed = OnXCSurfaceDestroyed,
+  .DispatchTouchEvent = OnXCDispatchTouchEvent,
+};
+
 static napi_value SetXComponent(napi_env env, napi_callback_info info) {
   size_t argc = 3;
   napi_value args[3] = { nullptr, nullptr, nullptr };
@@ -1113,16 +1179,27 @@ static napi_value SetXComponent(napi_env env, napi_callback_info info) {
   state->xComponentId = xComponentId;
 
   // 从 context 中提取 OH_NativeXComponent*。
-  // 注：SDK 无同步 GetNativeWindow API（旧路径 window 仅在 OnSurfaceCreated 回调中可得；
-  //     新路径 OH_ArkUI_XComponent_GetNativeWindow 接受 SurfaceHolder*，非此处 unwrap 所得类型）。
-  // nativeWindow 将由 A3 阶段的 surface-created 回调写入；此处只做合法性检查，不 crash。
+  // nativeWindow 由 OnSurfaceCreated 回调写入；此处仅注册回调，不直接获取 window。
   OH_NativeXComponent *nativeXC = nullptr;
   napi_unwrap(env, args[1], reinterpret_cast<void **>(&nativeXC));
-  // nativeXC 有效则 state->nativeWindow 由后续回调赋值，否则降级为 nullptr（骨架兼容）
+
+  // 切换渲染目标：先停止现有 avPlayer（surface 将失效），重置骨架态，再注册新回调。
+  if (state->avPlayer != nullptr) {
+    OH_AVPlayer_Stop(state->avPlayer);
+    OH_AVPlayer_Release(state->avPlayer);
+    state->avPlayer = nullptr;
+  }
   state->nativeWindow = nullptr;
+  state->surfaceReady = false;
 
   // 切换渲染目标后重置骨架态，避免旧 prepared/时间轴状态延续到新 surface。
   ResetRuntimeState(*state);
+
+  // 注册 XComponent 回调，OnSurfaceCreated 触发后写入 nativeWindow。
+  if (nativeXC != nullptr) {
+    OH_NativeXComponent_RegisterCallback(nativeXC, &s_xcCallback);
+  }
+
   EmitTimeUpdate(*state);
   return ReturnUndefinedOrThrow(env, "setXComponent failed to create return value");
 }
@@ -1151,9 +1228,35 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
     EmitError(state, ERR_PREPARE_EMPTY_XCOMPONENT, "prepare failed: xComponentId is empty");
     return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
   }
-    EmitBufferingChange(state, true);
+
+  // A3：创建 OH_AVPlayer 实例（每次 prepare 前确保实例存在）
+  if (state.avPlayer == nullptr) {
+    state.avPlayer = OH_AVPlayer_Create();
+    if (state.avPlayer == nullptr) {
+      EmitError(state, ERR_PREPARE_EMPTY_URL, "prepare failed: OH_AVPlayer_Create returned nullptr");
+      return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
+    }
+  }
+
+  // 设置播放源 URL
+  OH_AVErrCode avRet = OH_AVPlayer_SetURLSource(state.avPlayer, state.url.c_str());
+  if (avRet != AV_ERR_OK) {
+    EmitError(state, ERR_PREPARE_EMPTY_URL, "prepare failed: OH_AVPlayer_SetURLSource failed");
+    return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
+  }
+
+  // 绑定渲染 Surface（若 surface 已就绪）；否则等 OnSurfaceCreated 回调触发后再绑定
+  if (state.nativeWindow != nullptr) {
+    OH_AVPlayer_SetVideoSurface(state.avPlayer, state.nativeWindow);
+  }
+
+  // 触发异步 prepare（结果由 A4 的 OH_AVPlayer_SetPlayerCallback 回调处理）
+  // A3 阶段同时保留骨架同步回调，使上层 JS 逻辑不因 A3 而中断
+  OH_AVPlayer_Prepare(state.avPlayer);
+
+  EmitBufferingChange(state, true);
   state.prepared = true;
-  // Fire onPrepared synchronously on the current JS thread (skeleton behaviour)
+  // Fire onPrepared synchronously on the current JS thread (skeleton behaviour；A4 改为异步回调)
   if (state.onPreparedRef != nullptr && state.callbackEnv != nullptr) {
     if (!CallJsFunction(state.callbackEnv, state.onPreparedRef, 0, nullptr)) {
       return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
@@ -1161,7 +1264,7 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
   }
   // Push initial timeline tick after prepared so controller/subtitle bridge can sync immediately.
   EmitTimeUpdate(state);
-    EmitBufferingChange(state, false);
+  EmitBufferingChange(state, false);
   return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
 }
 
@@ -1284,6 +1387,10 @@ static napi_value Play(napi_env env, napi_callback_info info) {
   }
   state.playing = true;
   state.lastRealtimeMs = NowRealtimeMs();
+  // A3：驱动 OH_AVPlayer 真实播放
+  if (state.avPlayer != nullptr) {
+    OH_AVPlayer_Play(state.avPlayer);
+  }
   EmitTimeUpdate(state);
   return ReturnUndefinedOrThrow(env, "play failed to create return value");
 }
@@ -1313,6 +1420,10 @@ static napi_value Pause(napi_env env, napi_callback_info info) {
   AdvancePlaybackClockIfNeeded(state);
   state.playing = false;
   state.lastRealtimeMs = 0;
+  // A3：驱动 OH_AVPlayer 真实暂停
+  if (state.avPlayer != nullptr) {
+    OH_AVPlayer_Pause(state.avPlayer);
+  }
   EmitTimeUpdate(state);
   return ReturnUndefinedOrThrow(env, "pause failed to create return value");
 }
@@ -1359,6 +1470,10 @@ static napi_value Seek(napi_env env, napi_callback_info info) {
   state.currentTimeMs = positionMs;
   if (state.playing) {
     state.lastRealtimeMs = NowRealtimeMs();
+  }
+  // A3：驱动 OH_AVPlayer 真实 seek（PREVIOUS_SYNC 模式，适合直播与点播）
+  if (state.avPlayer != nullptr) {
+    OH_AVPlayer_Seek(state.avPlayer, static_cast<int32_t>(positionMs), AV_SEEK_PREVIOUS_SYNC);
   }
   EmitTimeUpdate(state);
   // Emit seekDone after confirming position; adapter uses this to fire onSeekDone
@@ -1421,11 +1536,18 @@ static napi_value Release(napi_env env, napi_callback_info info) {
     return ReturnUndefinedOrThrow(env, "release failed to create return value");
   }
   NativePlayerSkeletonState &state = iter->second;
+  // A3：先停止并释放 OH_AVPlayer，再清理其他状态
+  if (state.avPlayer != nullptr) {
+    OH_AVPlayer_Stop(state.avPlayer);
+    OH_AVPlayer_Release(state.avPlayer);
+    state.avPlayer = nullptr;
+  }
   ResetRuntimeState(state);
   state.url.clear();
   state.headersJson.clear();
   state.xComponentId.clear();
   state.nativeWindow = nullptr;  // 只清引用，生命周期归 XComponent，不调用 release
+  state.surfaceReady = false;
   ClearCallbackRefs(state, env);
   state.callbackEnv = nullptr;
   g_players.erase(iter);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -6,11 +6,13 @@
 #include <memory>
 #include <cerrno>
 #include <cstring>
+#include <mutex>
 
 #include "napi/native_api.h"
 #include <ace/xcomponent/native_interface_xcomponent.h>
 #include <native_window/external_window.h>
 #include <multimedia/player_framework/avplayer.h>
+#include <multimedia/player_framework/native_avformat.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -665,10 +667,17 @@ struct NativePlayerSkeletonState {
   napi_ref onCompletedRef = nullptr;
   napi_ref onBufferingChangeRef = nullptr;
   napi_ref onSeekDoneRef = nullptr;
+  // A4：threadsafe function handles（媒体线程 → JS 线程回调）
+  napi_threadsafe_function tsfOnPrepared = nullptr;
+  napi_threadsafe_function tsfOnCompleted = nullptr;
+  napi_threadsafe_function tsfOnTimeUpdate = nullptr;
+  napi_threadsafe_function tsfOnError = nullptr;
 };
 
 static std::unordered_map<int32_t, NativePlayerSkeletonState> g_players;
 static int32_t g_nextHandle = 1;
+// A4：保护 g_players 跨线程访问（XC 表面回调来自 UI 线程，AV 回调来自媒体线程）
+static std::mutex g_playersMutex;
 
 #ifndef VIDALL_MAX_PLAYER_COUNT
 #define VIDALL_MAX_PLAYER_COUNT 100000UL
@@ -879,6 +888,14 @@ static void DeleteRefIfPresent(napi_env env, napi_ref &ref) {
   ref = nullptr;
 }
 
+// A4：中止并释放 threadsafe function（napi_tsfn_abort 丢弃所有待处理回调，防止 Release 后悬挂访问）
+static void ReleaseTsfIfPresent(napi_threadsafe_function &tsf) {
+  if (tsf != nullptr) {
+    napi_release_threadsafe_function(tsf, napi_tsfn_abort);
+    tsf = nullptr;
+  }
+}
+
 static void EmitCompleted(const NativePlayerSkeletonState &state) {
   if (state.onCompletedRef == nullptr || state.callbackEnv == nullptr) {
     return;
@@ -914,6 +931,11 @@ static void ClearCallbackRefs(NativePlayerSkeletonState &state, napi_env fallbac
   DeleteRefIfPresent(deleteEnv, state.onCompletedRef);
   DeleteRefIfPresent(deleteEnv, state.onBufferingChangeRef);
   DeleteRefIfPresent(deleteEnv, state.onSeekDoneRef);
+  // A4：释放 threadsafe functions（abort 确保已入队的回调不再执行，防止 Release 后悬挂访问）
+  ReleaseTsfIfPresent(state.tsfOnPrepared);
+  ReleaseTsfIfPresent(state.tsfOnCompleted);
+  ReleaseTsfIfPresent(state.tsfOnTimeUpdate);
+  ReleaseTsfIfPresent(state.tsfOnError);
 }
 
 static bool EnsurePreparedOrEmitError(
@@ -1089,6 +1111,78 @@ static napi_value SetHeaders(napi_env env, napi_callback_info info) {
 // OH_NativeXComponent 静态回调（供所有 player 共用一套函数指针）
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// A4：OH_AVPlayer 状态 / 错误回调（媒体线程调用，userData = NativePlayerSkeletonState*）
+// 使用新式带 userData 的回调 API：OH_AVPlayer_SetOnInfoCallback / SetOnErrorCallback
+// 注意：不在此处持有 g_playersMutex，避免与 Release() → OH_AVPlayer_Release 产生死锁；
+//      生命周期安全由 Release() 中"先 OH_AVPlayer_Release 再 ReleaseTsfIfPresent"序列保证。
+// ---------------------------------------------------------------------------
+
+static void OnAVPlayerInfoCB(OH_AVPlayer *player, AVPlayerOnInfoType type,
+                              OH_AVFormat *infoBody, void *userData) {
+  (void)player; // 通过 state->avPlayer 访问，此处不直接使用
+  NativePlayerSkeletonState *state = static_cast<NativePlayerSkeletonState *>(userData);
+  if (state == nullptr || infoBody == nullptr) {
+    return;
+  }
+  switch (type) {
+    case AV_INFO_TYPE_STATE_CHANGE: {
+      int32_t avStateVal = 0;
+      if (!OH_AVFormat_GetIntValue(infoBody, OH_PLAYER_STATE, &avStateVal)) {
+        break;
+      }
+      AVPlayerState avState = static_cast<AVPlayerState>(avStateVal);
+      if (avState == AV_PREPARED) {
+        // 获取时长（GetDuration 返回 int32_t 毫秒）
+        int32_t durationMs = 0;
+        OH_AVPlayer_GetDuration(state->avPlayer, &durationMs);
+        state->durationMs = static_cast<int64_t>(durationMs);
+        state->prepared = true;
+        if (state->tsfOnPrepared != nullptr) {
+          napi_call_threadsafe_function(state->tsfOnPrepared, nullptr, napi_tsfn_nonblocking);
+        }
+      } else if (avState == AV_COMPLETED) {
+        state->playing = false;
+        if (state->tsfOnCompleted != nullptr) {
+          napi_call_threadsafe_function(state->tsfOnCompleted, nullptr, napi_tsfn_nonblocking);
+        }
+      } else if (avState == AV_PLAYING) {
+        state->playing = true;
+      } else if (avState == AV_PAUSED) {
+        state->playing = false;
+      }
+      break;
+    }
+    case AV_INFO_TYPE_POSITION_UPDATE: {
+      int32_t posMs = 0;
+      if (OH_AVFormat_GetIntValue(infoBody, OH_PLAYER_CURRENT_POSITION, &posMs)) {
+        state->currentTimeMs = static_cast<int64_t>(posMs);
+      }
+      if (state->tsfOnTimeUpdate != nullptr) {
+        napi_call_threadsafe_function(state->tsfOnTimeUpdate, nullptr, napi_tsfn_nonblocking);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+static void OnAVPlayerErrorCB(OH_AVPlayer *player, int32_t errorCode,
+                               const char *errorMsg, void *userData) {
+  (void)player;
+  (void)errorCode;
+  NativePlayerSkeletonState *state = static_cast<NativePlayerSkeletonState *>(userData);
+  if (state == nullptr) {
+    return;
+  }
+  if (state->tsfOnError != nullptr) {
+    // 堆分配错误信息字符串，由 tsfOnError call_js_cb 负责 delete
+    auto *msg = new std::string(errorMsg ? errorMsg : "AVPlayer error");
+    napi_call_threadsafe_function(state->tsfOnError, msg, napi_tsfn_nonblocking);
+  }
+}
+
 static void OnXCSurfaceCreated(OH_NativeXComponent *component, void *window) {
   char idBuf[OH_XCOMPONENT_ID_LEN_MAX + 1] = {0};
   uint64_t idSize = sizeof(idBuf);
@@ -1097,6 +1191,7 @@ static void OnXCSurfaceCreated(OH_NativeXComponent *component, void *window) {
     return;
   }
   const std::string xcId(idBuf);
+  std::lock_guard<std::mutex> lock(g_playersMutex); // A4: 保护 g_players 跨线程遍历
   for (auto &pair : g_players) {
     if (pair.second.xComponentId == xcId) {
       pair.second.nativeWindow = static_cast<OHNativeWindow *>(window);
@@ -1125,6 +1220,7 @@ static void OnXCSurfaceDestroyed(OH_NativeXComponent *component, void *window) {
     return;
   }
   const std::string xcId(idBuf);
+  std::lock_guard<std::mutex> lock(g_playersMutex); // A4: 保护 g_players 跨线程遍历
   for (auto &pair : g_players) {
     if (pair.second.xComponentId == xcId) {
       pair.second.nativeWindow = nullptr;
@@ -1250,21 +1346,17 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
     OH_AVPlayer_SetVideoSurface(state.avPlayer, state.nativeWindow);
   }
 
-  // 触发异步 prepare（结果由 A4 的 OH_AVPlayer_SetPlayerCallback 回调处理）
-  // A3 阶段同时保留骨架同步回调，使上层 JS 逻辑不因 A3 而中断
+  // A4：注册媒体状态回调（在 Prepare 调用前注册）
+  // 使用新式带 userData 的 API（SDK API 12+），不持有 g_playersMutex 以避免与 Release 死锁
+  OH_AVPlayer_SetOnInfoCallback(state.avPlayer, OnAVPlayerInfoCB, &state);
+  OH_AVPlayer_SetOnErrorCallback(state.avPlayer, OnAVPlayerErrorCB, &state);
+
+  // 异步 prepare：SDK 中无 PrepareAsync，OH_AVPlayer_Prepare 本身为非阻塞；
+  // prepared 标志与 onPrepared 回调均由 OnAVPlayerInfoCB 在 AV_PREPARED 状态时通过 TSF 触发
   OH_AVPlayer_Prepare(state.avPlayer);
 
+  // 在 JS 线程发出"开始缓冲"通知；prepared / onPrepared / EmitTimeUpdate 改由异步回调完成
   EmitBufferingChange(state, true);
-  state.prepared = true;
-  // Fire onPrepared synchronously on the current JS thread (skeleton behaviour；A4 改为异步回调)
-  if (state.onPreparedRef != nullptr && state.callbackEnv != nullptr) {
-    if (!CallJsFunction(state.callbackEnv, state.onPreparedRef, 0, nullptr)) {
-      return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
-    }
-  }
-  // Push initial timeline tick after prepared so controller/subtitle bridge can sync immediately.
-  EmitTimeUpdate(state);
-  EmitBufferingChange(state, false);
   return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
 }
 
@@ -1352,6 +1444,67 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
     }
   }
   state.callbackEnv = env;
+
+  // A4：为每个回调额外创建 threadsafe function，供媒体线程异步回调 ArkTS
+  // call_js_cb 均为无捕获 lambda（可隐式转换为函数指针），在 JS 线程上执行
+  {
+    napi_value resName;
+    napi_create_string_utf8(env, "tsfOnPrepared", NAPI_AUTO_LENGTH, &resName);
+    napi_create_threadsafe_function(
+      env, args[1], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
+      [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        napi_value undef;
+        napi_get_undefined(tsfEnv, &undef);
+        napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
+      },
+      &state.tsfOnPrepared);
+  }
+  {
+    napi_value resName;
+    napi_create_string_utf8(env, "tsfOnCompleted", NAPI_AUTO_LENGTH, &resName);
+    napi_create_threadsafe_function(
+      env, args[4], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
+      [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        napi_value undef;
+        napi_get_undefined(tsfEnv, &undef);
+        napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
+      },
+      &state.tsfOnCompleted);
+  }
+  {
+    napi_value resName;
+    napi_create_string_utf8(env, "tsfOnTimeUpdate", NAPI_AUTO_LENGTH, &resName);
+    napi_create_threadsafe_function(
+      env, args[3], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
+      [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        // ctx = NativePlayerSkeletonState*，读取当前播放位置
+        auto *st = static_cast<NativePlayerSkeletonState *>(ctx);
+        napi_value timeValue;
+        napi_create_int64(tsfEnv, st->currentTimeMs, &timeValue);
+        napi_value undef;
+        napi_get_undefined(tsfEnv, &undef);
+        napi_call_function(tsfEnv, undef, jsCb, 1, &timeValue, nullptr);
+      },
+      &state.tsfOnTimeUpdate);
+  }
+  {
+    napi_value resName;
+    napi_create_string_utf8(env, "tsfOnError", NAPI_AUTO_LENGTH, &resName);
+    napi_create_threadsafe_function(
+      env, args[2], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
+      [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        // data = heap std::string* 错误信息，由 OnAVPlayerErrorCB 分配，此处负责 delete
+        std::string *msg = static_cast<std::string *>(data);
+        napi_value errorStr;
+        napi_create_string_utf8(tsfEnv,
+          msg ? msg->c_str() : "AVPlayer error", NAPI_AUTO_LENGTH, &errorStr);
+        napi_value undef;
+        napi_get_undefined(tsfEnv, &undef);
+        napi_call_function(tsfEnv, undef, jsCb, 1, &errorStr, nullptr);
+        delete msg;
+      },
+      &state.tsfOnError);
+  }
 
   // 若回调在 prepared 之后才注册，主动补发一次状态，避免上层错过时序。
   if (state.prepared) {
@@ -1536,10 +1689,14 @@ static napi_value Release(napi_env env, napi_callback_info info) {
     return ReturnUndefinedOrThrow(env, "release failed to create return value");
   }
   NativePlayerSkeletonState &state = iter->second;
-  // A3：先停止并释放 OH_AVPlayer，再清理其他状态
+  // A4 顺序说明：
+  //   1. OH_AVPlayer_Release：等待所有媒体线程回调执行完毕（含 OnAVPlayerInfoCB / OnAVPlayerErrorCB）
+  //   2. ClearCallbackRefs（含 ReleaseTsfIfPresent napi_tsfn_abort）：此时媒体线程已无回调，
+  //      abort 可安全丢弃 OH_AVPlayer_Release 前已入队但尚未在 JS 线程执行的 TSF 调用
+  //   3. 再 erase state：上两步完成后状态指针不再被任何线程访问
   if (state.avPlayer != nullptr) {
     OH_AVPlayer_Stop(state.avPlayer);
-    OH_AVPlayer_Release(state.avPlayer);
+    OH_AVPlayer_Release(state.avPlayer); // 阻塞直到媒体线程所有回调执行完毕
     state.avPlayer = nullptr;
   }
   ResetRuntimeState(state);
@@ -1548,7 +1705,7 @@ static napi_value Release(napi_env env, napi_callback_info info) {
   state.xComponentId.clear();
   state.nativeWindow = nullptr;  // 只清引用，生命周期归 XComponent，不调用 release
   state.surfaceReady = false;
-  ClearCallbackRefs(state, env);
+  ClearCallbackRefs(state, env); // 内部含 ReleaseTsfIfPresent(napi_tsfn_abort)
   state.callbackEnv = nullptr;
   g_players.erase(iter);
   return ReturnUndefinedOrThrow(env, "release failed to create return value");

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -674,6 +674,12 @@ struct NativePlayerSkeletonState {
   napi_threadsafe_function tsfOnCompleted = nullptr;
   napi_threadsafe_function tsfOnTimeUpdate = nullptr;
   napi_threadsafe_function tsfOnError = nullptr;
+  // PR#49 修复：新增 buffering=false 和 seekDone TSF，供媒体线程异步触发
+  napi_threadsafe_function tsfOnBufferingFalse = nullptr;
+  napi_threadsafe_function tsfOnSeekDone = nullptr;
+  // PR#49 修复（问题6）：per-player mutex，保护 state 字段的跨线程读写
+  // 注意：std::mutex 不可拷贝/移动；unordered_map 通过节点指针操作，不需要拷贝值
+  std::mutex stateMutex;
 };
 
 static std::unordered_map<int32_t, NativePlayerSkeletonState> g_players;
@@ -718,6 +724,7 @@ static void ThrowRangeError(napi_env env, const char *message) {
 }
 
 static NativePlayerSkeletonState *FindPlayerOrThrow(napi_env env, int32_t handle) {
+  std::lock_guard<std::mutex> lock(g_playersMutex); // PR#49（问题3）：保护 g_players 跨线程访问
   auto iter = g_players.find(handle);
   if (iter == g_players.end()) {
     ThrowRangeError(env, "invalid player handle");
@@ -953,6 +960,9 @@ static void ClearCallbackRefs(NativePlayerSkeletonState &state, napi_env fallbac
   ReleaseTsfIfPresent(state.tsfOnCompleted);
   ReleaseTsfIfPresent(state.tsfOnTimeUpdate);
   ReleaseTsfIfPresent(state.tsfOnError);
+  // PR#49：新增两个 TSF
+  ReleaseTsfIfPresent(state.tsfOnBufferingFalse);
+  ReleaseTsfIfPresent(state.tsfOnSeekDone);
 }
 
 static bool EnsurePreparedOrEmitError(
@@ -1009,6 +1019,7 @@ static void ResetRuntimeState(NativePlayerSkeletonState &state) {
 
 static napi_value CreatePlayer(napi_env env, napi_callback_info info) {
   (void)info;
+  std::lock_guard<std::mutex> lock(g_playersMutex); // PR#49（问题3）：保护 g_players 写操作
   if (g_players.size() >= MAX_PLAYER_COUNT) {
     ThrowRangeError(env, "player count limit reached");
     return nullptr;
@@ -1018,7 +1029,8 @@ static napi_value CreatePlayer(napi_env env, napi_callback_info info) {
     return nullptr;
   }
   const int32_t handle = g_nextHandle++;
-  g_players[handle] = NativePlayerSkeletonState();
+  // 使用 operator[] 原地默认构造（NativePlayerSkeletonState 含 std::mutex，不可拷贝/移动赋值）
+  (void)g_players[handle];
   napi_value handleValue = ReturnInt32OrThrow(env, handle, "createPlayer failed to create return handle");
   if (handleValue == nullptr) {
     g_players.erase(handle);
@@ -1129,6 +1141,12 @@ static napi_value SetHeaders(napi_env env, napi_callback_info info) {
 // OH_NativeXComponent 静态回调（供所有 player 共用一套函数指针）
 // ---------------------------------------------------------------------------
 
+// PR#49 修复（问题5）：OnAVPlayerErrorCB 携带 code+msg 两个字段，TSF data 指针
+struct ErrorData {
+  int32_t code;
+  std::string *msg;  // heap-allocated，由 tsfOnError call_js_cb 负责 delete
+};
+
 // ---------------------------------------------------------------------------
 // A4：OH_AVPlayer 状态 / 错误回调（媒体线程调用，userData = NativePlayerSkeletonState*）
 // 使用新式带 userData 的回调 API：OH_AVPlayer_SetOnInfoCallback / SetOnErrorCallback
@@ -1154,30 +1172,64 @@ static void OnAVPlayerInfoCB(OH_AVPlayer *player, AVPlayerOnInfoType type,
         // 获取时长（GetDuration 返回 int32_t 毫秒）
         int32_t durationMs = 0;
         OH_AVPlayer_GetDuration(state->avPlayer, &durationMs);
-        state->durationMs = static_cast<int64_t>(durationMs);
-        state->prepared = true;
+        {
+          // PR#49（问题6）：锁保护 state 字段写；TSF 调用在锁外，避免死锁
+          std::lock_guard<std::mutex> lock(state->stateMutex);
+          state->durationMs = static_cast<int64_t>(durationMs);
+          state->prepared = true;
+        }
         if (state->tsfOnPrepared != nullptr) {
           napi_call_threadsafe_function(state->tsfOnPrepared, nullptr, napi_tsfn_nonblocking);
         }
+        // PR#49（问题4）：buffering=false 随 tsfOnPrepared 的 call_js_cb 一并发出（见 SetCallbacks）
       } else if (avState == AV_COMPLETED) {
-        state->playing = false;
+        {
+          std::lock_guard<std::mutex> lock(state->stateMutex);
+          state->playing = false;
+        }
         if (state->tsfOnCompleted != nullptr) {
           napi_call_threadsafe_function(state->tsfOnCompleted, nullptr, napi_tsfn_nonblocking);
         }
+        // PR#49（问题4）：buffering=false 随 tsfOnCompleted 的 call_js_cb 一并发出（见 SetCallbacks）
       } else if (avState == AV_PLAYING) {
-        state->playing = true;
+        {
+          std::lock_guard<std::mutex> lock(state->stateMutex);
+          state->playing = true;
+        }
+        // PR#49（问题4）：播放开始时发出 buffering=false
+        if (state->tsfOnBufferingFalse != nullptr) {
+          napi_call_threadsafe_function(state->tsfOnBufferingFalse, nullptr, napi_tsfn_nonblocking);
+        }
       } else if (avState == AV_PAUSED) {
-        state->playing = false;
+        {
+          std::lock_guard<std::mutex> lock(state->stateMutex);
+          state->playing = false;
+        }
+        // PR#49（问题4）：暂停时 buffering 应结束
+        if (state->tsfOnBufferingFalse != nullptr) {
+          napi_call_threadsafe_function(state->tsfOnBufferingFalse, nullptr, napi_tsfn_nonblocking);
+        }
       }
       break;
     }
     case AV_INFO_TYPE_POSITION_UPDATE: {
       int32_t posMs = 0;
       if (OH_AVFormat_GetIntValue(infoBody, OH_PLAYER_CURRENT_POSITION, &posMs)) {
+        std::lock_guard<std::mutex> lock(state->stateMutex); // PR#49（问题6）
         state->currentTimeMs = static_cast<int64_t>(posMs);
       }
       if (state->tsfOnTimeUpdate != nullptr) {
         napi_call_threadsafe_function(state->tsfOnTimeUpdate, nullptr, napi_tsfn_nonblocking);
+      }
+      break;
+    }
+    case AV_INFO_TYPE_SEEKDONE: {
+      // PR#49（问题7）：OH_AVPlayer_Seek 是异步的，seekDone 应在此回调触发，而非 Seek() 返回时
+      if (state->tsfOnTimeUpdate != nullptr) {
+        napi_call_threadsafe_function(state->tsfOnTimeUpdate, nullptr, napi_tsfn_nonblocking);
+      }
+      if (state->tsfOnSeekDone != nullptr) {
+        napi_call_threadsafe_function(state->tsfOnSeekDone, nullptr, napi_tsfn_nonblocking);
       }
       break;
     }
@@ -1189,15 +1241,21 @@ static void OnAVPlayerInfoCB(OH_AVPlayer *player, AVPlayerOnInfoType type,
 static void OnAVPlayerErrorCB(OH_AVPlayer *player, int32_t errorCode,
                                const char *errorMsg, void *userData) {
   (void)player;
-  (void)errorCode;
   NativePlayerSkeletonState *state = static_cast<NativePlayerSkeletonState *>(userData);
   if (state == nullptr) {
     return;
   }
   if (state->tsfOnError != nullptr) {
-    // 堆分配错误信息字符串，由 tsfOnError call_js_cb 负责 delete
-    auto *msg = new std::string(errorMsg ? errorMsg : "AVPlayer error");
-    napi_call_threadsafe_function(state->tsfOnError, msg, napi_tsfn_nonblocking);
+    // PR#49（问题5）：携带 code+msg，由 tsfOnError call_js_cb 负责 delete
+    auto *errData = new ErrorData{
+      errorCode,
+      new std::string(errorMsg ? errorMsg : "AVPlayer error")
+    };
+    napi_call_threadsafe_function(state->tsfOnError, errData, napi_tsfn_nonblocking);
+  }
+  // PR#49（问题4）：error 路径同样需要结束 buffering 状态
+  if (state->tsfOnBufferingFalse != nullptr) {
+    napi_call_threadsafe_function(state->tsfOnBufferingFalse, nullptr, napi_tsfn_nonblocking);
   }
 }
 
@@ -1266,6 +1324,8 @@ static void OnXCSurfaceDestroyed(OH_NativeXComponent *component, void *window) {
       break;
     }
   }
+  // PR#49（问题9）：清除悬空的 pending window 缓存，避免 surface 销毁后 use-after-free
+  g_pendingWindows.erase(xcId);
 }
 
 static void OnXCDispatchTouchEvent(OH_NativeXComponent *component, void *window) {
@@ -1514,9 +1574,12 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
     napi_create_threadsafe_function(
       env, args[1], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
       [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        // PR#49（问题4）：prepared 时同步发出 buffering=false，确保 UI 退出加载态
+        auto *st = static_cast<NativePlayerSkeletonState *>(ctx);
         napi_value undef;
         napi_get_undefined(tsfEnv, &undef);
         napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
+        EmitBufferingChange(*st, false);
       },
       &state.tsfOnPrepared);
   }
@@ -1526,9 +1589,12 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
     napi_create_threadsafe_function(
       env, args[4], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
       [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        // PR#49（问题4）：completed 时同步发出 buffering=false
+        auto *st = static_cast<NativePlayerSkeletonState *>(ctx);
         napi_value undef;
         napi_get_undefined(tsfEnv, &undef);
         napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
+        EmitBufferingChange(*st, false);
       },
       &state.tsfOnCompleted);
   }
@@ -1554,17 +1620,53 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
     napi_create_threadsafe_function(
       env, args[2], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
       [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
-        // data = heap std::string* 错误信息，由 OnAVPlayerErrorCB 分配，此处负责 delete
-        std::string *msg = static_cast<std::string *>(data);
-        napi_value errorStr;
+        // PR#49（问题5）：data = heap ErrorData*，携带 code+msg，此处负责 delete
+        auto *errData = static_cast<ErrorData *>(data);
+        napi_value codeVal = nullptr;
+        napi_create_int32(tsfEnv, errData ? errData->code : -1, &codeVal);
+        napi_value msgVal = nullptr;
         napi_create_string_utf8(tsfEnv,
-          msg ? msg->c_str() : "AVPlayer error", NAPI_AUTO_LENGTH, &errorStr);
+          (errData && errData->msg) ? errData->msg->c_str() : "AVPlayer error",
+          NAPI_AUTO_LENGTH, &msgVal);
+        napi_value argv[2] = { codeVal, msgVal };
         napi_value undef;
         napi_get_undefined(tsfEnv, &undef);
-        napi_call_function(tsfEnv, undef, jsCb, 1, &errorStr, nullptr);
-        delete msg;
+        napi_call_function(tsfEnv, undef, jsCb, 2, argv, nullptr);
+        if (errData) {
+          delete errData->msg;
+          delete errData;
+        }
       },
       &state.tsfOnError);
+  }
+  // PR#49（问题4/7）：为 AV_PLAYING/AV_PAUSED/error 创建 buffering=false TSF；
+  //                    为 AV_INFO_TYPE_SEEKDONE 创建 seekDone TSF
+  if (hasBufferingArg) {
+    napi_value resName;
+    napi_create_string_utf8(env, "tsfOnBufferingFalse", NAPI_AUTO_LENGTH, &resName);
+    napi_create_threadsafe_function(
+      env, args[5], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
+      [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        // 直接调用 onBufferingChange(false)；不使用 ctx，由 jsCb（args[5]）接收
+        napi_value boolFalse = nullptr;
+        napi_get_boolean(tsfEnv, false, &boolFalse);
+        napi_value undef;
+        napi_get_undefined(tsfEnv, &undef);
+        napi_call_function(tsfEnv, undef, jsCb, 1, &boolFalse, nullptr);
+      },
+      &state.tsfOnBufferingFalse);
+  }
+  if (hasSeekDoneArg) {
+    napi_value resName;
+    napi_create_string_utf8(env, "tsfOnSeekDone", NAPI_AUTO_LENGTH, &resName);
+    napi_create_threadsafe_function(
+      env, args[6], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
+      [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        napi_value undef;
+        napi_get_undefined(tsfEnv, &undef);
+        napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
+      },
+      &state.tsfOnSeekDone);
   }
 
   // 若回调在 prepared 之后才注册，主动补发一次状态，避免上层错过时序。
@@ -1595,12 +1697,16 @@ static napi_value Play(napi_env env, napi_callback_info info) {
   )) {
     return ReturnUndefinedOrThrow(env, "play failed to create return value");
   }
-  if (state.playing) {
-    // 幂等处理：已在播放态时忽略重复 play。
-    return ReturnUndefinedOrThrow(env, "play failed to create return value");
+  {
+    // PR#49（问题6）：保护 playing/lastRealtimeMs 写操作；OH_AVPlayer_Play 在锁外调用
+    std::lock_guard<std::mutex> lock(state.stateMutex);
+    if (state.playing) {
+      // 幂等处理：已在播放态时忽略重复 play。
+      return ReturnUndefinedOrThrow(env, "play failed to create return value");
+    }
+    state.playing = true;
+    state.lastRealtimeMs = NowRealtimeMs();
   }
-  state.playing = true;
-  state.lastRealtimeMs = NowRealtimeMs();
   // A3：驱动 OH_AVPlayer 真实播放
   if (state.avPlayer != nullptr) {
     OH_AVPlayer_Play(state.avPlayer);
@@ -1627,13 +1733,17 @@ static napi_value Pause(napi_env env, napi_callback_info info) {
   )) {
     return ReturnUndefinedOrThrow(env, "pause failed to create return value");
   }
-  if (!state.playing) {
-    // 幂等处理：已暂停时忽略重复 pause。
-    return ReturnUndefinedOrThrow(env, "pause failed to create return value");
+  {
+    // PR#49（问题6）：保护 playing/lastRealtimeMs/currentTimeMs 写操作；OH_AVPlayer_Pause 在锁外
+    std::lock_guard<std::mutex> lock(state.stateMutex);
+    if (!state.playing) {
+      // 幂等处理：已暂停时忽略重复 pause。
+      return ReturnUndefinedOrThrow(env, "pause failed to create return value");
+    }
+    AdvancePlaybackClockIfNeeded(state);
+    state.playing = false;
+    state.lastRealtimeMs = 0;
   }
-  AdvancePlaybackClockIfNeeded(state);
-  state.playing = false;
-  state.lastRealtimeMs = 0;
   // A3：驱动 OH_AVPlayer 真实暂停
   if (state.avPlayer != nullptr) {
     OH_AVPlayer_Pause(state.avPlayer);
@@ -1678,21 +1788,23 @@ static napi_value Seek(napi_env env, napi_callback_info info) {
   if (positionMs < 0) {
     positionMs = 0;
   }
-  if (state.durationMs > 0 && positionMs > state.durationMs) {
-    positionMs = state.durationMs;
-  }
-  state.currentTimeMs = positionMs;
-  if (state.playing) {
-    state.lastRealtimeMs = NowRealtimeMs();
+  {
+    // PR#49（问题6）：保护 currentTimeMs/durationMs/lastRealtimeMs 读写；OH_AVPlayer_Seek 在锁外
+    std::lock_guard<std::mutex> lock(state.stateMutex);
+    if (state.durationMs > 0 && positionMs > state.durationMs) {
+      positionMs = state.durationMs;
+    }
+    state.currentTimeMs = positionMs;
+    if (state.playing) {
+      state.lastRealtimeMs = NowRealtimeMs();
+    }
   }
   // A3：驱动 OH_AVPlayer 真实 seek（PREVIOUS_SYNC 模式，适合直播与点播）
   if (state.avPlayer != nullptr) {
     OH_AVPlayer_Seek(state.avPlayer, static_cast<int32_t>(positionMs), AV_SEEK_PREVIOUS_SYNC);
   }
   EmitTimeUpdate(state);
-  // Emit seekDone after confirming position; adapter uses this to fire onSeekDone
-  // instead of relying on the synchronous call return.
-  EmitSeekDone(state);
+  // PR#49（问题7）：EmitSeekDone 移至 AV_INFO_TYPE_SEEKDONE 回调（异步完成后触发），此处不再调用
   return ReturnUndefinedOrThrow(env, "seek failed to create return value");
 }
 
@@ -1744,12 +1856,21 @@ static napi_value Release(napi_env env, napi_callback_info info) {
     ThrowTypeError(env, "release requires (handle)");
     return nullptr;
   }
-  auto iter = g_players.find(handle);
-  if (iter == g_players.end()) {
-    // 幂等处理：重复 release 直接视为成功。
-    return ReturnUndefinedOrThrow(env, "release failed to create return value");
+  // PR#49（问题3）：分两段持锁：
+  //   ① 持锁找到 state 指针后立即释放，避免 OH_AVPlayer_Release（阻塞）期间持有 g_playersMutex
+  //   ② OH_AVPlayer 操作全部在无锁下完成
+  //   ③ 最后再持锁 erase（JS 线程单线程，两段锁之间不会有其他 JS 代码修改 map 结构）
+  NativePlayerSkeletonState *statePtr = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(g_playersMutex);
+    auto iter = g_players.find(handle);
+    if (iter == g_players.end()) {
+      // 幂等处理：重复 release 直接视为成功。
+      return ReturnUndefinedOrThrow(env, "release failed to create return value");
+    }
+    statePtr = &iter->second;
   }
-  NativePlayerSkeletonState &state = iter->second;
+  NativePlayerSkeletonState &state = *statePtr;
   // A4 顺序说明：
   //   1. OH_AVPlayer_Release：等待所有媒体线程回调执行完毕（含 OnAVPlayerInfoCB / OnAVPlayerErrorCB）
   //   2. ClearCallbackRefs（含 ReleaseTsfIfPresent napi_tsfn_abort）：此时媒体线程已无回调，
@@ -1768,7 +1889,10 @@ static napi_value Release(napi_env env, napi_callback_info info) {
   state.surfaceReady = false;
   ClearCallbackRefs(state, env); // 内部含 ReleaseTsfIfPresent(napi_tsfn_abort)
   state.callbackEnv = nullptr;
-  g_players.erase(iter);
+  {
+    std::lock_guard<std::mutex> lock(g_playersMutex); // PR#49（问题3）：持锁 erase
+    g_players.erase(handle);
+  }
   return ReturnUndefinedOrThrow(env, "release failed to create return value");
 }
 

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -653,6 +653,7 @@ struct NativePlayerSkeletonState {
   OHNativeWindow *nativeWindow = nullptr;  // 渲染目标 Surface，生命周期归 XComponent，不 retain/release
   OH_AVPlayer *avPlayer = nullptr;          // OH_AVPlayer 实例，由 Prepare 创建，Release 销毁
   bool surfaceReady = false;               // OnSurfaceCreated 已触发
+  bool pendingPrepare = false;             // A5修复: surface未就绪时暂缓 Prepare，待 OnSurfaceCreated 后补发
   bool prepared = false;
   bool playing = false;
   int32_t selectedTrackIndex = -1;
@@ -983,6 +984,7 @@ static void AdvancePlaybackClockIfNeeded(NativePlayerSkeletonState &state) {
 static void ResetRuntimeState(NativePlayerSkeletonState &state) {
   state.prepared = false;
   state.playing = false;
+  state.pendingPrepare = false;  // A5修复: 切换 surface 时清除延迟标志
   state.selectedTrackIndex = -1;
   state.currentTimeMs = 0;
   state.durationMs = 0;
@@ -1196,9 +1198,14 @@ static void OnXCSurfaceCreated(OH_NativeXComponent *component, void *window) {
     if (pair.second.xComponentId == xcId) {
       pair.second.nativeWindow = static_cast<OHNativeWindow *>(window);
       pair.second.surfaceReady = true;
-      // 若 avPlayer 已创建且 url 已设置，立即绑定 surface（Prepare 先于 surface ready 的情形）
-      if (pair.second.avPlayer != nullptr && !pair.second.url.empty()) {
+      // A5修复: 若 avPlayer 已创建，立即绑定 surface
+      if (pair.second.avPlayer != nullptr) {
         OH_AVPlayer_SetVideoSurface(pair.second.avPlayer, pair.second.nativeWindow);
+        // 若 Prepare() 因 surface 未就绪而延迟，现在补发 Prepare
+        if (pair.second.pendingPrepare) {
+          pair.second.pendingPrepare = false;
+          OH_AVPlayer_Prepare(pair.second.avPlayer);
+        }
       }
       break;
     }
@@ -1341,9 +1348,12 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
     return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
   }
 
-  // 绑定渲染 Surface（若 surface 已就绪）；否则等 OnSurfaceCreated 回调触发后再绑定
+  // 绑定渲染 Surface：必须在 OH_AVPlayer_Prepare 之前调用
+  // A5修复: 若 surface 未就绪，设置 pendingPrepare 标志，等 OnSurfaceCreated 回调后再 Prepare
   if (state.nativeWindow != nullptr) {
     OH_AVPlayer_SetVideoSurface(state.avPlayer, state.nativeWindow);
+  } else {
+    state.pendingPrepare = true;
   }
 
   // A4：注册媒体状态回调（在 Prepare 调用前注册）
@@ -1351,9 +1361,12 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
   OH_AVPlayer_SetOnInfoCallback(state.avPlayer, OnAVPlayerInfoCB, &state);
   OH_AVPlayer_SetOnErrorCallback(state.avPlayer, OnAVPlayerErrorCB, &state);
 
-  // 异步 prepare：SDK 中无 PrepareAsync，OH_AVPlayer_Prepare 本身为非阻塞；
-  // prepared 标志与 onPrepared 回调均由 OnAVPlayerInfoCB 在 AV_PREPARED 状态时通过 TSF 触发
-  OH_AVPlayer_Prepare(state.avPlayer);
+  // 若 surface 已就绪，直接 Prepare；否则由 OnSurfaceCreated 补发
+  if (!state.pendingPrepare) {
+    // 异步 prepare：SDK 中无 PrepareAsync，OH_AVPlayer_Prepare 本身为非阻塞；
+    // prepared 标志与 onPrepared 回调均由 OnAVPlayerInfoCB 在 AV_PREPARED 状态时通过 TSF 触发
+    OH_AVPlayer_Prepare(state.avPlayer);
+  }
 
   // 在 JS 线程发出"开始缓冲"通知；prepared / onPrepared / EmitTimeUpdate 改由异步回调完成
   EmitBufferingChange(state, true);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -13,6 +13,7 @@
 #include <native_window/external_window.h>
 #include <multimedia/player_framework/avplayer.h>
 #include <multimedia/player_framework/native_avformat.h>
+#include <hilog/log.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -680,6 +681,21 @@ static int32_t g_nextHandle = 1;
 // A4：保护 g_players 跨线程访问（XC 表面回调来自 UI 线程，AV 回调来自媒体线程）
 static std::mutex g_playersMutex;
 
+// 修复 #48-A5：pending window 缓存
+// 根因：RegisterCallback 在 SetXComponent（onLoad 回调）中调用时 surface 已创建完毕，
+// OnSurfaceCreated 不会补发，nativeWindow 永远 nullptr。
+// 正确做法：在 Init() 中注册，此时 surface 尚未创建；若 OnSurfaceCreated 先于
+// SetXComponent 触发，缓存到 g_pendingWindows 待关联。
+struct PendingWindowInfo {
+  OH_NativeXComponent *nativeXC = nullptr;
+  OHNativeWindow *nativeWindow = nullptr;
+};
+// xcId → (nativeXC*, nativeWindow*)，供 SetXComponent 延迟关联
+static std::unordered_map<std::string, PendingWindowInfo> g_pendingWindows;
+// Init() 期间从 OH_NATIVE_XCOMPONENT_OBJ 取到的 nativeXC，
+// SetXComponent 用它判断是否需要重复注册（同一个 XComponent 无需重复注册）
+static OH_NativeXComponent *g_pendingXC = nullptr;
+
 #ifndef VIDALL_MAX_PLAYER_COUNT
 #define VIDALL_MAX_PLAYER_COUNT 100000UL
 #endif
@@ -1193,11 +1209,17 @@ static void OnXCSurfaceCreated(OH_NativeXComponent *component, void *window) {
     return;
   }
   const std::string xcId(idBuf);
+
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "OnXCSurfaceCreated: xcId=%s window=%p", xcId.c_str(), window);
+
   std::lock_guard<std::mutex> lock(g_playersMutex); // A4: 保护 g_players 跨线程遍历
+  bool found = false;
   for (auto &pair : g_players) {
     if (pair.second.xComponentId == xcId) {
       pair.second.nativeWindow = static_cast<OHNativeWindow *>(window);
       pair.second.surfaceReady = true;
+      found = true;
       // A5修复: 若 avPlayer 已创建，立即绑定 surface
       if (pair.second.avPlayer != nullptr) {
         OH_AVPlayer_SetVideoSurface(pair.second.avPlayer, pair.second.nativeWindow);
@@ -1209,6 +1231,15 @@ static void OnXCSurfaceCreated(OH_NativeXComponent *component, void *window) {
       }
       break;
     }
+  }
+
+  if (!found) {
+    // SetXComponent 还未被调用（Init 注册回调时序早于 ArkTS onLoad），
+    // 缓存 window，等 SetXComponent 来关联。
+    g_pendingWindows[xcId] = { component, static_cast<OHNativeWindow *>(window) };
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "OnXCSurfaceCreated: player 未就绪，缓存 window 待 SetXComponent 关联 xcId=%s",
+                 xcId.c_str());
   }
 }
 
@@ -1299,8 +1330,25 @@ static napi_value SetXComponent(napi_env env, napi_callback_info info) {
   ResetRuntimeState(*state);
 
   // 注册 XComponent 回调，OnSurfaceCreated 触发后写入 nativeWindow。
-  if (nativeXC != nullptr) {
+  // 修复 #48-A5: 若 Init() 已对同一 nativeXC 注册过（g_pendingXC），跳过重复注册；
+  // 不同 nativeXC（多 XComponent 场景或切换）则重新注册。
+  if (nativeXC != nullptr && nativeXC != g_pendingXC) {
     OH_NativeXComponent_RegisterCallback(nativeXC, &s_xcCallback);
+  }
+
+  // 修复 #48-A5: 检查 OnSurfaceCreated 是否已先行触发并缓存了 window
+  // （Init 中注册回调时序早于 ArkTS onLoad/SetXComponent）
+  {
+    std::lock_guard<std::mutex> pendingLock(g_playersMutex);
+    auto pendingIt = g_pendingWindows.find(xComponentId);
+    if (pendingIt != g_pendingWindows.end()) {
+      state->nativeWindow = pendingIt->second.nativeWindow;
+      state->surfaceReady = true;
+      g_pendingWindows.erase(pendingIt);
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                   "SetXComponent: 从 pending 恢复 nativeWindow=%p xcId=%s",
+                   state->nativeWindow, xComponentId.c_str());
+    }
   }
 
   EmitTimeUpdate(*state);
@@ -2170,9 +2218,6 @@ static napi_value GetNativeCapabilities(napi_env env, napi_callback_info info) {
   return result;
 }
 
-} // namespace
-
-EXTERN_C_START
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     { "createPlayer", nullptr, CreatePlayer, nullptr, nullptr, nullptr, napi_default, nullptr },
@@ -2199,9 +2244,37 @@ static napi_value Init(napi_env env, napi_value exports) {
     ThrowTypeError(env, "failed to define native module properties");
     return nullptr;
   }
+
+  // 修复 #48-A5: 在模块挂载期注册 XComponent 回调
+  // 当 XComponent 使用 libraryname: 'vidall_core_player_napi' 时，HarmonyOS 在
+  // surface 创建前调用 Init() 并将 OH_NATIVE_XCOMPONENT_OBJ 注入 exports。
+  // 在此处注册回调，OnSurfaceCreated 就会在 surface 创建时正确触发，
+  // 而不是等到 ArkTS onLoad 回调中的 SetXComponent() 时才注册（彼时 surface 已创建，
+  // 不会补发 OnSurfaceCreated，导致 nativeWindow 永远是 nullptr）。
+  napi_value xcExport = nullptr;
+  napi_status xcStatus = napi_get_named_property(env, exports, OH_NATIVE_XCOMPONENT_OBJ, &xcExport);
+  if (xcStatus == napi_ok && xcExport != nullptr) {
+    OH_NativeXComponent *nativeXC = nullptr;
+    napi_unwrap(env, xcExport, reinterpret_cast<void **>(&nativeXC));
+    if (nativeXC != nullptr) {
+      OH_NativeXComponent_RegisterCallback(nativeXC, &s_xcCallback);
+      g_pendingXC = nativeXC;
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                   "Init: 已在 XComponent 挂载期注册回调，等待 OnSurfaceCreated (nativeXC=%p)",
+                   nativeXC);
+    } else {
+      OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                   "Init: OH_NATIVE_XCOMPONENT_OBJ 存在但 napi_unwrap 返回 nullptr");
+    }
+  } else {
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "Init: 未检测到 OH_NATIVE_XCOMPONENT_OBJ（非 XComponent 绑定加载，属正常）");
+  }
+
   return exports;
 }
-EXTERN_C_END
+
+} // namespace
 
 static napi_module vidallCorePlayerModule = {
   .nm_version = 1,

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1112,18 +1112,14 @@ static napi_value SetXComponent(napi_env env, napi_callback_info info) {
   }
   state->xComponentId = xComponentId;
 
-  // 从 context 中提取 OHNativeWindow*，失败时降级兼容（不 crash）
+  // 从 context 中提取 OH_NativeXComponent*。
+  // 注：SDK 无同步 GetNativeWindow API（旧路径 window 仅在 OnSurfaceCreated 回调中可得；
+  //     新路径 OH_ArkUI_XComponent_GetNativeWindow 接受 SurfaceHolder*，非此处 unwrap 所得类型）。
+  // nativeWindow 将由 A3 阶段的 surface-created 回调写入；此处只做合法性检查，不 crash。
   OH_NativeXComponent *nativeXC = nullptr;
-  if (napi_unwrap(env, args[1], reinterpret_cast<void **>(&nativeXC)) == napi_ok
-      && nativeXC != nullptr) {
-    OHNativeWindow *nativeWindow = nullptr;
-    int32_t ret = OH_NativeXComponent_GetNativeWindow(nativeXC, &nativeWindow);
-    if (ret == 0 && nativeWindow != nullptr) {
-      state->nativeWindow = nativeWindow;
-    }
-    // ret != 0 或 nativeWindow == nullptr：骨架降级兼容，nativeWindow 保持 nullptr
-  }
-  // napi_unwrap 失败（如单测环境）：nativeWindow 保持 nullptr，不影响骨架流程
+  napi_unwrap(env, args[1], reinterpret_cast<void **>(&nativeXC));
+  // nativeXC 有效则 state->nativeWindow 由后续回调赋值，否则降级为 nullptr（骨架兼容）
+  state->nativeWindow = nullptr;
 
   // 切换渲染目标后重置骨架态，避免旧 prepared/时间轴状态延续到新 surface。
   ResetRuntimeState(*state);

--- a/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
@@ -651,6 +651,16 @@ export class IjkPlayerAdapter implements IPlayer {
         return;
       }
       try {
+        // 修复: onPrepared 时 getDuration() 可能返回 0（部分流媒体格式 duration 延迟就绪），
+        // 在每次轮询 tick 中补偿获取，确保 VideoPlayerController.onTimeUpdate 能读到有效值。
+        if (this._duration <= 0) {
+          const lateDuration = this.ijk.getDuration();
+          if (lateDuration > 0) {
+            this._duration = lateDuration;
+            hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+              `[timeUpdate] duration 延迟就绪: ${this._duration}ms session=${this._sessionId}`);
+          }
+        }
         const pos = this.ijk.getCurrentPosition();
         if (pos !== this._currentTime) {
           this._currentTime = pos;

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -521,9 +521,17 @@ export class VidAllPlayerAdapter implements IPlayer {
     if (sepIdx < 0) {
       return url;
     }
+    // 检查 authority 段（scheme:// 到第一个 / 之间）是否已含 userinfo（@ 符号），
+    // 若已含则跳过注入，避免生成双重 @ 的非法 URL（幂等保护）。
+    const afterProto = sepIdx + 3;
+    const slashIdx = url.indexOf('/', afterProto);
+    const authority = slashIdx >= 0 ? url.substring(afterProto, slashIdx) : url.substring(afterProto);
+    if (authority.includes('@')) {
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG, 'buildUrlWithAuth: URL 已含 userinfo，跳过注入');
+      return url;
+    }
     const result = `${url.substring(0, sepIdx + 3)}${userInfo}@${url.substring(sepIdx + 3)}`;
-    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `buildUrlWithAuth: 已将 Basic Auth 凭据嵌入 URL userinfo（user=${encodedUser}）`);
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG, 'buildUrlWithAuth: 已将 Basic Auth 凭据嵌入 URL userinfo');
     return result;
   }
 

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -4,6 +4,7 @@ import { hilog } from '@kit.PerformanceAnalysisKit';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { CommonConstants } from '../../../common/constants/CommonConstants';
 import * as VidAllCorePlayerNapiModule from 'libvidall_core_player_napi.so';
+import buffer from '@ohos.buffer';
 
 const TAG = '[VidAllPlayerAdapter]';
 const METRICS_TAG = 'VidAll_Metrics';
@@ -146,8 +147,11 @@ export class VidAllPlayerAdapter implements IPlayer {
     }
 
     this._playerHandle = this.callNativeWithValue('createPlayer', () => VidAllCorePlayerNapi.createPlayer());
+    // OH_AVPlayer_SetURLSource 不支持自定义 HTTP 头；将 Basic Auth 凭据嵌入 URL userinfo
+    // （RFC 3986：http://user:pass@host/path），FFmpeg 底层会自动提取并发送 Authorization 头。
+    const urlForNative = this.buildUrlWithAuth(videoData.videoSrc, videoData.httpHeader);
     this.callNativeVoid('setSource', () => {
-      VidAllCorePlayerNapi.setSource(this._playerHandle, videoData.videoSrc);
+      VidAllCorePlayerNapi.setSource(this._playerHandle, urlForNative);
     });
     const headersJson = this.buildHeadersJson(videoData.httpHeader);
     if (headersJson.length > 0) {
@@ -442,6 +446,85 @@ export class VidAllPlayerAdapter implements IPlayer {
       safeHeaders[key] = headers[key];
     }
     return JSON.stringify(safeHeaders);
+  }
+
+  /**
+   * 将 HTTP Basic Auth 凭据嵌入 URL userinfo（http://user:pass@host/path）。
+   *
+   * 背景：OH_AVPlayer_SetURLSource 不支持自定义 HTTP 头；NDK avplayer.h 中也无
+   * OH_AVPlayer_SetMediaSource 或等效的 header API。底层 FFmpeg 可识别 URL userinfo
+   * 并自动生成 Authorization: Basic 头，从而通过 WebDAV 服务器的 401 鉴权。
+   *
+   * 实现：从 headers['Authorization'] 中提取 "Basic <base64>" 部分，
+   * 用 @ohos.buffer 解码得到 "user:password"，拼入 URL scheme 之后。
+   * user 和 password 各自做 encodeURIComponent 防止特殊字符破坏 URL 解析。
+   *
+   * 若 Authorization 头不存在或格式不符，原样返回 url。
+   */
+  private buildUrlWithAuth(url: string, headers?: Record<string, string>): string {
+    if (!headers) {
+      return url;
+    }
+    // 大小写不敏感地查找 Authorization 头
+    let authValue: string = '';
+    const keys = Object.keys(headers);
+    for (let i = 0; i < keys.length; i++) {
+      if (keys[i].toLowerCase() === 'authorization') {
+        authValue = headers[keys[i]];
+        break;
+      }
+    }
+    if (authValue.length === 0) {
+      return url;
+    }
+    // 解析 "Basic <base64credentials>"
+    const spaceIdx = authValue.indexOf(' ');
+    if (spaceIdx < 0) {
+      return url;
+    }
+    const scheme = authValue.substring(0, spaceIdx).toLowerCase();
+    if (scheme !== 'basic') {
+      // 非 Basic Auth，不处理（Digest/Bearer 等无法通过 userinfo 传递）
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `buildUrlWithAuth: 非 Basic Auth (${scheme})，跳过 userinfo 嵌入`);
+      return url;
+    }
+    const base64Creds = authValue.substring(spaceIdx + 1).trim();
+    let creds: string;
+    try {
+      // buffer.from(str, 'base64').toString('utf-8') 与 CryptoUtil 相同用法
+      creds = buffer.from(base64Creds, 'base64').toString('utf-8');
+    } catch {
+      hilog.error(CommonConstants.LOG_DOMAIN, TAG,
+        'buildUrlWithAuth: base64 decode 失败，跳过 userinfo 嵌入');
+      return url;
+    }
+    if (creds.length === 0) {
+      return url;
+    }
+    // 拆分 user:password（密码本身可能含 ':'）
+    const colonIdx = creds.indexOf(':');
+    let user: string;
+    let pass: string;
+    if (colonIdx < 0) {
+      user = creds;
+      pass = '';
+    } else {
+      user = creds.substring(0, colonIdx);
+      pass = creds.substring(colonIdx + 1);
+    }
+    const encodedUser = encodeURIComponent(user);
+    const encodedPass = encodeURIComponent(pass);
+    const userInfo = pass.length > 0 ? `${encodedUser}:${encodedPass}` : encodedUser;
+    // 找到 scheme:// 位置并在 // 之后插入 userInfo@
+    const sepIdx = url.indexOf('://');
+    if (sepIdx < 0) {
+      return url;
+    }
+    const result = `${url.substring(0, sepIdx + 3)}${userInfo}@${url.substring(sepIdx + 3)}`;
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `buildUrlWithAuth: 已将 Basic Auth 凭据嵌入 URL userinfo（user=${encodedUser}）`);
+    return result;
   }
 
   async selectTrack(trackIndex: number): Promise<void> {


### PR DESCRIPTION
## 概述

实现 Issue #48 Phase A：基于 OH_AVPlayer C API 的 native 播放器渲染管线，使 VidAll TV 的 native 后端能够真正输出视频画面与声音。

**真机验收：✅ 有画面 + 有声音**

## 变更模块

### C++ 层（`entry/src/main/cpp/`）

- **CMakeLists.txt**：链接 `libavplayer.so`、`libnative_window.so`、`libace_ndk.z.so`、`libnative_media_core.so`、`libhilog_ndk.z.so`
- **vidall_core_player_napi.cpp**：
  - `NativePlayerSkeletonState`：新增 `OHNativeWindow*`、`OH_AVPlayer*`、`surfaceReady`、`pendingPrepare`、4 个 TSF 字段
  - `Init()`：在 NAPI 模块挂载期注册 `OH_NativeXComponent_Callback`（根本修复：surface 创建前注册，`OnSurfaceCreated` 可正确触发）
  - `g_pendingWindows`/`g_pendingXC`：处理 `OnSurfaceCreated` 早于 `SetXComponent` 的时序竞态
  - `Prepare()`：完整 OH_AVPlayer 管线（Create → SetURLSource → SetVideoSurface → Prepare）
  - `Play/Pause/Seek/Release`：驱动 OH_AVPlayer API
  - `OH_AVPlayer_SetOnInfoCallback`/`SetOnErrorCallback`：真实异步回调，通过 4 个 `napi_threadsafe_function` 桥接到 ArkTS
  - `static std::mutex g_playersMutex`：保护 `g_players` 遍历的线程安全

### ArkTS 层（`entry/src/main/ets/`）

- **VidAllPlayerAdapter.ets**：新增 `buildUrlWithAuth()` 方法，将 `Authorization: Basic` header 嵌入 URL userinfo（绕过 OH_AVPlayer 无 HTTP Header API 限制）
- **IjkPlayerAdapter.ets**：`startTimeUpdateTimer()` 轮询 tick 中补偿读取延迟就绪的 `getDuration()`，修复 fallback 后进度条无法 seek 的问题

## 关键技术决策

| 问题 | 方案 |
|---|---|
| OH_AVPlayer 无 HTTP Header API | URL userinfo 嵌入（`http://user:pass@host/path`） |
| `OnSurfaceCreated` 永不触发 | 在 `NAPI Init()` 注册回调（早于 surface 创建） |
| 时序竞态（surface 先于 SetXComponent 到达） | `g_pendingWindows` 缓存 window，`SetXComponent` 时恢复 |
| AV 回调跨线程调用 ArkTS | `napi_threadsafe_function` 桥接（4 个 TSF：prepared/completed/timeUpdate/error） |
| IJK fallback 后 duration=0 | IjkPlayerAdapter timer tick 中延迟补偿 `getDuration()` |

## 已知限制（Phase B 解决）

- 不支持 AC-3/Dolby Digital 音频（OH_AVPlayer 无 AC-3 解码器）
- 不支持 DTS 音频
- 无 FFmpeg 软解兜底（Phase B 规划）

Closes #48 Phase A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-threaded, surface-aware native video playback with robust lifecycle and async playback event callbacks
  * HTTP Basic Authentication embedding for protected video URLs

* **Bug Fixes**
  * Reliable duration reporting during initialization and time updates to prevent incorrect time displays
<!-- end of auto-generated comment: release notes by coderabbit.ai -->