### PR TITLE
调研: 收口 HarmonyOS TV 硬解能力与 surface 方案验证

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | 功能 | 说明 |
 |---|---|
-| 🎬 视频播放 | AVPlayer 主链 + IJKPlayer 兜底，支持 mp4/mkv 等主流格式 |
+| 🎬 视频播放 | AVPlayer 主链 + Native 实验后端 + IJKPlayer 兜底，支持 mp4/mkv 等主流格式 |
 | 🌐 WebDAV 文件源 | 基于 libcurl 的 HTTPS WebDAV，支持 PikPak、群晖、Alist 等 |
 | 🔍 视频扫描 | 递归扫描配置目录，自动去重，支持深度限制 |
 | 🎭 元数据刮削 | 接入 TMDB API，自动匹配海报、简介、类型、年份 |
@@ -30,6 +30,7 @@
 │           C++ Native 层                     │
 │  vidall_core_player_napi.cpp                │
 │  ├── AVPlayer 控制（XComponent 渲染）       │
+│  ├── Native backend（OH_AVPlayer/FFmpeg/EGL）│
 │  ├── ffprobe  媒体信息探测                  │
 │  ├── webdavRequest  libcurl HTTPS 请求      │
 │  └── downloadToFile  libcurl 文件下载       │
@@ -43,6 +44,7 @@
 ```
 VideoPlayerController (ArkTS)
   ├── AVPlayerAdapter      ← HarmonyOS 原生，主链
+  ├── VidAllPlayerAdapter  ← Native 实验后端（AVPlayer 接管 + FFmpeg/EGL 回退）
   └── IjkPlayerAdapter     ← IJKPlayer，兜底
 ```
 
@@ -113,6 +115,7 @@ VidAll_TV/
 │           ├── components/core/player/  # 播放器核心
 │           │   ├── VideoPlayerController.ets
 │           │   ├── AVPlayerAdapter.ets
+│           │   ├── VidAllPlayerAdapter.ets
 │           │   └── IjkPlayerAdapter.ets
 │           ├── db/                      # 数据库（RelationalStore）
 │           │   └── FileSourceDatabase.ets
@@ -173,7 +176,8 @@ hdc shell hilog | grep VidAll_TLS_Audit
 
 | 问题 | 原因 | 状态 |
 |---|---|---|
-| AC-3/DTS 音频无法播放 | AVPlayer 不内置 AC-3 解码器 | 规划引入 FFmpeg NAPI |
+| Native 4K/10bit 片源偶发卡顿 | 当前为 FFmpeg 软解 + CPU `sws_scale` 路径，吞吐接近设备上限 | 后续转 #50 硬解主路径 |
+| AC-3/DTS 音频无法播放 | AVPlayer 不内置 AC-3 解码器；Native/FFmpeg 路径已接通基础送显 | 持续完善中 |
 | SMB/NFS 文件源 | 尚未实现 | Phase 2 |
 | AVMetadataExtractor 不支持远程 URL | API 20 起才有 `setUrlSource` | 待 SDK 升级 |
 | 帧率显示偶有 ×100（如 2397） | AVPlayer 内部单位问题 | 已在 VideoInfoUtil 修正 |

--- a/README.md
+++ b/README.md
@@ -172,12 +172,26 @@ hdc shell hilog | grep VidAll_TLS_Audit
 
 ---
 
+## Native 后端当前状态
+
+当前播放器默认仍以 `AVPlayer` 为主链，`native` 后端用于承接更可控的播放路径与格式兼容验证。
+
+- `native + AVPlayer` 路径已完成 XComponent 接管，支持真实出画、`pause / play / seek` 与时间轴回调
+- `native + FFmpeg` 路径已完成 demux、解码、OpenGL ES 渲染、`OH_AudioRenderer` 送显与基础字幕桥接
+- Native 内嵌字幕已实现：可枚举、可切换、可显示
+- `native + FFmpeg` 当前仍是**软解视频 + CPU `sws_scale` 转换 + GLES 贴图**，4K/10bit 片源吞吐仍偏紧
+- `native + FFmpeg` 运行时音轨切换已拆分到 `#55`，不再阻塞 `#48` 收口
+- 下一阶段主线为 `#50`：在保留 FFmpeg 容器与状态机控制的前提下，引入**硬解视频主路径 + 软解回退**
+
+---
+
 ## 已知限制
 
 | 问题 | 原因 | 状态 |
 |---|---|---|
 | Native 4K/10bit 片源偶发卡顿 | 当前为 FFmpeg 软解 + CPU `sws_scale` 路径，吞吐接近设备上限 | 后续转 #50 硬解主路径 |
-| AC-3/DTS 音频无法播放 | AVPlayer 不内置 AC-3 解码器；Native/FFmpeg 路径已接通基础送显 | 持续完善中 |
+| AVPlayer 无法直接播放 AC-3/DTS | AVPlayer 不内置 AC-3/DTS 解码器；需走 Native/FFmpeg 路径兜底 | Native/FFmpeg 基础链路已打通，持续完善中 |
+| Native/FFmpeg 运行时音轨切换未完成 | 当前 FFmpeg 子路径仍以固定默认音轨运行为主，完整切轨能力已拆到 `#55` | 规划中 |
 | SMB/NFS 文件源 | 尚未实现 | Phase 2 |
 | AVMetadataExtractor 不支持远程 URL | API 20 起才有 `setUrlSource` | 待 SDK 升级 |
 | 帧率显示偶有 ×100（如 2397） | AVPlayer 内部单位问题 | 已在 VideoInfoUtil 修正 |

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -135,6 +135,7 @@ if(VIDALL_ENABLE_OH_AVPLAYER)
     libnative_media_core.so  # A4：OH_AVFormat_GetIntValue（avplayer new-style info callback）
     libnative_media_codecbase.so
     libnative_media_acodec.so
+    libnative_media_vdec.so
   )
 else()
   message(STATUS "VIDALL_ENABLE_OH_AVPLAYER=OFF — OH_AVPlayer C API disabled")

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -44,6 +44,13 @@ option(VIDALL_ENABLE_FFMPEG "Enable FFmpeg demux/decode path" ON)
 if(VIDALL_ENABLE_FFMPEG)
     target_compile_definitions(vidall_core_player_napi PRIVATE VIDALL_ENABLE_FFMPEG=1)
     message(STATUS "VIDALL_ENABLE_FFMPEG=ON — FFmpeg demux path enabled")
+    # B3：OpenGL ES YUV 渲染管线需要 EGL 上下文与 GLES2 库
+    # B4：OH_AudioRenderer PCM 送显需要 libohaudio
+    target_link_libraries(vidall_core_player_napi PRIVATE
+        EGL          # EGL 上下文（创建 window surface / context）
+        GLESv2       # OpenGL ES 2.0（shader / texture / draw）
+        libohaudio.so  # B4：OH_AudioRenderer（PCM 音频送显）
+    )
 else()
     target_compile_definitions(vidall_core_player_napi PRIVATE VIDALL_ENABLE_FFMPEG=0)
     message(STATUS "VIDALL_ENABLE_FFMPEG=OFF — FFmpeg demux path disabled")

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -133,6 +133,8 @@ if(VIDALL_ENABLE_OH_AVPLAYER)
     libavplayer.so
     libace_ndk.z.so
     libnative_media_core.so  # A4：OH_AVFormat_GetIntValue（avplayer new-style info callback）
+    libnative_media_codecbase.so
+    libnative_media_acodec.so
   )
 else()
   message(STATUS "VIDALL_ENABLE_OH_AVPLAYER=OFF — OH_AVPlayer C API disabled")

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -37,6 +37,19 @@ target_include_directories(vidall_core_player_napi PRIVATE
 )
 
 # ---------------------------------------------------------------------------
+# B1：FFmpeg demux/decode 路径编译开关
+# 默认 ON；可通过 cmake -DVIDALL_ENABLE_FFMPEG=OFF 关闭（仅保留 OH_AVPlayer 路径）。
+# ---------------------------------------------------------------------------
+option(VIDALL_ENABLE_FFMPEG "Enable FFmpeg demux/decode path" ON)
+if(VIDALL_ENABLE_FFMPEG)
+    target_compile_definitions(vidall_core_player_napi PRIVATE VIDALL_ENABLE_FFMPEG=1)
+    message(STATUS "VIDALL_ENABLE_FFMPEG=ON — FFmpeg demux path enabled")
+else()
+    target_compile_definitions(vidall_core_player_napi PRIVATE VIDALL_ENABLE_FFMPEG=0)
+    message(STATUS "VIDALL_ENABLE_FFMPEG=OFF — FFmpeg demux path disabled")
+endif()
+
+# ---------------------------------------------------------------------------
 # libcurl 集成（HTTPS WebDAV 支持）
 #
 # 使用方式：

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -47,8 +47,8 @@ if(VIDALL_ENABLE_FFMPEG)
     # B3：OpenGL ES YUV 渲染管线需要 EGL 上下文与 GLES2 库
     # B4：OH_AudioRenderer PCM 送显需要 libohaudio
     target_link_libraries(vidall_core_player_napi PRIVATE
-        EGL          # EGL 上下文（创建 window surface / context）
-        GLESv2       # OpenGL ES 2.0（shader / texture / draw）
+        libEGL.so      # EGL 上下文（创建 window surface / context）
+        libGLESv2.so   # OpenGL ES 2.0（shader / texture / draw）
         libohaudio.so  # B4：OH_AudioRenderer（PCM 音频送显）
     )
 else()

--- a/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
+++ b/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
@@ -78,6 +78,16 @@ export const getNativeCapabilities: () => {
   libcurlVersion: string;
 };
 
+export const queryAudioDecoderCapability: (codecOrMime: string) => {
+  capabilityKnown: boolean;
+  supported: boolean;
+  isHardware: boolean;
+  maxChannels: number;
+  decoderName: string;
+  mimeType: string;
+  errorMessage: string;
+};
+
 export const setCallbacks: (
   handle: number,
   onPrepared: () => void,

--- a/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
+++ b/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
@@ -124,5 +124,7 @@ export const setCallbacks: (
   onTimeUpdate: (posMs: number) => void,
   onCompleted: () => void,
   onBufferingChange: (isBuffering: boolean) => void,
-  onSeekDone: () => void
+  onSeekDone: () => void,
+  onFfmpegSwitching: () => void,
+  onSubtitleUpdate: (info: { duration: number; startTime: number; text: string }) => void
 ) => void;

--- a/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
+++ b/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
@@ -88,6 +88,35 @@ export const queryAudioDecoderCapability: (codecOrMime: string) => {
   errorMessage: string;
 };
 
+export const queryVideoDecoderCapability: (codecOrMime: string) => {
+  capabilityKnown: boolean;
+  supported: boolean;
+  isHardware: boolean;
+  maxWidth: number;
+  maxHeight: number;
+  minWidth: number;
+  minHeight: number;
+  maxFrameRate: number;
+  minFrameRate: number;
+  widthAlignment: number;
+  heightAlignment: number;
+  maxInstances: number;
+  decoderName: string;
+  mimeType: string;
+  errorMessage: string;
+};
+
+export const probeVideoDecoderSurface: (handle: number, codecOrMime: string) => {
+  success: boolean;
+  stage: string;
+  capabilityKnown: boolean;
+  isHardware: boolean;
+  decoderName: string;
+  mimeType: string;
+  stateSummary: string;
+  errorMessage: string;
+};
+
 export const setCallbacks: (
   handle: number,
   onPrepared: () => void,

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -908,6 +908,10 @@ struct NativePlayerSkeletonState {
   int64_t ffmpegDurationMs = 0;
   // B3：nativeWindow 尚未就绪时（OnXCSurfaceCreated 还未触发）延迟启动渲染线程的标志
   bool pendingFfmpegRender = false;
+  // B6：AVPlayer 报错切 FFmpeg 时，先异步释放 AVPlayer 对 NativeWindow 的占用，再启动 FFmpeg。
+  std::thread ffmpegFallbackThread;
+  bool ffmpegFallbackInProgress = false;
+  bool cancelPendingFfmpegFallback = false;
 };
 
 static std::unordered_map<int32_t, NativePlayerSkeletonState> g_players;
@@ -1245,6 +1249,23 @@ static void ResetRuntimeState(NativePlayerSkeletonState &state) {
   state.currentTimeMs = 0;
   state.durationMs = 0;
   state.lastRealtimeMs = 0;
+}
+
+static void JoinFfmpegFallbackThread(NativePlayerSkeletonState &state) {
+  std::thread threadToJoin;
+  {
+    std::lock_guard<std::mutex> lk(state.stateMutex);
+    if (state.ffmpegFallbackThread.joinable()) {
+      std::swap(threadToJoin, state.ffmpegFallbackThread);
+    }
+  }
+  if (threadToJoin.joinable()) {
+    if (threadToJoin.get_id() == std::this_thread::get_id()) {
+      threadToJoin.detach();
+    } else {
+      threadToJoin.join();
+    }
+  }
 }
 
 static napi_value CreatePlayer(napi_env env, napi_callback_info info) {
@@ -3317,14 +3338,56 @@ static void OnAVPlayerErrorCB(OH_AVPlayer *player, int32_t errorCode,
   // AV_ERR_UNSUPPORT (= 4) 表示格式/编解码器不支持；通用错误也尝试 FFmpeg 路径。
   // 条件：尚未启动 FFmpeg 路径 && URL 不为空
   if (!state->useFfmpegPath && !state->url.empty()) {
-    state->useFfmpegPath = true;
-    const std::string urlCopy = state->url; // OnAVPlayerErrorCB 来自媒体线程，避免持有 state 太久
+    const std::string urlCopy = state->url;
+    {
+      std::lock_guard<std::mutex> lk(state->stateMutex);
+      if (state->useFfmpegPath || state->ffmpegFallbackInProgress) {
+        return;
+      }
+      state->useFfmpegPath = true;
+      state->cancelPendingFfmpegFallback = false;
+      state->ffmpegFallbackInProgress = true;
+    }
+    JoinFfmpegFallbackThread(*state);
     OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                 "OnAVPlayerErrorCB: switching to FFmpeg demux path for url=%s", urlCopy.c_str());
-    // StartFfmpegDemux 内部会 avformat_open_input（可能阻塞），
-    // 在媒体线程直接调用会影响 OH_AVPlayer 回调链路。
-    // B1 阶段直接在此线程启动（open 有 10s 超时保障），B2 阶段可改为独立 dispatch 线程。
-    StartFfmpegDemux(state, urlCopy);
+                 "OnAVPlayerErrorCB: scheduling AVPlayer->FFmpeg handoff for url=%s", urlCopy.c_str());
+    state->ffmpegFallbackThread = std::thread([state, urlCopy]() {
+      OH_AVPlayer *avToRelease = nullptr;
+      {
+        std::lock_guard<std::mutex> lk(state->stateMutex);
+        avToRelease = state->avPlayer;
+        state->avPlayer = nullptr;
+      }
+      if (avToRelease != nullptr) {
+        const OH_AVErrCode stopRc = OH_AVPlayer_Stop(avToRelease);
+        const OH_AVErrCode detachRc = OH_AVPlayer_SetVideoSurface(avToRelease, nullptr);
+        OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                     "FFmpegFallbackThread: stopRc=%{public}d detachRc=%{public}d, releasing AVPlayer before EGL handoff",
+                     static_cast<int32_t>(stopRc), static_cast<int32_t>(detachRc));
+        const OH_AVErrCode releaseRc = OH_AVPlayer_Release(avToRelease);
+        OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                     "FFmpegFallbackThread: releaseRc=%{public}d", static_cast<int32_t>(releaseRc));
+      } else {
+        OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                     "FFmpegFallbackThread: avPlayer already null, skip release");
+      }
+
+      bool cancelled = false;
+      {
+        std::lock_guard<std::mutex> lk(state->stateMutex);
+        cancelled = state->cancelPendingFfmpegFallback;
+        state->ffmpegFallbackInProgress = false;
+      }
+      if (cancelled) {
+        OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                     "FFmpegFallbackThread: cancelled before StartFfmpegDemux");
+        return;
+      }
+
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                   "FFmpegFallbackThread: AVPlayer released, start FFmpeg demux for url=%s", urlCopy.c_str());
+      StartFfmpegDemux(state, urlCopy);
+    });
     // B6修复：FFmpeg 路径已接管，抑制 tsfOnError，防止 ArkTS fallbackNativeToIjk()
     // 抢占 XComponent surface，导致 FFmpeg EGL 初始化失败。
     // FFmpeg 准备好后会通过 tsfOnPrepared 通知 ArkTS；
@@ -3480,9 +3543,11 @@ static napi_value SetXComponent(napi_env env, napi_callback_info info) {
   OH_AVPlayer *avToRelease = nullptr;
   {
     std::lock_guard<std::mutex> lk(state->stateMutex);
+    state->cancelPendingFfmpegFallback = true;
     avToRelease = state->avPlayer;
     state->avPlayer = nullptr;
   }
+  JoinFfmpegFallbackThread(*state);
   if (avToRelease != nullptr) {
     OH_AVPlayer_Stop(avToRelease);
     OH_AVPlayer_Release(avToRelease);
@@ -4022,9 +4087,11 @@ static napi_value Release(napi_env env, napi_callback_info info) {
   OH_AVPlayer *avToRelease = nullptr;
   {
     std::lock_guard<std::mutex> lk(state.stateMutex);
+    state.cancelPendingFfmpegFallback = true;
     avToRelease = state.avPlayer;
     state.avPlayer = nullptr;
   }
+  JoinFfmpegFallbackThread(state);
   if (avToRelease != nullptr) {
     OH_AVPlayer_Stop(avToRelease);
     OH_AVPlayer_Release(avToRelease); // 阻塞直到媒体线程所有回调执行完毕

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1553,6 +1553,19 @@ static double AudioClock(const FfmpegContext *ctx) {
   return static_cast<double>(baseMs + deltaMs) / 1000.0;
 }
 
+static double VideoFramePtsSeconds(const FfmpegContext *ctx, const AVFrame *frame) {
+  if (ctx == nullptr || frame == nullptr || ctx->videoStreamIdx < 0 || ctx->fmtCtx == nullptr) {
+    return 0.0;
+  }
+  const int64_t frameTs = (frame->best_effort_timestamp != AV_NOPTS_VALUE)
+      ? frame->best_effort_timestamp
+      : frame->pts;
+  if (frameTs == AV_NOPTS_VALUE) {
+    return 0.0;
+  }
+  return frameTs * av_q2d(ctx->fmtCtx->streams[ctx->videoStreamIdx]->time_base);
+}
+
 // ---------------------------------------------------------------------------
 // B5：清空所有 packet/frame 队列（seek 时调用，清除过期数据）
 // ---------------------------------------------------------------------------
@@ -1872,6 +1885,33 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
         break;
       }
 
+      if (ctx->videoSyncGraceFrames.load(std::memory_order_relaxed) <= 0
+          && !ctx->playbackPaused.load(std::memory_order_relaxed)) {
+        const double videoPts = VideoFramePtsSeconds(ctx, frame);
+        const double audioClock = AudioClock(ctx);
+        const double diff = videoPts - audioClock;
+        if (videoPts > 0.0 && diff < -0.8) {
+          static int droppedDecodeFrames = 0;
+          droppedDecodeFrames++;
+          if (droppedDecodeFrames == 1 || (droppedDecodeFrames % 30) == 0) {
+            int packetBacklog = 0;
+            {
+              std::lock_guard<std::mutex> lock(ctx->videoQueue.mtx);
+              packetBacklog = static_cast<int>(ctx->videoQueue.packets.size());
+            }
+            OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                         "VideoDecodeThread: skip late frame diffMs=%{public}d videoPtsMs=%{public}d audioClockMs=%{public}d packetBacklog=%{public}d count=%{public}d",
+                         static_cast<int>(diff * 1000.0),
+                         static_cast<int>(videoPts * 1000.0),
+                         static_cast<int>(audioClock * 1000.0),
+                         packetBacklog,
+                         droppedDecodeFrames);
+          }
+          av_frame_unref(frame);
+          continue;
+        }
+      }
+
       // 将帧移入 videoFrameQueue（背压等待，防止解码过快撑爆内存）
       // ── B6：格式转换 + 超 1920 降采样 + CPU 侧 YUV→RGBA 转换 ──
       // 1. 所有格式统一通过 sws_scale 转换为 AV_PIX_FMT_RGBA（包括 yuv420p10le/yuv420p）
@@ -1902,7 +1942,7 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
           ctx->swsCtx = sws_getContext(
               frame->width, frame->height, static_cast<AVPixelFormat>(frame->format),
               dstW, dstH, AV_PIX_FMT_RGBA,
-              SWS_BILINEAR, nullptr, nullptr, nullptr);
+              SWS_FAST_BILINEAR, nullptr, nullptr, nullptr);
           ctx->lastSwsSrcFmt = frame->format;
           ctx->lastSwsSrcW   = frame->width;
           OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
@@ -2549,7 +2589,7 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
       const bool bypassSync = ctx->videoSyncGraceFrames.load(std::memory_order_relaxed) > 0
           || frameTs == AV_NOPTS_VALUE;
       if (!bypassSync) {
-        const double videoPts = frameTs * av_q2d(ctx->fmtCtx->streams[ctx->videoStreamIdx]->time_base);
+        const double videoPts = VideoFramePtsSeconds(ctx, frame);
         const double audioClock = AudioClock(ctx);
         const double diff = videoPts - audioClock;
 

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -744,6 +744,7 @@ struct GlFunctions {
     void (*PixelStorei)(GLenum, GLint) = nullptr;
     GLenum (*GetError)() = nullptr;
     const GLubyte* (*GetString)(GLenum) = nullptr;
+    void (*GetIntegerv)(GLenum, GLint*) = nullptr;
 };
 
 // FFmpeg 上下文：格式探测 + demux 线程 + 双队列
@@ -2079,9 +2080,10 @@ static bool LoadGLFunctions(GlFunctions &gl) {
     LOAD(PixelStorei,             "glPixelStorei")
     LOAD(GetError,                "glGetError")
     LOAD(GetString,               "glGetString")
+    LOAD(GetIntegerv,             "glGetIntegerv")
 #undef LOAD
     OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                 "LoadGLFunctions: all %{public}d GL functions loaded", 36);
+                 "LoadGLFunctions: all %{public}d GL functions loaded", 37);
     return true;
 }
 
@@ -2362,10 +2364,21 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   // GL context 验证诊断（使用已加载的函数指针）
   {
     const GLubyte *glVer = ctx->gl.GetString(GL_VERSION);
+    const GLubyte *glVendor = ctx->gl.GetString(GL_VENDOR);
+    const GLubyte *glRenderer = ctx->gl.GetString(GL_RENDERER);
+    const GLubyte *glslVer = ctx->gl.GetString(GL_SHADING_LANGUAGE_VERSION);
+    GLint maxTextureSize = 0;
+    ctx->gl.GetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
     GLenum glErr = ctx->gl.GetError();
     OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                  "RenderThreadFunc: GL_VERSION=%{public}s glGetError=0x%{public}x",
                  glVer ? (const char*)glVer : "null", glErr);
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "RenderThreadFunc: GL_VENDOR=%{public}s GL_RENDERER=%{public}s GLSL=%{public}s maxTex=%{public}d",
+                 glVendor ? (const char*)glVendor : "null",
+                 glRenderer ? (const char*)glRenderer : "null",
+                 glslVer ? (const char*)glslVer : "null",
+                 maxTextureSize);
   }
 
   // 3. 初始化 GL 资源（shader/纹理/VBO）
@@ -2457,11 +2470,11 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
       }
     }
 
-    // 5. 上传 YUV420P → 3 张 GL_R8 纹理（GLES 3 标准单通道格式，shader 用 .r 分量采样）
+    // 5. 上传 RGBA 帧到单张 GL 纹理
     const int w = frame->width;
     const int h = frame->height;
 
-    // B6 诊断日志：第一帧打印格式与 linesize（fmt=2 表示 AV_PIX_FMT_RGBA，ls0=width*4）
+    // B6 诊断日志：第一帧打印格式与 linesize
     {
       static bool firstFrameLogged = false;
       if (!firstFrameLogged) {
@@ -2472,35 +2485,62 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
       }
     }
 
-    ctx->gl.PixelStorei(GL_UNPACK_ALIGNMENT, 4);  // GL_RGBA 每像素 4 字节，默认对齐 4 即可
+    int drainedErrors = 0;
+    for (;;) {
+      const GLenum staleErr = ctx->gl.GetError();
+      if (staleErr == GL_NO_ERROR) {
+        break;
+      }
+      drainedErrors++;
+      OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                   "RenderThread: drained stale gl error=0x%{public}x", staleErr);
+    }
 
-    // Fix #48-B6: 首帧（或分辨率切换时）用 glTexImage2D 分配纹理存储；
-    // 后续帧改用 glTexSubImage2D 直接更新数据，避免每帧重新分配。
-    // 格式：GL_RGBA（internalFormat）+ GL_RGBA（format）—— 最兼容格式，规避 GL_R8/GL_LUMINANCE OOM。
+    ctx->gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+    // Fix #48-B6-2: 首帧/尺寸变化先用 glTexImage2D(nullptr) 分配，再用 glTexSubImage2D 上传。
     const bool sizeChanged = (w != ctx->textureW || h != ctx->textureH);
 
     ctx->gl.ActiveTexture(GL_TEXTURE0);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->rgbaTexture);
+    bool uploadOk = true;
     if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0,
-                     GL_RGBA, GL_UNSIGNED_BYTE, frame->data[0]);
-        // 诊断: 仅在首帧或尺寸变更时检查 GL 错误
-        {
-            GLenum glErr = ctx->gl.GetError();
-            OH_LOG_Print(LOG_APP, glErr == GL_NO_ERROR ? LOG_INFO : LOG_ERROR,
-                         0xFF00, "VidAll",
-                         "RenderThread: glTexImage2D RGBA err=0x%{public}x w=%{public}d h=%{public}d",
-                         glErr, w, h);
-        }
-    } else {
-        ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h,
-                        GL_RGBA, GL_UNSIGNED_BYTE, frame->data[0]);
+      ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0,
+                         GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+      const GLenum allocErr = ctx->gl.GetError();
+      OH_LOG_Print(LOG_APP, allocErr == GL_NO_ERROR ? LOG_INFO : LOG_ERROR,
+                   0xFF00, "VidAll",
+                   "RenderThread: glTexImage2D alloc err=0x%{public}x w=%{public}d h=%{public}d drained=%{public}d",
+                   allocErr, w, h, drainedErrors);
+      if (allocErr != GL_NO_ERROR) {
+        uploadOk = false;
+      }
+    }
+
+    if (uploadOk) {
+      ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h,
+                            GL_RGBA, GL_UNSIGNED_BYTE, frame->data[0]);
+      const GLenum uploadErr = ctx->gl.GetError();
+      if (!ctx->texturesInitialized || sizeChanged || uploadErr != GL_NO_ERROR) {
+        OH_LOG_Print(LOG_APP, uploadErr == GL_NO_ERROR ? LOG_INFO : LOG_ERROR,
+                     0xFF00, "VidAll",
+                     "RenderThread: glTexSubImage2D upload err=0x%{public}x w=%{public}d h=%{public}d ls0=%{public}d",
+                     uploadErr, w, h, frame->linesize[0]);
+      }
+      if (uploadErr != GL_NO_ERROR) {
+        uploadOk = false;
+      }
+    }
+
+    if (!uploadOk) {
+      av_frame_free(&frame);
+      continue;
     }
 
     if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->texturesInitialized = true;
-        ctx->textureW = w;
-        ctx->textureH = h;
+      ctx->texturesInitialized = true;
+      ctx->textureW = w;
+      ctx->textureH = h;
     }
 
     // 6. 用 RGBA passthrough program 绘制全屏 quad（triangle strip，4 顶点）
@@ -2514,12 +2554,33 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
     ctx->gl.VertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, stride,
                           reinterpret_cast<const void *>(2 * sizeof(float)));
     ctx->gl.DrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    {
+      static bool firstDrawLogged = false;
+      const GLenum drawErr = ctx->gl.GetError();
+      if (!firstDrawLogged || drawErr != GL_NO_ERROR) {
+        firstDrawLogged = true;
+        OH_LOG_Print(LOG_APP, drawErr == GL_NO_ERROR ? LOG_INFO : LOG_ERROR,
+                     0xFF00, "VidAll",
+                     "RenderThread: glDrawArrays err=0x%{public}x", drawErr);
+      }
+    }
     ctx->gl.DisableVertexAttribArray(0);
     ctx->gl.DisableVertexAttribArray(1);
     ctx->gl.BindBuffer(GL_ARRAY_BUFFER, 0);
 
     // 7. 提交帧到屏幕
-    eglSwapBuffers(ctx->eglDisplay, ctx->eglSurface);
+    {
+      static bool firstSwapLogged = false;
+      const EGLBoolean swapOk = eglSwapBuffers(ctx->eglDisplay, ctx->eglSurface);
+      const EGLint swapErr = eglGetError();
+      if (!firstSwapLogged || swapOk != EGL_TRUE) {
+        firstSwapLogged = true;
+        OH_LOG_Print(LOG_APP, swapOk == EGL_TRUE ? LOG_INFO : LOG_ERROR,
+                     0xFF00, "VidAll",
+                     "RenderThread: eglSwapBuffers ok=%{public}d err=0x%{public}x",
+                     swapOk == EGL_TRUE ? 1 : 0, swapErr);
+      }
+    }
 
     // 8. 释放当前帧
     av_frame_free(&frame);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1878,7 +1878,7 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
   EGLint major = 0, minor = 0;
   if (!eglInitialize(ctx->eglDisplay, &major, &minor)) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                 "FfmpegInitEGL: eglInitialize failed err=0x%x", eglGetError());
+                 "FfmpegInitEGL: eglInitialize failed err=0x%{public}x", eglGetError());
     return false;
   }
   EGLint attribs[] = {
@@ -1894,15 +1894,32 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
   if (!eglChooseConfig(ctx->eglDisplay, attribs, &config, 1, &numConfigs) ||
       numConfigs == 0) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                 "FfmpegInitEGL: eglChooseConfig failed err=0x%x", eglGetError());
+                 "FfmpegInitEGL: eglChooseConfig failed err=0x%{public}x", eglGetError());
     return false;
   }
-  ctx->eglSurface = eglCreateWindowSurface(
-      ctx->eglDisplay, config,
-      reinterpret_cast<EGLNativeWindowType>(nativeWindow), nullptr);
+  // 修复1: 打印 nativeWindow 指针，并清除历史 EGL 错误，确保后续 eglGetError 干净
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "FfmpegInitEGL: calling eglCreateWindowSurface window=%{public}p", nativeWindow);
+  (void)eglGetError(); // 清除待处理的 EGL 错误
+  // 修复3: eglCreateWindowSurface 失败时重试 3 次（间隔 100ms），
+  //        防御 OH_AVPlayer 异步清理尚未完成导致 Window 仍被占用的情况。
+  ctx->eglSurface = EGL_NO_SURFACE;
+  for (int attempt = 0; attempt < 3 && ctx->eglSurface == EGL_NO_SURFACE; attempt++) {
+    if (attempt > 0) {
+      OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                   "FfmpegInitEGL: retry eglCreateWindowSurface attempt=%{public}d", attempt + 1);
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      (void)eglGetError(); // 重试前清除错误
+    }
+    ctx->eglSurface = eglCreateWindowSurface(
+        ctx->eglDisplay, config,
+        reinterpret_cast<EGLNativeWindowType>(nativeWindow), nullptr);
+  }
   if (ctx->eglSurface == EGL_NO_SURFACE) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                 "FfmpegInitEGL: eglCreateWindowSurface failed err=0x%x", eglGetError());
+                 "FfmpegInitEGL: eglCreateWindowSurface failed after 3 attempts"
+                 " err=0x%{public}x window=%{public}p",
+                 eglGetError(), nativeWindow);
     return false;
   }
   EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
@@ -1910,7 +1927,7 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
       eglCreateContext(ctx->eglDisplay, config, EGL_NO_CONTEXT, ctxAttribs);
   if (ctx->eglContext == EGL_NO_CONTEXT) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                 "FfmpegInitEGL: eglCreateContext failed err=0x%x", eglGetError());
+                 "FfmpegInitEGL: eglCreateContext failed err=0x%{public}x", eglGetError());
     return false;
   }
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
@@ -2056,24 +2073,35 @@ static void FfmpegCleanupGLResources(FfmpegContext *ctx) {
 static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   FfmpegContext *ctx = state->ffmpegCtx.get();
 
-  // 0. 释放 OH_AVPlayer，解除其对 NativeWindow 的 EGL surface 绑定。
-  //    必须在 FfmpegInitEGL 之前执行，否则 eglCreateWindowSurface 因 Window 已被占用而失败。
-  //    RenderThreadFunc 运行在独立线程（非 OH_AVPlayer 回调线程），调用 Release 安全。
+  // 0. 修复2: 在 OH_AVPlayer_Release 之前，于锁内同时取出 nativeWindow 到局部变量。
+  //    OH_AVPlayer_Release 可能触发 OnXCSurfaceDestroyed，其在 g_playersMutex 保护下
+  //    把 state->nativeWindow 置 null，若直接使用 state->nativeWindow 会产生竞态。
+  //    用 localWindow 持有指针即可规避。
+  OHNativeWindow *localWindow = nullptr;
   OH_AVPlayer *avToRelease = nullptr;
   {
     std::lock_guard<std::mutex> lk(state->stateMutex);
-    avToRelease = state->avPlayer;
+    localWindow   = state->nativeWindow; // 在锁内同时取出，保证一致性
+    avToRelease   = state->avPlayer;
     state->avPlayer = nullptr;
   }
-  if (avToRelease != nullptr) {
-    OH_AVPlayer_Stop(avToRelease);
-    OH_AVPlayer_Release(avToRelease);
-    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                 "RenderThreadFunc: released OH_AVPlayer to free NativeWindow EGL binding");
+
+  if (localWindow == nullptr) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "RenderThreadFunc: nativeWindow is null, cannot init EGL, abort");
+    ctx->renderRunning.store(false);
+    return;
   }
 
-  // 1. EGL 初始化（创建 display/surface/context）
-  if (!FfmpegInitEGL(ctx, state->nativeWindow)) {
+  if (avToRelease != nullptr) {
+    OH_AVPlayer_Stop(avToRelease);
+    OH_AVPlayer_Release(avToRelease); // 阻塞；可能触发 OnXCSurfaceDestroyed 置 null state->nativeWindow
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "RenderThreadFunc: released OH_AVPlayer (localWindow=%{public}p)", localWindow);
+  }
+
+  // 1. EGL 初始化（使用局部保存的 localWindow，不受 OH_AVPlayer_Release 回调影响）
+  if (!FfmpegInitEGL(ctx, localWindow)) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
                  "RenderThreadFunc: FfmpegInitEGL failed, exit");
     ctx->renderRunning.store(false);
@@ -2084,7 +2112,7 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   if (!eglMakeCurrent(ctx->eglDisplay, ctx->eglSurface,
                       ctx->eglSurface, ctx->eglContext)) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                 "RenderThreadFunc: eglMakeCurrent failed err=0x%x", eglGetError());
+                 "RenderThreadFunc: eglMakeCurrent failed err=0x%{public}x", eglGetError());
     ctx->renderRunning.store(false);
     return;
   }

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -811,6 +811,7 @@ struct FfmpegContext {
   int audioSampleRate{0};                    // swr 输出采样率（48000），FfmpegInitSwr 后固定
   std::atomic<int64_t> audioClockBaseMs{0};  // seek 后的主时钟基准，timeUpdate = base + playedSamples/sampleRate
   std::atomic<bool> playbackPaused{false};   // FFmpeg 路径的真实暂停态：音频回调/视频渲染均需读取
+  std::atomic<int32_t> videoSyncGraceFrames{0}; // seek/启动后前若干帧绕过 AV sync，先让画面稳定出帧
 
   // B5：seek 请求（Seek() NAPI 写入，DemuxThreadFunc 消费）
   std::atomic<bool> seekRequested{false};
@@ -1643,6 +1644,7 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
       }
       ctx->audioClockBaseMs.store(targetMs, std::memory_order_relaxed);
       ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
+      ctx->videoSyncGraceFrames.store(90, std::memory_order_relaxed);
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                    "DemuxThread: seeked to %lld ms", static_cast<long long>(targetMs));
       // 发出 seekDone TSF 通知 ArkTS
@@ -1913,6 +1915,7 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
                         frame->linesize, 0, frame->height,
                         convertedFrame->data, convertedFrame->linesize);
               convertedFrame->pts     = frame->pts;
+              convertedFrame->best_effort_timestamp = frame->best_effort_timestamp;
               convertedFrame->pkt_dts = frame->pkt_dts;
               renderFrame = convertedFrame;
             } else {
@@ -2533,27 +2536,46 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
 
     // B5：AV 同步：以音频时钟为主时钟，决定等待或丢帧
     if (ctx->videoStreamIdx >= 0 && ctx->audioSampleRate > 0) {
-      const double videoPts = (frame->pts != AV_NOPTS_VALUE)
-          ? frame->pts * av_q2d(ctx->fmtCtx->streams[ctx->videoStreamIdx]->time_base)
-          : 0.0;
-      const double audioClock = AudioClock(ctx);
-      const double diff = videoPts - audioClock;
+      const int64_t frameTs = (frame->best_effort_timestamp != AV_NOPTS_VALUE)
+          ? frame->best_effort_timestamp
+          : frame->pts;
+      const bool bypassSync = ctx->videoSyncGraceFrames.load(std::memory_order_relaxed) > 0
+          || frameTs == AV_NOPTS_VALUE;
+      if (!bypassSync) {
+        const double videoPts = frameTs * av_q2d(ctx->fmtCtx->streams[ctx->videoStreamIdx]->time_base);
+        const double audioClock = AudioClock(ctx);
+        const double diff = videoPts - audioClock;
 
-      if (diff > 0.1) {
-        // 视频超前音频 100ms 以上：等待音频跟上，最多等 200ms（B5-QA: 500→200 降低 AV sync 延迟）
-        const int sleepMs = static_cast<int>(std::min(diff * 1000.0, 200.0));
-        std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
-      } else if (diff < -0.5) {
-        // 视频落后音频 500ms 以上：丢弃此帧（追帧）
-        av_frame_free(&frame);
-        continue;
+        if (diff > 0.2) {
+          // 视频略超前：短暂等待音频，避免单帧 sleep 过长造成肉眼卡顿
+          const int sleepMs = static_cast<int>(std::min(diff * 1000.0, 50.0));
+          std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
+        } else if (diff < -2.0) {
+          static int droppedLateFrames = 0;
+          droppedLateFrames++;
+          if (droppedLateFrames == 1 || (droppedLateFrames % 30) == 0) {
+            OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                         "RenderThread: drop late frame diffMs=%{public}d videoPtsMs=%{public}d audioClockMs=%{public}d count=%{public}d",
+                         static_cast<int>(diff * 1000.0),
+                         static_cast<int>(videoPts * 1000.0),
+                         static_cast<int>(audioClock * 1000.0),
+                         droppedLateFrames);
+          }
+          av_frame_free(&frame);
+          continue;
+        } else {
+          static int droppedLateFrames = 0;
+          droppedLateFrames = 0;
+        }
+      } else if (ctx->videoSyncGraceFrames.load(std::memory_order_relaxed) > 0) {
+        ctx->videoSyncGraceFrames.fetch_sub(1, std::memory_order_relaxed);
       }
 
       // B5：每 200ms 上报一次播放位置给 ArkTS（以音频时钟为准）
       const auto now = std::chrono::steady_clock::now();
       if (std::chrono::duration_cast<std::chrono::milliseconds>(now - lastEmitTime).count() >= 200) {
         lastEmitTime = now;
-        const int64_t posMs = static_cast<int64_t>(audioClock * 1000.0);
+        const int64_t posMs = static_cast<int64_t>(AudioClock(ctx) * 1000.0);
         {
           std::lock_guard<std::mutex> lk(state->stateMutex);
           state->currentTimeMs = posMs;
@@ -2972,6 +2994,7 @@ static void StartFfmpegAudio(NativePlayerSkeletonState *state) {
   ctx->playbackPaused.store(false, std::memory_order_relaxed);
   ctx->audioClockBaseMs.store(0, std::memory_order_relaxed);
   ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
+  ctx->videoSyncGraceFrames.store(90, std::memory_order_relaxed);
   const OH_AudioStream_Result result = OH_AudioRenderer_Start(ctx->audioRenderer);
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                "StartFfmpegAudio: OH_AudioRenderer_Start result=%d", result);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -781,9 +781,9 @@ struct FfmpegContext {
 
   // B3：OpenGL ES 资源（在渲染线程 makeCurrent 后初始化）
   GLuint yuvProgram = 0;   // YUV→RGB GLSL program
-  GLuint textureY = 0;     // Y 分量纹理（GL_LUMINANCE，width×height）
-  GLuint textureU = 0;     // U 分量纹理（GL_LUMINANCE，width/2×height/2）
-  GLuint textureV = 0;     // V 分量纹理（GL_LUMINANCE，width/2×height/2）
+  GLuint textureY = 0;     // Y 分量纹理（GL_R8，width×height）
+  GLuint textureU = 0;     // U 分量纹理（GL_R8，width/2×height/2）
+  GLuint textureV = 0;     // V 分量纹理（GL_R8，width/2×height/2）
   GLuint quadVBO = 0;      // 全屏四边形顶点缓冲
 
   // Fix #48-B6: 首帧后置 true，后续帧用 TexSubImage2D 避免每帧重分配 GPU 纹理存储
@@ -2167,10 +2167,10 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
                  eglGetError(), nativeWindow);
     return false;
   }
-  // 修复 #48-B6: 退回 GLES 2 context——GLES 3 context 在 EGL_RENDERABLE_TYPE=ES2_BIT 的
-  // config 下触发 GPU 纹理内存 OOM（0x505），改用 GL_LUMINANCE（GLES 2 合法单通道格式）
-  // 配合 GLES 2 context 可绕过该限制。
-  EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
+  // 修复 #48-B6: 设备驱动始终返回 GLES 3.2 context（GL_VERSION=OpenGL ES 3.2），
+  // GL_LUMINANCE 在 GLES 3 中已废弃，即使 1920×1080 也触发 OOM（0x505）。
+  // 改用 GLES 3 context + GL_R8（GLES 3 标准单通道格式），配合 sws_scale 1920 降采样。
+  EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE};
   ctx->eglContext =
       eglCreateContext(ctx->eglDisplay, config, EGL_NO_CONTEXT, ctxAttribs);
   if (ctx->eglContext == EGL_NO_CONTEXT) {
@@ -2260,7 +2260,7 @@ static bool FfmpegInitGLResources(FfmpegContext *ctx) {
   ctx->gl.Uniform1i(ctx->gl.GetUniformLocation(ctx->yuvProgram, "u_textureU"), 1);
   ctx->gl.Uniform1i(ctx->gl.GetUniformLocation(ctx->yuvProgram, "u_textureV"), 2);
 
-  // 3. 创建 Y/U/V 三张 GL_LUMINANCE 纹理（实际尺寸由第一帧决定）
+  // 3. 创建 Y/U/V 三张 GL_R8 纹理（GLES 3 标准单通道格式，实际尺寸由第一帧决定）
   ctx->gl.GenTextures(1, &ctx->textureY);
   ctx->gl.GenTextures(1, &ctx->textureU);
   ctx->gl.GenTextures(1, &ctx->textureV);
@@ -2476,7 +2476,7 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
       }
     }
 
-    // 5. 上传 YUV420P → 3 张 GL_LUMINANCE 纹理（GLES 2 合法单通道格式，绕过 GLES 3 OOM）
+    // 5. 上传 YUV420P → 3 张 GL_R8 纹理（GLES 3 标准单通道格式，shader 用 .r 分量采样）
     const int w = frame->width;
     const int h = frame->height;
 
@@ -2497,13 +2497,14 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
 
     // Fix #48-B6: 首帧（或分辨率切换时）用 glTexImage2D 分配纹理存储；
     // 后续帧改用 glTexSubImage2D 直接更新数据，避免每帧重新分配导致 GL_OUT_OF_MEMORY。
+    // 格式：GL_R8（internalFormat）+ GL_RED（format）—— GLES 3 标准单通道格式。
     const bool sizeChanged = (w != ctx->textureW || h != ctx->textureH);
 
     ctx->gl.ActiveTexture(GL_TEXTURE0);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureY);
     if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w, h, 0,
-                     GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[0]);
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0,
+                     GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
         // 诊断: 仅在首帧或尺寸变更时检查 GL 错误，避免日志刷屏
         {
             GLenum glErr = ctx->gl.GetError();
@@ -2515,27 +2516,27 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
         }
     } else {
         ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h,
-                        GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[0]);
+                        GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
     }
 
     ctx->gl.ActiveTexture(GL_TEXTURE1);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureU);
     if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
-                     GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[1]);
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w / 2, h / 2, 0,
+                     GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
     } else {
         ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w / 2, h / 2,
-                        GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[1]);
+                        GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
     }
 
     ctx->gl.ActiveTexture(GL_TEXTURE2);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureV);
     if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
-                     GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[2]);
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w / 2, h / 2, 0,
+                     GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
     } else {
         ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w / 2, h / 2,
-                        GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[2]);
+                        GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
     }
 
     if (!ctx->texturesInitialized || sizeChanged) {

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -809,6 +809,8 @@ struct FfmpegContext {
   // B5：音频时钟（主时钟）
   std::atomic<int64_t> audioPtsSamples{0};  // 已渲染的音频样本数（stereo stereo 计数，swr 输出 48kHz）
   int audioSampleRate{0};                    // swr 输出采样率（48000），FfmpegInitSwr 后固定
+  std::atomic<int64_t> audioClockBaseMs{0};  // seek 后的主时钟基准，timeUpdate = base + playedSamples/sampleRate
+  std::atomic<bool> playbackPaused{false};   // FFmpeg 路径的真实暂停态：音频回调/视频渲染均需读取
 
   // B5：seek 请求（Seek() NAPI 写入，DemuxThreadFunc 消费）
   std::atomic<bool> seekRequested{false};
@@ -1536,9 +1538,12 @@ static int FfmpegOpenInput(FfmpegContext *ctx, const std::string &url) {
 // ---------------------------------------------------------------------------
 
 static double AudioClock(const FfmpegContext *ctx) {
-  if (ctx->audioSampleRate <= 0) return 0.0;
-  return static_cast<double>(ctx->audioPtsSamples.load(std::memory_order_relaxed))
-         / static_cast<double>(ctx->audioSampleRate);
+  const double baseSeconds =
+      static_cast<double>(ctx->audioClockBaseMs.load(std::memory_order_relaxed)) / 1000.0;
+  if (ctx->audioSampleRate <= 0) return baseSeconds;
+  return baseSeconds +
+         static_cast<double>(ctx->audioPtsSamples.load(std::memory_order_relaxed)) /
+         static_cast<double>(ctx->audioSampleRate);
 }
 
 // ---------------------------------------------------------------------------
@@ -1629,7 +1634,14 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
         if (ctx->videoCodecCtx != nullptr) avcodec_flush_buffers(ctx->videoCodecCtx);
         if (ctx->audioCodecCtx != nullptr) avcodec_flush_buffers(ctx->audioCodecCtx);
       }
-      // 重置音频时钟（seek 后从新位置重新计时）
+      // seek 后重置 renderer 缓冲与音频时钟：新时钟 = 目标位置 + 之后已渲染样本
+      if (ctx->audioRenderer != nullptr) {
+        const OH_AudioStream_Result flushResult = OH_AudioRenderer_Flush(ctx->audioRenderer);
+        OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                     "DemuxThread: OH_AudioRenderer_Flush result=%{public}d",
+                     static_cast<int32_t>(flushResult));
+      }
+      ctx->audioClockBaseMs.store(targetMs, std::memory_order_relaxed);
       ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                    "DemuxThread: seeked to %lld ms", static_cast<long long>(targetMs));
@@ -1641,6 +1653,12 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
         if (st != nullptr) {
           std::lock_guard<std::mutex> lk(st->stateMutex);
           st->currentTimeMs = targetMs;
+        }
+      }
+      {
+        NativePlayerSkeletonState *st = ctx->ownerState.load(std::memory_order_acquire);
+        if (st != nullptr && st->tsfOnTimeUpdate != nullptr) {
+          napi_call_threadsafe_function(st->tsfOnTimeUpdate, nullptr, napi_tsfn_nonblocking);
         }
       }
       {
@@ -2488,6 +2506,11 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   auto lastEmitTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
 
   while (ctx->renderRunning.load()) {
+    if (ctx->playbackPaused.load(std::memory_order_relaxed)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(16));
+      continue;
+    }
+
     // 4. 从 videoFrameQueue 消费一帧（最多等 16ms）
     AVFrame *frame = nullptr;
     {
@@ -2784,6 +2807,11 @@ static OH_AudioData_Callback_Result AudioWriteDataCallback(
     return AUDIO_DATA_CALLBACK_RESULT_VALID;
   }
 
+  if (ctx->playbackPaused.load(std::memory_order_relaxed)) {
+    memset(audioData, 0, static_cast<size_t>(audioDataSize));
+    return AUDIO_DATA_CALLBACK_RESULT_VALID;
+  }
+
   auto *dst = static_cast<int16_t *>(audioData);
   // stereo S16：每帧 = 2 声道 × 2 字节 = 4 字节
   const int samplesNeeded = audioDataSize / static_cast<int>(2 * sizeof(int16_t));
@@ -2935,6 +2963,9 @@ static void StartFfmpegAudio(NativePlayerSkeletonState *state) {
     return;
   }
 
+  ctx->playbackPaused.store(false, std::memory_order_relaxed);
+  ctx->audioClockBaseMs.store(0, std::memory_order_relaxed);
+  ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
   const OH_AudioStream_Result result = OH_AudioRenderer_Start(ctx->audioRenderer);
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                "StartFfmpegAudio: OH_AudioRenderer_Start result=%d", result);
@@ -3895,6 +3926,21 @@ static napi_value Play(napi_env env, napi_callback_info info) {
     state.playing = true;
     state.lastRealtimeMs = NowRealtimeMs();
   }
+  if (state.useFfmpegPath && state.ffmpegCtx != nullptr) {
+    state.ffmpegCtx->playbackPaused.store(false, std::memory_order_relaxed);
+    if (state.ffmpegCtx->audioRenderer != nullptr) {
+      const OH_AudioStream_Result result = OH_AudioRenderer_Start(state.ffmpegCtx->audioRenderer);
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                   "Play: FFmpeg path OH_AudioRenderer_Start result=%{public}d",
+                   static_cast<int32_t>(result));
+    }
+    {
+      std::lock_guard<std::mutex> lock(state.stateMutex);
+      state.currentTimeMs = static_cast<int64_t>(AudioClock(state.ffmpegCtx.get()) * 1000.0);
+    }
+    EmitTimeUpdate(state);
+    return ReturnUndefinedOrThrow(env, "play failed to create return value");
+  }
   // A3：驱动 OH_AVPlayer 真实播放
   if (state.avPlayer != nullptr) {
     OH_AVPlayer_Play(state.avPlayer);
@@ -3928,9 +3974,24 @@ static napi_value Pause(napi_env env, napi_callback_info info) {
       // 幂等处理：已暂停时忽略重复 pause。
       return ReturnUndefinedOrThrow(env, "pause failed to create return value");
     }
-    AdvancePlaybackClockIfNeeded(state);
+    if (state.useFfmpegPath && state.ffmpegCtx != nullptr) {
+      state.currentTimeMs = static_cast<int64_t>(AudioClock(state.ffmpegCtx.get()) * 1000.0);
+    } else {
+      AdvancePlaybackClockIfNeeded(state);
+    }
     state.playing = false;
     state.lastRealtimeMs = 0;
+  }
+  if (state.useFfmpegPath && state.ffmpegCtx != nullptr) {
+    state.ffmpegCtx->playbackPaused.store(true, std::memory_order_relaxed);
+    if (state.ffmpegCtx->audioRenderer != nullptr) {
+      const OH_AudioStream_Result result = OH_AudioRenderer_Pause(state.ffmpegCtx->audioRenderer);
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                   "Pause: FFmpeg path OH_AudioRenderer_Pause result=%{public}d",
+                   static_cast<int32_t>(result));
+    }
+    EmitTimeUpdate(state);
+    return ReturnUndefinedOrThrow(env, "pause failed to create return value");
   }
   // A3：驱动 OH_AVPlayer 真实暂停
   if (state.avPlayer != nullptr) {
@@ -3986,8 +4047,11 @@ static napi_value Seek(napi_env env, napi_callback_info info) {
       }
       state.currentTimeMs = positionMs;
     }
+    state.ffmpegCtx->audioClockBaseMs.store(positionMs, std::memory_order_relaxed);
+    state.ffmpegCtx->audioPtsSamples.store(0, std::memory_order_relaxed);
     state.ffmpegCtx->seekTargetMs.store(positionMs);
     state.ffmpegCtx->seekRequested.store(true);
+    EmitTimeUpdate(state);
     OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                  "Seek: FFmpeg path seek requested to %lld ms",
                  static_cast<long long>(positionMs));

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #include <libavutil/dict.h>
 #include <libavutil/error.h>
 #include <libavutil/time.h>
+#include <libswresample/swresample.h>  // B4：PCM 格式转换（fltp/s16/etc → s16 for OH_AudioRenderer）
 }
 
 #if !defined(VIDALL_HAS_LIBCURL)
@@ -37,6 +38,15 @@ extern "C" {
 #if VIDALL_HAS_LIBCURL
 #include <curl/curl.h>
 #endif
+
+// B3：EGL + OpenGL ES 2.0（YUV 渲染管线）
+#include <EGL/egl.h>
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
+// B4：OH_AudioRenderer（PCM 送显）
+#include <ohaudio/native_audiostreambuilder.h>
+#include <ohaudio/native_audiorenderer.h>
 
 namespace {
 
@@ -700,6 +710,28 @@ struct FfmpegContext {
   // B2：解码帧输出队列
   AVFrameQueue videoFrameQueue;
   AVFrameQueue audioFrameQueue;
+
+  // B3：EGL 上下文（只在渲染线程内操作）
+  EGLDisplay eglDisplay = EGL_NO_DISPLAY;
+  EGLSurface eglSurface = EGL_NO_SURFACE;
+  EGLContext eglContext = EGL_NO_CONTEXT;
+
+  // B3：OpenGL ES 资源（在渲染线程 makeCurrent 后初始化）
+  GLuint yuvProgram = 0;   // YUV→RGB GLSL program
+  GLuint textureY = 0;     // Y 分量纹理（GL_LUMINANCE，width×height）
+  GLuint textureU = 0;     // U 分量纹理（GL_LUMINANCE，width/2×height/2）
+  GLuint textureV = 0;     // V 分量纹理（GL_LUMINANCE，width/2×height/2）
+  GLuint quadVBO = 0;      // 全屏四边形顶点缓冲
+
+  // B3：渲染线程
+  std::thread renderThread;
+  std::atomic<bool> renderRunning{false};
+
+  // B4：音频渲染（OH_AudioRenderer，回调模型，由音频系统线程驱动）
+  OH_AudioRenderer *audioRenderer = nullptr;
+  OH_AudioStreamBuilder *audioBuilder = nullptr;
+  SwrContext *swrCtx = nullptr;          // libswresample 重采样上下文（源格式 → stereo S16 48kHz）
+  std::vector<int16_t> pcmLeftover;      // swr_convert 溢出缓冲：跨 callback 的剩余 PCM 数据
 };
 
 struct NativePlayerSkeletonState {
@@ -743,6 +775,8 @@ struct NativePlayerSkeletonState {
   int32_t ffmpegHeight = 0;
   double ffmpegFps = 0.0;
   int64_t ffmpegDurationMs = 0;
+  // B3：nativeWindow 尚未就绪时（OnXCSurfaceCreated 还未触发）延迟启动渲染线程的标志
+  bool pendingFfmpegRender = false;
 };
 
 static std::unordered_map<int32_t, NativePlayerSkeletonState> g_players;
@@ -1648,6 +1682,252 @@ static void AudioDecodeThreadFunc(FfmpegContext *ctx) {
 // B2：启动/停止解码线程
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// B4：SwrContext 初始化（源格式 → stereo S16LE 48kHz）
+// ---------------------------------------------------------------------------
+
+static bool FfmpegInitSwr(FfmpegContext *ctx) {
+  AVCodecContext *aCtx = ctx->audioCodecCtx;
+  if (aCtx == nullptr) {
+    return false;
+  }
+
+  // 目标格式：stereo S16LE 48000Hz（匹配 OH_AudioRenderer 配置）
+  AVChannelLayout outLayout = AV_CHANNEL_LAYOUT_STEREO;
+  const int ret = swr_alloc_set_opts2(
+      &ctx->swrCtx,
+      &outLayout,          AV_SAMPLE_FMT_S16, 48000,
+      &aCtx->ch_layout,    aCtx->sample_fmt,  aCtx->sample_rate,
+      0, nullptr);
+  if (ret < 0 || ctx->swrCtx == nullptr) {
+    char errbuf[128] = {0};
+    av_strerror(ret, errbuf, sizeof(errbuf));
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitSwr: swr_alloc_set_opts2 failed: %s", errbuf);
+    return false;
+  }
+
+  const int initRet = swr_init(ctx->swrCtx);
+  if (initRet < 0) {
+    char errbuf[128] = {0};
+    av_strerror(initRet, errbuf, sizeof(errbuf));
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitSwr: swr_init failed: %s", errbuf);
+    swr_free(&ctx->swrCtx);
+    return false;
+  }
+
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "FfmpegInitSwr: OK src(fmt=%d rate=%d ch=%d) → stereo S16 48kHz",
+               static_cast<int>(aCtx->sample_fmt), aCtx->sample_rate,
+               aCtx->ch_layout.nb_channels);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// B4：OH_AudioRenderer 写数据回调（由音频系统线程驱动，非阻塞消费 audioFrameQueue）
+// ---------------------------------------------------------------------------
+
+static OH_AudioData_Callback_Result AudioWriteDataCallback(
+    OH_AudioRenderer * /*renderer*/, void *userData,
+    void *audioData, int32_t audioDataSize) {
+  auto *ctx = static_cast<FfmpegContext *>(userData);
+  if (ctx == nullptr || ctx->swrCtx == nullptr || audioData == nullptr || audioDataSize <= 0) {
+    if (audioData != nullptr && audioDataSize > 0) {
+      memset(audioData, 0, static_cast<size_t>(audioDataSize));
+    }
+    return AUDIO_DATA_CALLBACK_RESULT_VALID;
+  }
+
+  auto *dst = static_cast<int16_t *>(audioData);
+  // stereo S16：每帧 = 2 声道 × 2 字节 = 4 字节
+  const int samplesNeeded = audioDataSize / static_cast<int>(2 * sizeof(int16_t));
+  int samplesFilled = 0;
+
+  // ── 步骤 1：先消费上一次 swr_convert 的溢出缓冲 ──────────────────────────
+  if (!ctx->pcmLeftover.empty()) {
+    // pcmLeftover 存储 interleaved stereo s16：每个 "样本" 占 2 个 int16_t（L+R）
+    const int leftoverSamples = static_cast<int>(ctx->pcmLeftover.size()) / 2;
+    const int toCopy = std::min(leftoverSamples, samplesNeeded);
+    memcpy(dst, ctx->pcmLeftover.data(),
+           static_cast<size_t>(toCopy) * 2 * sizeof(int16_t));
+    samplesFilled += toCopy;
+    if (toCopy < leftoverSamples) {
+      ctx->pcmLeftover.erase(ctx->pcmLeftover.begin(),
+                             ctx->pcmLeftover.begin() + toCopy * 2);
+    } else {
+      ctx->pcmLeftover.clear();
+    }
+  }
+
+  // ── 步骤 2：从 audioFrameQueue 拉帧，swr_convert → 填充 dst ──────────────
+  while (samplesFilled < samplesNeeded) {
+    AVFrame *frame = nullptr;
+    {
+      std::unique_lock<std::mutex> lock(ctx->audioFrameQueue.mtx);
+      if (!ctx->audioFrameQueue.frames.empty()) {
+        frame = ctx->audioFrameQueue.frames.front();
+        ctx->audioFrameQueue.frames.pop();
+      }
+    }
+    if (frame != nullptr) {
+      // 通知解码线程队列有空位
+      ctx->audioFrameQueue.cv.notify_all();
+    } else {
+      // 无可用帧：填充静音，避免 underrun 杂音
+      memset(dst + samplesFilled * 2, 0,
+             static_cast<size_t>(samplesNeeded - samplesFilled) * 2 * sizeof(int16_t));
+      samplesFilled = samplesNeeded;
+      break;
+    }
+
+    // swr_convert 输出缓冲：预留 frame->nb_samples + resampler 延迟余量
+    const int maxOut = frame->nb_samples + 256;
+    std::vector<int16_t> tempBuf(static_cast<size_t>(maxOut * 2));
+    uint8_t *outPtr = reinterpret_cast<uint8_t *>(tempBuf.data());
+    // frame->data 是 uint8_t*[AV_NUM_DATA_POINTERS]，swr_convert 要求 const uint8_t** 输入
+    // 通过临时数组规避 C++ 对 T** → const T** 的类型安全限制
+    const uint8_t *inData[AV_NUM_DATA_POINTERS] = {};
+    for (int i = 0; i < AV_NUM_DATA_POINTERS; i++) {
+      inData[i] = frame->data[i];
+    }
+    const int converted = swr_convert(ctx->swrCtx,
+        &outPtr, maxOut,
+        inData, frame->nb_samples);
+    av_frame_free(&frame);
+
+    if (converted <= 0) {
+      continue;
+    }
+
+    const int canFill = samplesNeeded - samplesFilled;
+    const int toCopy = std::min(converted, canFill);
+    memcpy(dst + samplesFilled * 2, tempBuf.data(),
+           static_cast<size_t>(toCopy) * 2 * sizeof(int16_t));
+    samplesFilled += toCopy;
+
+    if (converted > toCopy) {
+      // 多余样本存入溢出缓冲，下次 callback 优先消费
+      ctx->pcmLeftover.insert(ctx->pcmLeftover.end(),
+                              tempBuf.begin() + toCopy * 2,
+                              tempBuf.begin() + converted * 2);
+    }
+  }
+
+  return AUDIO_DATA_CALLBACK_RESULT_VALID;
+}
+
+// ---------------------------------------------------------------------------
+// B4：OH_AudioRenderer 初始化（stereo S16LE 48kHz，MOVIE 用途）
+// ---------------------------------------------------------------------------
+
+static bool FfmpegInitAudioRenderer(FfmpegContext *ctx) {
+  OH_AudioStream_Result result =
+      OH_AudioStreamBuilder_Create(&ctx->audioBuilder, AUDIOSTREAM_TYPE_RENDERER);
+  if (result != AUDIOSTREAM_SUCCESS || ctx->audioBuilder == nullptr) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitAudioRenderer: Create builder failed: %d", result);
+    return false;
+  }
+
+  OH_AudioStreamBuilder_SetSamplingRate(ctx->audioBuilder, 48000);
+  OH_AudioStreamBuilder_SetChannelCount(ctx->audioBuilder, 2);
+  OH_AudioStreamBuilder_SetSampleFormat(ctx->audioBuilder, AUDIOSTREAM_SAMPLE_S16LE);
+  OH_AudioStreamBuilder_SetEncodingType(ctx->audioBuilder, AUDIOSTREAM_ENCODING_TYPE_RAW);
+  // AUDIOSTREAM_USAGE_MOVIE：视频媒体播放场景，会触发正确的音频焦点策略
+  OH_AudioStreamBuilder_SetRendererInfo(ctx->audioBuilder, AUDIOSTREAM_USAGE_MOVIE);
+
+  // 注册写数据回调：音频系统在需要 PCM 数据时调用 AudioWriteDataCallback
+  result = OH_AudioStreamBuilder_SetRendererWriteDataCallback(
+      ctx->audioBuilder, AudioWriteDataCallback, ctx);
+  if (result != AUDIOSTREAM_SUCCESS) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitAudioRenderer: SetRendererWriteDataCallback failed: %d", result);
+    OH_AudioStreamBuilder_Destroy(ctx->audioBuilder);
+    ctx->audioBuilder = nullptr;
+    return false;
+  }
+
+  result = OH_AudioStreamBuilder_GenerateRenderer(ctx->audioBuilder, &ctx->audioRenderer);
+  if (result != AUDIOSTREAM_SUCCESS || ctx->audioRenderer == nullptr) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitAudioRenderer: GenerateRenderer failed: %d", result);
+    OH_AudioStreamBuilder_Destroy(ctx->audioBuilder);
+    ctx->audioBuilder = nullptr;
+    return false;
+  }
+
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "FfmpegInitAudioRenderer: renderer created (stereo S16LE 48kHz MOVIE)");
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// B4：启动/停止音频渲染器
+// ---------------------------------------------------------------------------
+
+static void StartFfmpegAudio(NativePlayerSkeletonState *state) {
+  if (state == nullptr || state->ffmpegCtx == nullptr) {
+    return;
+  }
+  FfmpegContext *ctx = state->ffmpegCtx.get();
+  if (ctx->audioCodecCtx == nullptr) {
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "StartFfmpegAudio: no audio stream, skip");
+    return;
+  }
+
+  if (!FfmpegInitSwr(ctx)) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "StartFfmpegAudio: FfmpegInitSwr failed");
+    return;
+  }
+
+  if (!FfmpegInitAudioRenderer(ctx)) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "StartFfmpegAudio: FfmpegInitAudioRenderer failed");
+    swr_free(&ctx->swrCtx);
+    return;
+  }
+
+  const OH_AudioStream_Result result = OH_AudioRenderer_Start(ctx->audioRenderer);
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "StartFfmpegAudio: OH_AudioRenderer_Start result=%d", result);
+}
+
+static void StopFfmpegAudio(NativePlayerSkeletonState *state) {
+  if (state == nullptr || state->ffmpegCtx == nullptr) {
+    return;
+  }
+  FfmpegContext *ctx = state->ffmpegCtx.get();
+
+  // 1. 停止并释放 renderer（调用后音频系统不再调用 callback，消费者安全关闭）
+  if (ctx->audioRenderer != nullptr) {
+    OH_AudioRenderer_Stop(ctx->audioRenderer);
+    OH_AudioRenderer_Release(ctx->audioRenderer);
+    ctx->audioRenderer = nullptr;
+  }
+
+  // 2. 销毁 builder
+  if (ctx->audioBuilder != nullptr) {
+    OH_AudioStreamBuilder_Destroy(ctx->audioBuilder);
+    ctx->audioBuilder = nullptr;
+  }
+
+  // 3. 释放 SwrContext
+  if (ctx->swrCtx != nullptr) {
+    swr_free(&ctx->swrCtx);
+  }
+
+  // 4. 清空溢出缓冲
+  ctx->pcmLeftover.clear();
+
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "StopFfmpegAudio: renderer stopped and released");
+}
+
+// B4 函数已在上方完整定义，此处无需重复前向声明
+
 static void StartFfmpegDecode(NativePlayerSkeletonState *state) {
   if (state == nullptr || state->ffmpegCtx == nullptr) {
     return;
@@ -1689,6 +1969,9 @@ static void StartFfmpegDecode(NativePlayerSkeletonState *state) {
     ctx->audioDecodeThread = std::thread(AudioDecodeThreadFunc, ctx);
   }
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "StartFfmpegDecode: decode threads launched");
+
+  // B4：解码器就绪后启动 OH_AudioRenderer（消费 audioFrameQueue）
+  StartFfmpegAudio(state);
 }
 
 static void StopFfmpegDecode(NativePlayerSkeletonState *state) {
@@ -1802,6 +2085,9 @@ static void StopFfmpegDemux(NativePlayerSkeletonState *state) {
     return;
   }
   FfmpegContext *ctx = state->ffmpegCtx.get();
+
+  // B4：先停止音频渲染器（消费者），再停止解码线程（生产者），避免 callback 访问已释放队列
+  StopFfmpegAudio(state);
 
   // B2：先停止解码线程（依赖 packet 队列），再停止 demux
   StopFfmpegDecode(state);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -803,6 +803,11 @@ struct FfmpegContext {
   //            DemuxThreadFunc(demux 线程) 读+解引用之间的 data race（UB）。
   std::atomic<NativePlayerSkeletonState *> ownerState{nullptr};
 
+  // B6：seek 与 decode 线程之间的 codec 操作互斥锁
+  // avcodec_flush_buffers / avcodec_send_packet / avcodec_receive_frame 不是线程安全的，
+  // 必须通过此 mutex 串行化访问同一个 AVCodecContext。
+  std::mutex codecMutex;
+
   // B6 安全析构兜底：正常路径由 StopFfmpegDemux 先 join 所有线程再 reset()。
   // 若存在异常路径导致析构器直接被调用（如 unique_ptr 提前 reset），先广播所有
   // abort/interrupt 标志，再按 Render→Decode→Demux 顺序 join，线程会迅速响应标志退出。
@@ -1574,9 +1579,12 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
       } else {
       // 清空所有 packet/frame 队列（旧数据）
       FlushFfmpegQueues(ctx);
-      // 刷新解码器内部缓冲区
-      if (ctx->videoCodecCtx != nullptr) avcodec_flush_buffers(ctx->videoCodecCtx);
-      if (ctx->audioCodecCtx != nullptr) avcodec_flush_buffers(ctx->audioCodecCtx);
+      // 刷新解码器内部缓冲区（hold codecMutex 防止与 decode 线程并发）
+      {
+        std::lock_guard<std::mutex> codecLk(ctx->codecMutex);
+        if (ctx->videoCodecCtx != nullptr) avcodec_flush_buffers(ctx->videoCodecCtx);
+        if (ctx->audioCodecCtx != nullptr) avcodec_flush_buffers(ctx->audioCodecCtx);
+      }
       // 重置音频时钟（seek 后从新位置重新计时）
       ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
@@ -1763,7 +1771,11 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
     ctx->videoQueue.cv.notify_all();  // 唤醒 demux 线程（队列有空位）
 
     // 发送到解码器
-    int ret = avcodec_send_packet(ctx->videoCodecCtx, pkt);
+    int ret;
+    {
+      std::lock_guard<std::mutex> codecLk(ctx->codecMutex);
+      ret = avcodec_send_packet(ctx->videoCodecCtx, pkt);
+    }
     av_packet_free(&pkt);
     if (ret < 0) {
       if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
@@ -1777,11 +1789,15 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
 
     // 接收所有可用解码帧
     while (ctx->decodeRunning.load()) {
-      ret = avcodec_receive_frame(ctx->videoCodecCtx, frame);
-      if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+      int receiveRet;
+      {
+        std::lock_guard<std::mutex> codecLk(ctx->codecMutex);
+        receiveRet = avcodec_receive_frame(ctx->videoCodecCtx, frame);
+      }
+      if (receiveRet == AVERROR(EAGAIN) || receiveRet == AVERROR_EOF) {
         break;
       }
-      if (ret < 0) {
+      if (receiveRet < 0) {
         break;
       }
 
@@ -1840,7 +1856,11 @@ static void AudioDecodeThreadFunc(FfmpegContext *ctx) {
     ctx->audioQueue.cv.notify_all();
 
     // 发送到解码器
-    int ret = avcodec_send_packet(ctx->audioCodecCtx, pkt);
+    int ret;
+    {
+      std::lock_guard<std::mutex> codecLk(ctx->codecMutex);
+      ret = avcodec_send_packet(ctx->audioCodecCtx, pkt);
+    }
     av_packet_free(&pkt);
     if (ret < 0) {
       if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
@@ -1854,11 +1874,15 @@ static void AudioDecodeThreadFunc(FfmpegContext *ctx) {
 
     // 接收所有可用解码帧（PCM，格式转换在 B4 做）
     while (ctx->decodeRunning.load()) {
-      ret = avcodec_receive_frame(ctx->audioCodecCtx, frame);
-      if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+      int receiveRet;
+      {
+        std::lock_guard<std::mutex> codecLk(ctx->codecMutex);
+        receiveRet = avcodec_receive_frame(ctx->audioCodecCtx, frame);
+      }
+      if (receiveRet == AVERROR(EAGAIN) || receiveRet == AVERROR_EOF) {
         break;
       }
-      if (ret < 0) {
+      if (receiveRet < 0) {
         break;
       }
 

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -2620,6 +2620,17 @@ static void StartFfmpegDemux(NativePlayerSkeletonState *state, const std::string
     av_strerror(ret, errbuf, sizeof(errbuf));
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
                  "StartFfmpegDemux: FfmpegOpenInput failed: %s", errbuf);
+    // B6修复：FFmpeg 也失败时，这才是真正的播放失败，上报 tsfOnError 给 ArkTS
+    if (state->tsfOnError != nullptr) {
+      auto *errData = new ErrorData{
+        ret,
+        new std::string(std::string("FFmpeg open failed: ") + errbuf)
+      };
+      napi_call_threadsafe_function(state->tsfOnError, errData, napi_tsfn_nonblocking);
+    }
+    if (state->tsfOnBufferingFalse != nullptr) {
+      napi_call_threadsafe_function(state->tsfOnBufferingFalse, nullptr, napi_tsfn_nonblocking);
+    }
     return;
   }
 
@@ -2819,6 +2830,13 @@ static void OnAVPlayerErrorCB(OH_AVPlayer *player, int32_t errorCode,
     // 在媒体线程直接调用会影响 OH_AVPlayer 回调链路。
     // B1 阶段直接在此线程启动（open 有 10s 超时保障），B2 阶段可改为独立 dispatch 线程。
     StartFfmpegDemux(state, urlCopy);
+    // B6修复：FFmpeg 路径已接管，抑制 tsfOnError，防止 ArkTS fallbackNativeToIjk()
+    // 抢占 XComponent surface，导致 FFmpeg EGL 初始化失败。
+    // FFmpeg 准备好后会通过 tsfOnPrepared 通知 ArkTS；
+    // FFmpeg 自身失败时，StartFfmpegDemux 内部负责触发 tsfOnError。
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "OnAVPlayerErrorCB: FFmpeg path taken over, suppressing tsfOnError/tsfOnBufferingFalse");
+    return;
   }
 
   if (state->tsfOnError != nullptr) {

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -2142,6 +2142,18 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
                "RenderThreadFunc: eglMakeCurrent OK, GL context current ctx=%{public}p",
                static_cast<void*>(eglGetCurrentContext()));
 
+  // GL context 验证诊断
+  {
+    const GLubyte *glVer = glGetString(GL_VERSION);
+    const GLubyte *glRenderer = glGetString(GL_RENDERER);
+    GLenum glErr = glGetError();
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "RenderThreadFunc: GL_VERSION=%{public}s GL_RENDERER=%{public}s glGetError=0x%{public}x",
+                 glVer ? (const char*)glVer : "null",
+                 glRenderer ? (const char*)glRenderer : "null",
+                 glErr);
+  }
+
   // 3. 初始化 GL 资源（shader/纹理/VBO）
   if (!FfmpegInitGLResources(ctx)) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1782,17 +1782,20 @@ static int FfmpegInitCodecs(FfmpegContext *ctx) {
       avcodec_free_context(&ctx->videoCodecCtx);
       return ret;
     }
-    // 多线程解码（frame-level），TV 端多核可充分利用
-    ctx->videoCodecCtx->thread_count = 2;
+    // 多线程解码（frame-level），4K/10bit 软解场景优先提高吞吐
+    const unsigned int hwThreads = std::thread::hardware_concurrency();
+    const int decodeThreads = static_cast<int>(std::min<unsigned int>(hwThreads > 0 ? hwThreads : 4, 8));
+    ctx->videoCodecCtx->thread_count = std::max(4, decodeThreads);
     ctx->videoCodecCtx->thread_type = FF_THREAD_FRAME;
     ret = avcodec_open2(ctx->videoCodecCtx, codec, nullptr);
     if (ret < 0) {
       avcodec_free_context(&ctx->videoCodecCtx);
       return ret;
     }
-    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                 "FfmpegInitCodecs: video decoder opened: %s %dx%d",
-                 codec->name, ctx->videoCodecCtx->width, ctx->videoCodecCtx->height);
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "FfmpegInitCodecs: video decoder opened: %s %dx%d threads=%d",
+                 codec->name, ctx->videoCodecCtx->width, ctx->videoCodecCtx->height,
+                 ctx->videoCodecCtx->thread_count);
   }
 
   // 音频解码器
@@ -1917,13 +1920,19 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
       // 1. 所有格式统一通过 sws_scale 转换为 AV_PIX_FMT_RGBA（包括 yuv420p10le/yuv420p）
       // 2. 4K 内容（3840×2160）宽度超过 1920 时同步降采样（保持宽高比）
       // 3. 使用 GL_RGBA/GL_UNSIGNED_BYTE 上传单张纹理，规避设备驱动对 GL_R8/GL_LUMINANCE 的 OOM bug
-      static const int MAX_RENDER_W = 1920;
+      static const int DEFAULT_MAX_RENDER_W = 1920;
+      static const int HEAVY_4K_MAX_RENDER_W = 1280;
       // 计算目标渲染分辨率（降采样到 1920 时保持宽高比，行/列对齐到偶数）
       int dstW = frame->width;
       int dstH = frame->height;
-      if (dstW > MAX_RENDER_W) {
-        dstH = dstH * MAX_RENDER_W / dstW;
-        dstW = MAX_RENDER_W;
+      int maxRenderW = DEFAULT_MAX_RENDER_W;
+      if (frame->width >= 3840 &&
+          (frame->format == AV_PIX_FMT_YUV420P10LE || frame->format == AV_PIX_FMT_P010LE)) {
+        maxRenderW = HEAVY_4K_MAX_RENDER_W;
+      }
+      if (dstW > maxRenderW) {
+        dstH = dstH * maxRenderW / dstW;
+        dstW = maxRenderW;
         dstH = (dstH + 1) & ~1;  // 偶数对齐
       }
       // 始终转换到 RGBA：yuv420p 也需要转换（CPU 侧 YUV→RGB），消除 GL 侧单通道 OOM
@@ -1943,13 +1952,13 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
               frame->width, frame->height, static_cast<AVPixelFormat>(frame->format),
               dstW, dstH, AV_PIX_FMT_RGBA,
               SWS_FAST_BILINEAR, nullptr, nullptr, nullptr);
-          ctx->lastSwsSrcFmt = frame->format;
-          ctx->lastSwsSrcW   = frame->width;
-          OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                       "VideoDecodeThread: SwsContext created %{public}dx%{public}d srcFmt=%{public}d"
-                       " -> %{public}dx%{public}d RGBA",
-                       frame->width, frame->height, frame->format, dstW, dstH);
-        }
+            ctx->lastSwsSrcFmt = frame->format;
+            ctx->lastSwsSrcW   = frame->width;
+            OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                        "VideoDecodeThread: SwsContext created %{public}dx%{public}d srcFmt=%{public}d"
+                        " -> %{public}dx%{public}d RGBA maxRenderW=%{public}d",
+                        frame->width, frame->height, frame->format, dstW, dstH, maxRenderW);
+          }
         if (ctx->swsCtx != nullptr) {
           convertedFrame = av_frame_alloc();
           if (convertedFrame != nullptr) {

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -42,17 +42,19 @@ extern "C" {
 
 // B3：EGL + OpenGL ES 2.0（YUV 渲染管线）
 #include <EGL/egl.h>
+#include <EGL/eglext.h>  // EGL_OPENGL_ES3_BIT_KHR
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
-// GL_RED 是 GLES 3.0 引入的单通道格式，GLES 2.0 头中无此宏；
-// 当前已改用 GL_LUMINANCE（GLES 2 合法格式），此宏仅供历史参考，未实际使用。
+// GL_RED / GL_R8 在 GLES 2.0 头文件中未定义，GLES 3.0 引入；此处补充宏定义供 GLES 3 context 使用。
 #ifndef GL_RED
 #  define GL_RED 0x1903
 #endif
-// GL_R8 是 GLES 3.0 引入的单通道有大小内部格式；GLES 2.0 头文件不含此宏。
-// 已改回 GL_LUMINANCE 绕过 GLES 3 context 的纹理 OOM 问题；此宏预留备用，当前未使用。
 #ifndef GL_R8
 #  define GL_R8 0x8229
+#endif
+// EGL_OPENGL_ES3_BIT 在部分旧版 EGL 头中仅以 KHR 扩展名存在；补充宏定义确保可用。
+#ifndef EGL_OPENGL_ES3_BIT
+#  define EGL_OPENGL_ES3_BIT EGL_OPENGL_ES3_BIT_KHR
 #endif
 
 // B4：OH_AudioRenderer（PCM 送显）
@@ -2115,13 +2117,16 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
                  "FfmpegInitEGL: eglBindAPI failed err=0x%{public}x", eglGetError());
     return false;
   }
+  // 修复 #48-B6: config 必须使用 EGL_OPENGL_ES3_BIT，与 GLES 3 context 匹配。
+  // 若用 EGL_OPENGL_ES2_BIT 选 config 再创建 GLES 3 context，驱动会限制 GPU 纹理内存池，
+  // 导致即使 1920×1080 的 GL_R8 纹理也返回 GL_OUT_OF_MEMORY（0x505）。
   EGLint attribs[] = {
       EGL_SURFACE_TYPE,    EGL_WINDOW_BIT,
-      EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+      EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
       EGL_RED_SIZE,   8,
       EGL_GREEN_SIZE, 8,
       EGL_BLUE_SIZE,  8,
-      EGL_ALPHA_SIZE, 8,   // 完整 RGBA，帮助选到与 NativeWindow 格式匹配的 config
+      EGL_ALPHA_SIZE, 8,
       EGL_NONE
   };
   EGLConfig config = nullptr;

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -45,12 +45,12 @@ extern "C" {
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 // GL_RED 是 GLES 3.0 引入的单通道格式，GLES 2.0 头中无此宏；
-// 函数指针已在运行时从 libGLESv2 加载，此处仅补充常量定义。
+// 当前已改用 GL_LUMINANCE（GLES 2 合法格式），此宏仅供历史参考，未实际使用。
 #ifndef GL_RED
 #  define GL_RED 0x1903
 #endif
 // GL_R8 是 GLES 3.0 引入的单通道有大小内部格式；GLES 2.0 头文件不含此宏。
-// 首帧 glTexImage2D 用 GL_R8 作为 internalformat，可避免驱动因格式歧义重复分配。
+// 已改回 GL_LUMINANCE 绕过 GLES 3 context 的纹理 OOM 问题；此宏预留备用，当前未使用。
 #ifndef GL_R8
 #  define GL_R8 0x8229
 #endif
@@ -2144,10 +2144,10 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
                  eglGetError(), nativeWindow);
     return false;
   }
-  // 修复 #48-B6: 升级至 GLES 3——GL_RED 作为 internalformat 在 GLES 2.0 中非法，
-  // 会导致 glTexImage2D 静默失败（GL_INVALID_ENUM）进而全黑。
-  // 设备实际运行 OpenGL ES 3.2，此处声明 version=3 即可激活 GLES 3 上下文。
-  EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE};
+  // 修复 #48-B6: 退回 GLES 2 context——GLES 3 context 在 EGL_RENDERABLE_TYPE=ES2_BIT 的
+  // config 下触发 GPU 纹理内存 OOM（0x505），改用 GL_LUMINANCE（GLES 2 合法单通道格式）
+  // 配合 GLES 2 context 可绕过该限制。
+  EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
   ctx->eglContext =
       eglCreateContext(ctx->eglDisplay, config, EGL_NO_CONTEXT, ctxAttribs);
   if (ctx->eglContext == EGL_NO_CONTEXT) {
@@ -2453,7 +2453,7 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
       }
     }
 
-    // 5. 上传 YUV420P → 3 张 GL_RED 纹理（Fix #48-B6-1b：GL_LUMINANCE 在 GLES 3.0 已废弃）
+    // 5. 上传 YUV420P → 3 张 GL_LUMINANCE 纹理（GLES 2 合法单通道格式，绕过 GLES 3 OOM）
     const int w = frame->width;
     const int h = frame->height;
 
@@ -2479,10 +2479,9 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
     ctx->gl.ActiveTexture(GL_TEXTURE0);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureY);
     if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0,
-                     GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
-        // 诊断: #48-B6 验证 GL_R8/GL_RED 在 GLES 3 context 下是否合法（应 GL_NO_ERROR）
-        // 仅在首帧或尺寸变更时打印，避免日志刷屏
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w, h, 0,
+                     GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[0]);
+        // 诊断: 仅在首帧或尺寸变更时检查 GL 错误，避免日志刷屏
         {
             GLenum glErr = ctx->gl.GetError();
             if (glErr != GL_NO_ERROR) {
@@ -2493,27 +2492,27 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
         }
     } else {
         ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h,
-                        GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
+                        GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[0]);
     }
 
     ctx->gl.ActiveTexture(GL_TEXTURE1);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureU);
     if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w / 2, h / 2, 0,
-                     GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
+                     GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[1]);
     } else {
         ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w / 2, h / 2,
-                        GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
+                        GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[1]);
     }
 
     ctx->gl.ActiveTexture(GL_TEXTURE2);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureV);
     if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w / 2, h / 2, 0,
-                     GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
+                     GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[2]);
     } else {
         ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w / 2, h / 2,
-                        GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
+                        GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[2]);
     }
 
     if (!ctx->texturesInitialized || sizeChanged) {

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -783,9 +783,7 @@ struct FfmpegContext {
 
   // B3：OpenGL ES 资源（在渲染线程 makeCurrent 后初始化）
   GLuint yuvProgram = 0;   // YUV→RGB GLSL program
-  GLuint textureY = 0;     // Y 分量纹理（GL_R8，width×height）
-  GLuint textureU = 0;     // U 分量纹理（GL_R8，width/2×height/2）
-  GLuint textureV = 0;     // V 分量纹理（GL_R8，width/2×height/2）
+  GLuint rgbaTexture = 0;  // RGBA 纹理（sws_scale CPU 侧 YUV→RGBA 后上传，GL_RGBA/GL_UNSIGNED_BYTE）
   GLuint quadVBO = 0;      // 全屏四边形顶点缓冲
 
   // Fix #48-B6: 首帧后置 true，后续帧用 TexSubImage2D 避免每帧重分配 GPU 纹理存储
@@ -801,7 +799,7 @@ struct FfmpegContext {
   OH_AudioRenderer *audioRenderer = nullptr;
   OH_AudioStreamBuilder *audioBuilder = nullptr;
   SwrContext *swrCtx = nullptr;          // libswresample 重采样上下文（源格式 → stereo S16 48kHz）
-  SwsContext *swsCtx = nullptr;          // libswscale 像素格式转换（yuv420p10le/etc → yuv420p，B6 HDR/DV 修复）
+  SwsContext *swsCtx = nullptr;          // libswscale：所有格式 → RGBA（CPU 侧 YUV→RGB 转换，B6 HDR/DV 修复）
   int lastSwsSrcFmt = -1;  // 上次 swsCtx 对应的源像素格式（格式或尺寸变化时重建）
   int lastSwsSrcW   = -1;  // 上次 swsCtx 对应的源宽度
   std::vector<int16_t> pcmLeftover;      // swr_convert 溢出缓冲：跨 callback 的剩余 PCM 数据
@@ -1825,10 +1823,10 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
       }
 
       // 将帧移入 videoFrameQueue（背压等待，防止解码过快撑爆内存）
-      // ── B6：格式转换 + 超 1920 降采样 ──
-      // 1. HDR/DV 内容解码输出 yuv420p10le（10-bit），必须转换到 yuv420p（8-bit）
-      // 2. 4K 内容（3840×2160）纹理分配在设备上触发 GL_OUT_OF_MEMORY（0x505），
-      //    宽度超过 1920 时通过 sws_scale 同步降采样到 1920×H（保持宽高比）。
+      // ── B6：格式转换 + 超 1920 降采样 + CPU 侧 YUV→RGBA 转换 ──
+      // 1. 所有格式统一通过 sws_scale 转换为 AV_PIX_FMT_RGBA（包括 yuv420p10le/yuv420p）
+      // 2. 4K 内容（3840×2160）宽度超过 1920 时同步降采样（保持宽高比）
+      // 3. 使用 GL_RGBA/GL_UNSIGNED_BYTE 上传单张纹理，规避设备驱动对 GL_R8/GL_LUMINANCE 的 OOM bug
       static const int MAX_RENDER_W = 1920;
       // 计算目标渲染分辨率（降采样到 1920 时保持宽高比，行/列对齐到偶数）
       int dstW = frame->width;
@@ -1836,9 +1834,10 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
       if (dstW > MAX_RENDER_W) {
         dstH = dstH * MAX_RENDER_W / dstW;
         dstW = MAX_RENDER_W;
-        dstH = (dstH + 1) & ~1;  // 偶数对齐（YUV420P 要求）
+        dstH = (dstH + 1) & ~1;  // 偶数对齐
       }
-      bool needConvert = (frame->format != AV_PIX_FMT_YUV420P) || (dstW != frame->width);
+      // 始终转换到 RGBA：yuv420p 也需要转换（CPU 侧 YUV→RGB），消除 GL 侧单通道 OOM
+      bool needConvert = true;
       AVFrame *renderFrame = frame;
       AVFrame *convertedFrame = nullptr;
       if (needConvert) {
@@ -1852,19 +1851,19 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
           }
           ctx->swsCtx = sws_getContext(
               frame->width, frame->height, static_cast<AVPixelFormat>(frame->format),
-              dstW, dstH, AV_PIX_FMT_YUV420P,
+              dstW, dstH, AV_PIX_FMT_RGBA,
               SWS_BILINEAR, nullptr, nullptr, nullptr);
           ctx->lastSwsSrcFmt = frame->format;
           ctx->lastSwsSrcW   = frame->width;
           OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                        "VideoDecodeThread: SwsContext created %{public}dx%{public}d srcFmt=%{public}d"
-                       " -> %{public}dx%{public}d yuv420p",
+                       " -> %{public}dx%{public}d RGBA",
                        frame->width, frame->height, frame->format, dstW, dstH);
         }
         if (ctx->swsCtx != nullptr) {
           convertedFrame = av_frame_alloc();
           if (convertedFrame != nullptr) {
-            convertedFrame->format = AV_PIX_FMT_YUV420P;
+            convertedFrame->format = AV_PIX_FMT_RGBA;
             convertedFrame->width  = dstW;
             convertedFrame->height = dstH;
             if (av_frame_get_buffer(convertedFrame, 32) == 0) {
@@ -2007,11 +2006,12 @@ static void AudioDecodeThreadFunc(FfmpegContext *ctx) {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// B3：GLSL shader 字符串（YUV420P → RGB，mediump float）
+// B3：GLSL shader 字符串（直接采样 RGBA 纹理，GPU 侧无需 YUV→RGB 转换）
 // ---------------------------------------------------------------------------
+// sws_scale 在 CPU 侧已完成 yuv420p → RGBA 转换，shader 只需 passthrough 采样。
+// 使用 GL_RGBA/GL_UNSIGNED_BYTE 是所有 GLES 版本中最兼容的格式，
+// 彻底规避 GL_R8/GL_LUMINANCE 在部分 HarmonyOS 驱动上的 OOM(0x505) bug。
 
-// 修复 #48-B6: 显式字符串拼接替代 R"()"，避免部分 HarmonyOS GLES 驱动对
-// raw string 开头换行符解析异常；同时增加 #version 100 声明。
 static const char *kVertexShaderSrc =
     "#version 100\n"
     "attribute vec4 a_position;\n"
@@ -2025,18 +2025,10 @@ static const char *kVertexShaderSrc =
 static const char *kFragmentShaderSrc =
     "#version 100\n"
     "precision mediump float;\n"
-    "uniform sampler2D u_textureY;\n"
-    "uniform sampler2D u_textureU;\n"
-    "uniform sampler2D u_textureV;\n"
+    "uniform sampler2D u_texture;\n"
     "varying vec2 v_texCoord;\n"
     "void main() {\n"
-    "    float y = texture2D(u_textureY, v_texCoord).r;\n"
-    "    float u = texture2D(u_textureU, v_texCoord).r - 0.5;\n"
-    "    float v = texture2D(u_textureV, v_texCoord).r - 0.5;\n"
-    "    float r = y + 1.402 * v;\n"
-    "    float g = y - 0.344136 * u - 0.714136 * v;\n"
-    "    float b = y + 1.772 * u;\n"
-    "    gl_FragColor = vec4(r, g, b, 1.0);\n"
+    "    gl_FragColor = texture2D(u_texture, v_texCoord);\n"
     "}\n";
 
 // ---------------------------------------------------------------------------
@@ -2259,24 +2251,17 @@ static bool FfmpegInitGLResources(FfmpegContext *ctx) {
     return false;
   }
 
-  // 2. 绑定 sampler uniform（GL_TEXTURE0=Y, GL_TEXTURE1=U, GL_TEXTURE2=V）
+  // 2. 绑定 sampler uniform（GL_TEXTURE0 = RGBA 纹理）
   ctx->gl.UseProgram(ctx->yuvProgram);
-  ctx->gl.Uniform1i(ctx->gl.GetUniformLocation(ctx->yuvProgram, "u_textureY"), 0);
-  ctx->gl.Uniform1i(ctx->gl.GetUniformLocation(ctx->yuvProgram, "u_textureU"), 1);
-  ctx->gl.Uniform1i(ctx->gl.GetUniformLocation(ctx->yuvProgram, "u_textureV"), 2);
+  ctx->gl.Uniform1i(ctx->gl.GetUniformLocation(ctx->yuvProgram, "u_texture"), 0);
 
-  // 3. 创建 Y/U/V 三张 GL_R8 纹理（GLES 3 标准单通道格式，实际尺寸由第一帧决定）
-  ctx->gl.GenTextures(1, &ctx->textureY);
-  ctx->gl.GenTextures(1, &ctx->textureU);
-  ctx->gl.GenTextures(1, &ctx->textureV);
-  const GLuint textures[3] = {ctx->textureY, ctx->textureU, ctx->textureV};
-  for (const GLuint tex : textures) {
-    ctx->gl.BindTexture(GL_TEXTURE_2D, tex);
-    ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  }
+  // 3. 创建单张 GL_RGBA 纹理（sws_scale 已在 CPU 侧完成 YUV→RGBA 转换）
+  ctx->gl.GenTextures(1, &ctx->rgbaTexture);
+  ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->rgbaTexture);
+  ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   ctx->gl.BindTexture(GL_TEXTURE_2D, 0);
 
   // 4. 全屏四边形 VBO（triangle strip，x/y 为 NDC，s/t 为 UV）
@@ -2295,9 +2280,8 @@ static bool FfmpegInitGLResources(FfmpegContext *ctx) {
 
   // 修复 #48-B6: %{public}u 让资源 ID 在 hilog 中可见
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-               "FfmpegInitGLResources: OK prog=%{public}u Y=%{public}u U=%{public}u V=%{public}u vbo=%{public}u",
-               ctx->yuvProgram, ctx->textureY, ctx->textureU, ctx->textureV,
-               ctx->quadVBO);
+               "FfmpegInitGLResources: OK prog=%{public}u rgba=%{public}u vbo=%{public}u",
+               ctx->yuvProgram, ctx->rgbaTexture, ctx->quadVBO);
   return true;
 }
 
@@ -2310,17 +2294,9 @@ static void FfmpegCleanupGLResources(FfmpegContext *ctx) {
     ctx->gl.DeleteBuffers(1, &ctx->quadVBO);
     ctx->quadVBO = 0;
   }
-  if (ctx->textureY != 0) {
-    ctx->gl.DeleteTextures(1, &ctx->textureY);
-    ctx->textureY = 0;
-  }
-  if (ctx->textureU != 0) {
-    ctx->gl.DeleteTextures(1, &ctx->textureU);
-    ctx->textureU = 0;
-  }
-  if (ctx->textureV != 0) {
-    ctx->gl.DeleteTextures(1, &ctx->textureV);
-    ctx->textureV = 0;
+  if (ctx->rgbaTexture != 0) {
+    ctx->gl.DeleteTextures(1, &ctx->rgbaTexture);
+    ctx->rgbaTexture = 0;
   }
   if (ctx->yuvProgram != 0) {
     ctx->gl.DeleteProgram(ctx->yuvProgram);
@@ -2485,63 +2461,40 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
     const int w = frame->width;
     const int h = frame->height;
 
-    // B6 诊断日志：第一帧打印格式与 linesize，用于确认 sws_scale 是否生效
+    // B6 诊断日志：第一帧打印格式与 linesize（fmt=2 表示 AV_PIX_FMT_RGBA，ls0=width*4）
     {
       static bool firstFrameLogged = false;
       if (!firstFrameLogged) {
         firstFrameLogged = true;
         OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                     "RenderThread: first frame w=%{public}d h=%{public}d fmt=%{public}d "
-                     "ls0=%{public}d ls1=%{public}d",
-                     frame->width, frame->height, frame->format,
-                     frame->linesize[0], frame->linesize[1]);
+                     "RenderThread: first frame w=%{public}d h=%{public}d fmt=%{public}d ls0=%{public}d",
+                     frame->width, frame->height, frame->format, frame->linesize[0]);
       }
     }
 
-    ctx->gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    ctx->gl.PixelStorei(GL_UNPACK_ALIGNMENT, 4);  // GL_RGBA 每像素 4 字节，默认对齐 4 即可
 
     // Fix #48-B6: 首帧（或分辨率切换时）用 glTexImage2D 分配纹理存储；
-    // 后续帧改用 glTexSubImage2D 直接更新数据，避免每帧重新分配导致 GL_OUT_OF_MEMORY。
-    // 格式：GL_R8（internalFormat）+ GL_RED（format）—— GLES 3 标准单通道格式。
+    // 后续帧改用 glTexSubImage2D 直接更新数据，避免每帧重新分配。
+    // 格式：GL_RGBA（internalFormat）+ GL_RGBA（format）—— 最兼容格式，规避 GL_R8/GL_LUMINANCE OOM。
     const bool sizeChanged = (w != ctx->textureW || h != ctx->textureH);
 
     ctx->gl.ActiveTexture(GL_TEXTURE0);
-    ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureY);
+    ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->rgbaTexture);
     if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0,
-                     GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
-        // 诊断: 仅在首帧或尺寸变更时检查 GL 错误，避免日志刷屏
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0,
+                     GL_RGBA, GL_UNSIGNED_BYTE, frame->data[0]);
+        // 诊断: 仅在首帧或尺寸变更时检查 GL 错误
         {
             GLenum glErr = ctx->gl.GetError();
-            if (glErr != GL_NO_ERROR) {
-                OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                             "RenderThread: glTexImage2D Y error=0x%{public}x"
-                             " w=%{public}d h=%{public}d", glErr, w, h);
-            }
+            OH_LOG_Print(glErr == GL_NO_ERROR ? LOG_INFO : LOG_ERROR,
+                         LOG_APP, 0xFF00, "VidAll",
+                         "RenderThread: glTexImage2D RGBA err=0x%{public}x w=%{public}d h=%{public}d",
+                         glErr, w, h);
         }
     } else {
         ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h,
-                        GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
-    }
-
-    ctx->gl.ActiveTexture(GL_TEXTURE1);
-    ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureU);
-    if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w / 2, h / 2, 0,
-                     GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
-    } else {
-        ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w / 2, h / 2,
-                        GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
-    }
-
-    ctx->gl.ActiveTexture(GL_TEXTURE2);
-    ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureV);
-    if (!ctx->texturesInitialized || sizeChanged) {
-        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w / 2, h / 2, 0,
-                     GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
-    } else {
-        ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w / 2, h / 2,
-                        GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
+                        GL_RGBA, GL_UNSIGNED_BYTE, frame->data[0]);
     }
 
     if (!ctx->texturesInitialized || sizeChanged) {
@@ -2550,7 +2503,7 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
         ctx->textureH = h;
     }
 
-    // 6. 用 YUV program 绘制全屏 quad（triangle strip，4 顶点）
+    // 6. 用 RGBA passthrough program 绘制全屏 quad（triangle strip，4 顶点）
     ctx->gl.UseProgram(ctx->yuvProgram);
     ctx->gl.BindBuffer(GL_ARRAY_BUFFER, ctx->quadVBO);
     const GLsizei stride = static_cast<GLsizei>(4 * sizeof(float));

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -748,6 +748,37 @@ struct FfmpegContext {
   // B5-QA fix：改为 atomic ptr，消除 StopFfmpegDemux(主线程) 写 nullptr 与
   //            DemuxThreadFunc(demux 线程) 读+解引用之间的 data race（UB）。
   std::atomic<NativePlayerSkeletonState *> ownerState{nullptr};
+
+  // B6 安全析构兜底：正常路径由 StopFfmpegDemux 先 join 所有线程再 reset()。
+  // 若存在异常路径导致析构器直接被调用（如 unique_ptr 提前 reset），先广播所有
+  // abort/interrupt 标志，再按 Render→Decode→Demux 顺序 join，线程会迅速响应标志退出。
+  // 禁止 detach：detach 后线程仍会访问已释放的 FfmpegContext 成员，导致 UAF。
+  ~FfmpegContext() {
+    interruptFlag.store(true, std::memory_order_release);
+    demuxRunning.store(false, std::memory_order_release);
+    decodeRunning.store(false, std::memory_order_release);
+    renderRunning.store(false, std::memory_order_release);
+    ownerState.store(nullptr, std::memory_order_release);
+
+    // 唤醒所有阻塞在 cv.wait 的线程，使其检查 abort 标志后退出
+    { std::lock_guard<std::mutex> lk(videoFrameQueue.mtx); videoFrameQueue.abort = true; }
+    videoFrameQueue.cv.notify_all();
+    { std::lock_guard<std::mutex> lk(audioFrameQueue.mtx); audioFrameQueue.abort = true; }
+    audioFrameQueue.cv.notify_all();
+    { std::lock_guard<std::mutex> lk(videoQueue.mtx); videoQueue.abort = true; }
+    videoQueue.cv.notify_all();
+    { std::lock_guard<std::mutex> lk(audioQueue.mtx); audioQueue.abort = true; }
+    audioQueue.cv.notify_all();
+
+    // join 顺序：render（依赖 videoFrameQueue）→ decode（依赖 packet 队列）→ demux（生产者）
+    if (renderThread.joinable())      renderThread.join();
+    if (videoDecodeThread.joinable()) videoDecodeThread.join();
+    if (audioDecodeThread.joinable()) audioDecodeThread.join();
+    if (demuxThread.joinable())       demuxThread.join();
+
+    OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+        "FfmpegContext: safety destructor joined remaining threads");
+  }
 };
 
 struct NativePlayerSkeletonState {

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -780,6 +780,8 @@ struct NativePlayerSkeletonState {
   // PR#49 修复：新增 buffering=false 和 seekDone TSF，供媒体线程异步触发
   napi_threadsafe_function tsfOnBufferingFalse = nullptr;
   napi_threadsafe_function tsfOnSeekDone = nullptr;
+  // B6修复：FFmpeg 接管时通知 ArkTS 重置 native 就绪守卫计时器，防止 3.5s 误 fallback
+  napi_threadsafe_function tsfOnFfmpegSwitching = nullptr;
   // PR#49 修复（问题6）：per-player mutex，保护 state 字段的跨线程读写
   // 注意：std::mutex 不可拷贝/移动；unordered_map 通过节点指针操作，不需要拷贝值
   std::mutex stateMutex;
@@ -1076,6 +1078,8 @@ static void ClearCallbackRefs(NativePlayerSkeletonState &state, napi_env fallbac
   // PR#49：新增两个 TSF
   ReleaseTsfIfPresent(state.tsfOnBufferingFalse);
   ReleaseTsfIfPresent(state.tsfOnSeekDone);
+  // B6修复：释放 FFmpeg 接管通知 TSF
+  ReleaseTsfIfPresent(state.tsfOnFfmpegSwitching);
 }
 
 static bool EnsurePreparedOrEmitError(
@@ -2836,6 +2840,11 @@ static void OnAVPlayerErrorCB(OH_AVPlayer *player, int32_t errorCode,
     // FFmpeg 自身失败时，StartFfmpegDemux 内部负责触发 tsfOnError。
     OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                  "OnAVPlayerErrorCB: FFmpeg path taken over, suppressing tsfOnError/tsfOnBufferingFalse");
+    // B6修复：通知 ArkTS FFmpeg 已接管，让上层重置守卫计时器至 15s，
+    // 避免 3.5s 超时误触 fallbackNativeToIjk 导致 surface 被 IJK 抢占。
+    if (state->tsfOnFfmpegSwitching != nullptr) {
+      napi_call_threadsafe_function(state->tsfOnFfmpegSwitching, nullptr, napi_tsfn_nonblocking);
+    }
     return;
   }
 
@@ -3080,20 +3089,21 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
 }
 
 static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
-  size_t argc = 7;
-  napi_value args[7] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+  size_t argc = 8;
+  napi_value args[8] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
   if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok) {
     ThrowTypeError(env, "setCallbacks failed to read args");
     return nullptr;
   }
   if (argc < 5) {
     ThrowTypeError(env,
-      "setCallbacks requires (handle, onPrepared, onError, onTimeUpdate, onCompleted[, onBufferingChange[, onSeekDone]])");
+      "setCallbacks requires (handle, onPrepared, onError, onTimeUpdate, onCompleted[, onBufferingChange[, onSeekDone[, onFfmpegSwitching]]])");
     return nullptr;
   }
   int32_t handle = 0;
   const bool hasBufferingArg = (argc >= 6);
   const bool hasSeekDoneArg = (argc >= 7);
+  const bool hasFfmpegSwitchingArg = (argc >= 8);
   if (napi_get_value_int32(env, args[0], &handle) != napi_ok) {
     ThrowTypeError(env, "setCallbacks handle must be int32");
     return nullptr;
@@ -3265,6 +3275,24 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
         napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
       },
       &state.tsfOnSeekDone);
+  }
+  // B6修复：注册 tsfOnFfmpegSwitching（可选，args[7]）
+  // FFmpeg 接管后通知 ArkTS 重置守卫计时器至 15s，防止 3.5s 超时误触 fallback。
+  if (hasFfmpegSwitchingArg) {
+    napi_valuetype argType = napi_undefined;
+    napi_typeof(env, args[7], &argType);
+    if (argType == napi_function) {
+      napi_value resName;
+      napi_create_string_utf8(env, "tsfOnFfmpegSwitching", NAPI_AUTO_LENGTH, &resName);
+      napi_create_threadsafe_function(
+        env, args[7], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
+        [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+          napi_value undef;
+          napi_get_undefined(tsfEnv, &undef);
+          napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
+        },
+        &state.tsfOnFfmpegSwitching);
+    }
   }
 
   // 若回调在 prepared 之后才注册，主动补发一次状态，避免上层错过时序。

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -653,6 +653,7 @@ static napi_value Ffprobe(napi_env env, napi_callback_info info) {
 
 // ---------------------------------------------------------------------------
 // B1：FFmpeg 自研解码路径 — packet 队列 + demux 线程
+// B2：视频/音频解码线程 + 帧队列
 // ---------------------------------------------------------------------------
 
 // 线程安全的 AVPacket 队列（视频/音频各一个）
@@ -662,6 +663,15 @@ struct AVPacketQueue {
   std::condition_variable cv;
   bool abort = false;
   int maxSize = 64;
+};
+
+// B2：线程安全的 AVFrame 队列（解码输出，供渲染/音频线程消费）
+struct AVFrameQueue {
+  std::queue<AVFrame *> frames;
+  std::mutex mtx;
+  std::condition_variable cv;
+  bool abort = false;
+  int maxSize = 4;  // 视频帧不需要太大，以控制内存压力
 };
 
 // FFmpeg 上下文：格式探测 + demux 线程 + 双队列
@@ -677,6 +687,19 @@ struct FfmpegContext {
   std::atomic<bool> interruptFlag{false};
   // HTTP headers（"Key: Value\r\n" 格式，供 avformat_open_input 使用）
   std::string httpHeaders;
+
+  // B2：解码器上下文
+  AVCodecContext *videoCodecCtx = nullptr;
+  AVCodecContext *audioCodecCtx = nullptr;
+
+  // B2：解码线程
+  std::thread videoDecodeThread;
+  std::thread audioDecodeThread;
+  std::atomic<bool> decodeRunning{false};
+
+  // B2：解码帧输出队列
+  AVFrameQueue videoFrameQueue;
+  AVFrameQueue audioFrameQueue;
 };
 
 struct NativePlayerSkeletonState {
@@ -715,6 +738,11 @@ struct NativePlayerSkeletonState {
   // B1：FFmpeg 自研路径标志与上下文
   bool useFfmpegPath = false;  // OH_AVPlayer 报错后设为 true，切换到 FFmpeg 路径
   std::unique_ptr<FfmpegContext> ffmpegCtx;
+  // B2：媒体信息（解码器初始化后填充，供 onPrepared 回调使用）
+  int32_t ffmpegWidth = 0;
+  int32_t ffmpegHeight = 0;
+  double ffmpegFps = 0.0;
+  int64_t ffmpegDurationMs = 0;
 };
 
 static std::unordered_map<int32_t, NativePlayerSkeletonState> g_players;
@@ -1393,6 +1421,350 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
 }
 
 // 启动 FFmpeg demux 线程（在 OH_AVPlayer 报错后从媒体线程调用）
+static void StartFfmpegDecode(NativePlayerSkeletonState *state);
+static void StopFfmpegDecode(NativePlayerSkeletonState *state);
+
+// ---------------------------------------------------------------------------
+// B2：解码器初始化
+// ---------------------------------------------------------------------------
+
+static int FfmpegInitCodecs(FfmpegContext *ctx) {
+  // 视频解码器
+  if (ctx->videoStreamIdx >= 0) {
+    AVStream *vs = ctx->fmtCtx->streams[ctx->videoStreamIdx];
+    const AVCodec *codec = avcodec_find_decoder(vs->codecpar->codec_id);
+    if (!codec) {
+      OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                   "FfmpegInitCodecs: no video decoder for codec_id=%d", vs->codecpar->codec_id);
+      return AVERROR_DECODER_NOT_FOUND;
+    }
+    ctx->videoCodecCtx = avcodec_alloc_context3(codec);
+    if (!ctx->videoCodecCtx) {
+      return AVERROR(ENOMEM);
+    }
+    int ret = avcodec_parameters_to_context(ctx->videoCodecCtx, vs->codecpar);
+    if (ret < 0) {
+      avcodec_free_context(&ctx->videoCodecCtx);
+      return ret;
+    }
+    // 多线程解码（frame-level），TV 端多核可充分利用
+    ctx->videoCodecCtx->thread_count = 2;
+    ctx->videoCodecCtx->thread_type = FF_THREAD_FRAME;
+    ret = avcodec_open2(ctx->videoCodecCtx, codec, nullptr);
+    if (ret < 0) {
+      avcodec_free_context(&ctx->videoCodecCtx);
+      return ret;
+    }
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "FfmpegInitCodecs: video decoder opened: %s %dx%d",
+                 codec->name, ctx->videoCodecCtx->width, ctx->videoCodecCtx->height);
+  }
+
+  // 音频解码器
+  if (ctx->audioStreamIdx >= 0) {
+    AVStream *as = ctx->fmtCtx->streams[ctx->audioStreamIdx];
+    const AVCodec *codec = avcodec_find_decoder(as->codecpar->codec_id);
+    if (!codec) {
+      OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                   "FfmpegInitCodecs: no audio decoder for codec_id=%d", as->codecpar->codec_id);
+      return AVERROR_DECODER_NOT_FOUND;
+    }
+    ctx->audioCodecCtx = avcodec_alloc_context3(codec);
+    if (!ctx->audioCodecCtx) {
+      return AVERROR(ENOMEM);
+    }
+    int ret = avcodec_parameters_to_context(ctx->audioCodecCtx, as->codecpar);
+    if (ret < 0) {
+      avcodec_free_context(&ctx->audioCodecCtx);
+      return ret;
+    }
+    ret = avcodec_open2(ctx->audioCodecCtx, codec, nullptr);
+    if (ret < 0) {
+      avcodec_free_context(&ctx->audioCodecCtx);
+      return ret;
+    }
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "FfmpegInitCodecs: audio decoder opened: %s ch=%d sr=%d",
+                 codec->name, ctx->audioCodecCtx->ch_layout.nb_channels,
+                 ctx->audioCodecCtx->sample_rate);
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// B2：视频解码线程
+// ---------------------------------------------------------------------------
+
+static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "VideoDecodeThread: started");
+  AVFrame *frame = av_frame_alloc();
+  if (!frame) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll", "VideoDecodeThread: av_frame_alloc failed");
+    return;
+  }
+
+  while (ctx->decodeRunning.load()) {
+    // 从 videoQueue 取 packet（背压等待）
+    AVPacket *pkt = nullptr;
+    {
+      std::unique_lock<std::mutex> lock(ctx->videoQueue.mtx);
+      ctx->videoQueue.cv.wait(lock, [&] {
+        return !ctx->videoQueue.packets.empty() || ctx->videoQueue.abort || !ctx->decodeRunning.load();
+      });
+      if (!ctx->decodeRunning.load() || ctx->videoQueue.abort) {
+        break;
+      }
+      pkt = ctx->videoQueue.packets.front();
+      ctx->videoQueue.packets.pop();
+    }
+    ctx->videoQueue.cv.notify_all();  // 唤醒 demux 线程（队列有空位）
+
+    // 发送到解码器
+    int ret = avcodec_send_packet(ctx->videoCodecCtx, pkt);
+    av_packet_free(&pkt);
+    if (ret < 0) {
+      if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
+        char errbuf[64] = {0};
+        av_strerror(ret, errbuf, sizeof(errbuf));
+        OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                     "VideoDecodeThread: send_packet error: %s", errbuf);
+      }
+      continue;
+    }
+
+    // 接收所有可用解码帧
+    while (ctx->decodeRunning.load()) {
+      ret = avcodec_receive_frame(ctx->videoCodecCtx, frame);
+      if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+        break;
+      }
+      if (ret < 0) {
+        break;
+      }
+
+      // 将帧移入 videoFrameQueue（背压等待，防止解码过快撑爆内存）
+      AVFrame *frameCopy = av_frame_alloc();
+      if (frameCopy) {
+        av_frame_move_ref(frameCopy, frame);
+        std::unique_lock<std::mutex> lock(ctx->videoFrameQueue.mtx);
+        ctx->videoFrameQueue.cv.wait(lock, [&] {
+          return static_cast<int>(ctx->videoFrameQueue.frames.size()) < ctx->videoFrameQueue.maxSize
+              || ctx->videoFrameQueue.abort
+              || !ctx->decodeRunning.load();
+        });
+        if (!ctx->videoFrameQueue.abort && ctx->decodeRunning.load()) {
+          ctx->videoFrameQueue.frames.push(frameCopy);
+          lock.unlock();
+          ctx->videoFrameQueue.cv.notify_all();
+        } else {
+          lock.unlock();
+          av_frame_free(&frameCopy);
+        }
+      }
+    }
+  }
+
+  av_frame_free(&frame);
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "VideoDecodeThread: exited");
+}
+
+// ---------------------------------------------------------------------------
+// B2：音频解码线程
+// ---------------------------------------------------------------------------
+
+static void AudioDecodeThreadFunc(FfmpegContext *ctx) {
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "AudioDecodeThread: started");
+  AVFrame *frame = av_frame_alloc();
+  if (!frame) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll", "AudioDecodeThread: av_frame_alloc failed");
+    return;
+  }
+
+  while (ctx->decodeRunning.load()) {
+    // 从 audioQueue 取 packet
+    AVPacket *pkt = nullptr;
+    {
+      std::unique_lock<std::mutex> lock(ctx->audioQueue.mtx);
+      ctx->audioQueue.cv.wait(lock, [&] {
+        return !ctx->audioQueue.packets.empty() || ctx->audioQueue.abort || !ctx->decodeRunning.load();
+      });
+      if (!ctx->decodeRunning.load() || ctx->audioQueue.abort) {
+        break;
+      }
+      pkt = ctx->audioQueue.packets.front();
+      ctx->audioQueue.packets.pop();
+    }
+    ctx->audioQueue.cv.notify_all();
+
+    // 发送到解码器
+    int ret = avcodec_send_packet(ctx->audioCodecCtx, pkt);
+    av_packet_free(&pkt);
+    if (ret < 0) {
+      if (ret != AVERROR(EAGAIN) && ret != AVERROR_EOF) {
+        char errbuf[64] = {0};
+        av_strerror(ret, errbuf, sizeof(errbuf));
+        OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                     "AudioDecodeThread: send_packet error: %s", errbuf);
+      }
+      continue;
+    }
+
+    // 接收所有可用解码帧（PCM，格式转换在 B4 做）
+    while (ctx->decodeRunning.load()) {
+      ret = avcodec_receive_frame(ctx->audioCodecCtx, frame);
+      if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
+        break;
+      }
+      if (ret < 0) {
+        break;
+      }
+
+      AVFrame *frameCopy = av_frame_alloc();
+      if (frameCopy) {
+        av_frame_move_ref(frameCopy, frame);
+        std::unique_lock<std::mutex> lock(ctx->audioFrameQueue.mtx);
+        ctx->audioFrameQueue.cv.wait(lock, [&] {
+          return static_cast<int>(ctx->audioFrameQueue.frames.size()) < ctx->audioFrameQueue.maxSize
+              || ctx->audioFrameQueue.abort
+              || !ctx->decodeRunning.load();
+        });
+        if (!ctx->audioFrameQueue.abort && ctx->decodeRunning.load()) {
+          ctx->audioFrameQueue.frames.push(frameCopy);
+          lock.unlock();
+          ctx->audioFrameQueue.cv.notify_all();
+        } else {
+          lock.unlock();
+          av_frame_free(&frameCopy);
+        }
+      }
+    }
+  }
+
+  av_frame_free(&frame);
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "AudioDecodeThread: exited");
+}
+
+// ---------------------------------------------------------------------------
+// B2：启动/停止解码线程
+// ---------------------------------------------------------------------------
+
+static void StartFfmpegDecode(NativePlayerSkeletonState *state) {
+  if (state == nullptr || state->ffmpegCtx == nullptr) {
+    return;
+  }
+  FfmpegContext *ctx = state->ffmpegCtx.get();
+
+  // 初始化解码器
+  const int ret = FfmpegInitCodecs(ctx);
+  if (ret < 0) {
+    char errbuf[128] = {0};
+    av_strerror(ret, errbuf, sizeof(errbuf));
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "StartFfmpegDecode: FfmpegInitCodecs failed: %s", errbuf);
+    return;
+  }
+
+  // 记录媒体信息（供 ArkTS onPrepared 读取）
+  if (ctx->videoStreamIdx >= 0 && ctx->videoCodecCtx != nullptr) {
+    state->ffmpegWidth = ctx->videoCodecCtx->width;
+    state->ffmpegHeight = ctx->videoCodecCtx->height;
+    AVStream *vs = ctx->fmtCtx->streams[ctx->videoStreamIdx];
+    const AVRational fr = vs->avg_frame_rate;
+    state->ffmpegFps = (fr.den > 0) ? static_cast<double>(fr.num) / fr.den : 0.0;
+  }
+  if (ctx->fmtCtx->duration != AV_NOPTS_VALUE) {
+    state->ffmpegDurationMs = ctx->fmtCtx->duration / (AV_TIME_BASE / 1000);
+  }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "StartFfmpegDecode: %dx%d fps=%.2f durationMs=%lld",
+               state->ffmpegWidth, state->ffmpegHeight,
+               state->ffmpegFps, static_cast<long long>(state->ffmpegDurationMs));
+
+  // 启动解码线程
+  ctx->decodeRunning.store(true);
+  if (ctx->videoCodecCtx != nullptr) {
+    ctx->videoDecodeThread = std::thread(VideoDecodeThreadFunc, ctx);
+  }
+  if (ctx->audioCodecCtx != nullptr) {
+    ctx->audioDecodeThread = std::thread(AudioDecodeThreadFunc, ctx);
+  }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "StartFfmpegDecode: decode threads launched");
+}
+
+static void StopFfmpegDecode(NativePlayerSkeletonState *state) {
+  if (state == nullptr || state->ffmpegCtx == nullptr) {
+    return;
+  }
+  FfmpegContext *ctx = state->ffmpegCtx.get();
+
+  // 1. 通知解码线程退出
+  ctx->decodeRunning.store(false);
+
+  // 2. Abort 帧队列（唤醒可能阻塞在背压等待的解码线程）
+  {
+    std::lock_guard<std::mutex> lk(ctx->videoFrameQueue.mtx);
+    ctx->videoFrameQueue.abort = true;
+  }
+  ctx->videoFrameQueue.cv.notify_all();
+  {
+    std::lock_guard<std::mutex> lk(ctx->audioFrameQueue.mtx);
+    ctx->audioFrameQueue.abort = true;
+  }
+  ctx->audioFrameQueue.cv.notify_all();
+
+  // 3. Abort packet 队列（唤醒可能阻塞在取 packet 的解码线程）
+  {
+    std::lock_guard<std::mutex> lk(ctx->videoQueue.mtx);
+    ctx->videoQueue.abort = true;
+  }
+  ctx->videoQueue.cv.notify_all();
+  {
+    std::lock_guard<std::mutex> lk(ctx->audioQueue.mtx);
+    ctx->audioQueue.abort = true;
+  }
+  ctx->audioQueue.cv.notify_all();
+
+  // 4. Join 解码线程
+  if (ctx->videoDecodeThread.joinable()) {
+    ctx->videoDecodeThread.join();
+  }
+  if (ctx->audioDecodeThread.joinable()) {
+    ctx->audioDecodeThread.join();
+  }
+
+  // 5. 释放帧队列中残留帧
+  {
+    std::lock_guard<std::mutex> lk(ctx->videoFrameQueue.mtx);
+    while (!ctx->videoFrameQueue.frames.empty()) {
+      AVFrame *f = ctx->videoFrameQueue.frames.front();
+      ctx->videoFrameQueue.frames.pop();
+      av_frame_free(&f);
+    }
+  }
+  {
+    std::lock_guard<std::mutex> lk(ctx->audioFrameQueue.mtx);
+    while (!ctx->audioFrameQueue.frames.empty()) {
+      AVFrame *f = ctx->audioFrameQueue.frames.front();
+      ctx->audioFrameQueue.frames.pop();
+      av_frame_free(&f);
+    }
+  }
+
+  // 6. 释放解码器上下文
+  if (ctx->videoCodecCtx != nullptr) {
+    avcodec_free_context(&ctx->videoCodecCtx);
+  }
+  if (ctx->audioCodecCtx != nullptr) {
+    avcodec_free_context(&ctx->audioCodecCtx);
+  }
+
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "StopFfmpegDecode: decode stopped and cleaned");
+}
+
+// ---------------------------------------------------------------------------
+// B1：demux 线程启动/停止（B2 在其中调用解码线程）
+// ---------------------------------------------------------------------------
+
 static void StartFfmpegDemux(NativePlayerSkeletonState *state, const std::string &url) {
   if (state == nullptr || url.empty()) {
     return;
@@ -1419,6 +1791,9 @@ static void StartFfmpegDemux(NativePlayerSkeletonState *state, const std::string
   state->ffmpegCtx = std::move(ctx);
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                "StartFfmpegDemux: demux thread launched for url=%s", url.c_str());
+
+  // B2：demux 就绪后立即初始化解码器并启动解码线程
+  StartFfmpegDecode(state);
 }
 
 // 停止 demux 线程并释放所有 FFmpeg 资源
@@ -1427,6 +1802,9 @@ static void StopFfmpegDemux(NativePlayerSkeletonState *state) {
     return;
   }
   FfmpegContext *ctx = state->ffmpegCtx.get();
+
+  // B2：先停止解码线程（依赖 packet 队列），再停止 demux
+  StopFfmpegDecode(state);
 
   // 1. 通知中断：让阻塞的 av_read_frame / avformat_open_input 尽快返回
   ctx->interruptFlag.store(true);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -2816,6 +2816,7 @@ static OH_AudioData_Callback_Result AudioWriteDataCallback(
   // stereo S16：每帧 = 2 声道 × 2 字节 = 4 字节
   const int samplesNeeded = audioDataSize / static_cast<int>(2 * sizeof(int16_t));
   int samplesFilled = 0;
+  int mediaSamplesFilled = 0;
 
   // ── 步骤 1：先消费上一次 swr_convert 的溢出缓冲 ──────────────────────────
   if (!ctx->pcmLeftover.empty()) {
@@ -2825,6 +2826,7 @@ static OH_AudioData_Callback_Result AudioWriteDataCallback(
     memcpy(dst, ctx->pcmLeftover.data(),
            static_cast<size_t>(toCopy) * 2 * sizeof(int16_t));
     samplesFilled += toCopy;
+    mediaSamplesFilled += toCopy;
     if (toCopy < leftoverSamples) {
       ctx->pcmLeftover.erase(ctx->pcmLeftover.begin(),
                              ctx->pcmLeftover.begin() + toCopy * 2);
@@ -2878,6 +2880,7 @@ static OH_AudioData_Callback_Result AudioWriteDataCallback(
     memcpy(dst + samplesFilled * 2, tempBuf.data(),
            static_cast<size_t>(toCopy) * 2 * sizeof(int16_t));
     samplesFilled += toCopy;
+    mediaSamplesFilled += toCopy;
 
     if (converted > toCopy) {
       // 多余样本存入溢出缓冲，下次 callback 优先消费
@@ -2887,8 +2890,11 @@ static OH_AudioData_Callback_Result AudioWriteDataCallback(
     }
   }
 
-  // B5：更新音频时钟（本次 callback 共输出 samplesNeeded 个样本）
-  ctx->audioPtsSamples.fetch_add(static_cast<int64_t>(samplesNeeded), std::memory_order_relaxed);
+  // B5：音频时钟只累计真实媒体样本，不把 underrun 填充的静音计入主时钟。
+  // 否则启动/seek 后音频时钟会虚假快进，RenderThread 会把视频帧误判为“严重落后”并大量丢帧。
+  if (mediaSamplesFilled > 0) {
+    ctx->audioPtsSamples.fetch_add(static_cast<int64_t>(mediaSamplesFilled), std::memory_order_relaxed);
+  }
 
   return AUDIO_DATA_CALLBACK_RESULT_VALID;
 }

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #include <libavutil/error.h>
 #include <libavutil/time.h>
 #include <libswresample/swresample.h>  // B4：PCM 格式转换（fltp/s16/etc → s16 for OH_AudioRenderer）
+#include <libswscale/swscale.h>        // B6：视频像素格式转换（yuv420p10le/etc → yuv420p，修复 HDR/DV 黑屏）
 }
 
 #if !defined(VIDALL_HAS_LIBCURL)
@@ -788,6 +789,7 @@ struct FfmpegContext {
   OH_AudioRenderer *audioRenderer = nullptr;
   OH_AudioStreamBuilder *audioBuilder = nullptr;
   SwrContext *swrCtx = nullptr;          // libswresample 重采样上下文（源格式 → stereo S16 48kHz）
+  SwsContext *swsCtx = nullptr;          // libswscale 像素格式转换（yuv420p10le/etc → yuv420p，B6 HDR/DV 修复）
   std::vector<int16_t> pcmLeftover;      // swr_convert 溢出缓冲：跨 callback 的剩余 PCM 数据
 
   // B5：音频时钟（主时钟）
@@ -837,6 +839,11 @@ struct FfmpegContext {
 
     OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
         "FfmpegContext: safety destructor joined remaining threads");
+    // 释放 SwsContext（视频格式转换，B6 HDR/DV 修复）
+    if (swsCtx != nullptr) {
+      sws_freeContext(swsCtx);
+      swsCtx = nullptr;
+    }
   }
 };
 
@@ -1802,9 +1809,52 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
       }
 
       // 将帧移入 videoFrameQueue（背压等待，防止解码过快撑爆内存）
+      // ── B6：强制转换到 YUV420P（8-bit），渲染管线只处理 yuv420p ──
+      // HDR/DV 内容解码输出 yuv420p10le（10-bit），GL 侧以 GL_UNSIGNED_BYTE 上传，
+      // 若不转换则纹理数据完全错误 → 黑屏。此处懒创建/复用 SwsContext。
+      AVFrame *renderFrame = frame;
+      AVFrame *convertedFrame = nullptr;
+      if (frame->format != AV_PIX_FMT_YUV420P) {
+        // 输入格式变化时重建 SwsContext（首次 or 格式切换）
+        if (ctx->swsCtx == nullptr) {
+          ctx->swsCtx = sws_getContext(
+              frame->width, frame->height, static_cast<AVPixelFormat>(frame->format),
+              frame->width, frame->height, AV_PIX_FMT_YUV420P,
+              SWS_BILINEAR, nullptr, nullptr, nullptr);
+          OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                       "VideoDecodeThread: SwsContext created srcFmt=%{public}d -> yuv420p",
+                       frame->format);
+        }
+        if (ctx->swsCtx != nullptr) {
+          convertedFrame = av_frame_alloc();
+          if (convertedFrame != nullptr) {
+            convertedFrame->format = AV_PIX_FMT_YUV420P;
+            convertedFrame->width  = frame->width;
+            convertedFrame->height = frame->height;
+            if (av_frame_get_buffer(convertedFrame, 32) == 0) {
+              sws_scale(ctx->swsCtx,
+                        reinterpret_cast<const uint8_t * const *>(frame->data),
+                        frame->linesize, 0, frame->height,
+                        convertedFrame->data, convertedFrame->linesize);
+              convertedFrame->pts     = frame->pts;
+              convertedFrame->pkt_dts = frame->pkt_dts;
+              renderFrame = convertedFrame;
+            } else {
+              av_frame_free(&convertedFrame);
+              convertedFrame = nullptr;
+              // fallback：直接用原始帧（可能渲染异常，但不崩溃）
+              OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                           "VideoDecodeThread: av_frame_get_buffer failed, fallback to raw frame");
+            }
+          }
+        }
+      }
+      // ── 结束格式转换 ──
+
       AVFrame *frameCopy = av_frame_alloc();
       if (frameCopy) {
-        av_frame_move_ref(frameCopy, frame);
+        // 使用 renderFrame（可能是转换后的 convertedFrame，也可能是原始 frame）
+        av_frame_move_ref(frameCopy, renderFrame);
         std::unique_lock<std::mutex> lock(ctx->videoFrameQueue.mtx);
         ctx->videoFrameQueue.cv.wait(lock, [&] {
           return static_cast<int>(ctx->videoFrameQueue.frames.size()) < ctx->videoFrameQueue.maxSize
@@ -1820,7 +1870,13 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
           av_frame_free(&frameCopy);
         }
       }
-    }
+      // 释放 convertedFrame shell（move_ref 已转走数据引用，此处 free 空帧，安全）
+      if (convertedFrame != nullptr) {
+        av_frame_free(&convertedFrame);
+      }
+      // 清理原始 frame 数据引用（convertedFrame 转换时 frame 仍持有原始数据）
+      av_frame_unref(frame);
+    }  // end inner while (receive_frame loop)
   }
 
   av_frame_free(&frame);
@@ -2387,6 +2443,20 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
     // 5. 上传 YUV420P → 3 张 GL_RED 纹理（Fix #48-B6-1b：GL_LUMINANCE 在 GLES 3.0 已废弃）
     const int w = frame->width;
     const int h = frame->height;
+
+    // B6 诊断日志：第一帧打印格式与 linesize，用于确认 sws_scale 是否生效
+    {
+      static bool firstFrameLogged = false;
+      if (!firstFrameLogged) {
+        firstFrameLogged = true;
+        OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                     "RenderThread: first frame w=%{public}d h=%{public}d fmt=%{public}d "
+                     "ls0=%{public}d ls1=%{public}d",
+                     frame->width, frame->height, frame->format,
+                     frame->linesize[0], frame->linesize[1]);
+      }
+    }
+
     ctx->gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
     ctx->gl.ActiveTexture(GL_TEXTURE0);
@@ -2874,6 +2944,11 @@ static void StopFfmpegDecode(NativePlayerSkeletonState *state) {
   }
 
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "StopFfmpegDecode: decode stopped and cleaned");
+  // 释放 SwsContext（视频格式转换，B6 HDR/DV 修复）；decode 线程已 join，访问安全
+  if (ctx->swsCtx != nullptr) {
+    sws_freeContext(ctx->swsCtx);
+    ctx->swsCtx = nullptr;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -2134,7 +2134,10 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
                  eglGetError(), nativeWindow);
     return false;
   }
-  EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
+  // 修复 #48-B6: 升级至 GLES 3——GL_RED 作为 internalformat 在 GLES 2.0 中非法，
+  // 会导致 glTexImage2D 静默失败（GL_INVALID_ENUM）进而全黑。
+  // 设备实际运行 OpenGL ES 3.2，此处声明 version=3 即可激活 GLES 3 上下文。
+  EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE};
   ctx->eglContext =
       eglCreateContext(ctx->eglDisplay, config, EGL_NO_CONTEXT, ctxAttribs);
   if (ctx->eglContext == EGL_NO_CONTEXT) {
@@ -2463,6 +2466,15 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureY);
     ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RED, w, h, 0,
                  GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
+    // 诊断: #48-B6 验证 GL_RED 在 GLES 3 context 下是否合法（应 GL_NO_ERROR）
+    {
+        GLenum glErr = ctx->gl.GetError();
+        if (glErr != GL_NO_ERROR) {
+            OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                         "RenderThread: glTexImage2D Y error=0x%{public}x"
+                         " w=%{public}d h=%{public}d", glErr, w, h);
+        }
+    }
 
     ctx->gl.ActiveTexture(GL_TEXTURE1);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureU);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -43,6 +43,11 @@ extern "C" {
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
+// GL_RED 是 GLES 3.0 引入的单通道格式，GLES 2.0 头中无此宏；
+// 函数指针已在运行时从 libGLESv2 加载，此处仅补充常量定义。
+#ifndef GL_RED
+#  define GL_RED 0x1903
+#endif
 
 // B4：OH_AudioRenderer（PCM 送显）
 #include <ohaudio/native_audiostreambuilder.h>
@@ -1554,6 +1559,9 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
     if (ctx->seekRequested.exchange(false)) {
       const int64_t targetMs = ctx->seekTargetMs.load();
       const int64_t targetUs = targetMs * 1000LL;  // AV_TIME_BASE = 1e6
+      // Fix #48-B6-2：seek 前先 unref pkt，防止 fmtCtx 持有上次 av_read_frame 残留数据
+      // 导致 seek 后首次 av_read_frame 触发 FFmpeg 内部状态机断言 (SIGABRT)。
+      av_packet_unref(pkt);
       // B5-QA fix：检查 av_seek_frame 返回值；失败时跳过 flush/reset/seekDone，
       //            避免在无效位置继续解码并产生误导性回调。
       int seekRet = av_seek_frame(ctx->fmtCtx, -1, targetUs, AVSEEK_FLAG_BACKWARD);
@@ -1562,8 +1570,8 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
         av_strerror(seekRet, errBuf, sizeof(errBuf));
         OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
                      "DemuxThread: av_seek_frame failed: %s", errBuf);
-        continue;
-      }
+        // seek 失败不 continue：让后续 av_read_frame 继续在原位置读包，避免卡死。
+      } else {
       // 清空所有 packet/frame 队列（旧数据）
       FlushFfmpegQueues(ctx);
       // 刷新解码器内部缓冲区
@@ -1589,7 +1597,8 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
           napi_call_threadsafe_function(st->tsfOnSeekDone, nullptr, napi_tsfn_nonblocking);
         }
       }
-    }
+      } // end else (seekRet >= 0)
+    } // end if (seekRequested)
 
     int ret = av_read_frame(ctx->fmtCtx, pkt);
     if (ret == AVERROR_EOF) {
@@ -2273,6 +2282,27 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                "RenderThreadFunc: render loop started");
 
+  // Fix #48-B6-1a：设置 Viewport 为 EGL surface 实际尺寸（全屏渲染）
+  // GLES 默认 viewport 为 (0,0,0,0)，不调此函数所有绘制结果均被裁剪到空区域导致黑屏。
+  {
+    EGLint surfW = 0, surfH = 0;
+    eglQuerySurface(ctx->eglDisplay, ctx->eglSurface, EGL_WIDTH, &surfW);
+    eglQuerySurface(ctx->eglDisplay, ctx->eglSurface, EGL_HEIGHT, &surfH);
+    if (surfW > 0 && surfH > 0) {
+      ctx->gl.Viewport(0, 0, surfW, surfH);
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                   "RenderThreadFunc: Viewport set to %{public}d x %{public}d", surfW, surfH);
+    } else {
+      OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                   "RenderThreadFunc: eglQuerySurface failed, surfW=%{public}d surfH=%{public}d",
+                   surfW, surfH);
+    }
+    // 初始清屏，确保第一帧前屏幕不显示随机内容
+    ctx->gl.ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    ctx->gl.Clear(GL_COLOR_BUFFER_BIT);
+    eglSwapBuffers(ctx->eglDisplay, ctx->eglSurface);
+  }
+
   // B5：时间上报节流（每 200ms 通过 tsfOnTimeUpdate 上报一次播放位置）
   auto lastEmitTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
 
@@ -2330,25 +2360,25 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
       }
     }
 
-    // 5. 上传 YUV420P → 3 张 GL_LUMINANCE 纹理
+    // 5. 上传 YUV420P → 3 张 GL_RED 纹理（Fix #48-B6-1b：GL_LUMINANCE 在 GLES 3.0 已废弃）
     const int w = frame->width;
     const int h = frame->height;
     ctx->gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
     ctx->gl.ActiveTexture(GL_TEXTURE0);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureY);
-    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w, h, 0,
-                 GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[0]);
+    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RED, w, h, 0,
+                 GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
 
     ctx->gl.ActiveTexture(GL_TEXTURE1);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureU);
-    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
-                 GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[1]);
+    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RED, w / 2, h / 2, 0,
+                 GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
 
     ctx->gl.ActiveTexture(GL_TEXTURE2);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureV);
-    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
-                 GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[2]);
+    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RED, w / 2, h / 2, 0,
+                 GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
 
     // 6. 用 YUV program 绘制全屏 quad（triangle strip，4 顶点）
     ctx->gl.UseProgram(ctx->yuvProgram);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1837,32 +1837,34 @@ static void AudioDecodeThreadFunc(FfmpegContext *ctx) {
 // B3：GLSL shader 字符串（YUV420P → RGB，mediump float）
 // ---------------------------------------------------------------------------
 
-static const char *kVertexShaderSrc = R"(
-attribute vec4 a_position;
-attribute vec2 a_texCoord;
-varying vec2 v_texCoord;
-void main() {
-    gl_Position = a_position;
-    v_texCoord = a_texCoord;
-}
-)";
+// 修复 #48-B6: 显式字符串拼接替代 R"()"，避免部分 HarmonyOS GLES 驱动对
+// raw string 开头换行符解析异常；同时增加 #version 100 声明。
+static const char *kVertexShaderSrc =
+    "#version 100\n"
+    "attribute vec4 a_position;\n"
+    "attribute vec2 a_texCoord;\n"
+    "varying vec2 v_texCoord;\n"
+    "void main() {\n"
+    "    gl_Position = a_position;\n"
+    "    v_texCoord = a_texCoord;\n"
+    "}\n";
 
-static const char *kFragmentShaderSrc = R"(
-precision mediump float;
-uniform sampler2D u_textureY;
-uniform sampler2D u_textureU;
-uniform sampler2D u_textureV;
-varying vec2 v_texCoord;
-void main() {
-    float y = texture2D(u_textureY, v_texCoord).r;
-    float u = texture2D(u_textureU, v_texCoord).r - 0.5;
-    float v = texture2D(u_textureV, v_texCoord).r - 0.5;
-    float r = y + 1.402 * v;
-    float g = y - 0.344136 * u - 0.714136 * v;
-    float b = y + 1.772 * u;
-    gl_FragColor = vec4(r, g, b, 1.0);
-}
-)";
+static const char *kFragmentShaderSrc =
+    "#version 100\n"
+    "precision mediump float;\n"
+    "uniform sampler2D u_textureY;\n"
+    "uniform sampler2D u_textureU;\n"
+    "uniform sampler2D u_textureV;\n"
+    "varying vec2 v_texCoord;\n"
+    "void main() {\n"
+    "    float y = texture2D(u_textureY, v_texCoord).r;\n"
+    "    float u = texture2D(u_textureU, v_texCoord).r - 0.5;\n"
+    "    float v = texture2D(u_textureV, v_texCoord).r - 0.5;\n"
+    "    float r = y + 1.402 * v;\n"
+    "    float g = y - 0.344136 * u - 0.714136 * v;\n"
+    "    float b = y + 1.772 * u;\n"
+    "    gl_FragColor = vec4(r, g, b, 1.0);\n"
+    "}\n";
 
 // ---------------------------------------------------------------------------
 // B3：EGL 初始化（在渲染线程内调用，nativeWindow 提供 EGLNativeWindowType）
@@ -1941,8 +1943,9 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
                  "FfmpegInitEGL: eglCreateContext failed err=0x%{public}x", eglGetError());
     return false;
   }
+  // 修复 #48-B6: %{public}d 让 EGL 版本号在 HarmonyOS hilog 中可见
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-               "FfmpegInitEGL: OK EGL %d.%d", major, minor);
+               "FfmpegInitEGL: OK EGL %{public}d.%{public}d", major, minor);
   return true;
 }
 
@@ -1953,6 +1956,10 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
 static GLuint CompileShader(GLenum type, const char *src) {
   const GLuint shader = glCreateShader(type);
   if (shader == 0) {
+    // 修复 #48-B6: glCreateShader 返回 0 说明 GL context 尚未生效
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "CompileShader: glCreateShader returned 0 (no GL context?) type=%{public}u",
+                 type);
     return 0;
   }
   glShaderSource(shader, 1, &src, nullptr);
@@ -1965,8 +1972,13 @@ static GLuint CompileShader(GLenum type, const char *src) {
     if (len > 1) {
       std::string log(static_cast<size_t>(len), '\0');
       glGetShaderInfoLog(shader, len, nullptr, &log[0]);
+      // 修复 #48-B6: %{public}s 才能在 HarmonyOS hilog 中显示字符串内容（%s 为私有格式）
       OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                   "CompileShader: type=%u err: %s", type, log.c_str());
+                   "CompileShader: type=%{public}u compile error: %{public}s",
+                   type, log.c_str());
+    } else {
+      OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                   "CompileShader: type=%{public}u compile error (no info log)", type);
     }
     glDeleteShader(shader);
     return 0;
@@ -2041,8 +2053,9 @@ static bool FfmpegInitGLResources(FfmpegContext *ctx) {
                quadVertices, GL_STATIC_DRAW);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 
+  // 修复 #48-B6: %{public}u 让资源 ID 在 hilog 中可见
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-               "FfmpegInitGLResources: OK prog=%u Y=%u U=%u V=%u vbo=%u",
+               "FfmpegInitGLResources: OK prog=%{public}u Y=%{public}u U=%{public}u V=%{public}u vbo=%{public}u",
                ctx->yuvProgram, ctx->textureY, ctx->textureU, ctx->textureV,
                ctx->quadVBO);
   return true;

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1887,6 +1887,7 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
       EGL_RED_SIZE,   8,
       EGL_GREEN_SIZE, 8,
       EGL_BLUE_SIZE,  8,
+      EGL_ALPHA_SIZE, 8,   // 完整 RGBA，帮助选到与 NativeWindow 格式匹配的 config
       EGL_NONE
   };
   EGLConfig config = nullptr;
@@ -1897,10 +1898,20 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
                  "FfmpegInitEGL: eglChooseConfig failed err=0x%{public}x", eglGetError());
     return false;
   }
-  // 修复1: 打印 nativeWindow 指针，并清除历史 EGL 错误，确保后续 eglGetError 干净
+  // 修复4 (#48-B6): HarmonyOS 必须在 eglCreateWindowSurface 前设置 NativeWindow buffer 格式
+  //   与 EGL Config 匹配，否则返回 EGL_BAD_MATCH (0x3009)。
+  EGLint nativeVisualId = 0;
+  eglGetConfigAttrib(ctx->eglDisplay, config, EGL_NATIVE_VISUAL_ID, &nativeVisualId);
+  if (nativeVisualId == 0) {
+    nativeVisualId = 3;  // fallback: NATIVEBUFFER_PIXEL_FMT_RGBA_8888 = 3 in OpenHarmony
+  }
+  OH_NativeWindow_NativeWindowHandleOpt(nativeWindow, SET_FORMAT, nativeVisualId);
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-               "FfmpegInitEGL: calling eglCreateWindowSurface window=%{public}p", nativeWindow);
-  (void)eglGetError(); // 清除待处理的 EGL 错误
+               "FfmpegInitEGL: set NativeWindow format=%{public}d window=%{public}p",
+               nativeVisualId, nativeWindow);
+
+  // 清除历史 EGL 错误，确保后续 eglGetError 干净
+  (void)eglGetError();
   // 修复3: eglCreateWindowSurface 失败时重试 3 次（间隔 100ms），
   //        防御 OH_AVPlayer 异步清理尚未完成导致 Window 仍被占用的情况。
   ctx->eglSurface = EGL_NO_SURFACE;

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -49,6 +49,11 @@ extern "C" {
 #ifndef GL_RED
 #  define GL_RED 0x1903
 #endif
+// GL_R8 是 GLES 3.0 引入的单通道有大小内部格式；GLES 2.0 头文件不含此宏。
+// 首帧 glTexImage2D 用 GL_R8 作为 internalformat，可避免驱动因格式歧义重复分配。
+#ifndef GL_R8
+#  define GL_R8 0x8229
+#endif
 
 // B4：OH_AudioRenderer（PCM 送显）
 #include <ohaudio/native_audiostreambuilder.h>
@@ -780,6 +785,11 @@ struct FfmpegContext {
   GLuint textureU = 0;     // U 分量纹理（GL_LUMINANCE，width/2×height/2）
   GLuint textureV = 0;     // V 分量纹理（GL_LUMINANCE，width/2×height/2）
   GLuint quadVBO = 0;      // 全屏四边形顶点缓冲
+
+  // Fix #48-B6: 首帧后置 true，后续帧用 TexSubImage2D 避免每帧重分配 GPU 纹理存储
+  bool texturesInitialized = false;
+  int  textureW = 0;       // 当前已分配纹理宽（用于 sizeChanged 校验）
+  int  textureH = 0;       // 当前已分配纹理高
 
   // B3：渲染线程
   std::thread renderThread;
@@ -2462,29 +2472,55 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
 
     ctx->gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
+    // Fix #48-B6: 首帧（或分辨率切换时）用 glTexImage2D 分配纹理存储；
+    // 后续帧改用 glTexSubImage2D 直接更新数据，避免每帧重新分配导致 GL_OUT_OF_MEMORY。
+    const bool sizeChanged = (w != ctx->textureW || h != ctx->textureH);
+
     ctx->gl.ActiveTexture(GL_TEXTURE0);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureY);
-    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RED, w, h, 0,
-                 GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
-    // 诊断: #48-B6 验证 GL_RED 在 GLES 3 context 下是否合法（应 GL_NO_ERROR）
-    {
-        GLenum glErr = ctx->gl.GetError();
-        if (glErr != GL_NO_ERROR) {
-            OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                         "RenderThread: glTexImage2D Y error=0x%{public}x"
-                         " w=%{public}d h=%{public}d", glErr, w, h);
+    if (!ctx->texturesInitialized || sizeChanged) {
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0,
+                     GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
+        // 诊断: #48-B6 验证 GL_R8/GL_RED 在 GLES 3 context 下是否合法（应 GL_NO_ERROR）
+        // 仅在首帧或尺寸变更时打印，避免日志刷屏
+        {
+            GLenum glErr = ctx->gl.GetError();
+            if (glErr != GL_NO_ERROR) {
+                OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                             "RenderThread: glTexImage2D Y error=0x%{public}x"
+                             " w=%{public}d h=%{public}d", glErr, w, h);
+            }
         }
+    } else {
+        ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h,
+                        GL_RED, GL_UNSIGNED_BYTE, frame->data[0]);
     }
 
     ctx->gl.ActiveTexture(GL_TEXTURE1);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureU);
-    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RED, w / 2, h / 2, 0,
-                 GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
+    if (!ctx->texturesInitialized || sizeChanged) {
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w / 2, h / 2, 0,
+                     GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
+    } else {
+        ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w / 2, h / 2,
+                        GL_RED, GL_UNSIGNED_BYTE, frame->data[1]);
+    }
 
     ctx->gl.ActiveTexture(GL_TEXTURE2);
     ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureV);
-    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RED, w / 2, h / 2, 0,
-                 GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
+    if (!ctx->texturesInitialized || sizeChanged) {
+        ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_R8, w / 2, h / 2, 0,
+                     GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
+    } else {
+        ctx->gl.TexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w / 2, h / 2,
+                        GL_RED, GL_UNSIGNED_BYTE, frame->data[2]);
+    }
+
+    if (!ctx->texturesInitialized || sizeChanged) {
+        ctx->texturesInitialized = true;
+        ctx->textureW = w;
+        ctx->textureH = h;
+    }
 
     // 6. 用 YUV program 绘制全屏 quad（triangle strip，4 顶点）
     ctx->gl.UseProgram(ctx->yuvProgram);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -684,6 +684,9 @@ struct AVFrameQueue {
   int maxSize = 4;  // 视频帧不需要太大，以控制内存压力
 };
 
+// 前向声明，供 FfmpegContext 持有反向指针（FFmpeg ctx 由 state 独占拥有，生命周期安全）
+struct NativePlayerSkeletonState;
+
 // FFmpeg 上下文：格式探测 + demux 线程 + 双队列
 struct FfmpegContext {
   AVFormatContext *fmtCtx = nullptr;
@@ -732,6 +735,17 @@ struct FfmpegContext {
   OH_AudioStreamBuilder *audioBuilder = nullptr;
   SwrContext *swrCtx = nullptr;          // libswresample 重采样上下文（源格式 → stereo S16 48kHz）
   std::vector<int16_t> pcmLeftover;      // swr_convert 溢出缓冲：跨 callback 的剩余 PCM 数据
+
+  // B5：音频时钟（主时钟）
+  std::atomic<int64_t> audioPtsSamples{0};  // 已渲染的音频样本数（stereo stereo 计数，swr 输出 48kHz）
+  int audioSampleRate{0};                    // swr 输出采样率（48000），FfmpegInitSwr 后固定
+
+  // B5：seek 请求（Seek() NAPI 写入，DemuxThreadFunc 消费）
+  std::atomic<bool> seekRequested{false};
+  std::atomic<int64_t> seekTargetMs{-1};
+
+  // B5：反向指针，供 DemuxThreadFunc 发出 seekDone TSF；生命周期安全（state 独占拥有 ffmpegCtx）
+  NativePlayerSkeletonState *ownerState{nullptr};
 };
 
 struct NativePlayerSkeletonState {
@@ -1377,6 +1391,65 @@ static int FfmpegOpenInput(FfmpegContext *ctx, const std::string &url) {
   return 0;
 }
 
+// ---------------------------------------------------------------------------
+// B5：音频时钟辅助（主时钟，单位：秒）
+// ---------------------------------------------------------------------------
+
+static double AudioClock(const FfmpegContext *ctx) {
+  if (ctx->audioSampleRate <= 0) return 0.0;
+  return static_cast<double>(ctx->audioPtsSamples.load(std::memory_order_relaxed))
+         / static_cast<double>(ctx->audioSampleRate);
+}
+
+// ---------------------------------------------------------------------------
+// B5：清空所有 packet/frame 队列（seek 时调用，清除过期数据）
+// ---------------------------------------------------------------------------
+
+static void FlushFfmpegQueues(FfmpegContext *ctx) {
+  {
+    std::lock_guard<std::mutex> lk(ctx->videoQueue.mtx);
+    while (!ctx->videoQueue.packets.empty()) {
+      AVPacket *p = ctx->videoQueue.packets.front();
+      ctx->videoQueue.packets.pop();
+      av_packet_free(&p);
+    }
+  }
+  ctx->videoQueue.cv.notify_all();
+
+  {
+    std::lock_guard<std::mutex> lk(ctx->audioQueue.mtx);
+    while (!ctx->audioQueue.packets.empty()) {
+      AVPacket *p = ctx->audioQueue.packets.front();
+      ctx->audioQueue.packets.pop();
+      av_packet_free(&p);
+    }
+  }
+  ctx->audioQueue.cv.notify_all();
+
+  {
+    std::lock_guard<std::mutex> lk(ctx->videoFrameQueue.mtx);
+    while (!ctx->videoFrameQueue.frames.empty()) {
+      AVFrame *f = ctx->videoFrameQueue.frames.front();
+      ctx->videoFrameQueue.frames.pop();
+      av_frame_free(&f);
+    }
+  }
+  ctx->videoFrameQueue.cv.notify_all();
+
+  {
+    std::lock_guard<std::mutex> lk(ctx->audioFrameQueue.mtx);
+    while (!ctx->audioFrameQueue.frames.empty()) {
+      AVFrame *f = ctx->audioFrameQueue.frames.front();
+      ctx->audioFrameQueue.frames.pop();
+      av_frame_free(&f);
+    }
+  }
+  ctx->audioFrameQueue.cv.notify_all();
+
+  // 清空 swr 溢出缓冲（避免 seek 后播放旧数据）
+  ctx->pcmLeftover.clear();
+}
+
 // demux 线程主循环：持续读帧，分发至视频/音频队列
 static void DemuxThreadFunc(FfmpegContext *ctx) {
   if (ctx == nullptr || ctx->fmtCtx == nullptr) {
@@ -1391,6 +1464,31 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
   }
 
   while (ctx->demuxRunning.load()) {
+    // B5：检查 seek 请求（由 Seek() NAPI 设置，在 demux 线程消费以保证 avformat 线程安全）
+    if (ctx->seekRequested.exchange(false)) {
+      const int64_t targetMs = ctx->seekTargetMs.load();
+      const int64_t targetUs = targetMs * 1000LL;  // AV_TIME_BASE = 1e6
+      av_seek_frame(ctx->fmtCtx, -1, targetUs, AVSEEK_FLAG_BACKWARD);
+      // 清空所有 packet/frame 队列（旧数据）
+      FlushFfmpegQueues(ctx);
+      // 刷新解码器内部缓冲区
+      if (ctx->videoCodecCtx != nullptr) avcodec_flush_buffers(ctx->videoCodecCtx);
+      if (ctx->audioCodecCtx != nullptr) avcodec_flush_buffers(ctx->audioCodecCtx);
+      // 重置音频时钟（seek 后从新位置重新计时）
+      ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                   "DemuxThread: seeked to %lld ms", static_cast<long long>(targetMs));
+      // 发出 seekDone TSF 通知 ArkTS
+      if (ctx->ownerState != nullptr) {
+        NativePlayerSkeletonState *st = ctx->ownerState;
+        std::lock_guard<std::mutex> lk(st->stateMutex);
+        st->currentTimeMs = targetMs;
+      }
+      if (ctx->ownerState != nullptr && ctx->ownerState->tsfOnSeekDone != nullptr) {
+        napi_call_threadsafe_function(ctx->ownerState->tsfOnSeekDone, nullptr, napi_tsfn_nonblocking);
+      }
+    }
+
     int ret = av_read_frame(ctx->fmtCtx, pkt);
     if (ret == AVERROR_EOF) {
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "DemuxThread: EOF reached");
@@ -1933,6 +2031,9 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                "RenderThreadFunc: render loop started");
 
+  // B5：时间上报节流（每 200ms 通过 tsfOnTimeUpdate 上报一次播放位置）
+  auto lastEmitTime = std::chrono::steady_clock::now() - std::chrono::seconds(1);
+
   while (ctx->renderRunning.load()) {
     // 4. 从 videoFrameQueue 消费一帧（最多等 16ms）
     AVFrame *frame = nullptr;
@@ -1952,6 +2053,39 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
 
     if (frame == nullptr) {
       continue;
+    }
+
+    // B5：AV 同步：以音频时钟为主时钟，决定等待或丢帧
+    if (ctx->videoStreamIdx >= 0 && ctx->audioSampleRate > 0) {
+      const double videoPts = (frame->pts != AV_NOPTS_VALUE)
+          ? frame->pts * av_q2d(ctx->fmtCtx->streams[ctx->videoStreamIdx]->time_base)
+          : 0.0;
+      const double audioClock = AudioClock(ctx);
+      const double diff = videoPts - audioClock;
+
+      if (diff > 0.1) {
+        // 视频超前音频 100ms 以上：等待音频跟上，最多等 500ms
+        const int sleepMs = static_cast<int>(std::min(diff * 1000.0, 500.0));
+        std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
+      } else if (diff < -0.5) {
+        // 视频落后音频 500ms 以上：丢弃此帧（追帧）
+        av_frame_free(&frame);
+        continue;
+      }
+
+      // B5：每 200ms 上报一次播放位置给 ArkTS（以音频时钟为准）
+      const auto now = std::chrono::steady_clock::now();
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(now - lastEmitTime).count() >= 200) {
+        lastEmitTime = now;
+        const int64_t posMs = static_cast<int64_t>(audioClock * 1000.0);
+        {
+          std::lock_guard<std::mutex> lk(state->stateMutex);
+          state->currentTimeMs = posMs;
+        }
+        if (state->tsfOnTimeUpdate != nullptr) {
+          napi_call_threadsafe_function(state->tsfOnTimeUpdate, nullptr, napi_tsfn_nonblocking);
+        }
+      }
     }
 
     // 5. 上传 YUV420P → 3 张 GL_LUMINANCE 纹理
@@ -2103,6 +2237,8 @@ static bool FfmpegInitSwr(FfmpegContext *ctx) {
                "FfmpegInitSwr: OK src(fmt=%d rate=%d ch=%d) → stereo S16 48kHz",
                static_cast<int>(aCtx->sample_fmt), aCtx->sample_rate,
                aCtx->ch_layout.nb_channels);
+  // B5：记录 swr 输出采样率，供音频时钟计算（48kHz 固定）
+  ctx->audioSampleRate = 48000;
   return true;
 }
 
@@ -2196,11 +2332,11 @@ static OH_AudioData_Callback_Result AudioWriteDataCallback(
     }
   }
 
+  // B5：更新音频时钟（本次 callback 共输出 samplesNeeded 个样本）
+  ctx->audioPtsSamples.fetch_add(static_cast<int64_t>(samplesNeeded), std::memory_order_relaxed);
+
   return AUDIO_DATA_CALLBACK_RESULT_VALID;
 }
-
-// ---------------------------------------------------------------------------
-// B4：OH_AudioRenderer 初始化（stereo S16LE 48kHz，MOVIE 用途）
 // ---------------------------------------------------------------------------
 
 static bool FfmpegInitAudioRenderer(FfmpegContext *ctx) {
@@ -2342,6 +2478,13 @@ static void StartFfmpegDecode(NativePlayerSkeletonState *state) {
                state->ffmpegWidth, state->ffmpegHeight,
                state->ffmpegFps, static_cast<long long>(state->ffmpegDurationMs));
 
+  // B5：设置 durationMs 并标记 prepared，确保 ArkTS getDuration() 返回正确值
+  {
+    std::lock_guard<std::mutex> lk(state->stateMutex);
+    state->durationMs = state->ffmpegDurationMs;
+    state->prepared = true;
+  }
+
   // 启动解码线程
   ctx->decodeRunning.store(true);
   if (ctx->videoCodecCtx != nullptr) {
@@ -2357,6 +2500,14 @@ static void StartFfmpegDecode(NativePlayerSkeletonState *state) {
 
   // B3：启动 OpenGL ES YUV 渲染线程（消费 videoFrameQueue）
   StartFfmpegRender(state);
+
+  // B5：触发 onPrepared 回调（通知 ArkTS 播放器已就绪，duration 已设置）
+  if (state->tsfOnPrepared != nullptr) {
+    napi_call_threadsafe_function(state->tsfOnPrepared, nullptr, napi_tsfn_nonblocking);
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "StartFfmpegDecode: tsfOnPrepared triggered, durationMs=%lld",
+                 static_cast<long long>(state->durationMs));
+  }
 }
 
 static void StopFfmpegDecode(NativePlayerSkeletonState *state) {
@@ -2454,6 +2605,9 @@ static void StartFfmpegDemux(NativePlayerSkeletonState *state, const std::string
     return;
   }
 
+  // B5：设置反向指针，供 DemuxThreadFunc 发出 seekDone TSF
+  ctx->ownerState = state;
+
   ctx->demuxRunning.store(true);
   ctx->demuxThread = std::thread(DemuxThreadFunc, ctx.get());
   state->ffmpegCtx = std::move(ctx);
@@ -2483,6 +2637,8 @@ static void StopFfmpegDemux(NativePlayerSkeletonState *state) {
   // 1. 通知中断：让阻塞的 av_read_frame / avformat_open_input 尽快返回
   ctx->interruptFlag.store(true);
   ctx->demuxRunning.store(false);
+  // B5：清除 ownerState 反向指针，防止 join 后悬挂访问（demux 线程循环已由 demuxRunning=false 终止）
+  ctx->ownerState = nullptr;
 
   // 2. 唤醒可能阻塞在 cv.wait 的 demux 线程（队列满等待）
   {
@@ -3192,6 +3348,24 @@ static napi_value Seek(napi_env env, napi_callback_info info) {
   if (positionMs < 0) {
     positionMs = 0;
   }
+
+  // B5：FFmpeg 路径：通过原子标志异步触发 demux 线程执行 av_seek_frame
+  if (state.useFfmpegPath && state.ffmpegCtx != nullptr) {
+    {
+      std::lock_guard<std::mutex> lock(state.stateMutex);
+      if (state.durationMs > 0 && positionMs > state.durationMs) {
+        positionMs = state.durationMs;
+      }
+      state.currentTimeMs = positionMs;
+    }
+    state.ffmpegCtx->seekTargetMs.store(positionMs);
+    state.ffmpegCtx->seekRequested.store(true);
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "Seek: FFmpeg path seek requested to %lld ms",
+                 static_cast<long long>(positionMs));
+    return ReturnUndefinedOrThrow(env, "seek failed to create return value");
+  }
+
   {
     // PR#49（问题6）：保护 currentTimeMs/durationMs/lastRealtimeMs 读写；OH_AVPlayer_Seek 在锁外
     std::lock_guard<std::mutex> lock(state.stateMutex);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -2487,8 +2487,8 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
         // 诊断: 仅在首帧或尺寸变更时检查 GL 错误
         {
             GLenum glErr = ctx->gl.GetError();
-            OH_LOG_Print(glErr == GL_NO_ERROR ? LOG_INFO : LOG_ERROR,
-                         LOG_APP, 0xFF00, "VidAll",
+            OH_LOG_Print(LOG_APP, glErr == GL_NO_ERROR ? LOG_INFO : LOG_ERROR,
+                         0xFF00, "VidAll",
                          "RenderThread: glTexImage2D RGBA err=0x%{public}x w=%{public}d h=%{public}d",
                          glErr, w, h);
         }

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1683,6 +1683,388 @@ static void AudioDecodeThreadFunc(FfmpegContext *ctx) {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
+// B3：GLSL shader 字符串（YUV420P → RGB，mediump float）
+// ---------------------------------------------------------------------------
+
+static const char *kVertexShaderSrc = R"(
+attribute vec4 a_position;
+attribute vec2 a_texCoord;
+varying vec2 v_texCoord;
+void main() {
+    gl_Position = a_position;
+    v_texCoord = a_texCoord;
+}
+)";
+
+static const char *kFragmentShaderSrc = R"(
+precision mediump float;
+uniform sampler2D u_textureY;
+uniform sampler2D u_textureU;
+uniform sampler2D u_textureV;
+varying vec2 v_texCoord;
+void main() {
+    float y = texture2D(u_textureY, v_texCoord).r;
+    float u = texture2D(u_textureU, v_texCoord).r - 0.5;
+    float v = texture2D(u_textureV, v_texCoord).r - 0.5;
+    float r = y + 1.402 * v;
+    float g = y - 0.344136 * u - 0.714136 * v;
+    float b = y + 1.772 * u;
+    gl_FragColor = vec4(r, g, b, 1.0);
+}
+)";
+
+// ---------------------------------------------------------------------------
+// B3：EGL 初始化（在渲染线程内调用，nativeWindow 提供 EGLNativeWindowType）
+// ---------------------------------------------------------------------------
+
+static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
+  ctx->eglDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  if (ctx->eglDisplay == EGL_NO_DISPLAY) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitEGL: eglGetDisplay failed");
+    return false;
+  }
+  EGLint major = 0, minor = 0;
+  if (!eglInitialize(ctx->eglDisplay, &major, &minor)) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitEGL: eglInitialize failed err=0x%x", eglGetError());
+    return false;
+  }
+  EGLint attribs[] = {
+      EGL_SURFACE_TYPE,    EGL_WINDOW_BIT,
+      EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+      EGL_RED_SIZE,   8,
+      EGL_GREEN_SIZE, 8,
+      EGL_BLUE_SIZE,  8,
+      EGL_NONE
+  };
+  EGLConfig config = nullptr;
+  EGLint numConfigs = 0;
+  if (!eglChooseConfig(ctx->eglDisplay, attribs, &config, 1, &numConfigs) ||
+      numConfigs == 0) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitEGL: eglChooseConfig failed err=0x%x", eglGetError());
+    return false;
+  }
+  ctx->eglSurface = eglCreateWindowSurface(
+      ctx->eglDisplay, config,
+      reinterpret_cast<EGLNativeWindowType>(nativeWindow), nullptr);
+  if (ctx->eglSurface == EGL_NO_SURFACE) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitEGL: eglCreateWindowSurface failed err=0x%x", eglGetError());
+    return false;
+  }
+  EGLint ctxAttribs[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
+  ctx->eglContext =
+      eglCreateContext(ctx->eglDisplay, config, EGL_NO_CONTEXT, ctxAttribs);
+  if (ctx->eglContext == EGL_NO_CONTEXT) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitEGL: eglCreateContext failed err=0x%x", eglGetError());
+    return false;
+  }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "FfmpegInitEGL: OK EGL %d.%d", major, minor);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// B3：shader 编译辅助
+// ---------------------------------------------------------------------------
+
+static GLuint CompileShader(GLenum type, const char *src) {
+  const GLuint shader = glCreateShader(type);
+  if (shader == 0) {
+    return 0;
+  }
+  glShaderSource(shader, 1, &src, nullptr);
+  glCompileShader(shader);
+  GLint status = 0;
+  glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
+  if (status == GL_FALSE) {
+    GLint len = 0;
+    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &len);
+    if (len > 1) {
+      std::string log(static_cast<size_t>(len), '\0');
+      glGetShaderInfoLog(shader, len, nullptr, &log[0]);
+      OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                   "CompileShader: type=%u err: %s", type, log.c_str());
+    }
+    glDeleteShader(shader);
+    return 0;
+  }
+  return shader;
+}
+
+// ---------------------------------------------------------------------------
+// B3：GL 资源初始化（在渲染线程 makeCurrent 后调用）
+// ---------------------------------------------------------------------------
+
+static bool FfmpegInitGLResources(FfmpegContext *ctx) {
+  // 1. 编译 & 链接 YUV→RGB program
+  const GLuint vs = CompileShader(GL_VERTEX_SHADER, kVertexShaderSrc);
+  const GLuint fs = CompileShader(GL_FRAGMENT_SHADER, kFragmentShaderSrc);
+  if (vs == 0 || fs == 0) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitGLResources: shader compile failed");
+    if (vs != 0) { glDeleteShader(vs); }
+    if (fs != 0) { glDeleteShader(fs); }
+    return false;
+  }
+  ctx->yuvProgram = glCreateProgram();
+  glAttachShader(ctx->yuvProgram, vs);
+  glAttachShader(ctx->yuvProgram, fs);
+  glBindAttribLocation(ctx->yuvProgram, 0, "a_position");
+  glBindAttribLocation(ctx->yuvProgram, 1, "a_texCoord");
+  glLinkProgram(ctx->yuvProgram);
+  glDeleteShader(vs);
+  glDeleteShader(fs);
+  GLint linked = 0;
+  glGetProgramiv(ctx->yuvProgram, GL_LINK_STATUS, &linked);
+  if (linked == GL_FALSE) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitGLResources: program link failed");
+    glDeleteProgram(ctx->yuvProgram);
+    ctx->yuvProgram = 0;
+    return false;
+  }
+
+  // 2. 绑定 sampler uniform（GL_TEXTURE0=Y, GL_TEXTURE1=U, GL_TEXTURE2=V）
+  glUseProgram(ctx->yuvProgram);
+  glUniform1i(glGetUniformLocation(ctx->yuvProgram, "u_textureY"), 0);
+  glUniform1i(glGetUniformLocation(ctx->yuvProgram, "u_textureU"), 1);
+  glUniform1i(glGetUniformLocation(ctx->yuvProgram, "u_textureV"), 2);
+
+  // 3. 创建 Y/U/V 三张 GL_LUMINANCE 纹理（实际尺寸由第一帧决定）
+  glGenTextures(1, &ctx->textureY);
+  glGenTextures(1, &ctx->textureU);
+  glGenTextures(1, &ctx->textureV);
+  const GLuint textures[3] = {ctx->textureY, ctx->textureU, ctx->textureV};
+  for (const GLuint tex : textures) {
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  }
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  // 4. 全屏四边形 VBO（triangle strip，x/y 为 NDC，s/t 为 UV）
+  // 顺序：左下、右下、左上、右上（匹配 UV 坐标 y 从下往上）
+  const float quadVertices[] = {
+      -1.0f, -1.0f,  0.0f, 1.0f,
+       1.0f, -1.0f,  1.0f, 1.0f,
+      -1.0f,  1.0f,  0.0f, 0.0f,
+       1.0f,  1.0f,  1.0f, 0.0f,
+  };
+  glGenBuffers(1, &ctx->quadVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, ctx->quadVBO);
+  glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(sizeof(quadVertices)),
+               quadVertices, GL_STATIC_DRAW);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "FfmpegInitGLResources: OK prog=%u Y=%u U=%u V=%u vbo=%u",
+               ctx->yuvProgram, ctx->textureY, ctx->textureU, ctx->textureV,
+               ctx->quadVBO);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// B3：GL 资源释放（在渲染线程内、eglMakeCurrent 有效时调用）
+// ---------------------------------------------------------------------------
+
+static void FfmpegCleanupGLResources(FfmpegContext *ctx) {
+  if (ctx->quadVBO != 0) {
+    glDeleteBuffers(1, &ctx->quadVBO);
+    ctx->quadVBO = 0;
+  }
+  if (ctx->textureY != 0) {
+    glDeleteTextures(1, &ctx->textureY);
+    ctx->textureY = 0;
+  }
+  if (ctx->textureU != 0) {
+    glDeleteTextures(1, &ctx->textureU);
+    ctx->textureU = 0;
+  }
+  if (ctx->textureV != 0) {
+    glDeleteTextures(1, &ctx->textureV);
+    ctx->textureV = 0;
+  }
+  if (ctx->yuvProgram != 0) {
+    glDeleteProgram(ctx->yuvProgram);
+    ctx->yuvProgram = 0;
+  }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "FfmpegCleanupGLResources: done");
+}
+
+// ---------------------------------------------------------------------------
+// B3：渲染线程（消费 videoFrameQueue，上传 YUV 纹理，eglSwapBuffers）
+// ---------------------------------------------------------------------------
+
+static void RenderThreadFunc(NativePlayerSkeletonState *state) {
+  FfmpegContext *ctx = state->ffmpegCtx.get();
+
+  // 1. EGL 初始化（创建 display/surface/context）
+  if (!FfmpegInitEGL(ctx, state->nativeWindow)) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "RenderThreadFunc: FfmpegInitEGL failed, exit");
+    ctx->renderRunning.store(false);
+    return;
+  }
+
+  // 2. 将 EGL context 绑定到当前线程
+  if (!eglMakeCurrent(ctx->eglDisplay, ctx->eglSurface,
+                      ctx->eglSurface, ctx->eglContext)) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "RenderThreadFunc: eglMakeCurrent failed err=0x%x", eglGetError());
+    ctx->renderRunning.store(false);
+    return;
+  }
+
+  // 3. 初始化 GL 资源（shader/纹理/VBO）
+  if (!FfmpegInitGLResources(ctx)) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "RenderThreadFunc: FfmpegInitGLResources failed, exit");
+    ctx->renderRunning.store(false);
+    return;
+  }
+
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "RenderThreadFunc: render loop started");
+
+  while (ctx->renderRunning.load()) {
+    // 4. 从 videoFrameQueue 消费一帧（最多等 16ms）
+    AVFrame *frame = nullptr;
+    {
+      std::unique_lock<std::mutex> lock(ctx->videoFrameQueue.mtx);
+      ctx->videoFrameQueue.cv.wait_for(lock, std::chrono::milliseconds(16), [&] {
+        return !ctx->videoFrameQueue.frames.empty() ||
+               ctx->videoFrameQueue.abort;
+      });
+      if (!ctx->videoFrameQueue.frames.empty()) {
+        frame = ctx->videoFrameQueue.frames.front();
+        ctx->videoFrameQueue.frames.pop();
+      }
+    }
+    // 通知解码线程队列有空位
+    ctx->videoFrameQueue.cv.notify_all();
+
+    if (frame == nullptr) {
+      continue;
+    }
+
+    // 5. 上传 YUV420P → 3 张 GL_LUMINANCE 纹理
+    const int w = frame->width;
+    const int h = frame->height;
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, ctx->textureY);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w, h, 0,
+                 GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[0]);
+
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, ctx->textureU);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
+                 GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[1]);
+
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, ctx->textureV);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
+                 GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[2]);
+
+    // 6. 用 YUV program 绘制全屏 quad（triangle strip，4 顶点）
+    glUseProgram(ctx->yuvProgram);
+    glBindBuffer(GL_ARRAY_BUFFER, ctx->quadVBO);
+    const GLsizei stride = static_cast<GLsizei>(4 * sizeof(float));
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, stride,
+                          reinterpret_cast<const void *>(0));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, stride,
+                          reinterpret_cast<const void *>(2 * sizeof(float)));
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    glDisableVertexAttribArray(0);
+    glDisableVertexAttribArray(1);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    // 7. 提交帧到屏幕
+    eglSwapBuffers(ctx->eglDisplay, ctx->eglSurface);
+
+    // 8. 释放当前帧
+    av_frame_free(&frame);
+  }
+
+  // 清理 GL 资源（makeCurrent 仍有效）
+  FfmpegCleanupGLResources(ctx);
+
+  // 清理 EGL
+  eglMakeCurrent(ctx->eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                 EGL_NO_CONTEXT);
+  eglDestroySurface(ctx->eglDisplay, ctx->eglSurface);
+  ctx->eglSurface = EGL_NO_SURFACE;
+  eglDestroyContext(ctx->eglDisplay, ctx->eglContext);
+  ctx->eglContext = EGL_NO_CONTEXT;
+  eglTerminate(ctx->eglDisplay);
+  ctx->eglDisplay = EGL_NO_DISPLAY;
+
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "RenderThreadFunc: render thread exited");
+}
+
+// ---------------------------------------------------------------------------
+// B3：启动 / 停止渲染线程
+// ---------------------------------------------------------------------------
+
+static void StartFfmpegRender(NativePlayerSkeletonState *state) {
+  if (state == nullptr || state->ffmpegCtx == nullptr) {
+    return;
+  }
+  FfmpegContext *ctx = state->ffmpegCtx.get();
+  if (ctx->videoCodecCtx == nullptr) {
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "StartFfmpegRender: no video stream, skip");
+    return;
+  }
+  if (state->nativeWindow == nullptr) {
+    // Surface 尚未就绪，延迟到 OnXCSurfaceCreated 触发后再启动
+    state->pendingFfmpegRender = true;
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "StartFfmpegRender: nativeWindow not ready, pendingFfmpegRender=true");
+    return;
+  }
+  state->pendingFfmpegRender = false;
+  ctx->renderRunning.store(true);
+  ctx->renderThread = std::thread(RenderThreadFunc, state);
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "StartFfmpegRender: render thread started");
+}
+
+static void StopFfmpegRender(NativePlayerSkeletonState *state) {
+  if (state == nullptr || state->ffmpegCtx == nullptr) {
+    return;
+  }
+  FfmpegContext *ctx = state->ffmpegCtx.get();
+  state->pendingFfmpegRender = false;
+  if (!ctx->renderRunning.load()) {
+    return;
+  }
+  ctx->renderRunning.store(false);
+  // 唤醒可能阻塞在 videoFrameQueue.cv.wait_for 的渲染线程
+  {
+    std::lock_guard<std::mutex> lk(ctx->videoFrameQueue.mtx);
+    ctx->videoFrameQueue.abort = true;
+  }
+  ctx->videoFrameQueue.cv.notify_all();
+  if (ctx->renderThread.joinable()) {
+    ctx->renderThread.join();
+  }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "StopFfmpegRender: render thread stopped");
+}
+
+// ---------------------------------------------------------------------------
 // B4：SwrContext 初始化（源格式 → stereo S16LE 48kHz）
 // ---------------------------------------------------------------------------
 
@@ -1972,6 +2354,9 @@ static void StartFfmpegDecode(NativePlayerSkeletonState *state) {
 
   // B4：解码器就绪后启动 OH_AudioRenderer（消费 audioFrameQueue）
   StartFfmpegAudio(state);
+
+  // B3：启动 OpenGL ES YUV 渲染线程（消费 videoFrameQueue）
+  StartFfmpegRender(state);
 }
 
 static void StopFfmpegDecode(NativePlayerSkeletonState *state) {
@@ -2085,6 +2470,9 @@ static void StopFfmpegDemux(NativePlayerSkeletonState *state) {
     return;
   }
   FfmpegContext *ctx = state->ffmpegCtx.get();
+
+  // B3：先停止渲染线程（消费 videoFrameQueue），避免访问已释放帧数据
+  StopFfmpegRender(state);
 
   // B4：先停止音频渲染器（消费者），再停止解码线程（生产者），避免 callback 访问已释放队列
   StopFfmpegAudio(state);
@@ -2290,6 +2678,10 @@ static void OnXCSurfaceCreated(OH_NativeXComponent *component, void *window) {
       pair.second.nativeWindow = static_cast<OHNativeWindow *>(window);
       pair.second.surfaceReady = true;
       found = true;
+      // B3：若 FFmpeg 渲染线程在等待 nativeWindow，现在 Surface 就绪，补发启动
+      if (pair.second.useFfmpegPath && pair.second.pendingFfmpegRender) {
+        StartFfmpegRender(&pair.second);
+      }
       // A5修复: 若 avPlayer 已创建，立即绑定 surface
       if (pair.second.avPlayer != nullptr) {
         OH_AVPlayer_SetVideoSurface(pair.second.avPlayer, pair.second.nativeWindow);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1883,6 +1883,13 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
                  "FfmpegInitEGL: eglInitialize failed err=0x%{public}x", eglGetError());
     return false;
   }
+  // 修复 #48-B6: HarmonyOS 必须显式绑定 EGL client API，否则 eglMakeCurrent 后
+  // GL dispatch table 不挂载，所有 GL 函数（含 glCreateShader）均走 no-op 返回 0
+  if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "FfmpegInitEGL: eglBindAPI failed err=0x%{public}x", eglGetError());
+    return false;
+  }
   EGLint attribs[] = {
       EGL_SURFACE_TYPE,    EGL_WINDOW_BIT,
       EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
@@ -2122,6 +2129,8 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   }
 
   // 2. 将 EGL context 绑定到当前线程
+  // 修复 #48-B6: 线程级显式 bind API，确保此线程的 GL dispatch table 正确挂载
+  eglBindAPI(EGL_OPENGL_ES_API);
   if (!eglMakeCurrent(ctx->eglDisplay, ctx->eglSurface,
                       ctx->eglSurface, ctx->eglContext)) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
@@ -2130,7 +2139,8 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
     return;
   }
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-               "RenderThreadFunc: eglMakeCurrent OK, GL context current");
+               "RenderThreadFunc: eglMakeCurrent OK, GL context current ctx=%{public}p",
+               static_cast<void*>(eglGetCurrentContext()));
 
   // 3. 初始化 GL 资源（shader/纹理/VBO）
   if (!FfmpegInitGLResources(ctx)) {

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -6,6 +6,8 @@
 #include <memory>
 #include <cerrno>
 #include <cstring>
+#include <cctype>
+#include <algorithm>
 #include <mutex>
 #include <thread>
 #include <queue>
@@ -17,6 +19,7 @@
 #include <native_buffer/native_buffer.h>
 #include <native_window/external_window.h>
 #include <multimedia/player_framework/avplayer.h>
+#include <multimedia/player_framework/native_avcapability.h>
 #include <multimedia/player_framework/native_avformat.h>
 #include <hilog/log.h>
 
@@ -63,6 +66,8 @@ extern "C" {
 #include <ohaudio/native_audiorenderer.h>
 
 namespace {
+
+constexpr bool kEnableNativeSubtitleDiagLog = false;
 
 static void ThrowTypeError(napi_env env, const char *message);
 static bool ReadUtf8String(napi_env env, napi_value value, std::string &output);
@@ -992,6 +997,14 @@ static napi_value CreateInt64(napi_env env, int64_t value) {
 static napi_value CreateUint32(napi_env env, uint32_t value) {
   napi_value result = nullptr;
   if (napi_create_uint32(env, value, &result) != napi_ok) {
+    return nullptr;
+  }
+  return result;
+}
+
+static napi_value CreateString(napi_env env, const char *value) {
+  napi_value result = nullptr;
+  if (napi_create_string_utf8(env, value, NAPI_AUTO_LENGTH, &result) != napi_ok) {
     return nullptr;
   }
   return result;
@@ -3456,18 +3469,32 @@ static void OnAVPlayerInfoCB(OH_AVPlayer *player, AVPlayerOnInfoType type,
       int64_t durationMs = 0;
       int32_t startTimeInt = 0;
       int32_t durationInt = 0;
-      if (OH_AVFormat_GetStringValue(infoBody, "text", &text) && text != nullptr) {
+      if ((OH_AVFormat_GetStringValue(infoBody, "subtitle_text", &text) ||
+           OH_AVFormat_GetStringValue(infoBody, "text", &text)) && text != nullptr) {
         subtitleData->text = new std::string(text);
       }
-      if (OH_AVFormat_GetLongValue(infoBody, "startTime", &startTimeMs)) {
+      if (OH_AVFormat_GetLongValue(infoBody, "subtitle_pts", &startTimeMs) ||
+          OH_AVFormat_GetLongValue(infoBody, "startTime", &startTimeMs)) {
         subtitleData->startTimeMs = startTimeMs;
-      } else if (OH_AVFormat_GetIntValue(infoBody, "startTime", &startTimeInt)) {
+      } else if (OH_AVFormat_GetIntValue(infoBody, "subtitle_pts", &startTimeInt) ||
+                 OH_AVFormat_GetIntValue(infoBody, "startTime", &startTimeInt)) {
         subtitleData->startTimeMs = static_cast<int64_t>(startTimeInt);
       }
-      if (OH_AVFormat_GetLongValue(infoBody, "duration", &durationMs)) {
+      if (OH_AVFormat_GetLongValue(infoBody, "subtitle_duration", &durationMs) ||
+          OH_AVFormat_GetLongValue(infoBody, "duration", &durationMs)) {
         subtitleData->durationMs = durationMs;
-      } else if (OH_AVFormat_GetIntValue(infoBody, "duration", &durationInt)) {
+      } else if (OH_AVFormat_GetIntValue(infoBody, "subtitle_duration", &durationInt) ||
+                 OH_AVFormat_GetIntValue(infoBody, "duration", &durationInt)) {
         subtitleData->durationMs = static_cast<int64_t>(durationInt);
+      }
+      if (kEnableNativeSubtitleDiagLog) {
+        const char *dumpInfo = OH_AVFormat_DumpInfo(infoBody);
+        OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                     "SubtitleUpdate: text=%{public}s start=%{public}lld duration=%{public}lld dump=%{public}s",
+                     subtitleData->text != nullptr ? subtitleData->text->c_str() : "(null)",
+                     static_cast<long long>(subtitleData->startTimeMs),
+                     static_cast<long long>(subtitleData->durationMs),
+                     dumpInfo != nullptr ? dumpInfo : "(null)");
       }
       napi_call_threadsafe_function(state->tsfOnSubtitleUpdate, subtitleData, napi_tsfn_nonblocking);
       break;
@@ -4313,19 +4340,23 @@ static napi_value SelectTrack(napi_env env, napi_callback_info info) {
   if (wasPlaying) {
     OH_AVPlayer_Pause(avPlayer);
   }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "SelectTrack: previous=%{public}d target=%{public}d wasPlaying=%{public}d",
+               previousTrackIndex, trackIndex, wasPlaying ? 1 : 0);
 
   OH_AVErrCode rc = AV_ERR_OK;
   if (trackIndex >= 0) {
     rc = OH_AVPlayer_SelectTrack(avPlayer, trackIndex);
-  } else if (previousTrackIndex >= 0) {
-    rc = OH_AVPlayer_DeselectTrack(avPlayer, previousTrackIndex);
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "SelectTrack: select target=%{public}d rc=%{public}d",
+                 trackIndex, static_cast<int32_t>(rc));
   }
 
   if (rc != AV_ERR_OK) {
     if (wasPlaying) {
       OH_AVPlayer_Play(avPlayer);
     }
-    EmitError(state, ERR_SELECT_TRACK_FAILED, "selectTrack failed: OH_AVPlayer_SelectTrack/DeselectTrack returned error");
+    EmitError(state, ERR_SELECT_TRACK_FAILED, "selectTrack failed: OH_AVPlayer_SelectTrack returned error");
     return ReturnUndefinedOrThrow(env, "selectTrack failed to create return value");
   }
 
@@ -4842,6 +4873,179 @@ static napi_value GetNativeCapabilities(napi_env env, napi_callback_info info) {
   return result;
 }
 
+struct AudioDecoderCapabilityResult {
+  bool capabilityKnown = false;
+  bool supported = false;
+  bool isHardware = false;
+  int32_t maxChannels = 0;
+  std::string decoderName;
+  std::string mimeType;
+  std::string errorMessage;
+};
+
+static std::string ToLowerString(const std::string &value) {
+  std::string result = value;
+  std::transform(result.begin(), result.end(), result.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return result;
+}
+
+static std::vector<std::string> BuildAudioMimeCandidates(const std::string &codecOrMime) {
+  const std::string normalized = ToLowerString(codecOrMime);
+  if (normalized.empty()) {
+    return {};
+  }
+
+  std::vector<std::string> candidates;
+  auto pushUnique = [&candidates](const std::string &candidate) {
+    if (candidate.empty()) {
+      return;
+    }
+    if (std::find(candidates.begin(), candidates.end(), candidate) == candidates.end()) {
+      candidates.push_back(candidate);
+    }
+  };
+
+  if (normalized.rfind("audio/", 0) == 0) {
+    pushUnique(normalized);
+  }
+
+  if (normalized == "aac" || normalized == "mp4a" || normalized == "mp4a-latm") {
+    pushUnique("audio/mp4a-latm");
+  } else if (normalized == "mp3" || normalized == "mpeg" || normalized == "mpga") {
+    pushUnique("audio/mpeg");
+  } else if (normalized == "flac") {
+    pushUnique("audio/flac");
+  } else if (normalized == "vorbis") {
+    pushUnique("audio/vorbis");
+  } else if (normalized == "opus") {
+    pushUnique("audio/opus");
+  } else if (normalized == "pcm" || normalized == "pcm_s16le" || normalized == "pcm_s24le" ||
+             normalized == "pcm_s32le" || normalized == "audio/raw") {
+    pushUnique("audio/raw");
+  } else if (normalized == "ac3" || normalized == "ac-3") {
+    pushUnique("audio/ac3");
+  } else if (normalized == "eac3" || normalized == "e-ac-3") {
+    pushUnique("audio/eac3");
+  } else if (normalized == "dts") {
+    pushUnique("audio/vnd.dts");
+  } else if (normalized == "dtshd" || normalized == "dts-hd" || normalized == "dts_hd") {
+    pushUnique("audio/vnd.dts.hd");
+  } else if (normalized == "truehd" || normalized == "true-hd") {
+    pushUnique("audio/truehd");
+  } else if (normalized == "ape") {
+    pushUnique("audio/ape");
+  } else if (normalized == "alac") {
+    pushUnique("audio/alac");
+  } else if (normalized == "vivid" || normalized == "audio vivid") {
+    pushUnique("audio/audio-vivid");
+  }
+
+  return candidates;
+}
+
+static AudioDecoderCapabilityResult QueryAudioDecoderCapabilityInternal(const std::string &codecOrMime) {
+  AudioDecoderCapabilityResult result;
+  const std::vector<std::string> mimeCandidates = BuildAudioMimeCandidates(codecOrMime);
+  if (mimeCandidates.empty()) {
+    result.errorMessage = "unsupported codec mapping";
+    return result;
+  }
+
+  result.capabilityKnown = true;
+  result.mimeType = mimeCandidates.front();
+
+  for (const std::string &mime : mimeCandidates) {
+    OH_AVCapability *capability = OH_AVCodec_GetCapabilityByCategory(mime.c_str(), false, HARDWARE);
+    bool isHardware = true;
+    if (capability == nullptr) {
+      capability = OH_AVCodec_GetCapabilityByCategory(mime.c_str(), false, SOFTWARE);
+      isHardware = false;
+    }
+    if (capability == nullptr) {
+      capability = OH_AVCodec_GetCapability(mime.c_str(), false);
+      if (capability != nullptr) {
+        isHardware = OH_AVCapability_IsHardware(capability);
+      }
+    }
+    if (capability == nullptr) {
+      continue;
+    }
+
+    result.supported = true;
+    result.isHardware = isHardware;
+    result.mimeType = mime;
+
+    const char *decoderName = OH_AVCapability_GetName(capability);
+    if (decoderName != nullptr) {
+      result.decoderName = decoderName;
+    }
+
+    OH_AVRange channelRange;
+    channelRange.minVal = 0;
+    channelRange.maxVal = 0;
+    if (OH_AVCapability_GetAudioChannelCountRange(capability, &channelRange) == AV_ERR_OK) {
+      result.maxChannels = channelRange.maxVal;
+    }
+    return result;
+  }
+
+  result.errorMessage = "decoder not found";
+  return result;
+}
+
+static napi_value QueryAudioDecoderCapability(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1] = { nullptr };
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok) {
+    ThrowTypeError(env, "queryAudioDecoderCapability failed to read args");
+    return nullptr;
+  }
+  if (argc < 1) {
+    ThrowTypeError(env, "queryAudioDecoderCapability requires (codecOrMime)");
+    return nullptr;
+  }
+
+  std::string codecOrMime;
+  if (!ReadUtf8String(env, args[0], codecOrMime)) {
+    ThrowTypeError(env, "queryAudioDecoderCapability codecOrMime must be string");
+    return nullptr;
+  }
+
+  const AudioDecoderCapabilityResult capability = QueryAudioDecoderCapabilityInternal(codecOrMime);
+  napi_value result = nullptr;
+  if (napi_create_object(env, &result) != napi_ok || result == nullptr) {
+    ThrowTypeError(env, "queryAudioDecoderCapability failed to create result object");
+    return nullptr;
+  }
+
+  napi_value capabilityKnown = CreateBoolean(env, capability.capabilityKnown);
+  napi_value supported = CreateBoolean(env, capability.supported);
+  napi_value isHardware = CreateBoolean(env, capability.isHardware);
+  napi_value maxChannels = CreateInt32(env, capability.maxChannels);
+  napi_value decoderName = CreateString(env, capability.decoderName.c_str());
+  napi_value mimeType = CreateString(env, capability.mimeType.c_str());
+  napi_value errorMessage = CreateString(env, capability.errorMessage.c_str());
+  if (capabilityKnown == nullptr || supported == nullptr || isHardware == nullptr ||
+      maxChannels == nullptr || decoderName == nullptr || mimeType == nullptr || errorMessage == nullptr) {
+    ThrowTypeError(env, "queryAudioDecoderCapability failed to create result fields");
+    return nullptr;
+  }
+
+  if (napi_set_named_property(env, result, "capabilityKnown", capabilityKnown) != napi_ok ||
+      napi_set_named_property(env, result, "supported", supported) != napi_ok ||
+      napi_set_named_property(env, result, "isHardware", isHardware) != napi_ok ||
+      napi_set_named_property(env, result, "maxChannels", maxChannels) != napi_ok ||
+      napi_set_named_property(env, result, "decoderName", decoderName) != napi_ok ||
+      napi_set_named_property(env, result, "mimeType", mimeType) != napi_ok ||
+      napi_set_named_property(env, result, "errorMessage", errorMessage) != napi_ok) {
+    ThrowTypeError(env, "queryAudioDecoderCapability failed to set result fields");
+    return nullptr;
+  }
+  return result;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     { "createPlayer", nullptr, CreatePlayer, nullptr, nullptr, nullptr, napi_default, nullptr },
@@ -4862,7 +5066,8 @@ static napi_value Init(napi_env env, napi_value exports) {
     { "ffmpegSelfCheck", nullptr, FfmpegSelfCheck, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "webdavRequest", nullptr, WebdavRequest, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "downloadToFile", nullptr, DownloadToFile, nullptr, nullptr, nullptr, napi_default, nullptr },
-    { "getNativeCapabilities", nullptr, GetNativeCapabilities, nullptr, nullptr, nullptr, napi_default, nullptr }
+    { "getNativeCapabilities", nullptr, GetNativeCapabilities, nullptr, nullptr, nullptr, napi_default, nullptr },
+    { "queryAudioDecoderCapability", nullptr, QueryAudioDecoderCapability, nullptr, nullptr, nullptr, napi_default, nullptr }
   };
   if (napi_define_properties(env, exports, sizeof(descriptors) / sizeof(descriptors[0]), descriptors) != napi_ok) {
     ThrowTypeError(env, "failed to define native module properties");

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -745,7 +745,9 @@ struct FfmpegContext {
   std::atomic<int64_t> seekTargetMs{-1};
 
   // B5：反向指针，供 DemuxThreadFunc 发出 seekDone TSF；生命周期安全（state 独占拥有 ffmpegCtx）
-  NativePlayerSkeletonState *ownerState{nullptr};
+  // B5-QA fix：改为 atomic ptr，消除 StopFfmpegDemux(主线程) 写 nullptr 与
+  //            DemuxThreadFunc(demux 线程) 读+解引用之间的 data race（UB）。
+  std::atomic<NativePlayerSkeletonState *> ownerState{nullptr};
 };
 
 struct NativePlayerSkeletonState {
@@ -1468,7 +1470,16 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
     if (ctx->seekRequested.exchange(false)) {
       const int64_t targetMs = ctx->seekTargetMs.load();
       const int64_t targetUs = targetMs * 1000LL;  // AV_TIME_BASE = 1e6
-      av_seek_frame(ctx->fmtCtx, -1, targetUs, AVSEEK_FLAG_BACKWARD);
+      // B5-QA fix：检查 av_seek_frame 返回值；失败时跳过 flush/reset/seekDone，
+      //            避免在无效位置继续解码并产生误导性回调。
+      int seekRet = av_seek_frame(ctx->fmtCtx, -1, targetUs, AVSEEK_FLAG_BACKWARD);
+      if (seekRet < 0) {
+        char errBuf[AV_ERROR_MAX_STRING_SIZE];
+        av_strerror(seekRet, errBuf, sizeof(errBuf));
+        OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                     "DemuxThread: av_seek_frame failed: %s", errBuf);
+        continue;
+      }
       // 清空所有 packet/frame 队列（旧数据）
       FlushFfmpegQueues(ctx);
       // 刷新解码器内部缓冲区
@@ -1479,13 +1490,20 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                    "DemuxThread: seeked to %lld ms", static_cast<long long>(targetMs));
       // 发出 seekDone TSF 通知 ArkTS
-      if (ctx->ownerState != nullptr) {
-        NativePlayerSkeletonState *st = ctx->ownerState;
-        std::lock_guard<std::mutex> lk(st->stateMutex);
-        st->currentTimeMs = targetMs;
+      // B5-QA fix：通过 atomic load(acquire) 读取 ownerState，消除与主线程写 nullptr 的竞态；
+      //            两次独立 load 分别保护"写 currentTimeMs"和"调用 TSF"两个临界区。
+      {
+        NativePlayerSkeletonState *st = ctx->ownerState.load(std::memory_order_acquire);
+        if (st != nullptr) {
+          std::lock_guard<std::mutex> lk(st->stateMutex);
+          st->currentTimeMs = targetMs;
+        }
       }
-      if (ctx->ownerState != nullptr && ctx->ownerState->tsfOnSeekDone != nullptr) {
-        napi_call_threadsafe_function(ctx->ownerState->tsfOnSeekDone, nullptr, napi_tsfn_nonblocking);
+      {
+        NativePlayerSkeletonState *st = ctx->ownerState.load(std::memory_order_acquire);
+        if (st != nullptr && st->tsfOnSeekDone != nullptr) {
+          napi_call_threadsafe_function(st->tsfOnSeekDone, nullptr, napi_tsfn_nonblocking);
+        }
       }
     }
 
@@ -2064,8 +2082,8 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
       const double diff = videoPts - audioClock;
 
       if (diff > 0.1) {
-        // 视频超前音频 100ms 以上：等待音频跟上，最多等 500ms
-        const int sleepMs = static_cast<int>(std::min(diff * 1000.0, 500.0));
+        // 视频超前音频 100ms 以上：等待音频跟上，最多等 200ms（B5-QA: 500→200 降低 AV sync 延迟）
+        const int sleepMs = static_cast<int>(std::min(diff * 1000.0, 200.0));
         std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
       } else if (diff < -0.5) {
         // 视频落后音频 500ms 以上：丢弃此帧（追帧）
@@ -2638,7 +2656,9 @@ static void StopFfmpegDemux(NativePlayerSkeletonState *state) {
   ctx->interruptFlag.store(true);
   ctx->demuxRunning.store(false);
   // B5：清除 ownerState 反向指针，防止 join 后悬挂访问（demux 线程循环已由 demuxRunning=false 终止）
-  ctx->ownerState = nullptr;
+  // B5-QA fix：atomic store(release) 保证主线程写 nullptr 对 demux 线程的 load(acquire) 可见，
+  //            消除与 DemuxThreadFunc 读+解引用之间的 data race。
+  ctx->ownerState.store(nullptr, std::memory_order_release);
 
   // 2. 唤醒可能阻塞在 cv.wait 的 demux 线程（队列满等待）
   {

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -2097,31 +2097,20 @@ static void FfmpegCleanupGLResources(FfmpegContext *ctx) {
 static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   FfmpegContext *ctx = state->ffmpegCtx.get();
 
-  // 0. 修复2: 在 OH_AVPlayer_Release 之前，于锁内同时取出 nativeWindow 到局部变量。
-  //    OH_AVPlayer_Release 可能触发 OnXCSurfaceDestroyed，其在 g_playersMutex 保护下
-  //    把 state->nativeWindow 置 null，若直接使用 state->nativeWindow 会产生竞态。
-  //    用 localWindow 持有指针即可规避。
+  // 0. 在锁内读取 nativeWindow 到局部变量，避免与 OnXCSurfaceDestroyed 的竞态。
+  //    注意：不在此处释放 avPlayer —— OH_AVPlayer code=9 从未创建 EGL 资源，
+  //    且 Release() 会在播放器销毁时正确清理。
   OHNativeWindow *localWindow = nullptr;
-  OH_AVPlayer *avToRelease = nullptr;
   {
     std::lock_guard<std::mutex> lk(state->stateMutex);
-    localWindow   = state->nativeWindow; // 在锁内同时取出，保证一致性
-    avToRelease   = state->avPlayer;
-    state->avPlayer = nullptr;
+    localWindow = state->nativeWindow;
   }
 
   if (localWindow == nullptr) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                 "RenderThreadFunc: nativeWindow is null, cannot init EGL, abort");
+                 "RenderThreadFunc: nativeWindow is null, abort");
     ctx->renderRunning.store(false);
     return;
-  }
-
-  if (avToRelease != nullptr) {
-    OH_AVPlayer_Stop(avToRelease);
-    OH_AVPlayer_Release(avToRelease); // 阻塞；可能触发 OnXCSurfaceDestroyed 置 null state->nativeWindow
-    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                 "RenderThreadFunc: released OH_AVPlayer (localWindow=%{public}p)", localWindow);
   }
 
   // 1. EGL 初始化（使用局部保存的 localWindow，不受 OH_AVPlayer_Release 回调影响）
@@ -2140,6 +2129,8 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
     ctx->renderRunning.store(false);
     return;
   }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "RenderThreadFunc: eglMakeCurrent OK, GL context current");
 
   // 3. 初始化 GL 资源（shader/纹理/VBO）
   if (!FfmpegInitGLResources(ctx)) {

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -950,6 +950,8 @@ static constexpr int32_t ERR_SELECT_TRACK_NOT_PREPARED = 1004;
 static constexpr int32_t ERR_PAUSE_NOT_PREPARED = 1005;
 static constexpr int32_t ERR_SEEK_NOT_PREPARED = 1006;
 static constexpr int32_t ERR_SELECT_TRACK_INVALID_INDEX = 1007;
+static constexpr int32_t ERR_SELECT_TRACK_UNSUPPORTED = 1008;
+static constexpr int32_t ERR_SELECT_TRACK_FAILED = 1009;
 
 static void ThrowTypeError(napi_env env, const char *message) {
   napi_throw_type_error(env, nullptr, message);
@@ -4206,8 +4208,53 @@ static napi_value SelectTrack(napi_env env, napi_callback_info info) {
     EmitError(state, ERR_SELECT_TRACK_INVALID_INDEX, "selectTrack failed: trackIndex must be >= -1");
     return ReturnUndefinedOrThrow(env, "selectTrack failed to create return value");
   }
-  // Skeleton stage: cache selected track index only.
-  state.selectedTrackIndex = trackIndex;
+
+  if (state.useFfmpegPath && state.ffmpegCtx != nullptr) {
+    EmitError(state, ERR_SELECT_TRACK_UNSUPPORTED,
+              "selectTrack failed: FFmpeg path does not support native track switching yet");
+    return ReturnUndefinedOrThrow(env, "selectTrack failed to create return value");
+  }
+
+  OH_AVPlayer *avPlayer = nullptr;
+  bool wasPlaying = false;
+  int32_t previousTrackIndex = -1;
+  {
+    std::lock_guard<std::mutex> lk(state.stateMutex);
+    avPlayer = state.avPlayer;
+    wasPlaying = state.playing;
+    previousTrackIndex = state.selectedTrackIndex;
+  }
+  if (avPlayer == nullptr) {
+    EmitError(state, ERR_SELECT_TRACK_UNSUPPORTED, "selectTrack failed: avPlayer is unavailable");
+    return ReturnUndefinedOrThrow(env, "selectTrack failed to create return value");
+  }
+
+  if (wasPlaying) {
+    OH_AVPlayer_Pause(avPlayer);
+  }
+
+  OH_AVErrCode rc = AV_ERR_OK;
+  if (trackIndex >= 0) {
+    rc = OH_AVPlayer_SelectTrack(avPlayer, trackIndex);
+  } else if (previousTrackIndex >= 0) {
+    rc = OH_AVPlayer_DeselectTrack(avPlayer, previousTrackIndex);
+  }
+
+  if (rc != AV_ERR_OK) {
+    if (wasPlaying) {
+      OH_AVPlayer_Play(avPlayer);
+    }
+    EmitError(state, ERR_SELECT_TRACK_FAILED, "selectTrack failed: OH_AVPlayer_SelectTrack/DeselectTrack returned error");
+    return ReturnUndefinedOrThrow(env, "selectTrack failed to create return value");
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(state.stateMutex);
+    state.selectedTrackIndex = trackIndex;
+  }
+  if (wasPlaying) {
+    OH_AVPlayer_Play(avPlayer);
+  }
   return ReturnUndefinedOrThrow(env, "selectTrack failed to create return value");
 }
 

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -7,6 +7,10 @@
 #include <cerrno>
 #include <cstring>
 #include <mutex>
+#include <thread>
+#include <queue>
+#include <condition_variable>
+#include <atomic>
 
 #include "napi/native_api.h"
 #include <ace/xcomponent/native_interface_xcomponent.h>
@@ -647,6 +651,34 @@ static napi_value Ffprobe(napi_env env, napi_callback_info info) {
   return promise;
 }
 
+// ---------------------------------------------------------------------------
+// B1：FFmpeg 自研解码路径 — packet 队列 + demux 线程
+// ---------------------------------------------------------------------------
+
+// 线程安全的 AVPacket 队列（视频/音频各一个）
+struct AVPacketQueue {
+  std::queue<AVPacket *> packets;
+  std::mutex mtx;
+  std::condition_variable cv;
+  bool abort = false;
+  int maxSize = 64;
+};
+
+// FFmpeg 上下文：格式探测 + demux 线程 + 双队列
+struct FfmpegContext {
+  AVFormatContext *fmtCtx = nullptr;
+  int videoStreamIdx = -1;
+  int audioStreamIdx = -1;
+  AVPacketQueue videoQueue;
+  AVPacketQueue audioQueue;
+  std::thread demuxThread;
+  std::atomic<bool> demuxRunning{false};
+  // 中断标志：StopFfmpegDemux 设为 true，让阻塞的 av_read_frame 尽快返回
+  std::atomic<bool> interruptFlag{false};
+  // HTTP headers（"Key: Value\r\n" 格式，供 avformat_open_input 使用）
+  std::string httpHeaders;
+};
+
 struct NativePlayerSkeletonState {
   std::string url;
   std::string headersJson;
@@ -680,6 +712,9 @@ struct NativePlayerSkeletonState {
   // PR#49 修复（问题6）：per-player mutex，保护 state 字段的跨线程读写
   // 注意：std::mutex 不可拷贝/移动；unordered_map 通过节点指针操作，不需要拷贝值
   std::mutex stateMutex;
+  // B1：FFmpeg 自研路径标志与上下文
+  bool useFfmpegPath = false;  // OH_AVPlayer 报错后设为 true，切换到 FFmpeg 路径
+  std::unique_ptr<FfmpegContext> ffmpegCtx;
 };
 
 static std::unordered_map<int32_t, NativePlayerSkeletonState> g_players;
@@ -1148,7 +1183,301 @@ struct ErrorData {
 };
 
 // ---------------------------------------------------------------------------
-// A4：OH_AVPlayer 状态 / 错误回调（媒体线程调用，userData = NativePlayerSkeletonState*）
+// B1：FFmpeg demux 路径辅助函数
+// ---------------------------------------------------------------------------
+
+// av_read_frame 中断回调：interruptFlag 置 true 时让 FFmpeg 立即退出阻塞 IO
+static int FfmpegInterruptCallback(void *opaque) {
+  if (opaque == nullptr) {
+    return 0;
+  }
+  const auto *flag = static_cast<std::atomic<bool> *>(opaque);
+  return flag->load() ? 1 : 0;
+}
+
+// 将 headersJson（JSON 对象字符串）转换为 FFmpeg 所需的 "Key: Value\r\n" 格式。
+// 仅做轻量级手写解析，满足 WebDAV 鉴权场景（Authorization 等单层键值对）。
+// 复杂嵌套/转义场景不在 B1 范围内。
+static std::string BuildFfmpegHeadersFromJson(const std::string &headersJson) {
+  if (headersJson.empty() || headersJson.front() != '{') {
+    return {};
+  }
+  std::string result;
+  const std::string &src = headersJson;
+  const size_t len = src.size();
+  size_t i = 1; // 跳过 '{'
+  while (i < len) {
+    // 跳过空白
+    while (i < len && (src[i] == ' ' || src[i] == '\t' || src[i] == '\n' || src[i] == '\r')) {
+      ++i;
+    }
+    if (i >= len || src[i] == '}') {
+      break;
+    }
+    // 解析 key（期望 "key"）
+    if (src[i] != '"') {
+      break;
+    }
+    ++i; // skip opening quote
+    std::string key;
+    while (i < len && src[i] != '"') {
+      if (src[i] == '\\' && i + 1 < len) {
+        ++i; // skip escape
+      }
+      key += src[i++];
+    }
+    if (i < len) {
+      ++i; // skip closing quote
+    }
+    // 跳到 ':'
+    while (i < len && src[i] != ':') {
+      ++i;
+    }
+    if (i < len) {
+      ++i; // skip ':'
+    }
+    // 跳过空白
+    while (i < len && (src[i] == ' ' || src[i] == '\t')) {
+      ++i;
+    }
+    // 解析 value（期望 "value"）
+    if (i >= len || src[i] != '"') {
+      break;
+    }
+    ++i;
+    std::string value;
+    while (i < len && src[i] != '"') {
+      if (src[i] == '\\' && i + 1 < len) {
+        ++i;
+      }
+      value += src[i++];
+    }
+    if (i < len) {
+      ++i;
+    }
+    if (!key.empty()) {
+      result += key + ": " + value + "\r\n";
+    }
+    // 跳到 ',' 或 '}'
+    while (i < len && src[i] != ',' && src[i] != '}') {
+      ++i;
+    }
+    if (i < len && src[i] == ',') {
+      ++i;
+    }
+  }
+  return result;
+}
+
+// 打开 FFmpeg 格式上下文（含 HTTP Authorization 头与超时配置）
+static int FfmpegOpenInput(FfmpegContext *ctx, const std::string &url) {
+  if (ctx == nullptr) {
+    return AVERROR(EINVAL);
+  }
+  avformat_network_init();
+
+  ctx->fmtCtx = avformat_alloc_context();
+  if (ctx->fmtCtx == nullptr) {
+    return AVERROR(ENOMEM);
+  }
+  // 注册中断回调，以便 StopFfmpegDemux 能及时中断阻塞 IO
+  ctx->fmtCtx->interrupt_callback.callback = FfmpegInterruptCallback;
+  ctx->fmtCtx->interrupt_callback.opaque = &ctx->interruptFlag;
+
+  AVDictionary *opts = nullptr;
+  av_dict_set(&opts, "timeout", "10000000", 0);       // 10s open timeout（微秒）
+  av_dict_set(&opts, "reconnect", "1", 0);
+  av_dict_set(&opts, "reconnect_streamed", "1", 0);
+  if (!ctx->httpHeaders.empty()) {
+    av_dict_set(&opts, "headers", ctx->httpHeaders.c_str(), 0);
+  }
+
+  int ret = avformat_open_input(&ctx->fmtCtx, url.c_str(), nullptr, &opts);
+  av_dict_free(&opts);
+  if (ret < 0) {
+    avformat_free_context(ctx->fmtCtx);
+    ctx->fmtCtx = nullptr;
+    return ret;
+  }
+
+  ret = avformat_find_stream_info(ctx->fmtCtx, nullptr);
+  if (ret < 0) {
+    avformat_close_input(&ctx->fmtCtx);
+    return ret;
+  }
+
+  ctx->videoStreamIdx = av_find_best_stream(ctx->fmtCtx, AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0);
+  ctx->audioStreamIdx = av_find_best_stream(ctx->fmtCtx, AVMEDIA_TYPE_AUDIO, -1, -1, nullptr, 0);
+
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "FfmpegOpenInput: url=%s videoIdx=%d audioIdx=%d",
+               url.c_str(), ctx->videoStreamIdx, ctx->audioStreamIdx);
+  return 0;
+}
+
+// demux 线程主循环：持续读帧，分发至视频/音频队列
+static void DemuxThreadFunc(FfmpegContext *ctx) {
+  if (ctx == nullptr || ctx->fmtCtx == nullptr) {
+    return;
+  }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "DemuxThread: started");
+
+  AVPacket *pkt = av_packet_alloc();
+  if (pkt == nullptr) {
+    ctx->demuxRunning.store(false);
+    return;
+  }
+
+  while (ctx->demuxRunning.load()) {
+    int ret = av_read_frame(ctx->fmtCtx, pkt);
+    if (ret == AVERROR_EOF) {
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "DemuxThread: EOF reached");
+      break;
+    }
+    if (ret == AVERROR(EAGAIN)) {
+      // 暂时无数据，短暂休眠后重试
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      continue;
+    }
+    if (ret < 0) {
+      char errbuf[128] = {0};
+      av_strerror(ret, errbuf, sizeof(errbuf));
+      OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+                   "DemuxThread: av_read_frame error: %s", errbuf);
+      break;
+    }
+
+    if (pkt->stream_index == ctx->videoStreamIdx && ctx->videoStreamIdx >= 0) {
+      AVPacket *pktCopy = av_packet_alloc();
+      if (pktCopy != nullptr && av_packet_ref(pktCopy, pkt) == 0) {
+        std::unique_lock<std::mutex> lock(ctx->videoQueue.mtx);
+        ctx->videoQueue.cv.wait(lock, [&] {
+          return static_cast<int>(ctx->videoQueue.packets.size()) < ctx->videoQueue.maxSize
+              || ctx->videoQueue.abort;
+        });
+        if (!ctx->videoQueue.abort) {
+          ctx->videoQueue.packets.push(pktCopy);
+        } else {
+          av_packet_free(&pktCopy);
+        }
+        lock.unlock();
+        ctx->videoQueue.cv.notify_all();
+      } else if (pktCopy != nullptr) {
+        av_packet_free(&pktCopy);
+      }
+    } else if (pkt->stream_index == ctx->audioStreamIdx && ctx->audioStreamIdx >= 0) {
+      AVPacket *pktCopy = av_packet_alloc();
+      if (pktCopy != nullptr && av_packet_ref(pktCopy, pkt) == 0) {
+        std::unique_lock<std::mutex> lock(ctx->audioQueue.mtx);
+        ctx->audioQueue.cv.wait(lock, [&] {
+          return static_cast<int>(ctx->audioQueue.packets.size()) < ctx->audioQueue.maxSize
+              || ctx->audioQueue.abort;
+        });
+        if (!ctx->audioQueue.abort) {
+          ctx->audioQueue.packets.push(pktCopy);
+        } else {
+          av_packet_free(&pktCopy);
+        }
+        lock.unlock();
+        ctx->audioQueue.cv.notify_all();
+      } else if (pktCopy != nullptr) {
+        av_packet_free(&pktCopy);
+      }
+    }
+    av_packet_unref(pkt);
+  }
+
+  av_packet_free(&pkt);
+  ctx->demuxRunning.store(false);
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "DemuxThread: exited");
+}
+
+// 启动 FFmpeg demux 线程（在 OH_AVPlayer 报错后从媒体线程调用）
+static void StartFfmpegDemux(NativePlayerSkeletonState *state, const std::string &url) {
+  if (state == nullptr || url.empty()) {
+    return;
+  }
+  // 已经在运行则跳过
+  if (state->ffmpegCtx != nullptr && state->ffmpegCtx->demuxRunning.load()) {
+    return;
+  }
+
+  auto ctx = std::make_unique<FfmpegContext>();
+  ctx->httpHeaders = BuildFfmpegHeadersFromJson(state->headersJson);
+
+  const int ret = FfmpegOpenInput(ctx.get(), url);
+  if (ret < 0) {
+    char errbuf[128] = {0};
+    av_strerror(ret, errbuf, sizeof(errbuf));
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "StartFfmpegDemux: FfmpegOpenInput failed: %s", errbuf);
+    return;
+  }
+
+  ctx->demuxRunning.store(true);
+  ctx->demuxThread = std::thread(DemuxThreadFunc, ctx.get());
+  state->ffmpegCtx = std::move(ctx);
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "StartFfmpegDemux: demux thread launched for url=%s", url.c_str());
+}
+
+// 停止 demux 线程并释放所有 FFmpeg 资源
+static void StopFfmpegDemux(NativePlayerSkeletonState *state) {
+  if (state == nullptr || state->ffmpegCtx == nullptr) {
+    return;
+  }
+  FfmpegContext *ctx = state->ffmpegCtx.get();
+
+  // 1. 通知中断：让阻塞的 av_read_frame / avformat_open_input 尽快返回
+  ctx->interruptFlag.store(true);
+  ctx->demuxRunning.store(false);
+
+  // 2. 唤醒可能阻塞在 cv.wait 的 demux 线程（队列满等待）
+  {
+    std::lock_guard<std::mutex> lk(ctx->videoQueue.mtx);
+    ctx->videoQueue.abort = true;
+  }
+  ctx->videoQueue.cv.notify_all();
+  {
+    std::lock_guard<std::mutex> lk(ctx->audioQueue.mtx);
+    ctx->audioQueue.abort = true;
+  }
+  ctx->audioQueue.cv.notify_all();
+
+  // 3. 等待 demux 线程退出
+  if (ctx->demuxThread.joinable()) {
+    ctx->demuxThread.join();
+  }
+
+  // 4. 释放队列中残留 packet
+  {
+    std::lock_guard<std::mutex> lk(ctx->videoQueue.mtx);
+    while (!ctx->videoQueue.packets.empty()) {
+      AVPacket *p = ctx->videoQueue.packets.front();
+      ctx->videoQueue.packets.pop();
+      av_packet_free(&p);
+    }
+  }
+  {
+    std::lock_guard<std::mutex> lk(ctx->audioQueue.mtx);
+    while (!ctx->audioQueue.packets.empty()) {
+      AVPacket *p = ctx->audioQueue.packets.front();
+      ctx->audioQueue.packets.pop();
+      av_packet_free(&p);
+    }
+  }
+
+  // 5. 关闭格式上下文
+  if (ctx->fmtCtx != nullptr) {
+    avformat_close_input(&ctx->fmtCtx);
+  }
+
+  state->ffmpegCtx.reset();
+  state->useFfmpegPath = false;
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll", "StopFfmpegDemux: demux stopped and cleaned");
+}
+
+
 // 使用新式带 userData 的回调 API：OH_AVPlayer_SetOnInfoCallback / SetOnErrorCallback
 // 注意：不在此处持有 g_playersMutex，避免与 Release() → OH_AVPlayer_Release 产生死锁；
 //      生命周期安全由 Release() 中"先 OH_AVPlayer_Release 再 ReleaseTsfIfPresent"序列保证。
@@ -1245,6 +1574,25 @@ static void OnAVPlayerErrorCB(OH_AVPlayer *player, int32_t errorCode,
   if (state == nullptr) {
     return;
   }
+
+  OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
+               "OnAVPlayerErrorCB: errorCode=%d msg=%s useFfmpegPath=%d",
+               errorCode, errorMsg ? errorMsg : "(null)", state->useFfmpegPath ? 1 : 0);
+
+  // B1：OH_AVPlayer 报错时（IO 失败 / 编解码不支持）切换到 FFmpeg 自研路径。
+  // AV_ERR_UNSUPPORT (= 4) 表示格式/编解码器不支持；通用错误也尝试 FFmpeg 路径。
+  // 条件：尚未启动 FFmpeg 路径 && URL 不为空
+  if (!state->useFfmpegPath && !state->url.empty()) {
+    state->useFfmpegPath = true;
+    const std::string urlCopy = state->url; // OnAVPlayerErrorCB 来自媒体线程，避免持有 state 太久
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "OnAVPlayerErrorCB: switching to FFmpeg demux path for url=%s", urlCopy.c_str());
+    // StartFfmpegDemux 内部会 avformat_open_input（可能阻塞），
+    // 在媒体线程直接调用会影响 OH_AVPlayer 回调链路。
+    // B1 阶段直接在此线程启动（open 有 10s 超时保障），B2 阶段可改为独立 dispatch 线程。
+    StartFfmpegDemux(state, urlCopy);
+  }
+
   if (state->tsfOnError != nullptr) {
     // PR#49（问题5）：携带 code+msg，由 tsfOnError call_js_cb 负责 delete
     auto *errData = new ErrorData{
@@ -1881,6 +2229,8 @@ static napi_value Release(napi_env env, napi_callback_info info) {
     OH_AVPlayer_Release(state.avPlayer); // 阻塞直到媒体线程所有回调执行完毕
     state.avPlayer = nullptr;
   }
+  // B1：OH_AVPlayer_Release 完成后（媒体线程回调已全部结束），安全停止 demux 线程
+  StopFfmpegDemux(&state);
   ResetRuntimeState(state);
   state.url.clear();
   state.headersJson.clear();

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -2056,6 +2056,22 @@ static void FfmpegCleanupGLResources(FfmpegContext *ctx) {
 static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   FfmpegContext *ctx = state->ffmpegCtx.get();
 
+  // 0. 释放 OH_AVPlayer，解除其对 NativeWindow 的 EGL surface 绑定。
+  //    必须在 FfmpegInitEGL 之前执行，否则 eglCreateWindowSurface 因 Window 已被占用而失败。
+  //    RenderThreadFunc 运行在独立线程（非 OH_AVPlayer 回调线程），调用 Release 安全。
+  OH_AVPlayer *avToRelease = nullptr;
+  {
+    std::lock_guard<std::mutex> lk(state->stateMutex);
+    avToRelease = state->avPlayer;
+    state->avPlayer = nullptr;
+  }
+  if (avToRelease != nullptr) {
+    OH_AVPlayer_Stop(avToRelease);
+    OH_AVPlayer_Release(avToRelease);
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "RenderThreadFunc: released OH_AVPlayer to free NativeWindow EGL binding");
+  }
+
   // 1. EGL 初始化（创建 display/surface/context）
   if (!FfmpegInitEGL(ctx, state->nativeWindow)) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
@@ -3016,10 +3032,16 @@ static napi_value SetXComponent(napi_env env, napi_callback_info info) {
   napi_unwrap(env, args[1], reinterpret_cast<void **>(&nativeXC));
 
   // 切换渲染目标：先停止现有 avPlayer（surface 将失效），重置骨架态，再注册新回调。
-  if (state->avPlayer != nullptr) {
-    OH_AVPlayer_Stop(state->avPlayer);
-    OH_AVPlayer_Release(state->avPlayer);
+  // 用 stateMutex 保护，防止与 RenderThreadFunc 并发双释放。
+  OH_AVPlayer *avToRelease = nullptr;
+  {
+    std::lock_guard<std::mutex> lk(state->stateMutex);
+    avToRelease = state->avPlayer;
     state->avPlayer = nullptr;
+  }
+  if (avToRelease != nullptr) {
+    OH_AVPlayer_Stop(avToRelease);
+    OH_AVPlayer_Release(avToRelease);
   }
   state->nativeWindow = nullptr;
   state->surfaceReady = false;
@@ -3551,10 +3573,17 @@ static napi_value Release(napi_env env, napi_callback_info info) {
   //   2. ClearCallbackRefs（含 ReleaseTsfIfPresent napi_tsfn_abort）：此时媒体线程已无回调，
   //      abort 可安全丢弃 OH_AVPlayer_Release 前已入队但尚未在 JS 线程执行的 TSF 调用
   //   3. 再 erase state：上两步完成后状态指针不再被任何线程访问
-  if (state.avPlayer != nullptr) {
-    OH_AVPlayer_Stop(state.avPlayer);
-    OH_AVPlayer_Release(state.avPlayer); // 阻塞直到媒体线程所有回调执行完毕
+  // 取出 avPlayer（stateMutex 保护，防止与 RenderThreadFunc 并发双释放）。
+  // OH_AVPlayer_Release 必须在锁外调用，避免媒体线程回调尝试加锁时死锁。
+  OH_AVPlayer *avToRelease = nullptr;
+  {
+    std::lock_guard<std::mutex> lk(state.stateMutex);
+    avToRelease = state.avPlayer;
     state.avPlayer = nullptr;
+  }
+  if (avToRelease != nullptr) {
+    OH_AVPlayer_Stop(avToRelease);
+    OH_AVPlayer_Release(avToRelease); // 阻塞直到媒体线程所有回调执行完毕
   }
   // B1：OH_AVPlayer_Release 完成后（媒体线程回调已全部结束），安全停止 demux 线程
   StopFfmpegDemux(&state);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -889,6 +889,7 @@ struct NativePlayerSkeletonState {
   napi_ref onCompletedRef = nullptr;
   napi_ref onBufferingChangeRef = nullptr;
   napi_ref onSeekDoneRef = nullptr;
+  napi_ref onSubtitleUpdateRef = nullptr;
   // A4：threadsafe function handles（媒体线程 → JS 线程回调）
   napi_threadsafe_function tsfOnPrepared = nullptr;
   napi_threadsafe_function tsfOnCompleted = nullptr;
@@ -897,6 +898,7 @@ struct NativePlayerSkeletonState {
   // PR#49 修复：新增 buffering=false 和 seekDone TSF，供媒体线程异步触发
   napi_threadsafe_function tsfOnBufferingFalse = nullptr;
   napi_threadsafe_function tsfOnSeekDone = nullptr;
+  napi_threadsafe_function tsfOnSubtitleUpdate = nullptr;
   // B6修复：FFmpeg 接管时通知 ArkTS 重置 native 就绪守卫计时器，防止 3.5s 误 fallback
   napi_threadsafe_function tsfOnFfmpegSwitching = nullptr;
   // PR#49 修复（问题6）：per-player mutex，保护 state 字段的跨线程读写
@@ -1193,6 +1195,7 @@ static void ClearCallbackRefs(NativePlayerSkeletonState &state, napi_env fallbac
   DeleteRefIfPresent(deleteEnv, state.onCompletedRef);
   DeleteRefIfPresent(deleteEnv, state.onBufferingChangeRef);
   DeleteRefIfPresent(deleteEnv, state.onSeekDoneRef);
+  DeleteRefIfPresent(deleteEnv, state.onSubtitleUpdateRef);
   // A4：释放 threadsafe functions（abort 确保已入队的回调不再执行，防止 Release 后悬挂访问）
   ReleaseTsfIfPresent(state.tsfOnPrepared);
   ReleaseTsfIfPresent(state.tsfOnCompleted);
@@ -1201,6 +1204,7 @@ static void ClearCallbackRefs(NativePlayerSkeletonState &state, napi_env fallbac
   // PR#49：新增两个 TSF
   ReleaseTsfIfPresent(state.tsfOnBufferingFalse);
   ReleaseTsfIfPresent(state.tsfOnSeekDone);
+  ReleaseTsfIfPresent(state.tsfOnSubtitleUpdate);
   // B6修复：释放 FFmpeg 接管通知 TSF
   ReleaseTsfIfPresent(state.tsfOnFfmpegSwitching);
 }
@@ -1402,6 +1406,12 @@ static napi_value SetHeaders(napi_env env, napi_callback_info info) {
 struct ErrorData {
   int32_t code;
   std::string *msg;  // heap-allocated，由 tsfOnError call_js_cb 负责 delete
+};
+
+struct SubtitleData {
+  int64_t durationMs{0};
+  int64_t startTimeMs{0};
+  std::string *text{nullptr};
 };
 
 // ---------------------------------------------------------------------------
@@ -3436,6 +3446,32 @@ static void OnAVPlayerInfoCB(OH_AVPlayer *player, AVPlayerOnInfoType type,
       }
       break;
     }
+    case AV_INFO_TYPE_SUBTITLE_UPDATE: {
+      if (state->tsfOnSubtitleUpdate == nullptr) {
+        break;
+      }
+      auto *subtitleData = new SubtitleData();
+      const char *text = nullptr;
+      int64_t startTimeMs = 0;
+      int64_t durationMs = 0;
+      int32_t startTimeInt = 0;
+      int32_t durationInt = 0;
+      if (OH_AVFormat_GetStringValue(infoBody, "text", &text) && text != nullptr) {
+        subtitleData->text = new std::string(text);
+      }
+      if (OH_AVFormat_GetLongValue(infoBody, "startTime", &startTimeMs)) {
+        subtitleData->startTimeMs = startTimeMs;
+      } else if (OH_AVFormat_GetIntValue(infoBody, "startTime", &startTimeInt)) {
+        subtitleData->startTimeMs = static_cast<int64_t>(startTimeInt);
+      }
+      if (OH_AVFormat_GetLongValue(infoBody, "duration", &durationMs)) {
+        subtitleData->durationMs = durationMs;
+      } else if (OH_AVFormat_GetIntValue(infoBody, "duration", &durationInt)) {
+        subtitleData->durationMs = static_cast<int64_t>(durationInt);
+      }
+      napi_call_threadsafe_function(state->tsfOnSubtitleUpdate, subtitleData, napi_tsfn_nonblocking);
+      break;
+    }
     default:
       break;
   }
@@ -3770,21 +3806,22 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
 }
 
 static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
-  size_t argc = 8;
-  napi_value args[8] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+  size_t argc = 9;
+  napi_value args[9] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
   if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok) {
     ThrowTypeError(env, "setCallbacks failed to read args");
     return nullptr;
   }
   if (argc < 5) {
     ThrowTypeError(env,
-      "setCallbacks requires (handle, onPrepared, onError, onTimeUpdate, onCompleted[, onBufferingChange[, onSeekDone[, onFfmpegSwitching]]])");
+      "setCallbacks requires (handle, onPrepared, onError, onTimeUpdate, onCompleted[, onBufferingChange[, onSeekDone[, onFfmpegSwitching[, onSubtitleUpdate]]]])");
     return nullptr;
   }
   int32_t handle = 0;
   const bool hasBufferingArg = (argc >= 6);
   const bool hasSeekDoneArg = (argc >= 7);
   const bool hasFfmpegSwitchingArg = (argc >= 8);
+  const bool hasSubtitleUpdateArg = (argc >= 9);
   if (napi_get_value_int32(env, args[0], &handle) != napi_ok) {
     ThrowTypeError(env, "setCallbacks handle must be int32");
     return nullptr;
@@ -3813,6 +3850,11 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
   }
   if (hasSeekDoneArg) {
     if (!EnsureFunctionArg(env, args[6], "setCallbacks onSeekDone must be function")) {
+      return nullptr;
+    }
+  }
+  if (hasSubtitleUpdateArg) {
+    if (!EnsureFunctionArg(env, args[8], "setCallbacks onSubtitleUpdate must be function")) {
       return nullptr;
     }
   }
@@ -3850,6 +3892,13 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
     if (napi_create_reference(env, args[6], 1, &state.onSeekDoneRef) != napi_ok) {
       ClearCallbackRefs(state, env);
       ThrowTypeError(env, "setCallbacks failed to create onSeekDone callback reference");
+      return nullptr;
+    }
+  }
+  if (hasSubtitleUpdateArg) {
+    if (napi_create_reference(env, args[8], 1, &state.onSubtitleUpdateRef) != napi_ok) {
+      ClearCallbackRefs(state, env);
+      ThrowTypeError(env, "setCallbacks failed to create onSubtitleUpdate callback reference");
       return nullptr;
     }
   }
@@ -3956,6 +4005,38 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
         napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
       },
       &state.tsfOnSeekDone);
+  }
+  if (hasSubtitleUpdateArg) {
+    napi_value resName;
+    napi_create_string_utf8(env, "tsfOnSubtitleUpdate", NAPI_AUTO_LENGTH, &resName);
+    napi_create_threadsafe_function(
+      env, args[8], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
+      [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        auto *subtitleData = static_cast<SubtitleData *>(data);
+        napi_value infoObj = nullptr;
+        napi_create_object(tsfEnv, &infoObj);
+        if (subtitleData != nullptr) {
+          napi_value durationVal = nullptr;
+          napi_create_int64(tsfEnv, subtitleData->durationMs, &durationVal);
+          napi_set_named_property(tsfEnv, infoObj, "duration", durationVal);
+          napi_value startTimeVal = nullptr;
+          napi_create_int64(tsfEnv, subtitleData->startTimeMs, &startTimeVal);
+          napi_set_named_property(tsfEnv, infoObj, "startTime", startTimeVal);
+          napi_value textVal = nullptr;
+          napi_create_string_utf8(tsfEnv,
+            (subtitleData->text != nullptr) ? subtitleData->text->c_str() : "",
+            NAPI_AUTO_LENGTH, &textVal);
+          napi_set_named_property(tsfEnv, infoObj, "text", textVal);
+        }
+        napi_value undef;
+        napi_get_undefined(tsfEnv, &undef);
+        napi_call_function(tsfEnv, undef, jsCb, 1, &infoObj, nullptr);
+        if (subtitleData != nullptr) {
+          delete subtitleData->text;
+          delete subtitleData;
+        }
+      },
+      &state.tsfOnSubtitleUpdate);
   }
   // B6修复：注册 tsfOnFfmpegSwitching（可选，args[7]）
   // FFmpeg 接管后通知 ArkTS 重置守卫计时器至 15s，防止 3.5s 超时误触 fallback。

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -21,6 +21,7 @@
 #include <multimedia/player_framework/avplayer.h>
 #include <multimedia/player_framework/native_avcapability.h>
 #include <multimedia/player_framework/native_avformat.h>
+#include <multimedia/player_framework/native_avcodec_videodecoder.h>
 #include <hilog/log.h>
 
 extern "C" {
@@ -941,6 +942,8 @@ struct PendingWindowInfo {
 };
 // xcId → (nativeXC*, nativeWindow*)，供 SetXComponent 延迟关联
 static std::unordered_map<std::string, PendingWindowInfo> g_pendingWindows;
+// xcId → 当前仍然存活的 surface window。即使 player release，只要 XComponent 未销毁就可复用。
+static std::unordered_map<std::string, PendingWindowInfo> g_liveWindows;
 // Init() 期间从 OH_NATIVE_XCOMPONENT_OBJ 取到的 nativeXC，
 // SetXComponent 用它判断是否需要重复注册（同一个 XComponent 无需重复注册）
 static OH_NativeXComponent *g_pendingXC = nullptr;
@@ -3611,6 +3614,7 @@ static void OnXCSurfaceCreated(OH_NativeXComponent *component, void *window) {
                "OnXCSurfaceCreated: xcId=%s window=%p", xcId.c_str(), window);
 
   std::lock_guard<std::mutex> lock(g_playersMutex); // A4: 保护 g_players 跨线程遍历
+  g_liveWindows[xcId] = { component, static_cast<OHNativeWindow *>(window) };
   bool found = false;
   for (auto &pair : g_players) {
     if (pair.second.xComponentId == xcId) {
@@ -3669,6 +3673,7 @@ static void OnXCSurfaceDestroyed(OH_NativeXComponent *component, void *window) {
   }
   // PR#49（问题9）：清除悬空的 pending window 缓存，避免 surface 销毁后 use-after-free
   g_pendingWindows.erase(xcId);
+  g_liveWindows.erase(xcId);
 }
 
 static void OnXCDispatchTouchEvent(OH_NativeXComponent *component, void *window) {
@@ -3759,6 +3764,15 @@ static napi_value SetXComponent(napi_env env, napi_callback_info info) {
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                    "SetXComponent: 从 pending 恢复 nativeWindow=%p xcId=%s",
                    state->nativeWindow, xComponentId.c_str());
+    } else {
+      auto liveIt = g_liveWindows.find(xComponentId);
+      if (liveIt != g_liveWindows.end()) {
+        state->nativeWindow = liveIt->second.nativeWindow;
+        state->surfaceReady = state->nativeWindow != nullptr;
+        OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                     "SetXComponent: 从 live cache 恢复 nativeWindow=%p xcId=%s",
+                     state->nativeWindow, xComponentId.c_str());
+      }
     }
   }
 
@@ -4883,6 +4897,35 @@ struct AudioDecoderCapabilityResult {
   std::string errorMessage;
 };
 
+struct VideoDecoderCapabilityResult {
+  bool capabilityKnown = false;
+  bool supported = false;
+  bool isHardware = false;
+  int32_t minWidth = 0;
+  int32_t maxWidth = 0;
+  int32_t minHeight = 0;
+  int32_t maxHeight = 0;
+  int32_t minFrameRate = 0;
+  int32_t maxFrameRate = 0;
+  int32_t widthAlignment = 0;
+  int32_t heightAlignment = 0;
+  int32_t maxInstances = 0;
+  std::string decoderName;
+  std::string mimeType;
+  std::string errorMessage;
+};
+
+struct VideoDecoderSurfaceProbeResult {
+  bool success = false;
+  std::string stage;
+  bool capabilityKnown = false;
+  bool isHardware = false;
+  std::string decoderName;
+  std::string mimeType;
+  std::string stateSummary;
+  std::string errorMessage;
+};
+
 static std::string ToLowerString(const std::string &value) {
   std::string result = value;
   std::transform(result.begin(), result.end(), result.begin(), [](unsigned char ch) {
@@ -4945,6 +4988,51 @@ static std::vector<std::string> BuildAudioMimeCandidates(const std::string &code
   return candidates;
 }
 
+static std::vector<std::string> BuildVideoMimeCandidates(const std::string &codecOrMime) {
+  const std::string normalized = ToLowerString(codecOrMime);
+  if (normalized.empty()) {
+    return {};
+  }
+
+  std::vector<std::string> candidates;
+  auto pushUnique = [&candidates](const std::string &candidate) {
+    if (candidate.empty()) {
+      return;
+    }
+    if (std::find(candidates.begin(), candidates.end(), candidate) == candidates.end()) {
+      candidates.push_back(candidate);
+    }
+  };
+
+  if (normalized.rfind("video/", 0) == 0) {
+    pushUnique(normalized);
+  }
+
+  if (normalized == "h264" || normalized == "h.264" || normalized == "avc" || normalized == "x264") {
+    pushUnique("video/avc");
+  } else if (normalized == "h265" || normalized == "h.265" || normalized == "hevc" || normalized == "x265") {
+    pushUnique("video/hevc");
+  } else if (normalized == "av1" || normalized == "av01") {
+    pushUnique("video/av1");
+    pushUnique("video/av01");
+  } else if (normalized == "vp9") {
+    pushUnique("video/x-vnd.on2.vp9");
+  } else if (normalized == "vp8") {
+    pushUnique("video/x-vnd.on2.vp8");
+  } else if (normalized == "mpeg4" || normalized == "mp4v" || normalized == "mp4v-es" ||
+             normalized == "divx" || normalized == "xvid") {
+    pushUnique("video/mp4v-es");
+    pushUnique("video/divx");
+  } else if (normalized == "mpeg2") {
+    pushUnique("video/mpeg2");
+  } else if (normalized == "vc1" || normalized == "wvc1") {
+    pushUnique("video/vc1");
+    pushUnique("video/wvc1");
+  }
+
+  return candidates;
+}
+
 static AudioDecoderCapabilityResult QueryAudioDecoderCapabilityInternal(const std::string &codecOrMime) {
   AudioDecoderCapabilityResult result;
   const std::vector<std::string> mimeCandidates = BuildAudioMimeCandidates(codecOrMime);
@@ -4992,6 +5080,204 @@ static AudioDecoderCapabilityResult QueryAudioDecoderCapabilityInternal(const st
   }
 
   result.errorMessage = "decoder not found";
+  return result;
+}
+
+static VideoDecoderCapabilityResult QueryVideoDecoderCapabilityInternal(const std::string &codecOrMime) {
+  VideoDecoderCapabilityResult result;
+  const std::vector<std::string> mimeCandidates = BuildVideoMimeCandidates(codecOrMime);
+  if (mimeCandidates.empty()) {
+    result.errorMessage = "unsupported codec mapping";
+    return result;
+  }
+
+  result.capabilityKnown = true;
+  result.mimeType = mimeCandidates.front();
+
+  for (const std::string &mime : mimeCandidates) {
+    OH_AVCapability *capability = OH_AVCodec_GetCapabilityByCategory(mime.c_str(), false, HARDWARE);
+    bool isHardware = true;
+    if (capability == nullptr) {
+      capability = OH_AVCodec_GetCapabilityByCategory(mime.c_str(), false, SOFTWARE);
+      isHardware = false;
+    }
+    if (capability == nullptr) {
+      capability = OH_AVCodec_GetCapability(mime.c_str(), false);
+      if (capability != nullptr) {
+        isHardware = OH_AVCapability_IsHardware(capability);
+      }
+    }
+    if (capability == nullptr) {
+      continue;
+    }
+
+    result.supported = true;
+    result.isHardware = isHardware;
+    result.mimeType = mime;
+
+    const char *decoderName = OH_AVCapability_GetName(capability);
+    if (decoderName != nullptr) {
+      result.decoderName = decoderName;
+    }
+
+    result.maxInstances = OH_AVCapability_GetMaxSupportedInstances(capability);
+
+    OH_AVRange widthRange;
+    widthRange.minVal = 0;
+    widthRange.maxVal = 0;
+    if (OH_AVCapability_GetVideoWidthRange(capability, &widthRange) == AV_ERR_OK) {
+      result.minWidth = widthRange.minVal;
+      result.maxWidth = widthRange.maxVal;
+    }
+
+    OH_AVRange heightRange;
+    heightRange.minVal = 0;
+    heightRange.maxVal = 0;
+    if (OH_AVCapability_GetVideoHeightRange(capability, &heightRange) == AV_ERR_OK) {
+      result.minHeight = heightRange.minVal;
+      result.maxHeight = heightRange.maxVal;
+    }
+
+    OH_AVRange frameRateRange;
+    frameRateRange.minVal = 0;
+    frameRateRange.maxVal = 0;
+    if (OH_AVCapability_GetVideoFrameRateRange(capability, &frameRateRange) == AV_ERR_OK) {
+      result.minFrameRate = frameRateRange.minVal;
+      result.maxFrameRate = frameRateRange.maxVal;
+    }
+
+    int32_t widthAlignment = 0;
+    if (OH_AVCapability_GetVideoWidthAlignment(capability, &widthAlignment) == AV_ERR_OK) {
+      result.widthAlignment = widthAlignment;
+    }
+
+    int32_t heightAlignment = 0;
+    if (OH_AVCapability_GetVideoHeightAlignment(capability, &heightAlignment) == AV_ERR_OK) {
+      result.heightAlignment = heightAlignment;
+    }
+    return result;
+  }
+
+  result.errorMessage = "decoder not found";
+  return result;
+}
+
+static VideoDecoderSurfaceProbeResult ProbeVideoDecoderSurfaceInternal(
+  NativePlayerSkeletonState &state,
+  const std::string &codecOrMime
+) {
+  VideoDecoderSurfaceProbeResult result;
+  result.stage = "lookup";
+
+  OHNativeWindow *localWindow = nullptr;
+  bool hasAvPlayer = false;
+  bool hasFfmpegCtx = false;
+  bool prepared = false;
+  bool playing = false;
+  bool useFfmpegPath = false;
+  {
+    std::lock_guard<std::mutex> lk(state.stateMutex);
+    localWindow = state.nativeWindow;
+    hasAvPlayer = state.avPlayer != nullptr;
+    hasFfmpegCtx = state.ffmpegCtx != nullptr;
+    prepared = state.prepared;
+    playing = state.playing;
+    useFfmpegPath = state.useFfmpegPath;
+  }
+  result.stateSummary =
+    std::string("window=") + (localWindow != nullptr ? "ready" : "null") +
+    ", prepared=" + (prepared ? "true" : "false") +
+    ", playing=" + (playing ? "true" : "false") +
+    ", avPlayer=" + (hasAvPlayer ? "true" : "false") +
+    ", ffmpegCtx=" + (hasFfmpegCtx ? "true" : "false") +
+    ", useFfmpegPath=" + (useFfmpegPath ? "true" : "false");
+  if (localWindow == nullptr) {
+    result.errorMessage = "nativeWindow unavailable";
+    result.stage = "surface";
+    return result;
+  }
+
+  const VideoDecoderCapabilityResult capability = QueryVideoDecoderCapabilityInternal(codecOrMime);
+  result.capabilityKnown = capability.capabilityKnown;
+  result.isHardware = capability.isHardware;
+  result.decoderName = capability.decoderName;
+  result.mimeType = capability.mimeType;
+  if (!capability.capabilityKnown) {
+    result.errorMessage = capability.errorMessage.empty() ? "capability unknown" : capability.errorMessage;
+    return result;
+  }
+  if (!capability.supported) {
+    result.errorMessage = "decoder not supported";
+    return result;
+  }
+  if (!capability.isHardware) {
+    result.errorMessage = "hardware decoder unavailable";
+    return result;
+  }
+  if (capability.mimeType.empty()) {
+    result.errorMessage = "empty mime type";
+    return result;
+  }
+
+  OH_AVCodec *decoder = nullptr;
+  OH_AVFormat *format = nullptr;
+  OH_AVErrCode rc = AV_ERR_OK;
+  if (!capability.decoderName.empty()) {
+    decoder = OH_VideoDecoder_CreateByName(capability.decoderName.c_str());
+  }
+  if (decoder == nullptr) {
+    decoder = OH_VideoDecoder_CreateByMime(capability.mimeType.c_str());
+  }
+  if (decoder == nullptr) {
+    result.stage = "create";
+    result.errorMessage = "create decoder failed";
+    return result;
+  }
+
+  result.stage = "configure";
+  format = OH_AVFormat_CreateVideoFormat(capability.mimeType.c_str(), 1920, 1080);
+  if (format == nullptr) {
+    result.errorMessage = "create video format failed";
+    OH_VideoDecoder_Destroy(decoder);
+    return result;
+  }
+  OH_AVFormat_SetIntValue(format, OH_MD_KEY_WIDTH, 1920);
+  OH_AVFormat_SetIntValue(format, OH_MD_KEY_HEIGHT, 1080);
+  OH_AVFormat_SetIntValue(format, OH_MD_KEY_VIDEO_ENABLE_LOW_LATENCY, 1);
+
+  rc = OH_VideoDecoder_Configure(decoder, format);
+  if (rc != AV_ERR_OK) {
+    result.errorMessage = "configure failed: " + std::to_string(static_cast<int32_t>(rc));
+    OH_AVFormat_Destroy(format);
+    OH_VideoDecoder_Destroy(decoder);
+    return result;
+  }
+
+  result.stage = "setSurface";
+  rc = OH_VideoDecoder_SetSurface(decoder, localWindow);
+  if (rc != AV_ERR_OK) {
+    result.errorMessage = "set surface failed: " + std::to_string(static_cast<int32_t>(rc));
+    if (rc == AV_ERR_INVALID_STATE && (hasAvPlayer || hasFfmpegCtx || prepared || playing)) {
+      result.errorMessage += " (surface may be occupied by current playback pipeline)";
+    }
+    OH_AVFormat_Destroy(format);
+    OH_VideoDecoder_Destroy(decoder);
+    return result;
+  }
+
+  result.stage = "prepare";
+  rc = OH_VideoDecoder_Prepare(decoder);
+  if (rc != AV_ERR_OK) {
+    result.errorMessage = "prepare failed: " + std::to_string(static_cast<int32_t>(rc));
+    OH_AVFormat_Destroy(format);
+    OH_VideoDecoder_Destroy(decoder);
+    return result;
+  }
+
+  result.success = true;
+  result.stage = "done";
+  OH_AVFormat_Destroy(format);
+  OH_VideoDecoder_Destroy(decoder);
   return result;
 }
 
@@ -5046,6 +5332,137 @@ static napi_value QueryAudioDecoderCapability(napi_env env, napi_callback_info i
   return result;
 }
 
+static napi_value QueryVideoDecoderCapability(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1] = { nullptr };
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok) {
+    ThrowTypeError(env, "queryVideoDecoderCapability failed to read args");
+    return nullptr;
+  }
+  if (argc < 1) {
+    ThrowTypeError(env, "queryVideoDecoderCapability requires (codecOrMime)");
+    return nullptr;
+  }
+
+  std::string codecOrMime;
+  if (!ReadUtf8String(env, args[0], codecOrMime)) {
+    ThrowTypeError(env, "queryVideoDecoderCapability codecOrMime must be string");
+    return nullptr;
+  }
+
+  const VideoDecoderCapabilityResult capability = QueryVideoDecoderCapabilityInternal(codecOrMime);
+  napi_value result = nullptr;
+  if (napi_create_object(env, &result) != napi_ok || result == nullptr) {
+    ThrowTypeError(env, "queryVideoDecoderCapability failed to create result object");
+    return nullptr;
+  }
+
+  napi_value capabilityKnown = CreateBoolean(env, capability.capabilityKnown);
+  napi_value supported = CreateBoolean(env, capability.supported);
+  napi_value isHardware = CreateBoolean(env, capability.isHardware);
+  napi_value minWidth = CreateInt32(env, capability.minWidth);
+  napi_value maxWidth = CreateInt32(env, capability.maxWidth);
+  napi_value minHeight = CreateInt32(env, capability.minHeight);
+  napi_value maxHeight = CreateInt32(env, capability.maxHeight);
+  napi_value minFrameRate = CreateInt32(env, capability.minFrameRate);
+  napi_value maxFrameRate = CreateInt32(env, capability.maxFrameRate);
+  napi_value widthAlignment = CreateInt32(env, capability.widthAlignment);
+  napi_value heightAlignment = CreateInt32(env, capability.heightAlignment);
+  napi_value maxInstances = CreateInt32(env, capability.maxInstances);
+  napi_value decoderName = CreateString(env, capability.decoderName.c_str());
+  napi_value mimeType = CreateString(env, capability.mimeType.c_str());
+  napi_value errorMessage = CreateString(env, capability.errorMessage.c_str());
+  if (capabilityKnown == nullptr || supported == nullptr || isHardware == nullptr ||
+      minWidth == nullptr || maxWidth == nullptr || minHeight == nullptr || maxHeight == nullptr ||
+      minFrameRate == nullptr || maxFrameRate == nullptr || widthAlignment == nullptr ||
+      heightAlignment == nullptr || maxInstances == nullptr || decoderName == nullptr ||
+      mimeType == nullptr || errorMessage == nullptr) {
+    ThrowTypeError(env, "queryVideoDecoderCapability failed to create result fields");
+    return nullptr;
+  }
+
+  if (napi_set_named_property(env, result, "capabilityKnown", capabilityKnown) != napi_ok ||
+      napi_set_named_property(env, result, "supported", supported) != napi_ok ||
+      napi_set_named_property(env, result, "isHardware", isHardware) != napi_ok ||
+      napi_set_named_property(env, result, "minWidth", minWidth) != napi_ok ||
+      napi_set_named_property(env, result, "maxWidth", maxWidth) != napi_ok ||
+      napi_set_named_property(env, result, "minHeight", minHeight) != napi_ok ||
+      napi_set_named_property(env, result, "maxHeight", maxHeight) != napi_ok ||
+      napi_set_named_property(env, result, "minFrameRate", minFrameRate) != napi_ok ||
+      napi_set_named_property(env, result, "maxFrameRate", maxFrameRate) != napi_ok ||
+      napi_set_named_property(env, result, "widthAlignment", widthAlignment) != napi_ok ||
+      napi_set_named_property(env, result, "heightAlignment", heightAlignment) != napi_ok ||
+      napi_set_named_property(env, result, "maxInstances", maxInstances) != napi_ok ||
+      napi_set_named_property(env, result, "decoderName", decoderName) != napi_ok ||
+      napi_set_named_property(env, result, "mimeType", mimeType) != napi_ok ||
+      napi_set_named_property(env, result, "errorMessage", errorMessage) != napi_ok) {
+    ThrowTypeError(env, "queryVideoDecoderCapability failed to set result fields");
+    return nullptr;
+  }
+  return result;
+}
+
+static napi_value ProbeVideoDecoderSurface(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2] = { nullptr, nullptr };
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok) {
+    ThrowTypeError(env, "probeVideoDecoderSurface failed to read args");
+    return nullptr;
+  }
+  if (argc < 2) {
+    ThrowTypeError(env, "probeVideoDecoderSurface requires (handle, codecOrMime)");
+    return nullptr;
+  }
+
+  int32_t handle = 0;
+  if (napi_get_value_int32(env, args[0], &handle) != napi_ok) {
+    ThrowTypeError(env, "probeVideoDecoderSurface handle must be int32");
+    return nullptr;
+  }
+  std::string codecOrMime;
+  if (!ReadUtf8String(env, args[1], codecOrMime)) {
+    ThrowTypeError(env, "probeVideoDecoderSurface codecOrMime must be string");
+    return nullptr;
+  }
+
+  NativePlayerSkeletonState *statePtr = FindPlayerOrThrow(env, handle);
+  if (statePtr == nullptr) {
+    return nullptr;
+  }
+  const VideoDecoderSurfaceProbeResult probe = ProbeVideoDecoderSurfaceInternal(*statePtr, codecOrMime);
+
+  napi_value result = nullptr;
+  if (napi_create_object(env, &result) != napi_ok || result == nullptr) {
+    ThrowTypeError(env, "probeVideoDecoderSurface failed to create result object");
+    return nullptr;
+  }
+  napi_value success = CreateBoolean(env, probe.success);
+  napi_value stage = CreateString(env, probe.stage.c_str());
+  napi_value capabilityKnown = CreateBoolean(env, probe.capabilityKnown);
+  napi_value isHardware = CreateBoolean(env, probe.isHardware);
+  napi_value decoderName = CreateString(env, probe.decoderName.c_str());
+  napi_value mimeType = CreateString(env, probe.mimeType.c_str());
+  napi_value stateSummary = CreateString(env, probe.stateSummary.c_str());
+  napi_value errorMessage = CreateString(env, probe.errorMessage.c_str());
+  if (success == nullptr || stage == nullptr || capabilityKnown == nullptr || isHardware == nullptr ||
+      decoderName == nullptr || mimeType == nullptr || stateSummary == nullptr || errorMessage == nullptr) {
+    ThrowTypeError(env, "probeVideoDecoderSurface failed to create result fields");
+    return nullptr;
+  }
+  if (napi_set_named_property(env, result, "success", success) != napi_ok ||
+      napi_set_named_property(env, result, "stage", stage) != napi_ok ||
+      napi_set_named_property(env, result, "capabilityKnown", capabilityKnown) != napi_ok ||
+      napi_set_named_property(env, result, "isHardware", isHardware) != napi_ok ||
+      napi_set_named_property(env, result, "decoderName", decoderName) != napi_ok ||
+      napi_set_named_property(env, result, "mimeType", mimeType) != napi_ok ||
+      napi_set_named_property(env, result, "stateSummary", stateSummary) != napi_ok ||
+      napi_set_named_property(env, result, "errorMessage", errorMessage) != napi_ok) {
+    ThrowTypeError(env, "probeVideoDecoderSurface failed to set result fields");
+    return nullptr;
+  }
+  return result;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     { "createPlayer", nullptr, CreatePlayer, nullptr, nullptr, nullptr, napi_default, nullptr },
@@ -5067,7 +5484,9 @@ static napi_value Init(napi_env env, napi_value exports) {
     { "webdavRequest", nullptr, WebdavRequest, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "downloadToFile", nullptr, DownloadToFile, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "getNativeCapabilities", nullptr, GetNativeCapabilities, nullptr, nullptr, nullptr, napi_default, nullptr },
-    { "queryAudioDecoderCapability", nullptr, QueryAudioDecoderCapability, nullptr, nullptr, nullptr, napi_default, nullptr }
+    { "queryAudioDecoderCapability", nullptr, QueryAudioDecoderCapability, nullptr, nullptr, nullptr, napi_default, nullptr },
+    { "queryVideoDecoderCapability", nullptr, QueryVideoDecoderCapability, nullptr, nullptr, nullptr, napi_default, nullptr },
+    { "probeVideoDecoderSurface", nullptr, ProbeVideoDecoderSurface, nullptr, nullptr, nullptr, napi_default, nullptr }
   };
   if (napi_define_properties(env, exports, sizeof(descriptors) / sizeof(descriptors[0]), descriptors) != napi_ok) {
     ThrowTypeError(env, "failed to define native module properties");

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -14,6 +14,7 @@
 
 #include "napi/native_api.h"
 #include <ace/xcomponent/native_interface_xcomponent.h>
+#include <native_buffer/native_buffer.h>
 #include <native_window/external_window.h>
 #include <multimedia/player_framework/avplayer.h>
 #include <multimedia/player_framework/native_avformat.h>
@@ -2121,6 +2122,9 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
       EGL_GREEN_SIZE, 8,
       EGL_BLUE_SIZE,  8,
       EGL_ALPHA_SIZE, 8,
+      EGL_DEPTH_SIZE, 0,
+      EGL_STENCIL_SIZE, 0,
+      EGL_SAMPLE_BUFFERS, 0,
       EGL_NONE
   };
   EGLConfig config = nullptr;
@@ -2138,10 +2142,34 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
   if (nativeVisualId == 0) {
     nativeVisualId = 3;  // fallback: NATIVEBUFFER_PIXEL_FMT_RGBA_8888 = 3 in OpenHarmony
   }
-  OH_NativeWindow_NativeWindowHandleOpt(nativeWindow, SET_FORMAT, nativeVisualId);
+  const int32_t targetBufferW = 1920;
+  const int32_t targetBufferH = 1080;
+  const uint64_t usage = static_cast<uint64_t>(NATIVEBUFFER_USAGE_HW_RENDER | NATIVEBUFFER_USAGE_HW_TEXTURE);
+  const int32_t rcFormat = OH_NativeWindow_NativeWindowHandleOpt(nativeWindow, SET_FORMAT, nativeVisualId);
+  const int32_t rcGeometry = OH_NativeWindow_NativeWindowHandleOpt(
+      nativeWindow, SET_BUFFER_GEOMETRY, targetBufferW, targetBufferH);
+  const int32_t rcUsage = OH_NativeWindow_NativeWindowHandleOpt(nativeWindow, SET_USAGE, usage);
+  const int32_t rcSwapInterval = OH_NativeWindow_NativeWindowHandleOpt(nativeWindow, SET_SWAP_INTERVAL, 0);
+  int32_t bufferH = 0;
+  int32_t bufferW = 0;
+  int32_t bufferFormat = 0;
+  uint64_t bufferUsage = 0;
+  int32_t bufferSwapInterval = -1;
+  const int32_t rcGetGeometry = OH_NativeWindow_NativeWindowHandleOpt(
+      nativeWindow, GET_BUFFER_GEOMETRY, &bufferH, &bufferW);
+  const int32_t rcGetFormat = OH_NativeWindow_NativeWindowHandleOpt(nativeWindow, GET_FORMAT, &bufferFormat);
+  const int32_t rcGetUsage = OH_NativeWindow_NativeWindowHandleOpt(nativeWindow, GET_USAGE, &bufferUsage);
+  const int32_t rcGetSwapInterval = OH_NativeWindow_NativeWindowHandleOpt(
+      nativeWindow, GET_SWAP_INTERVAL, &bufferSwapInterval);
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-               "FfmpegInitEGL: set NativeWindow format=%{public}d window=%{public}p",
-               nativeVisualId, nativeWindow);
+               "FfmpegInitEGL: window=%{public}p format=%{public}d rcFormat=%{public}d target=%{public}d x %{public}d rcGeometry=%{public}d rcUsage=%{public}d rcSwapInterval=%{public}d",
+               nativeWindow, nativeVisualId, rcFormat, targetBufferW, targetBufferH,
+               rcGeometry, rcUsage, rcSwapInterval);
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "FfmpegInitEGL: queried geometry=%{public}d x %{public}d rcGetGeometry=%{public}d format=%{public}d rcGetFormat=%{public}d usage=%{public}llu rcGetUsage=%{public}d swapInterval=%{public}d rcGetSwapInterval=%{public}d",
+               bufferW, bufferH, rcGetGeometry, bufferFormat, rcGetFormat,
+               static_cast<unsigned long long>(bufferUsage), rcGetUsage,
+               bufferSwapInterval, rcGetSwapInterval);
 
   // 清除历史 EGL 错误，确保后续 eglGetError 干净
   (void)eglGetError();
@@ -2177,9 +2205,20 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
                  "FfmpegInitEGL: eglCreateContext failed err=0x%{public}x", eglGetError());
     return false;
   }
+  EGLint cfgBufferSize = 0;
+  EGLint cfgAlphaSize = 0;
+  EGLint cfgDepthSize = 0;
+  EGLint cfgStencilSize = 0;
+  eglGetConfigAttrib(ctx->eglDisplay, config, EGL_BUFFER_SIZE, &cfgBufferSize);
+  eglGetConfigAttrib(ctx->eglDisplay, config, EGL_ALPHA_SIZE, &cfgAlphaSize);
+  eglGetConfigAttrib(ctx->eglDisplay, config, EGL_DEPTH_SIZE, &cfgDepthSize);
+  eglGetConfigAttrib(ctx->eglDisplay, config, EGL_STENCIL_SIZE, &cfgStencilSize);
   // 修复 #48-B6: %{public}d 让 EGL 版本号在 HarmonyOS hilog 中可见
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-               "FfmpegInitEGL: OK EGL %{public}d.%{public}d", major, minor);
+                "FfmpegInitEGL: OK EGL %{public}d.%{public}d", major, minor);
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "FfmpegInitEGL: config nativeVisualId=%{public}d bufferSize=%{public}d alpha=%{public}d depth=%{public}d stencil=%{public}d",
+               nativeVisualId, cfgBufferSize, cfgAlphaSize, cfgDepthSize, cfgStencilSize);
   return true;
 }
 
@@ -2352,6 +2391,13 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                "RenderThreadFunc: eglMakeCurrent OK, GL context current ctx=%{public}p",
                static_cast<void*>(eglGetCurrentContext()));
+  {
+    const EGLBoolean swapIntervalOk = eglSwapInterval(ctx->eglDisplay, 0);
+    const EGLint swapIntervalErr = eglGetError();
+    OH_LOG_Print(LOG_APP, swapIntervalOk == EGL_TRUE ? LOG_INFO : LOG_WARN, 0xFF00, "VidAll",
+                 "RenderThreadFunc: eglSwapInterval(0) ok=%{public}d err=0x%{public}x",
+                 swapIntervalOk == EGL_TRUE ? 1 : 0, swapIntervalErr);
+  }
 
   // B3：加载 GL 函数指针（HarmonyOS 需要通过 eglGetProcAddress 动态加载）
   if (!LoadGLFunctions(ctx->gl)) {
@@ -2410,7 +2456,11 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
     // 初始清屏，确保第一帧前屏幕不显示随机内容
     ctx->gl.ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     ctx->gl.Clear(GL_COLOR_BUFFER_BIT);
-    eglSwapBuffers(ctx->eglDisplay, ctx->eglSurface);
+    const EGLBoolean probeSwapOk = eglSwapBuffers(ctx->eglDisplay, ctx->eglSurface);
+    const EGLint probeSwapErr = eglGetError();
+    OH_LOG_Print(LOG_APP, probeSwapOk == EGL_TRUE ? LOG_INFO : LOG_ERROR, 0xFF00, "VidAll",
+                 "RenderThreadFunc: probe eglSwapBuffers ok=%{public}d err=0x%{public}x",
+                 probeSwapOk == EGL_TRUE ? 1 : 0, probeSwapErr);
   }
 
   // B5：时间上报节流（每 200ms 通过 tsfOnTimeUpdate 上报一次播放位置）

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -807,10 +807,11 @@ struct FfmpegContext {
   std::vector<int16_t> pcmLeftover;      // swr_convert 溢出缓冲：跨 callback 的剩余 PCM 数据
 
   // B5：音频时钟（主时钟）
-  std::atomic<int64_t> audioPtsSamples{0};  // 已渲染的音频样本数（stereo stereo 计数，swr 输出 48kHz）
-  int audioSampleRate{0};                    // swr 输出采样率（48000），FfmpegInitSwr 后固定
-  std::atomic<int64_t> audioClockBaseMs{0};  // seek 后的主时钟基准，timeUpdate = base + playedSamples/sampleRate
-  std::atomic<bool> playbackPaused{false};   // FFmpeg 路径的真实暂停态：音频回调/视频渲染均需读取
+  std::atomic<int64_t> audioPtsSamples{0};        // 仅保留为诊断计数，不再直接作为主时钟
+  int audioSampleRate{0};                         // swr 输出采样率（48000），FfmpegInitSwr 后固定
+  std::atomic<int64_t> audioClockBaseMs{0};       // 当前播放锚点对应的媒体时间
+  std::atomic<int64_t> audioClockStartRealtimeMs{0}; // 当前播放锚点对应的 steady_clock 时间；暂停时为 0
+  std::atomic<bool> playbackPaused{false};        // FFmpeg 路径的真实暂停态：音频回调/视频渲染均需读取
   std::atomic<int32_t> videoSyncGraceFrames{0}; // seek/启动后前若干帧绕过 AV sync，先让画面稳定出帧
 
   // B5：seek 请求（Seek() NAPI 写入，DemuxThreadFunc 消费）
@@ -1539,12 +1540,17 @@ static int FfmpegOpenInput(FfmpegContext *ctx, const std::string &url) {
 // ---------------------------------------------------------------------------
 
 static double AudioClock(const FfmpegContext *ctx) {
-  const double baseSeconds =
-      static_cast<double>(ctx->audioClockBaseMs.load(std::memory_order_relaxed)) / 1000.0;
-  if (ctx->audioSampleRate <= 0) return baseSeconds;
-  return baseSeconds +
-         static_cast<double>(ctx->audioPtsSamples.load(std::memory_order_relaxed)) /
-         static_cast<double>(ctx->audioSampleRate);
+  const int64_t baseMs = ctx->audioClockBaseMs.load(std::memory_order_relaxed);
+  if (ctx->playbackPaused.load(std::memory_order_relaxed)) {
+    return static_cast<double>(baseMs) / 1000.0;
+  }
+  const int64_t startRealtimeMs = ctx->audioClockStartRealtimeMs.load(std::memory_order_relaxed);
+  if (startRealtimeMs <= 0) {
+    return static_cast<double>(baseMs) / 1000.0;
+  }
+  const int64_t nowMs = NowRealtimeMs();
+  const int64_t deltaMs = std::max<int64_t>(0, nowMs - startRealtimeMs);
+  return static_cast<double>(baseMs + deltaMs) / 1000.0;
 }
 
 // ---------------------------------------------------------------------------
@@ -1643,6 +1649,7 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
                      static_cast<int32_t>(flushResult));
       }
       ctx->audioClockBaseMs.store(targetMs, std::memory_order_relaxed);
+      ctx->audioClockStartRealtimeMs.store(NowRealtimeMs(), std::memory_order_relaxed);
       ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
       ctx->videoSyncGraceFrames.store(90, std::memory_order_relaxed);
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
@@ -2993,6 +3000,7 @@ static void StartFfmpegAudio(NativePlayerSkeletonState *state) {
 
   ctx->playbackPaused.store(false, std::memory_order_relaxed);
   ctx->audioClockBaseMs.store(0, std::memory_order_relaxed);
+  ctx->audioClockStartRealtimeMs.store(NowRealtimeMs(), std::memory_order_relaxed);
   ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
   ctx->videoSyncGraceFrames.store(90, std::memory_order_relaxed);
   const OH_AudioStream_Result result = OH_AudioRenderer_Start(ctx->audioRenderer);
@@ -3957,6 +3965,7 @@ static napi_value Play(napi_env env, napi_callback_info info) {
   }
   if (state.useFfmpegPath && state.ffmpegCtx != nullptr) {
     state.ffmpegCtx->playbackPaused.store(false, std::memory_order_relaxed);
+    state.ffmpegCtx->audioClockStartRealtimeMs.store(NowRealtimeMs(), std::memory_order_relaxed);
     if (state.ffmpegCtx->audioRenderer != nullptr) {
       const OH_AudioStream_Result result = OH_AudioRenderer_Start(state.ffmpegCtx->audioRenderer);
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
@@ -4012,6 +4021,9 @@ static napi_value Pause(napi_env env, napi_callback_info info) {
     state.lastRealtimeMs = 0;
   }
   if (state.useFfmpegPath && state.ffmpegCtx != nullptr) {
+    const int64_t pausedClockMs = static_cast<int64_t>(AudioClock(state.ffmpegCtx.get()) * 1000.0);
+    state.ffmpegCtx->audioClockBaseMs.store(pausedClockMs, std::memory_order_relaxed);
+    state.ffmpegCtx->audioClockStartRealtimeMs.store(0, std::memory_order_relaxed);
     state.ffmpegCtx->playbackPaused.store(true, std::memory_order_relaxed);
     if (state.ffmpegCtx->audioRenderer != nullptr) {
       const OH_AudioStream_Result result = OH_AudioRenderer_Pause(state.ffmpegCtx->audioRenderer);
@@ -4077,6 +4089,7 @@ static napi_value Seek(napi_env env, napi_callback_info info) {
       state.currentTimeMs = positionMs;
     }
     state.ffmpegCtx->audioClockBaseMs.store(positionMs, std::memory_order_relaxed);
+    state.ffmpegCtx->audioClockStartRealtimeMs.store(NowRealtimeMs(), std::memory_order_relaxed);
     state.ffmpegCtx->audioPtsSamples.store(0, std::memory_order_relaxed);
     state.ffmpegCtx->seekTargetMs.store(positionMs);
     state.ffmpegCtx->seekRequested.store(true);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -687,6 +687,52 @@ struct AVFrameQueue {
 // 前向声明，供 FfmpegContext 持有反向指针（FFmpeg ctx 由 state 独占拥有，生命周期安全）
 struct NativePlayerSkeletonState;
 
+// B3：GL 函数指针（通过 eglGetProcAddress 加载，适配 HarmonyOS GLES dispatch 机制）
+struct GlFunctions {
+    // Shader
+    GLuint (*CreateShader)(GLenum) = nullptr;
+    void (*ShaderSource)(GLuint, GLsizei, const GLchar**, const GLint*) = nullptr;
+    void (*CompileShader)(GLuint) = nullptr;
+    void (*GetShaderiv)(GLuint, GLenum, GLint*) = nullptr;
+    void (*GetShaderInfoLog)(GLuint, GLsizei, GLsizei*, GLchar*) = nullptr;
+    void (*DeleteShader)(GLuint) = nullptr;
+    // Program
+    GLuint (*CreateProgram)() = nullptr;
+    void (*AttachShader)(GLuint, GLuint) = nullptr;
+    void (*BindAttribLocation)(GLuint, GLuint, const GLchar*) = nullptr;
+    void (*LinkProgram)(GLuint) = nullptr;
+    void (*DeleteProgram)(GLuint) = nullptr;
+    void (*GetProgramiv)(GLuint, GLenum, GLint*) = nullptr;
+    void (*UseProgram)(GLuint) = nullptr;
+    GLint (*GetUniformLocation)(GLuint, const GLchar*) = nullptr;
+    void (*Uniform1i)(GLint, GLint) = nullptr;
+    // Texture
+    void (*GenTextures)(GLsizei, GLuint*) = nullptr;
+    void (*BindTexture)(GLenum, GLuint) = nullptr;
+    void (*TexParameteri)(GLenum, GLenum, GLint) = nullptr;
+    void (*TexImage2D)(GLenum, GLint, GLint, GLsizei, GLsizei, GLint, GLenum, GLenum, const void*) = nullptr;
+    void (*TexSubImage2D)(GLenum, GLint, GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, const void*) = nullptr;
+    void (*ActiveTexture)(GLenum) = nullptr;
+    void (*DeleteTextures)(GLsizei, const GLuint*) = nullptr;
+    // Buffer
+    void (*GenBuffers)(GLsizei, GLuint*) = nullptr;
+    void (*BindBuffer)(GLenum, GLuint) = nullptr;
+    void (*BufferData)(GLenum, GLsizeiptr, const void*, GLenum) = nullptr;
+    void (*DeleteBuffers)(GLsizei, const GLuint*) = nullptr;
+    // Draw
+    void (*VertexAttribPointer)(GLuint, GLint, GLenum, GLboolean, GLsizei, const void*) = nullptr;
+    void (*EnableVertexAttribArray)(GLuint) = nullptr;
+    void (*DisableVertexAttribArray)(GLuint) = nullptr;
+    void (*DrawArrays)(GLenum, GLint, GLsizei) = nullptr;
+    // State
+    void (*Viewport)(GLint, GLint, GLsizei, GLsizei) = nullptr;
+    void (*ClearColor)(GLfloat, GLfloat, GLfloat, GLfloat) = nullptr;
+    void (*Clear)(GLbitfield) = nullptr;
+    void (*PixelStorei)(GLenum, GLint) = nullptr;
+    GLenum (*GetError)() = nullptr;
+    const GLubyte* (*GetString)(GLenum) = nullptr;
+};
+
 // FFmpeg 上下文：格式探测 + demux 线程 + 双队列
 struct FfmpegContext {
   AVFormatContext *fmtCtx = nullptr;
@@ -718,6 +764,9 @@ struct FfmpegContext {
   EGLDisplay eglDisplay = EGL_NO_DISPLAY;
   EGLSurface eglSurface = EGL_NO_SURFACE;
   EGLContext eglContext = EGL_NO_CONTEXT;
+
+  // B3：通过 eglGetProcAddress 加载的 GL 函数指针（适配 HarmonyOS GLES dispatch 机制）
+  GlFunctions gl;
 
   // B3：OpenGL ES 资源（在渲染线程 makeCurrent 后初始化）
   GLuint yuvProgram = 0;   // YUV→RGB GLSL program
@@ -1867,6 +1916,60 @@ static const char *kFragmentShaderSrc =
     "}\n";
 
 // ---------------------------------------------------------------------------
+// B3：通过 eglGetProcAddress 加载 GL 函数指针（适配 HarmonyOS GLES dispatch 机制）
+// ---------------------------------------------------------------------------
+
+static bool LoadGLFunctions(GlFunctions &gl) {
+#define LOAD(field, name) \
+    gl.field = reinterpret_cast<decltype(gl.field)>(eglGetProcAddress(name)); \
+    if (!gl.field) { \
+        OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll", \
+                     "LoadGLFunctions: eglGetProcAddress(%{public}s) returned null", name); \
+        return false; \
+    }
+    LOAD(CreateShader,            "glCreateShader")
+    LOAD(ShaderSource,            "glShaderSource")
+    LOAD(CompileShader,           "glCompileShader")
+    LOAD(GetShaderiv,             "glGetShaderiv")
+    LOAD(GetShaderInfoLog,        "glGetShaderInfoLog")
+    LOAD(DeleteShader,            "glDeleteShader")
+    LOAD(CreateProgram,           "glCreateProgram")
+    LOAD(AttachShader,            "glAttachShader")
+    LOAD(BindAttribLocation,      "glBindAttribLocation")
+    LOAD(LinkProgram,             "glLinkProgram")
+    LOAD(DeleteProgram,           "glDeleteProgram")
+    LOAD(GetProgramiv,            "glGetProgramiv")
+    LOAD(UseProgram,              "glUseProgram")
+    LOAD(GetUniformLocation,      "glGetUniformLocation")
+    LOAD(Uniform1i,               "glUniform1i")
+    LOAD(GenTextures,             "glGenTextures")
+    LOAD(BindTexture,             "glBindTexture")
+    LOAD(TexParameteri,           "glTexParameteri")
+    LOAD(TexImage2D,              "glTexImage2D")
+    LOAD(TexSubImage2D,           "glTexSubImage2D")
+    LOAD(ActiveTexture,           "glActiveTexture")
+    LOAD(DeleteTextures,          "glDeleteTextures")
+    LOAD(GenBuffers,              "glGenBuffers")
+    LOAD(BindBuffer,              "glBindBuffer")
+    LOAD(BufferData,              "glBufferData")
+    LOAD(DeleteBuffers,           "glDeleteBuffers")
+    LOAD(VertexAttribPointer,     "glVertexAttribPointer")
+    LOAD(EnableVertexAttribArray, "glEnableVertexAttribArray")
+    LOAD(DisableVertexAttribArray,"glDisableVertexAttribArray")
+    LOAD(DrawArrays,              "glDrawArrays")
+    LOAD(Viewport,                "glViewport")
+    LOAD(ClearColor,              "glClearColor")
+    LOAD(Clear,                   "glClear")
+    LOAD(PixelStorei,             "glPixelStorei")
+    LOAD(GetError,                "glGetError")
+    LOAD(GetString,               "glGetString")
+#undef LOAD
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                 "LoadGLFunctions: all %{public}d GL functions loaded", 36);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
 // B3：EGL 初始化（在渲染线程内调用，nativeWindow 提供 EGLNativeWindowType）
 // ---------------------------------------------------------------------------
 
@@ -1960,25 +2063,25 @@ static bool FfmpegInitEGL(FfmpegContext *ctx, OHNativeWindow *nativeWindow) {
 // B3：shader 编译辅助
 // ---------------------------------------------------------------------------
 
-static GLuint CompileShader(GLenum type, const char *src) {
-  const GLuint shader = glCreateShader(type);
+static GLuint CompileShader(const GlFunctions &gl, GLenum type, const char *src) {
+  const GLuint shader = gl.CreateShader(type);
   if (shader == 0) {
     // 修复 #48-B6: glCreateShader 返回 0 说明 GL context 尚未生效
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
-                 "CompileShader: glCreateShader returned 0 (no GL context?) type=%{public}u",
+                 "CompileShader: CreateShader returned 0 type=%{public}u",
                  type);
     return 0;
   }
-  glShaderSource(shader, 1, &src, nullptr);
-  glCompileShader(shader);
+  gl.ShaderSource(shader, 1, &src, nullptr);
+  gl.CompileShader(shader);
   GLint status = 0;
-  glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
+  gl.GetShaderiv(shader, GL_COMPILE_STATUS, &status);
   if (status == GL_FALSE) {
     GLint len = 0;
-    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &len);
+    gl.GetShaderiv(shader, GL_INFO_LOG_LENGTH, &len);
     if (len > 1) {
       std::string log(static_cast<size_t>(len), '\0');
-      glGetShaderInfoLog(shader, len, nullptr, &log[0]);
+      gl.GetShaderInfoLog(shader, len, nullptr, &log[0]);
       // 修复 #48-B6: %{public}s 才能在 HarmonyOS hilog 中显示字符串内容（%s 为私有格式）
       OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
                    "CompileShader: type=%{public}u compile error: %{public}s",
@@ -1987,7 +2090,7 @@ static GLuint CompileShader(GLenum type, const char *src) {
       OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
                    "CompileShader: type=%{public}u compile error (no info log)", type);
     }
-    glDeleteShader(shader);
+    gl.DeleteShader(shader);
     return 0;
   }
   return shader;
@@ -1999,52 +2102,52 @@ static GLuint CompileShader(GLenum type, const char *src) {
 
 static bool FfmpegInitGLResources(FfmpegContext *ctx) {
   // 1. 编译 & 链接 YUV→RGB program
-  const GLuint vs = CompileShader(GL_VERTEX_SHADER, kVertexShaderSrc);
-  const GLuint fs = CompileShader(GL_FRAGMENT_SHADER, kFragmentShaderSrc);
+  const GLuint vs = CompileShader(ctx->gl, GL_VERTEX_SHADER, kVertexShaderSrc);
+  const GLuint fs = CompileShader(ctx->gl, GL_FRAGMENT_SHADER, kFragmentShaderSrc);
   if (vs == 0 || fs == 0) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
                  "FfmpegInitGLResources: shader compile failed");
-    if (vs != 0) { glDeleteShader(vs); }
-    if (fs != 0) { glDeleteShader(fs); }
+    if (vs != 0) { ctx->gl.DeleteShader(vs); }
+    if (fs != 0) { ctx->gl.DeleteShader(fs); }
     return false;
   }
-  ctx->yuvProgram = glCreateProgram();
-  glAttachShader(ctx->yuvProgram, vs);
-  glAttachShader(ctx->yuvProgram, fs);
-  glBindAttribLocation(ctx->yuvProgram, 0, "a_position");
-  glBindAttribLocation(ctx->yuvProgram, 1, "a_texCoord");
-  glLinkProgram(ctx->yuvProgram);
-  glDeleteShader(vs);
-  glDeleteShader(fs);
+  ctx->yuvProgram = ctx->gl.CreateProgram();
+  ctx->gl.AttachShader(ctx->yuvProgram, vs);
+  ctx->gl.AttachShader(ctx->yuvProgram, fs);
+  ctx->gl.BindAttribLocation(ctx->yuvProgram, 0, "a_position");
+  ctx->gl.BindAttribLocation(ctx->yuvProgram, 1, "a_texCoord");
+  ctx->gl.LinkProgram(ctx->yuvProgram);
+  ctx->gl.DeleteShader(vs);
+  ctx->gl.DeleteShader(fs);
   GLint linked = 0;
-  glGetProgramiv(ctx->yuvProgram, GL_LINK_STATUS, &linked);
+  ctx->gl.GetProgramiv(ctx->yuvProgram, GL_LINK_STATUS, &linked);
   if (linked == GL_FALSE) {
     OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
                  "FfmpegInitGLResources: program link failed");
-    glDeleteProgram(ctx->yuvProgram);
+    ctx->gl.DeleteProgram(ctx->yuvProgram);
     ctx->yuvProgram = 0;
     return false;
   }
 
   // 2. 绑定 sampler uniform（GL_TEXTURE0=Y, GL_TEXTURE1=U, GL_TEXTURE2=V）
-  glUseProgram(ctx->yuvProgram);
-  glUniform1i(glGetUniformLocation(ctx->yuvProgram, "u_textureY"), 0);
-  glUniform1i(glGetUniformLocation(ctx->yuvProgram, "u_textureU"), 1);
-  glUniform1i(glGetUniformLocation(ctx->yuvProgram, "u_textureV"), 2);
+  ctx->gl.UseProgram(ctx->yuvProgram);
+  ctx->gl.Uniform1i(ctx->gl.GetUniformLocation(ctx->yuvProgram, "u_textureY"), 0);
+  ctx->gl.Uniform1i(ctx->gl.GetUniformLocation(ctx->yuvProgram, "u_textureU"), 1);
+  ctx->gl.Uniform1i(ctx->gl.GetUniformLocation(ctx->yuvProgram, "u_textureV"), 2);
 
   // 3. 创建 Y/U/V 三张 GL_LUMINANCE 纹理（实际尺寸由第一帧决定）
-  glGenTextures(1, &ctx->textureY);
-  glGenTextures(1, &ctx->textureU);
-  glGenTextures(1, &ctx->textureV);
+  ctx->gl.GenTextures(1, &ctx->textureY);
+  ctx->gl.GenTextures(1, &ctx->textureU);
+  ctx->gl.GenTextures(1, &ctx->textureV);
   const GLuint textures[3] = {ctx->textureY, ctx->textureU, ctx->textureV};
   for (const GLuint tex : textures) {
-    glBindTexture(GL_TEXTURE_2D, tex);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    ctx->gl.BindTexture(GL_TEXTURE_2D, tex);
+    ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    ctx->gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   }
-  glBindTexture(GL_TEXTURE_2D, 0);
+  ctx->gl.BindTexture(GL_TEXTURE_2D, 0);
 
   // 4. 全屏四边形 VBO（triangle strip，x/y 为 NDC，s/t 为 UV）
   // 顺序：左下、右下、左上、右上（匹配 UV 坐标 y 从下往上）
@@ -2054,11 +2157,11 @@ static bool FfmpegInitGLResources(FfmpegContext *ctx) {
       -1.0f,  1.0f,  0.0f, 0.0f,
        1.0f,  1.0f,  1.0f, 0.0f,
   };
-  glGenBuffers(1, &ctx->quadVBO);
-  glBindBuffer(GL_ARRAY_BUFFER, ctx->quadVBO);
-  glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(sizeof(quadVertices)),
+  ctx->gl.GenBuffers(1, &ctx->quadVBO);
+  ctx->gl.BindBuffer(GL_ARRAY_BUFFER, ctx->quadVBO);
+  ctx->gl.BufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(sizeof(quadVertices)),
                quadVertices, GL_STATIC_DRAW);
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  ctx->gl.BindBuffer(GL_ARRAY_BUFFER, 0);
 
   // 修复 #48-B6: %{public}u 让资源 ID 在 hilog 中可见
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
@@ -2074,23 +2177,23 @@ static bool FfmpegInitGLResources(FfmpegContext *ctx) {
 
 static void FfmpegCleanupGLResources(FfmpegContext *ctx) {
   if (ctx->quadVBO != 0) {
-    glDeleteBuffers(1, &ctx->quadVBO);
+    ctx->gl.DeleteBuffers(1, &ctx->quadVBO);
     ctx->quadVBO = 0;
   }
   if (ctx->textureY != 0) {
-    glDeleteTextures(1, &ctx->textureY);
+    ctx->gl.DeleteTextures(1, &ctx->textureY);
     ctx->textureY = 0;
   }
   if (ctx->textureU != 0) {
-    glDeleteTextures(1, &ctx->textureU);
+    ctx->gl.DeleteTextures(1, &ctx->textureU);
     ctx->textureU = 0;
   }
   if (ctx->textureV != 0) {
-    glDeleteTextures(1, &ctx->textureV);
+    ctx->gl.DeleteTextures(1, &ctx->textureV);
     ctx->textureV = 0;
   }
   if (ctx->yuvProgram != 0) {
-    glDeleteProgram(ctx->yuvProgram);
+    ctx->gl.DeleteProgram(ctx->yuvProgram);
     ctx->yuvProgram = 0;
   }
   OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
@@ -2142,16 +2245,21 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
                "RenderThreadFunc: eglMakeCurrent OK, GL context current ctx=%{public}p",
                static_cast<void*>(eglGetCurrentContext()));
 
-  // GL context 验证诊断
+  // B3：加载 GL 函数指针（HarmonyOS 需要通过 eglGetProcAddress 动态加载）
+  if (!LoadGLFunctions(ctx->gl)) {
+    OH_LOG_Print(LOG_APP, LOG_ERROR, 0xFF00, "VidAll",
+                 "RenderThreadFunc: LoadGLFunctions failed, exit");
+    ctx->renderRunning.store(false);
+    return;
+  }
+
+  // GL context 验证诊断（使用已加载的函数指针）
   {
-    const GLubyte *glVer = glGetString(GL_VERSION);
-    const GLubyte *glRenderer = glGetString(GL_RENDERER);
-    GLenum glErr = glGetError();
+    const GLubyte *glVer = ctx->gl.GetString(GL_VERSION);
+    GLenum glErr = ctx->gl.GetError();
     OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                 "RenderThreadFunc: GL_VERSION=%{public}s GL_RENDERER=%{public}s glGetError=0x%{public}x",
-                 glVer ? (const char*)glVer : "null",
-                 glRenderer ? (const char*)glRenderer : "null",
-                 glErr);
+                 "RenderThreadFunc: GL_VERSION=%{public}s glGetError=0x%{public}x",
+                 glVer ? (const char*)glVer : "null", glErr);
   }
 
   // 3. 初始化 GL 资源（shader/纹理/VBO）
@@ -2225,37 +2333,37 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
     // 5. 上传 YUV420P → 3 张 GL_LUMINANCE 纹理
     const int w = frame->width;
     const int h = frame->height;
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    ctx->gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, ctx->textureY);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w, h, 0,
+    ctx->gl.ActiveTexture(GL_TEXTURE0);
+    ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureY);
+    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w, h, 0,
                  GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[0]);
 
-    glActiveTexture(GL_TEXTURE1);
-    glBindTexture(GL_TEXTURE_2D, ctx->textureU);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
+    ctx->gl.ActiveTexture(GL_TEXTURE1);
+    ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureU);
+    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
                  GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[1]);
 
-    glActiveTexture(GL_TEXTURE2);
-    glBindTexture(GL_TEXTURE_2D, ctx->textureV);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
+    ctx->gl.ActiveTexture(GL_TEXTURE2);
+    ctx->gl.BindTexture(GL_TEXTURE_2D, ctx->textureV);
+    ctx->gl.TexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w / 2, h / 2, 0,
                  GL_LUMINANCE, GL_UNSIGNED_BYTE, frame->data[2]);
 
     // 6. 用 YUV program 绘制全屏 quad（triangle strip，4 顶点）
-    glUseProgram(ctx->yuvProgram);
-    glBindBuffer(GL_ARRAY_BUFFER, ctx->quadVBO);
+    ctx->gl.UseProgram(ctx->yuvProgram);
+    ctx->gl.BindBuffer(GL_ARRAY_BUFFER, ctx->quadVBO);
     const GLsizei stride = static_cast<GLsizei>(4 * sizeof(float));
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, stride,
+    ctx->gl.EnableVertexAttribArray(0);
+    ctx->gl.VertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, stride,
                           reinterpret_cast<const void *>(0));
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, stride,
+    ctx->gl.EnableVertexAttribArray(1);
+    ctx->gl.VertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, stride,
                           reinterpret_cast<const void *>(2 * sizeof(float)));
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-    glDisableVertexAttribArray(0);
-    glDisableVertexAttribArray(1);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    ctx->gl.DrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    ctx->gl.DisableVertexAttribArray(0);
+    ctx->gl.DisableVertexAttribArray(1);
+    ctx->gl.BindBuffer(GL_ARRAY_BUFFER, 0);
 
     // 7. 提交帧到屏幕
     eglSwapBuffers(ctx->eglDisplay, ctx->eglSurface);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -819,6 +819,11 @@ struct FfmpegContext {
   std::atomic<int64_t> audioClockStartRealtimeMs{0}; // 当前播放锚点对应的 steady_clock 时间；暂停时为 0
   std::atomic<bool> playbackPaused{false};        // FFmpeg 路径的真实暂停态：音频回调/视频渲染均需读取
   std::atomic<int32_t> videoSyncGraceFrames{0}; // seek/启动后前若干帧绕过 AV sync，先让画面稳定出帧
+  int droppedDecodeFrames = 0;                    // 诊断：当前会话累计丢弃的解码帧
+  int droppedLateFrames = 0;                      // 诊断：当前会话累计丢弃的渲染晚到帧
+  bool firstFrameLogged = false;                  // 诊断：每个会话仅打印一次首帧日志
+  bool firstDrawLogged = false;                   // 诊断：每个会话仅打印一次首个 glDrawArrays 日志
+  bool firstSwapLogged = false;                   // 诊断：每个会话仅打印一次首个 eglSwapBuffers 日志
 
   // B5：seek 请求（Seek() NAPI 写入，DemuxThreadFunc 消费）
   std::atomic<bool> seekRequested{false};
@@ -1674,49 +1679,49 @@ static void DemuxThreadFunc(FfmpegContext *ctx) {
                      "DemuxThread: av_seek_frame failed: %s", errBuf);
         // seek 失败不 continue：让后续 av_read_frame 继续在原位置读包，避免卡死。
       } else {
-      // 清空所有 packet/frame 队列（旧数据）
-      FlushFfmpegQueues(ctx);
-      // 刷新解码器内部缓冲区（hold codecMutex 防止与 decode 线程并发）
-      {
-        std::lock_guard<std::mutex> codecLk(ctx->codecMutex);
-        if (ctx->videoCodecCtx != nullptr) avcodec_flush_buffers(ctx->videoCodecCtx);
-        if (ctx->audioCodecCtx != nullptr) avcodec_flush_buffers(ctx->audioCodecCtx);
-      }
-      // seek 后重置 renderer 缓冲与音频时钟：新时钟 = 目标位置 + 之后已渲染样本
-      if (ctx->audioRenderer != nullptr) {
-        const OH_AudioStream_Result flushResult = OH_AudioRenderer_Flush(ctx->audioRenderer);
+        // 清空所有 packet/frame 队列（旧数据）
+        FlushFfmpegQueues(ctx);
+        // 刷新解码器内部缓冲区（hold codecMutex 防止与 decode 线程并发）
+        {
+          std::lock_guard<std::mutex> codecLk(ctx->codecMutex);
+          if (ctx->videoCodecCtx != nullptr) avcodec_flush_buffers(ctx->videoCodecCtx);
+          if (ctx->audioCodecCtx != nullptr) avcodec_flush_buffers(ctx->audioCodecCtx);
+        }
+        // seek 后重置 renderer 缓冲与音频时钟：新时钟 = 目标位置 + 之后已渲染样本
+        if (ctx->audioRenderer != nullptr) {
+          const OH_AudioStream_Result flushResult = OH_AudioRenderer_Flush(ctx->audioRenderer);
+          OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+                       "DemuxThread: OH_AudioRenderer_Flush result=%{public}d",
+                       static_cast<int32_t>(flushResult));
+        }
+        ctx->audioClockBaseMs.store(targetMs, std::memory_order_relaxed);
+        ctx->audioClockStartRealtimeMs.store(NowRealtimeMs(), std::memory_order_relaxed);
+        ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
+        ctx->videoSyncGraceFrames.store(90, std::memory_order_relaxed);
         OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                     "DemuxThread: OH_AudioRenderer_Flush result=%{public}d",
-                     static_cast<int32_t>(flushResult));
-      }
-      ctx->audioClockBaseMs.store(targetMs, std::memory_order_relaxed);
-      ctx->audioClockStartRealtimeMs.store(NowRealtimeMs(), std::memory_order_relaxed);
-      ctx->audioPtsSamples.store(0, std::memory_order_relaxed);
-      ctx->videoSyncGraceFrames.store(90, std::memory_order_relaxed);
-      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                   "DemuxThread: seeked to %lld ms", static_cast<long long>(targetMs));
-      // 发出 seekDone TSF 通知 ArkTS
-      // B5-QA fix：通过 atomic load(acquire) 读取 ownerState，消除与主线程写 nullptr 的竞态；
-      //            两次独立 load 分别保护"写 currentTimeMs"和"调用 TSF"两个临界区。
-      {
-        NativePlayerSkeletonState *st = ctx->ownerState.load(std::memory_order_acquire);
-        if (st != nullptr) {
-          std::lock_guard<std::mutex> lk(st->stateMutex);
-          st->currentTimeMs = targetMs;
+                     "DemuxThread: seeked to %lld ms", static_cast<long long>(targetMs));
+        // 发出 seekDone TSF 通知 ArkTS
+        // B5-QA fix：通过 atomic load(acquire) 读取 ownerState，消除与主线程写 nullptr 的竞态；
+        //            两次独立 load 分别保护"写 currentTimeMs"和"调用 TSF"两个临界区。
+        {
+          NativePlayerSkeletonState *st = ctx->ownerState.load(std::memory_order_acquire);
+          if (st != nullptr) {
+            std::lock_guard<std::mutex> lk(st->stateMutex);
+            st->currentTimeMs = targetMs;
+          }
         }
-      }
-      {
-        NativePlayerSkeletonState *st = ctx->ownerState.load(std::memory_order_acquire);
-        if (st != nullptr && st->tsfOnTimeUpdate != nullptr) {
-          napi_call_threadsafe_function(st->tsfOnTimeUpdate, nullptr, napi_tsfn_nonblocking);
+        {
+          NativePlayerSkeletonState *st = ctx->ownerState.load(std::memory_order_acquire);
+          if (st != nullptr && st->tsfOnTimeUpdate != nullptr) {
+            napi_call_threadsafe_function(st->tsfOnTimeUpdate, nullptr, napi_tsfn_nonblocking);
+          }
         }
-      }
-      {
-        NativePlayerSkeletonState *st = ctx->ownerState.load(std::memory_order_acquire);
-        if (st != nullptr && st->tsfOnSeekDone != nullptr) {
-          napi_call_threadsafe_function(st->tsfOnSeekDone, nullptr, napi_tsfn_nonblocking);
+        {
+          NativePlayerSkeletonState *st = ctx->ownerState.load(std::memory_order_acquire);
+          if (st != nullptr && st->tsfOnSeekDone != nullptr) {
+            napi_call_threadsafe_function(st->tsfOnSeekDone, nullptr, napi_tsfn_nonblocking);
+          }
         }
-      }
       } // end else (seekRet >= 0)
     } // end if (seekRequested)
 
@@ -1820,7 +1825,7 @@ static int FfmpegInitCodecs(FfmpegContext *ctx) {
       avcodec_free_context(&ctx->videoCodecCtx);
       return ret;
     }
-      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                  "FfmpegInitCodecs: video decoder opened: %s %dx%d threads=%d",
                  codec->name, ctx->videoCodecCtx->width, ctx->videoCodecCtx->height,
                  ctx->videoCodecCtx->thread_count);
@@ -1922,9 +1927,8 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
         const double audioClock = AudioClock(ctx);
         const double diff = videoPts - audioClock;
         if (videoPts > 0.0 && diff < -0.8) {
-          static int droppedDecodeFrames = 0;
-          droppedDecodeFrames++;
-          if (droppedDecodeFrames == 1 || (droppedDecodeFrames % 30) == 0) {
+          ctx->droppedDecodeFrames++;
+          if (ctx->droppedDecodeFrames == 1 || (ctx->droppedDecodeFrames % 30) == 0) {
             int packetBacklog = 0;
             {
               std::lock_guard<std::mutex> lock(ctx->videoQueue.mtx);
@@ -1936,7 +1940,7 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
                          static_cast<int>(videoPts * 1000.0),
                          static_cast<int>(audioClock * 1000.0),
                          packetBacklog,
-                         droppedDecodeFrames);
+                         ctx->droppedDecodeFrames);
           }
           av_frame_unref(frame);
           continue;
@@ -2635,21 +2639,19 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
           const int sleepMs = static_cast<int>(std::min(diff * 1000.0, 50.0));
           std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
         } else if (diff < -2.0) {
-          static int droppedLateFrames = 0;
-          droppedLateFrames++;
-          if (droppedLateFrames == 1 || (droppedLateFrames % 30) == 0) {
+          ctx->droppedLateFrames++;
+          if (ctx->droppedLateFrames == 1 || (ctx->droppedLateFrames % 30) == 0) {
             OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
                          "RenderThread: drop late frame diffMs=%{public}d videoPtsMs=%{public}d audioClockMs=%{public}d count=%{public}d",
                          static_cast<int>(diff * 1000.0),
                          static_cast<int>(videoPts * 1000.0),
                          static_cast<int>(audioClock * 1000.0),
-                         droppedLateFrames);
+                         ctx->droppedLateFrames);
           }
           av_frame_free(&frame);
           continue;
         } else {
-          static int droppedLateFrames = 0;
-          droppedLateFrames = 0;
+          ctx->droppedLateFrames = 0;
         }
       } else if (ctx->videoSyncGraceFrames.load(std::memory_order_relaxed) > 0) {
         ctx->videoSyncGraceFrames.fetch_sub(1, std::memory_order_relaxed);
@@ -2676,9 +2678,8 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
 
     // B6 诊断日志：第一帧打印格式与 linesize
     {
-      static bool firstFrameLogged = false;
-      if (!firstFrameLogged) {
-        firstFrameLogged = true;
+      if (!ctx->firstFrameLogged) {
+        ctx->firstFrameLogged = true;
         OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
                      "RenderThread: first frame w=%{public}d h=%{public}d fmt=%{public}d ls0=%{public}d",
                      frame->width, frame->height, frame->format, frame->linesize[0]);
@@ -2755,10 +2756,9 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
                           reinterpret_cast<const void *>(2 * sizeof(float)));
     ctx->gl.DrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     {
-      static bool firstDrawLogged = false;
       const GLenum drawErr = ctx->gl.GetError();
-      if (!firstDrawLogged || drawErr != GL_NO_ERROR) {
-        firstDrawLogged = true;
+      if (!ctx->firstDrawLogged || drawErr != GL_NO_ERROR) {
+        ctx->firstDrawLogged = true;
         OH_LOG_Print(LOG_APP, drawErr == GL_NO_ERROR ? LOG_INFO : LOG_ERROR,
                      0xFF00, "VidAll",
                      "RenderThread: glDrawArrays err=0x%{public}x", drawErr);
@@ -2770,11 +2770,10 @@ static void RenderThreadFunc(NativePlayerSkeletonState *state) {
 
     // 7. 提交帧到屏幕
     {
-      static bool firstSwapLogged = false;
       const EGLBoolean swapOk = eglSwapBuffers(ctx->eglDisplay, ctx->eglSurface);
       const EGLint swapErr = eglGetError();
-      if (!firstSwapLogged || swapOk != EGL_TRUE) {
-        firstSwapLogged = true;
+      if (!ctx->firstSwapLogged || swapOk != EGL_TRUE) {
+        ctx->firstSwapLogged = true;
         OH_LOG_Print(LOG_APP, swapOk == EGL_TRUE ? LOG_INFO : LOG_ERROR,
                      0xFF00, "VidAll",
                      "RenderThread: eglSwapBuffers ok=%{public}d err=0x%{public}x",
@@ -3894,6 +3893,11 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
       return nullptr;
     }
   }
+  if (hasFfmpegSwitchingArg) {
+    if (!EnsureFunctionArg(env, args[7], "setCallbacks onFfmpegSwitching must be function")) {
+      return nullptr;
+    }
+  }
   if (hasSubtitleUpdateArg) {
     if (!EnsureFunctionArg(env, args[8], "setCallbacks onSubtitleUpdate must be function")) {
       return nullptr;
@@ -4082,20 +4086,16 @@ static napi_value SetCallbacks(napi_env env, napi_callback_info info) {
   // B6修复：注册 tsfOnFfmpegSwitching（可选，args[7]）
   // FFmpeg 接管后通知 ArkTS 重置守卫计时器至 15s，防止 3.5s 超时误触 fallback。
   if (hasFfmpegSwitchingArg) {
-    napi_valuetype argType = napi_undefined;
-    napi_typeof(env, args[7], &argType);
-    if (argType == napi_function) {
-      napi_value resName;
-      napi_create_string_utf8(env, "tsfOnFfmpegSwitching", NAPI_AUTO_LENGTH, &resName);
-      napi_create_threadsafe_function(
-        env, args[7], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
-        [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
-          napi_value undef;
-          napi_get_undefined(tsfEnv, &undef);
-          napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
-        },
-        &state.tsfOnFfmpegSwitching);
-    }
+    napi_value resName;
+    napi_create_string_utf8(env, "tsfOnFfmpegSwitching", NAPI_AUTO_LENGTH, &resName);
+    napi_create_threadsafe_function(
+      env, args[7], nullptr, resName, 0, 1, nullptr, nullptr, statePtr,
+      [](napi_env tsfEnv, napi_value jsCb, void *ctx, void *data) {
+        napi_value undef;
+        napi_get_undefined(tsfEnv, &undef);
+        napi_call_function(tsfEnv, undef, jsCb, 0, nullptr, nullptr);
+      },
+      &state.tsfOnFfmpegSwitching);
   }
 
   // 若回调在 prepared 之后才注册，主动补发一次状态，避免上层错过时序。

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -800,6 +800,8 @@ struct FfmpegContext {
   OH_AudioStreamBuilder *audioBuilder = nullptr;
   SwrContext *swrCtx = nullptr;          // libswresample 重采样上下文（源格式 → stereo S16 48kHz）
   SwsContext *swsCtx = nullptr;          // libswscale 像素格式转换（yuv420p10le/etc → yuv420p，B6 HDR/DV 修复）
+  int lastSwsSrcFmt = -1;  // 上次 swsCtx 对应的源像素格式（格式或尺寸变化时重建）
+  int lastSwsSrcW   = -1;  // 上次 swsCtx 对应的源宽度
   std::vector<int16_t> pcmLeftover;      // swr_convert 溢出缓冲：跨 callback 的剩余 PCM 数据
 
   // B5：音频时钟（主时钟）
@@ -853,6 +855,8 @@ struct FfmpegContext {
     if (swsCtx != nullptr) {
       sws_freeContext(swsCtx);
       swsCtx = nullptr;
+      lastSwsSrcFmt = -1;
+      lastSwsSrcW   = -1;
     }
   }
 };
@@ -1819,28 +1823,48 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
       }
 
       // 将帧移入 videoFrameQueue（背压等待，防止解码过快撑爆内存）
-      // ── B6：强制转换到 YUV420P（8-bit），渲染管线只处理 yuv420p ──
-      // HDR/DV 内容解码输出 yuv420p10le（10-bit），GL 侧以 GL_UNSIGNED_BYTE 上传，
-      // 若不转换则纹理数据完全错误 → 黑屏。此处懒创建/复用 SwsContext。
+      // ── B6：格式转换 + 超 1920 降采样 ──
+      // 1. HDR/DV 内容解码输出 yuv420p10le（10-bit），必须转换到 yuv420p（8-bit）
+      // 2. 4K 内容（3840×2160）纹理分配在设备上触发 GL_OUT_OF_MEMORY（0x505），
+      //    宽度超过 1920 时通过 sws_scale 同步降采样到 1920×H（保持宽高比）。
+      static const int MAX_RENDER_W = 1920;
+      // 计算目标渲染分辨率（降采样到 1920 时保持宽高比，行/列对齐到偶数）
+      int dstW = frame->width;
+      int dstH = frame->height;
+      if (dstW > MAX_RENDER_W) {
+        dstH = dstH * MAX_RENDER_W / dstW;
+        dstW = MAX_RENDER_W;
+        dstH = (dstH + 1) & ~1;  // 偶数对齐（YUV420P 要求）
+      }
+      bool needConvert = (frame->format != AV_PIX_FMT_YUV420P) || (dstW != frame->width);
       AVFrame *renderFrame = frame;
       AVFrame *convertedFrame = nullptr;
-      if (frame->format != AV_PIX_FMT_YUV420P) {
-        // 输入格式变化时重建 SwsContext（首次 or 格式切换）
-        if (ctx->swsCtx == nullptr) {
+      if (needConvert) {
+        // 格式或源宽度变化时重建 SwsContext
+        if (ctx->swsCtx == nullptr
+            || ctx->lastSwsSrcFmt != frame->format
+            || ctx->lastSwsSrcW   != frame->width) {
+          if (ctx->swsCtx != nullptr) {
+            sws_freeContext(ctx->swsCtx);
+            ctx->swsCtx = nullptr;
+          }
           ctx->swsCtx = sws_getContext(
               frame->width, frame->height, static_cast<AVPixelFormat>(frame->format),
-              frame->width, frame->height, AV_PIX_FMT_YUV420P,
+              dstW, dstH, AV_PIX_FMT_YUV420P,
               SWS_BILINEAR, nullptr, nullptr, nullptr);
+          ctx->lastSwsSrcFmt = frame->format;
+          ctx->lastSwsSrcW   = frame->width;
           OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
-                       "VideoDecodeThread: SwsContext created srcFmt=%{public}d -> yuv420p",
-                       frame->format);
+                       "VideoDecodeThread: SwsContext created %{public}dx%{public}d srcFmt=%{public}d"
+                       " -> %{public}dx%{public}d yuv420p",
+                       frame->width, frame->height, frame->format, dstW, dstH);
         }
         if (ctx->swsCtx != nullptr) {
           convertedFrame = av_frame_alloc();
           if (convertedFrame != nullptr) {
             convertedFrame->format = AV_PIX_FMT_YUV420P;
-            convertedFrame->width  = frame->width;
-            convertedFrame->height = frame->height;
+            convertedFrame->width  = dstW;
+            convertedFrame->height = dstH;
             if (av_frame_get_buffer(convertedFrame, 32) == 0) {
               sws_scale(ctx->swsCtx,
                         reinterpret_cast<const uint8_t * const *>(frame->data),
@@ -1852,14 +1876,13 @@ static void VideoDecodeThreadFunc(FfmpegContext *ctx) {
             } else {
               av_frame_free(&convertedFrame);
               convertedFrame = nullptr;
-              // fallback：直接用原始帧（可能渲染异常，但不崩溃）
               OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll",
                            "VideoDecodeThread: av_frame_get_buffer failed, fallback to raw frame");
             }
           }
         }
       }
-      // ── 结束格式转换 ──
+      // ── 结束格式转换与降采样 ──
 
       AVFrame *frameCopy = av_frame_alloc();
       if (frameCopy) {
@@ -2995,6 +3018,8 @@ static void StopFfmpegDecode(NativePlayerSkeletonState *state) {
   if (ctx->swsCtx != nullptr) {
     sws_freeContext(ctx->swsCtx);
     ctx->swsCtx = nullptr;
+    ctx->lastSwsSrcFmt = -1;
+    ctx->lastSwsSrcW   = -1;
   }
 }
 

--- a/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
@@ -8,6 +8,8 @@ import { AVPlayerState, VideoDataType } from './Constants';
 import { CommonConstants } from '../../../common/constants/CommonConstants';
 
 const TAG = '[AVPlayerAdapter]';
+const ENABLE_AVPLAYER_TRACK_DIAG_LOG = false;
+const ENABLE_AVPLAYER_SUBTITLE_DIAG_LOG = false;
 
 /**
  * AVPlayer 播放内核适配器
@@ -156,6 +158,15 @@ export class AVPlayerAdapter implements IPlayer {
         };
         result.push(info);
       }
+      if (ENABLE_AVPLAYER_TRACK_DIAG_LOG) {
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG, `getTrackInfos 返回轨道数: ${result.length}`);
+        for (let i = 0; i < result.length; i++) {
+          const track = result[i];
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `getTrackInfos 轨道[${i}]: index=${track.trackIndex} type=${track.trackType}` +
+            ` mime=${track.mimeType ?? ''} lang=${track.language ?? ''}`);
+        }
+      }
       return result;
     } catch (e) {
       hilog.error(CommonConstants.LOG_DOMAIN, TAG,
@@ -173,6 +184,8 @@ export class AVPlayerAdapter implements IPlayer {
     }
     const wasPlaying = this.avPlayer.state === AVPlayerState.PLAYING;
     try {
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        `selectTrack(${trackIndex}) 开始: wasPlaying=${wasPlaying ? 1 : 0}`);
       if (wasPlaying) { await this.avPlayer.pause(); }
       await this.avPlayer.selectTrack(trackIndex);
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, `selectTrack(${trackIndex}) 成功`);
@@ -327,6 +340,10 @@ export class AVPlayerAdapter implements IPlayer {
     // subtitleUpdate
     try {
       player.on('subtitleUpdate', (info: media.SubtitleInfo) => {
+        if (ENABLE_AVPLAYER_SUBTITLE_DIAG_LOG) {
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `subtitleUpdate: text="${info.text?.substring(0, 80) ?? ''}" start=${info.startTime ?? 0} duration=${info.duration ?? 0}`);
+        }
         if (this._onSubtitleUpdateCb) {
           const si: SubtitleInfo = {
             text: info.text,
@@ -336,7 +353,9 @@ export class AVPlayerAdapter implements IPlayer {
           this._onSubtitleUpdateCb(si);
         }
       });
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG, '内嵌字幕监听已注册');
+      if (ENABLE_AVPLAYER_SUBTITLE_DIAG_LOG) {
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG, '内嵌字幕监听已注册');
+      }
     } catch (e) {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         `subtitleUpdate 注册失败（可能当前 API 不支持）: ${JSON.stringify(e)}`);

--- a/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
@@ -8,10 +8,15 @@ import { VideoData } from './VideoData';
 import { VideoDataType } from './Constants';
 import { IPlayer, SubtitleInfo, TrackInfo } from './IPlayer';
 import { AssFileParser, SrtEntry, SrtParser } from './SubtitleRenderer';
+import { VidAllPlayerAdapter } from './VidAllPlayerAdapter';
 
 const TAG = '[SubtitleBridgeAdapter]';
 const MAX_SUBTITLE_PROBE_CANDIDATES = 12;
 const SUBTITLE_PROBE_BATCH_SIZE = 4;
+
+function isNativeFfmpegTrackSelectionUnavailable(player: IPlayer | undefined): boolean {
+  return player instanceof VidAllPlayerAdapter && player.isUsingFfmpegPath();
+}
 
 function tryDecode(bytes: Uint8Array, encoding: string): string {
   const decoder = new util.TextDecoder(encoding);
@@ -422,7 +427,9 @@ class BaseSubtitleBridgeAdapter implements ISubtitleBridgeAdapter {
       this.srtEntries = [];
       this.lastSrtText = '';
       this.currentSubtitleTrack = -1;
-      await this.player.selectTrack(-1);
+      if (!isNativeFfmpegTrackSelectionUnavailable(this.player)) {
+        await this.player.selectTrack(-1);
+      }
       return;
     }
 
@@ -430,19 +437,28 @@ class BaseSubtitleBridgeAdapter implements ISubtitleBridgeAdapter {
       return;
     }
 
-    this.activeSubtitleIndex = allIndex;
-    this.currentSubtitleText = '';
-
     const target = this.allSubtitleTracks[allIndex];
     if (target.kind === 'external') {
+      this.activeSubtitleIndex = allIndex;
+      this.currentSubtitleText = '';
       const entries = target.srtEntries ?? [];
       this.srtEntries = entries;
       this.lastSrtText = '';
       this.currentSubtitleTrack = -1;
-      await this.player.selectTrack(-1);
+      if (!isNativeFfmpegTrackSelectionUnavailable(this.player)) {
+        await this.player.selectTrack(-1);
+      }
       return;
     }
 
+    if (isNativeFfmpegTrackSelectionUnavailable(this.player)) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `[switchTrack] native/FFmpeg 子路径暂不支持内嵌字幕切换，忽略 allIndex=${allIndex}`);
+      return;
+    }
+
+    this.activeSubtitleIndex = allIndex;
+    this.currentSubtitleText = '';
     this.srtEntries = [];
     this.lastSrtText = '';
     const internalIndex = target.internalIndex ?? -1;

--- a/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
@@ -724,8 +724,11 @@ export class AvSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
     this.subtitleTracks = subtitleTracks;
     for (let i = 0; i < subtitleTracks.length; i++) {
       const track = subtitleTracks[i];
-      const displayName = track.language && track.language.length > 0
-        ? `字幕 ${i + 1} (${track.language})`
+      const languageName = track.language && track.language.length > 0
+        ? FfprobeUtil.getLanguageDisplayName(track.language)
+        : '';
+      const displayName = languageName.length > 0
+        ? `字幕 ${i + 1} (${languageName})`
         : `字幕 ${i + 1}`;
       const item: SubtitleTrackItem = {
         kind: 'internal',
@@ -735,6 +738,17 @@ export class AvSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
       items.push(item);
     }
     return items;
+  }
+}
+
+export class NativeAvSubtitleBridgeAdapter extends AvSubtitleBridgeAdapter {
+  protected findPreferredTrackIndex(): number {
+    for (let i = 0; i < this.allSubtitleTracks.length; i++) {
+      if (this.allSubtitleTracks[i].kind === 'external') {
+        return i;
+      }
+    }
+    return -1;
   }
 }
 

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -1,10 +1,14 @@
 import { IPlayer, SubtitleInfo, TrackInfo } from './IPlayer';
 import { VideoData } from './VideoData';
+import { media } from '@kit.MediaKit';
+import fs from '@ohos.file.fs';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { CommonConstants } from '../../../common/constants/CommonConstants';
 import * as VidAllCorePlayerNapiModule from 'libvidall_core_player_napi.so';
 import buffer from '@ohos.buffer';
+import { AVPlayerState, VideoDataType } from './Constants';
+import { encodeUrlPath } from '../../../utils/VideoPlayerUtil';
 
 const TAG = '[VidAllPlayerAdapter]';
 const METRICS_TAG = 'VidAll_Metrics';
@@ -89,6 +93,9 @@ export class VidAllPlayerAdapter implements IPlayer {
   private _onBufferingCb?: (isBuffering: boolean) => void;
   /** B6修复：FFmpeg 接管时通知上层重置 native 就绪守卫计时器 */
   private _onFfmpegSwitchingCb?: () => void;
+  private _usingFfmpegPath: boolean = false;
+  private _probedTrackInfos?: TrackInfo[];
+  private _probeTrackInfosPromise?: Promise<TrackInfo[]>;
   /** seek 完成确认门禁：true 表示有一次 seek 正在等待原生 seekDone 确认 */
   private _seekPending: boolean = false;
   /** seek 完成超时兜底：原生未在 600ms 内回调时自动触发 onSeekDone */
@@ -136,6 +143,9 @@ export class VidAllPlayerAdapter implements IPlayer {
     this._pendingXComponentId = pendingXComponentId;
     this._videoData = videoData;
     this._surfaceId = surfaceId;
+    this._usingFfmpegPath = false;
+    this._probedTrackInfos = undefined;
+    this._probeTrackInfosPromise = undefined;
     this._duration = 0;
     this._currentTime = 0;
     this._isPlaying = false;
@@ -264,6 +274,7 @@ export class VidAllPlayerAdapter implements IPlayer {
           // 避免 avformat_open_input（3-10s）期间 3.5s 守卫误触 fallbackNativeToIjk。
           hilog.info(CommonConstants.LOG_DOMAIN, TAG,
             `onFfmpegSwitching: handle=${currentHandle}, FFmpeg 接管，通知重置守卫计时器`);
+          this._usingFfmpegPath = true;
           this._onFfmpegSwitchingCb?.();
         },
         (info: SubtitleInfo) => {
@@ -397,6 +408,22 @@ export class VidAllPlayerAdapter implements IPlayer {
   }
 
   async getTrackInfos(): Promise<TrackInfo[]> {
+    if (!this._usingFfmpegPath) {
+      const probedTracks = await this.probeAvPlayerTrackInfos();
+      if (probedTracks.length > 0) {
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          `getTrackInfos 探测真实 AVPlayer 轨道: total=${probedTracks.length}`);
+        for (let i = 0; i < probedTracks.length; i++) {
+          const track = probedTracks[i];
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `getTrackInfos 探测轨道[${i}]: index=${track.trackIndex} type=${track.trackType}` +
+            ` mime=${track.mimeType ?? ''} lang=${track.language ?? ''}`);
+        }
+        return probedTracks;
+      }
+      throw new Error('native AVPlayer 轨道探测失败，已禁止回退到 preset 轨道');
+    }
+
     const tracks: TrackInfo[] = [];
     const videoData = this._videoData;
     if (!videoData) {
@@ -430,8 +457,152 @@ export class VidAllPlayerAdapter implements IPlayer {
     }
 
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `getTrackInfos 骨架返回预置轨道: total=${tracks.length}`);
+      `getTrackInfos 回退预置轨道: total=${tracks.length}`);
     return tracks;
+  }
+
+  private async probeAvPlayerTrackInfos(): Promise<TrackInfo[]> {
+    if (this._probedTrackInfos !== undefined) {
+      return this._probedTrackInfos;
+    }
+    if (this._probeTrackInfosPromise !== undefined) {
+      return this._probeTrackInfosPromise;
+    }
+    this._probeTrackInfosPromise = this.doProbeAvPlayerTrackInfos();
+    try {
+      const tracks = await this._probeTrackInfosPromise;
+      this._probedTrackInfos = tracks;
+      return tracks;
+    } finally {
+      this._probeTrackInfosPromise = undefined;
+    }
+  }
+
+  private async doProbeAvPlayerTrackInfos(): Promise<TrackInfo[]> {
+    const videoData = this._videoData;
+    if (!videoData) {
+      return [];
+    }
+
+    let player: media.AVPlayer;
+    try {
+      player = await media.createAVPlayer();
+    } catch (e) {
+      const err = e as BusinessError;
+      throw new Error(`probeTrackInfos createAVPlayer 失败: code=${err.code} msg=${err.message}`);
+    }
+
+    let file: fs.File | undefined = undefined;
+    try {
+      const tracks = await new Promise<TrackInfo[]>((resolve, reject) => {
+        let settled = false;
+        const finishResolve = (value: TrackInfo[]): void => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          resolve(value);
+        };
+        const finishReject = (error: Error): void => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          reject(error);
+        };
+
+        const timeoutId = setTimeout(() => {
+          finishReject(new Error('probeTrackInfos timeout after 5000ms'));
+        }, 5000);
+
+        player.on('error', (err: BusinessError) => {
+          clearTimeout(timeoutId);
+          finishReject(new Error(`probeTrackInfos error: ${err.code} ${err.message}`));
+        });
+
+        player.on('stateChange', (state: media.AVPlayerState) => {
+          if (state === AVPlayerState.INITIALIZED) {
+            player.prepare().catch((e: BusinessError) => {
+              clearTimeout(timeoutId);
+              finishReject(new Error(`probeTrackInfos prepare failed: ${e.code} ${e.message}`));
+            });
+          } else if (state === AVPlayerState.PREPARED) {
+            player.getTrackDescription().then((descs: media.MediaDescription[]) => {
+              clearTimeout(timeoutId);
+              const result: TrackInfo[] = [];
+              for (let i = 0; i < descs.length; i++) {
+                const desc = descs[i];
+                const rawType = desc[media.MediaDescriptionKey.MD_KEY_TRACK_TYPE] as number;
+                let trackType: 'video' | 'audio' | 'subtitle' = 'video';
+                if (rawType === media.MediaType.MEDIA_TYPE_AUD) {
+                  trackType = 'audio';
+                } else if (rawType === media.MediaType.MEDIA_TYPE_SUBTITLE) {
+                  trackType = 'subtitle';
+                } else if (rawType === media.MediaType.MEDIA_TYPE_VID) {
+                  trackType = 'video';
+                }
+                const info: TrackInfo = {
+                  trackIndex: desc[media.MediaDescriptionKey.MD_KEY_TRACK_INDEX] as number,
+                  trackType,
+                  mimeType: desc[media.MediaDescriptionKey.MD_KEY_CODEC_MIME] as string | undefined,
+                  language: desc[media.MediaDescriptionKey.MD_KEY_LANGUAGE] as string | undefined
+                };
+                result.push(info);
+              }
+              finishResolve(result);
+            }).catch((e: BusinessError) => {
+              clearTimeout(timeoutId);
+              finishReject(new Error(`probeTrackInfos getTrackDescription failed: ${e.code} ${e.message}`));
+            });
+          } else if (state === AVPlayerState.ERROR) {
+            clearTimeout(timeoutId);
+            finishReject(new Error('probeTrackInfos stateChange entered error'));
+          }
+        });
+
+        if (videoData.type === VideoDataType.URL) {
+          const encodedUrl = encodeUrlPath(videoData.videoSrc);
+          const mediaSource = media.createMediaSourceWithUrl(encodedUrl, videoData.httpHeader);
+          const playbackStrategy: media.PlaybackStrategy = {
+            preferredWidth: 1,
+            preferredHeight: 2,
+            preferredBufferDuration: 3,
+            preferredHdr: true
+          };
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `probeTrackInfos 使用编码 URL 探测轨道: ${encodedUrl}`);
+          try {
+            player.setMediaSource(mediaSource, playbackStrategy);
+          } catch (e) {
+            const err = e as BusinessError;
+            clearTimeout(timeoutId);
+            finishReject(new Error(`probeTrackInfos setMediaSource failed: ${err.code} ${err.message}`));
+          }
+        } else if (videoData.type === VideoDataType.FILE_URI) {
+          file = fs.openSync(videoData.videoSrc, fs.OpenMode.READ_ONLY);
+          player.fdSrc = { fd: file.fd };
+        } else {
+          clearTimeout(timeoutId);
+          finishReject(new Error('probeTrackInfos unsupported videoData type'));
+        }
+      });
+      return tracks;
+    } catch (e) {
+      const err = e as Error;
+      hilog.error(CommonConstants.LOG_DOMAIN, TAG, err.message);
+      throw err;
+    } finally {
+      if (file !== undefined) {
+        try {
+          fs.closeSync(file);
+        } catch (_) {
+        }
+      }
+      try {
+        await player.release();
+      } catch (_) {
+      }
+    }
   }
 
   private mapSubtitleCodecToMime(codecName?: string): string | undefined {
@@ -627,6 +798,9 @@ export class VidAllPlayerAdapter implements IPlayer {
     this._isPrepared = false;
     this._readyFired = false;
     this._videoData = undefined;
+    this._usingFfmpegPath = false;
+    this._probedTrackInfos = undefined;
+    this._probeTrackInfosPromise = undefined;
     this._duration = 0;
     this._currentTime = 0;
     this._surfaceId = '';

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -565,7 +565,7 @@ export class VidAllPlayerAdapter implements IPlayer {
       VidAllCorePlayerNapi.selectTrack(this._playerHandle, trackIndex);
     });
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `selectTrack 骨架调用完成: trackIndex=${trackIndex}`);
+      `selectTrack 原生调用完成: trackIndex=${trackIndex}`);
   }
 
   setSubtitleDelay(_delayMs: number): void {

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -109,6 +109,10 @@ export class VidAllPlayerAdapter implements IPlayer {
     return this._currentTime;
   }
 
+  isUsingFfmpegPath(): boolean {
+    return this._usingFfmpegPath;
+  }
+
   setPendingContext(context: object, xComponentId: string): void {
     this._pendingContext = context;
     this._pendingXComponentId = xComponentId;
@@ -738,6 +742,11 @@ export class VidAllPlayerAdapter implements IPlayer {
       const err = new Error(`轨道索引非法: ${trackIndex}`);
       this._onErrorCb?.(err);
       throw err;
+    }
+    if (this._usingFfmpegPath) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `selectTrack(${trackIndex}) 已跳过：native/FFmpeg 子路径暂不支持运行时切轨`);
+      return;
     }
     this.callNativeVoid('selectTrack', () => {
       VidAllCorePlayerNapi.selectTrack(this._playerHandle, trackIndex);

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -18,6 +18,7 @@ interface NativeXComponentFallbackContext {
 }
 
 interface VidAllCorePlayerNapiBridge {
+  probeVideoDecoderSurface: (handle: number, codecOrMime: string) => VideoDecoderSurfaceProbeResult;
   createPlayer: () => number;
   setSource: (handle: number, url: string) => void;
   setDurationHint: (handle: number, durationMs: number) => void;
@@ -46,6 +47,17 @@ interface VidAllCorePlayerNapiBridge {
 
 interface VidAllCorePlayerNapiBridgeModule {
   default?: VidAllCorePlayerNapiBridge;
+}
+
+interface VideoDecoderSurfaceProbeResult {
+  success: boolean;
+  stage: string;
+  capabilityKnown: boolean;
+  isHardware: boolean;
+  decoderName: string;
+  mimeType: string;
+  stateSummary: string;
+  errorMessage: string;
 }
 
 const playerBridgeModule = VidAllCorePlayerNapiModule as VidAllCorePlayerNapiBridgeModule | VidAllCorePlayerNapiBridge | undefined;
@@ -133,6 +145,19 @@ export class VidAllPlayerAdapter implements IPlayer {
     this._pendingContext = context;
     this._pendingXComponentId = xComponentId;
     await this.init(videoData, surfaceId);
+  }
+
+  async initSurfaceProbeContext(context: object, xComponentId: string): Promise<void> {
+    this._pendingContext = context;
+    this._pendingXComponentId = xComponentId;
+    await this.releaseInternal(false);
+    this._pendingContext = context;
+    this._pendingXComponentId = xComponentId;
+    this._surfaceId = xComponentId;
+    this._playerHandle = this.callNativeWithValue('createPlayer', () => VidAllCorePlayerNapi.createPlayer());
+    this.callNativeVoid('setXComponent', () => {
+      VidAllCorePlayerNapi.setXComponent(this._playerHandle, this._pendingContext as Object, this._pendingXComponentId);
+    });
   }
 
   async init(videoData: VideoData, surfaceId: string): Promise<void> {
@@ -753,6 +778,11 @@ export class VidAllPlayerAdapter implements IPlayer {
     });
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
       `selectTrack 原生调用完成: trackIndex=${trackIndex}`);
+  }
+
+  probeVideoDecoderSurface(codecOrMime: string): VideoDecoderSurfaceProbeResult {
+    return this.callNativeWithValue('probeVideoDecoderSurface', () =>
+      VidAllCorePlayerNapi.probeVideoDecoderSurface(this._playerHandle, codecOrMime));
   }
 
   setSubtitleDelay(_delayMs: number): void {

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -35,7 +35,8 @@ interface VidAllCorePlayerNapiBridge {
     onCompleted: () => void,
     onBufferingChange: (isBuffering: boolean) => void,
     onSeekDone: () => void,
-    onFfmpegSwitching: () => void
+    onFfmpegSwitching: () => void,
+    onSubtitleUpdate: (info: SubtitleInfo) => void
   ) => void;
 }
 
@@ -264,6 +265,12 @@ export class VidAllPlayerAdapter implements IPlayer {
           hilog.info(CommonConstants.LOG_DOMAIN, TAG,
             `onFfmpegSwitching: handle=${currentHandle}, FFmpeg 接管，通知重置守卫计时器`);
           this._onFfmpegSwitchingCb?.();
+        },
+        (info: SubtitleInfo) => {
+          if (this._playerHandle <= 0) {
+            return;
+          }
+          this._onSubtitleUpdateCb?.(info);
         }
       );
     });

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -34,7 +34,8 @@ interface VidAllCorePlayerNapiBridge {
     onTimeUpdate: (posMs: number) => void,
     onCompleted: () => void,
     onBufferingChange: (isBuffering: boolean) => void,
-    onSeekDone: () => void
+    onSeekDone: () => void,
+    onFfmpegSwitching: () => void
   ) => void;
 }
 
@@ -85,6 +86,8 @@ export class VidAllPlayerAdapter implements IPlayer {
   private _onSeekDoneCb?: () => void;
   private _onSubtitleUpdateCb?: (info: SubtitleInfo) => void;
   private _onBufferingCb?: (isBuffering: boolean) => void;
+  /** B6修复：FFmpeg 接管时通知上层重置 native 就绪守卫计时器 */
+  private _onFfmpegSwitchingCb?: () => void;
   /** seek 完成确认门禁：true 表示有一次 seek 正在等待原生 seekDone 确认 */
   private _seekPending: boolean = false;
   /** seek 完成超时兜底：原生未在 600ms 内回调时自动触发 onSeekDone */
@@ -107,6 +110,11 @@ export class VidAllPlayerAdapter implements IPlayer {
 
   setSeekDiagEnabled(enabled: boolean): void {
     this._enableSeekDiagLog = enabled;
+  }
+
+  /** B6修复：注册 FFmpeg 接管通知回调，由上层 VideoPlayerController 调用以重置守卫计时器 */
+  setFfmpegSwitchingCallback(cb: () => void): void {
+    this._onFfmpegSwitchingCb = cb;
   }
 
   async initWithContext(videoData: VideoData, surfaceId: string, context: object, xComponentId: string): Promise<void> {
@@ -249,6 +257,13 @@ export class VidAllPlayerAdapter implements IPlayer {
           hilog.info(CommonConstants.LOG_DOMAIN, METRICS_TAG,
             `{"event":"seek_result","backend":"native","result":"done","elapsed_ms":${seekDoneElapsed}}`);
           this._onSeekDoneCb?.();
+        },
+        () => {
+          // B6修复：FFmpeg 接管信号，通知上层重置 native 就绪守卫计时器至 15s，
+          // 避免 avformat_open_input（3-10s）期间 3.5s 守卫误触 fallbackNativeToIjk。
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `onFfmpegSwitching: handle=${currentHandle}, FFmpeg 接管，通知重置守卫计时器`);
+          this._onFfmpegSwitchingCb?.();
         }
       );
     });

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -68,13 +68,20 @@ struct VideoControls {
   @Builder
   SubtitleMenu() {
     Column() {
+      if (this.videoController.isNativeRuntimeTrackSwitchUnsupported()) {
+        Text(this.videoController.getRuntimeTrackSwitchHint())
+          .fontSize(12)
+          .fontColor('#97A9CD')
+          .width('100%')
+          .padding({ left: 20, right: 20, top: 8, bottom: 6 })
+      }
       List() {
         // 关闭字幕
         ListItem() {
           Row() {
             Text('关闭字幕')
               .fontSize(16)
-              .fontColor(Color.White)
+              .fontColor(this.videoController.canSwitchSubtitleTrack(-1) ? Color.White : '#7F8EA8')
             if (this.videoController.activeSubtitleIndex === -1) {
               SymbolGlyph($r('sys.symbol.checkmark'))
                 .fontColor([Color.White])
@@ -87,6 +94,9 @@ struct VideoControls {
           .padding({ left: 20, right: 20 })
         }
         .onClick(() => {
+          if (!this.videoController.canSwitchSubtitleTrack(-1)) {
+            return
+          }
           this.videoController.switchSubtitleTrack(-1)
           this.showSubtitleMenu = false
           this.enableAutoHide()
@@ -99,7 +109,7 @@ struct VideoControls {
               Column({ space: 2 }) {
                 Text(item.displayName)
                   .fontSize(16)
-                  .fontColor(Color.White)
+                  .fontColor(this.videoController.canSwitchSubtitleTrack(index) ? Color.White : '#7F8EA8')
                 if (item.kind === 'external') {
                   Text('外部文件')
                     .fontSize(11)
@@ -120,6 +130,9 @@ struct VideoControls {
             .padding({ left: 20, right: 20 })
           }
           .onClick(() => {
+            if (!this.videoController.canSwitchSubtitleTrack(index)) {
+              return
+            }
             this.videoController.switchSubtitleTrack(index)
             this.showSubtitleMenu = false
             this.enableAutoHide()
@@ -197,13 +210,20 @@ struct VideoControls {
   @Builder
   AudioMenu() {
     Column() {
+      if (this.videoController.isNativeRuntimeTrackSwitchUnsupported()) {
+        Text(this.videoController.getRuntimeTrackSwitchHint())
+          .fontSize(12)
+          .fontColor('#97A9CD')
+          .width('100%')
+          .padding({ left: 20, right: 20, top: 8, bottom: 6 })
+      }
       List() {
         ForEach(this.videoController.audioTracks, (item: AudioTrackItem, index: number) => {
           ListItem() {
             Row() {
               Text(item.displayName)
                 .fontSize(16)
-                .fontColor(Color.White)
+                .fontColor(this.videoController.canSwitchAudioTrack(index) ? Color.White : '#7F8EA8')
               if (this.videoController.activeAudioIndex === index) {
                 SymbolGlyph($r('sys.symbol.checkmark'))
                   .fontColor([Color.White])
@@ -216,6 +236,9 @@ struct VideoControls {
             .padding({ left: 20, right: 20 })
           }
           .onClick(() => {
+            if (!this.videoController.canSwitchAudioTrack(index)) {
+              return
+            }
             this.videoController.switchAudioTrack(index)
             this.showAudioMenu = false
             // forceStart=true：切换后不管当前 isPlaying 状态（switchAudioTrack 内部会 pause）
@@ -830,7 +853,7 @@ export struct SubtitleSelectorDrawerDialog {
           Row() {
             Text('关闭字幕')
               .fontSize(18)
-              .fontColor('#DDE4EE')
+              .fontColor(this.videoController.canSwitchSubtitleTrack(-1) ? '#DDE4EE' : '#7F8EA8')
           }
           .height(48)
           .padding({ left: 18, right: 18 })
@@ -840,6 +863,9 @@ export struct SubtitleSelectorDrawerDialog {
           .borderRadius(24)
           .border({ width: 1, color: 'rgba(255, 255, 255, 0.19)' })
           .onClick(() => {
+            if (!this.videoController.canSwitchSubtitleTrack(-1)) {
+              return
+            }
             this.videoController.switchSubtitleTrack(-1)
           })
 
@@ -863,6 +889,11 @@ export struct SubtitleSelectorDrawerDialog {
           .color('rgba(255, 255, 255, 0.15)')
 
         Column({ space: 8 }) {
+          if (this.videoController.isNativeRuntimeTrackSwitchUnsupported()) {
+            Text(this.videoController.getRuntimeTrackSwitchHint())
+              .fontSize(14)
+              .fontColor('#97A9CD')
+          }
           Text(`其他可用字幕 (${this.getAvailableSubtitleCount()})`)
             .fontSize(17)
             .fontColor('#97A9CD')
@@ -887,7 +918,7 @@ export struct SubtitleSelectorDrawerDialog {
 
                     Text(item.displayName)
                       .fontSize(17)
-                      .fontColor('#EAF0F7')
+                      .fontColor(this.videoController.canSwitchSubtitleTrack(index) ? '#EAF0F7' : '#7F8EA8')
                       .maxLines(1)
                       .textOverflow({ overflow: TextOverflow.Ellipsis })
                       .layoutWeight(1)
@@ -905,6 +936,9 @@ export struct SubtitleSelectorDrawerDialog {
                   .backgroundColor('rgba(255, 255, 255, 0.05)')
                   .borderRadius(14)
                   .onClick(() => {
+                    if (!this.videoController.canSwitchSubtitleTrack(index)) {
+                      return
+                    }
                     this.videoController.switchSubtitleTrack(index)
                   })
                 }

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -956,6 +956,9 @@ export struct SubtitleSelectorDrawerDialog {
               .backgroundColor('rgba(255, 255, 255, 0.03)')
               .borderRadius(14)
               .onClick(() => {
+                if (!this.videoController.canSwitchSubtitleTrack(-1)) {
+                  return
+                }
                 this.videoController.switchSubtitleTrack(-1)
               })
             }

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -192,6 +192,11 @@ export class VideoPlayerController {
   private subtitleAdapter: ISubtitleBridgeAdapter = new NoSubtitleBridgeAdapter();
   private nativeSubtitleMode: 'av' | 'external-only' = 'av';
   private currentVideoData?: VideoData;
+  private cachedNativeContext: object | null = null;
+  private cachedNativeXComponentId: string = '';
+  private cachedNativeProbeContext: object | null = null;
+  private cachedNativeProbeXComponentId: string = '';
+  private nativeSurfaceProbeRunning: boolean = false;
   private timeToSeek = -1
   private subtitleClearTimer?: number
   private subtitleRemainingTime: number = 0
@@ -1163,6 +1168,8 @@ export class VideoPlayerController {
       return;
     }
     const nativeAdapter = this.player as VidAllPlayerAdapter;
+    this.cachedNativeContext = context;
+    this.cachedNativeXComponentId = xComponentId;
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
       `setNativeContext: 绑定 XComponent id=${xComponentId}，开始 native 骨架 init...`);
     this.startNativeReadyGuard(this.playbackSessionId);
@@ -1183,6 +1190,128 @@ export class VideoPlayerController {
         this.fallbackNativeToIjk('native_init_error', 'native 初始化失败，已自动回退到 IJK 播放', err.message);
       }
     }
+  }
+
+  setNativeProbeContext(context: object, xComponentId: string): void {
+    this.cachedNativeProbeContext = context;
+    this.cachedNativeProbeXComponentId = xComponentId;
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `setNativeProbeContext: 已缓存 probe XComponent id=${xComponentId}`);
+  }
+
+  async runExclusiveNativeVideoDecoderSurfaceProbes(codecOrMimes: string[]): Promise<string[]> {
+    const summaries: string[] = [];
+    if (this.nativeSurfaceProbeRunning) {
+      const busySummary = 'surface probe 正在执行中';
+      this.lastErrorMessage = busySummary;
+      summaries.push(busySummary);
+      return summaries;
+    }
+    if (this.backend !== 'native') {
+      const summary = 'surface probe 仅支持 native 后端';
+      this.lastErrorMessage = summary;
+      summaries.push(summary);
+      return summaries;
+    }
+    if (!this.currentVideoData) {
+      const summary = 'surface probe 缺少当前视频数据';
+      this.lastErrorMessage = summary;
+      summaries.push(summary);
+      return summaries;
+    }
+    if (this.cachedNativeProbeContext !== null && this.cachedNativeProbeXComponentId.length > 0) {
+      const probeContext = this.cachedNativeProbeContext;
+      const probeXComponentId = this.cachedNativeProbeXComponentId;
+      const tempAdapter = new VidAllPlayerAdapter();
+      this.nativeSurfaceProbeRunning = true;
+      try {
+        await tempAdapter.initSurfaceProbeContext(probeContext, probeXComponentId);
+        for (let i = 0; i < codecOrMimes.length; i++) {
+          const codec = codecOrMimes[i];
+          try {
+            const result = tempAdapter.probeVideoDecoderSurface(codec);
+            const decoder = result.decoderName.length > 0 ? result.decoderName : 'unknown';
+            const summary = result.success
+              ? `${codec}: 专用 probe surface 成功 (${decoder})`
+              : `${codec}: 专用 probe surface 失败 stage=${result.stage} err=${result.errorMessage} state=${result.stateSummary}`;
+            summaries.push(summary);
+            hilog.info(CommonConstants.LOG_DOMAIN, TAG, `[surface-probe-dedicated] ${summary}`);
+          } catch (e) {
+            const message = this.safeErrorMessage(e);
+            const summary = `${codec}: 专用 probe surface 异常 ${message}`;
+            summaries.push(summary);
+            hilog.error(CommonConstants.LOG_DOMAIN, TAG, `[surface-probe-dedicated] ${summary}`);
+          }
+        }
+      } finally {
+        await tempAdapter.release().catch(() => {});
+        this.nativeSurfaceProbeRunning = false;
+      }
+      this.lastErrorMessage = summaries.length > 0 ? summaries[summaries.length - 1] : 'surface probe 已完成';
+      return summaries;
+    }
+    if (this.cachedNativeContext === null || this.cachedNativeXComponentId.length === 0) {
+      const summary = 'surface probe 缺少 XComponent 上下文';
+      this.lastErrorMessage = summary;
+      summaries.push(summary);
+      return summaries;
+    }
+
+    const resumePositionMs = this.currentTime;
+    const shouldResumePlaying = this.isPlaying;
+    const probeVideoData = this.currentVideoData;
+    const probeSurfaceId = this.surfaceId;
+    const probeContext = this.cachedNativeContext;
+    const probeXComponentId = this.cachedNativeXComponentId;
+    const tempAdapter = new VidAllPlayerAdapter();
+    this.nativeSurfaceProbeRunning = true;
+    this.isLoading = true;
+    this.stopProgressTimer();
+    this.pauseSubtitleTimer();
+    this.saveProgressNow();
+
+    try {
+      this.subtitleAdapter.release();
+      if (this.player) {
+        await this.player.release().catch(() => {});
+        this.player = undefined;
+      }
+      await tempAdapter.initSurfaceProbeContext(probeContext, probeXComponentId);
+      for (let i = 0; i < codecOrMimes.length; i++) {
+        const codec = codecOrMimes[i];
+        try {
+          const result = tempAdapter.probeVideoDecoderSurface(codec);
+          const decoder = result.decoderName.length > 0 ? result.decoderName : 'unknown';
+          const summary = result.success
+            ? `${codec}: 独占 surface probe 成功 (${decoder})`
+            : `${codec}: 独占 surface probe 失败 stage=${result.stage} err=${result.errorMessage} state=${result.stateSummary}`;
+          summaries.push(summary);
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG, `[surface-probe-exclusive] ${summary}`);
+        } catch (e) {
+          const message = this.safeErrorMessage(e);
+          const summary = `${codec}: 独占 surface probe 异常 ${message}`;
+          summaries.push(summary);
+          hilog.error(CommonConstants.LOG_DOMAIN, TAG, `[surface-probe-exclusive] ${summary}`);
+        }
+      }
+    } finally {
+      await tempAdapter.release().catch(() => {});
+      try {
+        this.pendingBackendResumeTimeMs = resumePositionMs > 0 ? resumePositionMs : -1;
+        this.pendingBackendResumePlay = shouldResumePlaying;
+        await this.initPlayer(probeVideoData, probeSurfaceId);
+        await this.setNativeContext(probeContext, probeXComponentId);
+      } catch (e) {
+        const restoreSummary = `surface probe 恢复播放失败: ${this.safeErrorMessage(e)}`;
+        summaries.push(restoreSummary);
+        hilog.error(CommonConstants.LOG_DOMAIN, TAG, `[surface-probe-exclusive] ${restoreSummary}`);
+      }
+      this.nativeSurfaceProbeRunning = false;
+      this.isLoading = false;
+    }
+
+    this.lastErrorMessage = summaries.length > 0 ? summaries[summaries.length - 1] : 'surface probe 已完成';
+    return summaries;
   }
 
   setNativeSeekDiagLogEnabled(enabled: boolean): void {
@@ -2284,6 +2413,28 @@ export class VideoPlayerController {
       return '';
     }
     return '当前为 native/FFmpeg 子路径：音轨切换与内嵌字幕切换暂不支持';
+  }
+
+  runNativeVideoDecoderSurfaceProbe(codecOrMime: string): string {
+    if (!(this.player instanceof VidAllPlayerAdapter)) {
+      return `${codecOrMime}: 当前不是 native 后端`;
+    }
+    try {
+      const result = this.player.probeVideoDecoderSurface(codecOrMime);
+      const decoder = result.decoderName.length > 0 ? result.decoderName : 'unknown';
+      const summary = result.success
+        ? `${codecOrMime}: surface probe 成功 (${decoder})`
+        : `${codecOrMime}: surface probe 失败 stage=${result.stage} err=${result.errorMessage} state=${result.stateSummary}`;
+      this.lastErrorMessage = summary;
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG, `[surface-probe] ${summary}`);
+      return summary;
+    } catch (e) {
+      const message = this.safeErrorMessage(e);
+      const summary = `${codecOrMime}: surface probe 异常 ${message}`;
+      this.lastErrorMessage = summary;
+      hilog.error(CommonConstants.LOG_DOMAIN, TAG, `[surface-probe] ${summary}`);
+      return summary;
+    }
   }
 
   private isNativeFfmpegPathActive(): boolean {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -2002,8 +2002,10 @@ export class VideoPlayerController {
       if (this.audioTracks.length > 0) {
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
           `[loadAudioTracks] 已提前填充 ${this.audioTracks.length} 条音轨，直接选择默认轨道`);
-        if (this.backend === 'ffmpeg') {
+        if (this.backend === 'ffmpeg' || this.isNativeFfmpegPathActive()) {
           this.activeAudioIndex = 0;
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            '[loadAudioTracks] FFmpeg 路径维持当前默认音轨，不触发原生 selectTrack');
         } else {
           await this.switchAudioTrack(0);
         }
@@ -2034,8 +2036,10 @@ export class VideoPlayerController {
       this.audioTracks = tracks;
 
       if (this.audioTracks.length > 0) {
-        if (this.backend === 'ffmpeg') {
+        if (this.backend === 'ffmpeg' || this.isNativeFfmpegPathActive()) {
           this.activeAudioIndex = 0;
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            '[loadAudioTracks] FFmpeg 路径维持当前默认音轨，不触发原生 selectTrack');
         } else {
           await this.switchAudioTrack(0);
         }
@@ -2192,6 +2196,15 @@ export class VideoPlayerController {
       return;
     }
 
+    if (this.isNativeFfmpegPathActive()) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `[switchAudioTrack] native/FFmpeg 子路径暂不支持运行时切换音轨，忽略 index=${trackIndex}`);
+      if (this.activeAudioIndex < 0) {
+        this.activeAudioIndex = 0;
+      }
+      return;
+    }
+
     // 初始化加载时（isReady 刚触发，尚未真正播放）直接切换，不需要暂停/恢复
     const wasPlaying = this.isPlaying;
     const seekBack = this.currentTime;
@@ -2240,6 +2253,43 @@ export class VideoPlayerController {
         await this.player.play().catch(() => {});
       }
     }
+  }
+
+  isNativeRuntimeTrackSwitchUnsupported(): boolean {
+    return this.isNativeFfmpegPathActive();
+  }
+
+  canSwitchAudioTrack(trackIndex: number): boolean {
+    if (!this.isNativeFfmpegPathActive()) {
+      return true;
+    }
+    return trackIndex === this.activeAudioIndex;
+  }
+
+  canSwitchSubtitleTrack(allIndex: number): boolean {
+    if (!this.isNativeFfmpegPathActive()) {
+      return true;
+    }
+    if (allIndex < 0) {
+      return true;
+    }
+    if (allIndex >= this.allSubtitleTracks.length) {
+      return false;
+    }
+    return this.allSubtitleTracks[allIndex].kind === 'external';
+  }
+
+  getRuntimeTrackSwitchHint(): string {
+    if (!this.isNativeFfmpegPathActive()) {
+      return '';
+    }
+    return '当前为 native/FFmpeg 子路径：音轨切换与内嵌字幕切换暂不支持';
+  }
+
+  private isNativeFfmpegPathActive(): boolean {
+    return this.backend === 'native' &&
+      this.player instanceof VidAllPlayerAdapter &&
+      this.player.isUsingFfmpegPath();
   }
 
   // ─────────────────────────────────────────────

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -11,11 +11,13 @@ import { VidAllPlayerAdapter } from "./VidAllPlayerAdapter";
 import { FileSourceDatabase } from "../../../db/files/FileSourceDatabase";
 import { PlayProgressEntity } from "../../../db/models/MediaEntity";
 import { FfprobeUtil } from "../../../utils/FfprobeUtil";
+import { DeviceCapabilityUtil } from "../../../utils/DeviceCapabilityUtil";
 import { FfmpegVideoFrameUtil } from "../../../utils/FfmpegVideoFrameUtil";
 import {
   AvSubtitleBridgeAdapter,
   IjkSubtitleBridgeAdapter,
   ISubtitleBridgeAdapter,
+  NativeAvSubtitleBridgeAdapter,
   NoSubtitleBridgeAdapter,
   SubtitleBridgeState,
   SubtitleTrackItem
@@ -66,7 +68,12 @@ interface AudioRoutingDecision {
   summary: string;
   detectedCodec: string;
   detectedChannels: number;
-  hardSupported: boolean;
+  systemSupported: boolean;
+  capabilityKnown: boolean;
+  capabilityMime: string;
+  maxSupportedChannels: number;
+  decoderName: string;
+  decoderIsHardware: boolean;
   precheckProbeFailed: boolean;
   precheckProbeError: string;
 }
@@ -139,7 +146,7 @@ export class VideoPlayerController {
     * 切换为 'native' 后，使用原生 so 播放器骨架适配器（当前阶段仅框架接入）。
     * 'ffmpeg' 后端已停止主路径接入，仅保留代码供后续参考。
    */
-  @Trace backend: PlayerBackend = 'native';
+  @Trace backend: PlayerBackend = 'avplayer';
 
   /** 当前使用的播放内核实例 */
   private player?: IPlayer;
@@ -147,6 +154,10 @@ export class VideoPlayerController {
   @Trace unsupportedFormatFallback: UnsupportedFormatFallback = 'native';
   /** 是否已由外部显式设置回退策略（为 true 时不再自动覆盖） */
   private unsupportedFallbackLockedByUser: boolean = false;
+  /** 是否已由外部显式锁定 preferred backend（用于调试/对照测试时禁止自动音频路由改写 backend）。 */
+  private backendLockedByUser: boolean = false;
+  /** 是否严格锁定当前 backend（锁定后禁止运行时自动 fallback 到其他后端）。 */
+  private strictBackendLockedByUser: boolean = false;
   @Trace name: ResourceStr = ''
   @Trace surfaceId: string = ''
   @Trace duration = 0
@@ -179,6 +190,7 @@ export class VideoPlayerController {
   @Trace audioTracks: AudioTrackItem[] = [];
   @Trace activeAudioIndex: number = -1;
   private subtitleAdapter: ISubtitleBridgeAdapter = new NoSubtitleBridgeAdapter();
+  private nativeSubtitleMode: 'av' | 'external-only' = 'av';
   private currentVideoData?: VideoData;
   private timeToSeek = -1
   private subtitleClearTimer?: number
@@ -306,7 +318,7 @@ export class VideoPlayerController {
       this.unsupportedFormatFallback = decision.fallback;
       videoData.ffmpegDecodeChannels = decision.preferredChannels;
       videoData.audioProbeSummary = decision.summary;
-      if (this.backend === 'avplayer' || this.backend === 'ffmpeg') {
+      if (!this.backendLockedByUser && (this.backend === 'avplayer' || this.backend === 'ffmpeg')) {
         this.backend = decision.preferredBackend;
       }
       if (decision.precheckProbeFailed && backendBeforeAutoRouting !== this.backend) {
@@ -401,11 +413,15 @@ export class VideoPlayerController {
           `[session=${capturedSessionId}] FFmpeg 接管信号收到，重置就绪守卫计时器为 15s`);
         if (capturedSessionId === this.playbackSessionId) {
           this.startNativeReadyGuard(capturedSessionId, 15000);
+          void this.switchNativeSubtitleAdapterToExternalOnly(capturedSessionId);
         }
       });
       adapter = nativeAdapter;
-      // native 骨架阶段先复用 IJK 字幕桥：隐藏内嵌轨，仅启用外置字幕时间轴。
-      this.subtitleAdapter = new IjkSubtitleBridgeAdapter();
+      this.nativeSubtitleMode = 'av';
+      // native 的 AVPlayer 子路径已支持内嵌字幕枚举、切换与 subtitleUpdate 事件桥接。
+      // 若后续切到 FFmpeg 子路径，再动态降级为仅外置字幕桥，避免出现无法生效的内嵌轨选项。
+      // native 初始化阶段不自动激活第一条内嵌字幕，避免 prepared 边界时机触发切轨回退。
+      this.subtitleAdapter = new NativeAvSubtitleBridgeAdapter();
     } else {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         'initPlayer: 使用 AVPlayerAdapter');
@@ -547,6 +563,13 @@ export class VideoPlayerController {
     });
     adapter.onUnsupportedFormat(() => {
       if (currentSessionId !== this.playbackSessionId) {
+        return;
+      }
+      if (this.strictBackendLockedByUser) {
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          '[strict-backend] 已阻止 avplayer unsupportedFormat 自动切换');
+        this.isLoading = false;
+        this.lastErrorMessage = 'AVPlayer 不支持当前格式（strict backend 已阻止自动切换）';
         return;
       }
       const targetBackend: PlayerBackend = this.unsupportedFormatFallback;
@@ -1185,6 +1208,25 @@ export class VideoPlayerController {
       'unsupportedFormatFallback 已恢复自动策略');
   }
 
+  setPreferredBackend(backend: PlayerBackend, strictLock: boolean = false): void {
+    this.backend = backend === 'ffmpeg' ? 'ijkplayer' : backend;
+    this.backendLockedByUser = true;
+    this.strictBackendLockedByUser = strictLock;
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `preferredBackend 已锁定为 ${this.backend}, strict=${strictLock ? 1 : 0}`);
+  }
+
+  resetPreferredBackendAutoPolicy(): void {
+    this.backendLockedByUser = false;
+    this.strictBackendLockedByUser = false;
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      'preferredBackend 已恢复自动策略');
+  }
+
+  isStrictPreferredBackendLocked(): boolean {
+    return this.strictBackendLockedByUser;
+  }
+
   /**
    * 依据预置音轨信息判断是否优先回退 ffmpeg。
    * 命中 AC-3/E-AC-3/DTS/TrueHD 时返回 true。
@@ -1224,7 +1266,12 @@ export class VideoPlayerController {
       summary: 'default: 未探测到音轨细节',
       detectedCodec: 'unknown',
       detectedChannels: 2,
-      hardSupported: true,
+      systemSupported: true,
+      capabilityKnown: false,
+      capabilityMime: '',
+      maxSupportedChannels: 0,
+      decoderName: '',
+      decoderIsHardware: false,
       precheckProbeFailed: false,
       precheckProbeError: ''
     };
@@ -1251,26 +1298,32 @@ export class VideoPlayerController {
 
     const normalizedCodec = (codecName ?? '').toLowerCase();
     const safeChannels = this.normalizeTargetChannels(channels);
-    const hardSupported = this.isLikelySystemHardDecodeSupported(normalizedCodec);
+    const capability = DeviceCapabilityUtil.queryNativeAudioDecoderCapability(normalizedCodec);
+    const channelSupported = capability.maxChannels <= 0 || safeChannels <= capability.maxChannels;
+    const systemSupported = capability.supported && channelSupported;
 
     const summary = `codec=${normalizedCodec.length > 0 ? normalizedCodec : 'unknown'}, ` +
-      `channels=${safeChannels}, hardSupported=${hardSupported}, precheckProbeFailed=${precheckProbeFailed}`;
+      `channels=${safeChannels}, systemSupported=${systemSupported}, capabilityKnown=${capability.capabilityKnown}, ` +
+      `decoder=${capability.decoderName.length > 0 ? capability.decoderName : 'unknown'}, ` +
+      `maxChannels=${capability.maxChannels}, precheckProbeFailed=${precheckProbeFailed}`;
 
-    let preferredBackend: PlayerBackend = hardSupported ? 'avplayer' : 'ijkplayer';
-    if (precheckProbeFailed && normalizedCodec.length === 0) {
-      // 前置探测失败且无可用音轨提示时，保守走软解后端，避免 AVPlayer 首次进入不可恢复错误态。
-      preferredBackend = 'ijkplayer';
-    }
+    // 默认优先 AVPlayer；是否真正需要软解回退，应以实际 prepare/播放结果为准，
+    // 不能仅凭首音轨 codec 或前置探测结果就提前切走主播放链路。
+    const preferredBackend: PlayerBackend = 'avplayer';
 
     const decision: AudioRoutingDecision = {
-      // 当前 ffmpeg 视频链路尚不可用，临时统一回退到 ijkplayer。
       preferredBackend,
       fallback: 'native',
       preferredChannels: safeChannels,
       summary,
       detectedCodec: normalizedCodec.length > 0 ? normalizedCodec : 'unknown',
       detectedChannels: safeChannels,
-      hardSupported,
+      systemSupported,
+      capabilityKnown: capability.capabilityKnown,
+      capabilityMime: capability.mimeType,
+      maxSupportedChannels: capability.maxChannels,
+      decoderName: capability.decoderName,
+      decoderIsHardware: capability.isHardware,
       precheckProbeFailed,
       precheckProbeError
     };
@@ -1287,15 +1340,15 @@ export class VideoPlayerController {
     const message =
       '[AudioCapability] ' +
       `detectedCodec=${decision.detectedCodec}, detectedChannels=${decision.detectedChannels}(${channelTag}), ` +
-      `hardSupported=${decision.hardSupported}, route=${decision.preferredBackend}, fallback=${decision.fallback}, ` +
-      `decodePlan=${currentDecodePlan}; ` +
-      `systemHardPreferred=[${SYSTEM_HARD_PREFERRED_CODECS.join(', ')}]; ` +
-      `systemSoftFallback=[${SYSTEM_SOFT_FALLBACK_CODECS.join(', ')}]; ` +
-      `channelHints=[${SUPPORTED_CHANNEL_LAYOUT_HINTS.join(', ')}]`;
+      `systemSupported=${decision.systemSupported}, capabilityKnown=${decision.capabilityKnown}, ` +
+      `decoder=${decision.decoderName.length > 0 ? decision.decoderName : 'unknown'}, ` +
+      `decoderIsHardware=${decision.decoderIsHardware}, capabilityMime=${decision.capabilityMime.length > 0 ? decision.capabilityMime : 'unknown'}, ` +
+      `maxChannels=${decision.maxSupportedChannels}, route=${decision.preferredBackend}, fallback=${decision.fallback}, ` +
+      `decodePlan=${currentDecodePlan}; channelHints=[${SUPPORTED_CHANNEL_LAYOUT_HINTS.join(', ')}]`;
 
     this.audioCapabilityText =
       `音频能力: 检测=${decision.detectedCodec} ${channelTag} | ` +
-      `硬解=${decision.hardSupported ? '是' : '否'} | ` +
+      `系统支持=${decision.systemSupported ? '是' : '否'} | ` +
       `当前路由=${decision.preferredBackend} | ` +
       `软解兜底=${decision.fallback}`;
 
@@ -1452,6 +1505,14 @@ export class VideoPlayerController {
 
   private fallbackNativeToIjk(fallbackReason: string, userMessage: string, detailMessage: string = ''): void {
     if (this.backend !== 'native') {
+      return;
+    }
+    if (this.strictBackendLockedByUser) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `[strict-backend] 已阻止 native -> ijkplayer 自动回退: reason=${fallbackReason}, detail=${detailMessage}`);
+      this.lastErrorMessage = `${userMessage}（strict backend 已阻止自动切换）`;
+      this.isLoading = false;
+      this.clearNativeReadyGuardTimer();
       return;
     }
     const fallbackPosition = this.player?.currentTime ?? this.currentTime;
@@ -1857,6 +1918,25 @@ export class VideoPlayerController {
     }
   }
 
+  private async switchNativeSubtitleAdapterToExternalOnly(sessionId: number): Promise<void> {
+    if (sessionId !== this.playbackSessionId || this.backend !== 'native') {
+      return;
+    }
+    if (this.nativeSubtitleMode === 'external-only') {
+      return;
+    }
+    this.nativeSubtitleMode = 'external-only';
+    this.subtitleAdapter.release();
+    this.subtitleAdapter = new IjkSubtitleBridgeAdapter();
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[session=${sessionId}] native 已切到 FFmpeg 子路径，字幕桥降级为仅外置字幕`);
+    if (this.isReady && this.player) {
+      await this.loadSubtitleTracks();
+      return;
+    }
+    this.applySubtitleBridgeState(this.subtitleAdapter.getState());
+  }
+
   /**
    * 按视频播放时间输出当前字幕轨与字幕内容，便于排查“有轨道但无显示”问题。
    */
@@ -2185,4 +2265,3 @@ export class VideoPlayerController {
   }
 
 }
-

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -393,6 +393,16 @@ export class VideoPlayerController {
         'initPlayer: 使用 VidAll Player Adapter，等待 UI 层调用 setNativeContext()');
       const nativeAdapter = new VidAllPlayerAdapter();
       nativeAdapter.setSeekDiagEnabled(this.nativeSeekDiagLogEnabled);
+      // B6修复：注册 FFmpeg 接管通知，FFmpeg 开始接管后将守卫计时器从 3.5s 延长到 15s，
+      // 防止 avformat_open_input 期间（最长 10s）提前触发 fallbackNativeToIjk。
+      const capturedSessionId = currentSessionId;
+      nativeAdapter.setFfmpegSwitchingCallback(() => {
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          `[session=${capturedSessionId}] FFmpeg 接管信号收到，重置就绪守卫计时器为 15s`);
+        if (capturedSessionId === this.playbackSessionId) {
+          this.startNativeReadyGuard(capturedSessionId, 15000);
+        }
+      });
       adapter = nativeAdapter;
       // native 骨架阶段先复用 IJK 字幕桥：隐藏内嵌轨，仅启用外置字幕时间轴。
       this.subtitleAdapter = new IjkSubtitleBridgeAdapter();
@@ -1415,7 +1425,7 @@ export class VideoPlayerController {
     }
   }
 
-  private startNativeReadyGuard(sessionId: number): void {
+  private startNativeReadyGuard(sessionId: number, guardMs: number = NATIVE_READY_GUARD_MS): void {
     this.clearNativeReadyGuardTimer();
     this.nativeReadyGuardTimer = setTimeout(() => {
       this.nativeReadyGuardTimer = undefined;
@@ -1437,7 +1447,7 @@ export class VideoPlayerController {
       if (currentDuration <= 0 && currentPosition <= 100) {
         this.fallbackNativeToIjk('native_no_timeline_output', 'native 未输出可播时间轴，已自动回退到 IJK 播放');
       }
-    }, NATIVE_READY_GUARD_MS);
+    }, guardMs);
   }
 
   private fallbackNativeToIjk(fallbackReason: string, userMessage: string, detailMessage: string = ''): void {

--- a/entry/src/main/ets/lib/WebDAVClient.ets
+++ b/entry/src/main/ets/lib/WebDAVClient.ets
@@ -470,10 +470,8 @@ export class WebDAVClient {
         }
       }
     }
-    if (!this._nativeCurlEnabled) {
+    if (shouldTryNativeFirst && !this._nativeCurlEnabled) {
       console.warn('WebDAV native transport unavailable, fallback to legacy transport');
-    } else if (!this.allowLegacyTransportFallback) {
-      throw new Error('legacy transport fallback disabled');
     }
     // ── 回退：现有 socket / http 实现 ──────────────────────────────────────
     if (this.isHttps) {

--- a/entry/src/main/ets/lib/WebDAVClient.ets
+++ b/entry/src/main/ets/lib/WebDAVClient.ets
@@ -322,6 +322,7 @@ export class WebDAVClient {
         const caps = getVidAllCorePlayerNapi().getNativeCapabilities();
         this._nativeCurlEnabled = caps.libcurlEnabled;
       } catch (e) {
+        console.warn(`WebDAV native capability probe failed, will optimistic-try native curl: ${JSON.stringify(e)}`);
         this._nativeCurlEnabled = false;
       }
     }
@@ -444,18 +445,34 @@ export class WebDAVClient {
     body?: string
   ): Promise<HttpResponse> {
     // ── native libcurl 优先路径 ────────────────────────────────────────────
-    if (this.checkNativeCurlEnabled()) {
+    const nativeCurlEnabled = this.checkNativeCurlEnabled();
+    const shouldTryNativeFirst = nativeCurlEnabled || this.isHttps;
+    if (shouldTryNativeFirst) {
       try {
-        return await this.sendViaNative(method, path, headers, body);
+        const response = await this.sendViaNative(method, path, headers, body);
+        this._nativeCurlEnabled = true;
+        return response;
       } catch (e) {
         const nativeErr = (e as Error).message;
-        if (!this.allowLegacyTransportFallback) {
+        const nativeUnavailable = nativeErr.includes('libcurl disabled') ||
+          nativeErr.includes('未加载') ||
+          nativeErr.includes('not loaded') ||
+          nativeErr.includes('getNativeCapabilities') ||
+          nativeErr.includes('webdavRequest') ||
+          nativeErr.includes('is not a function');
+        if (nativeUnavailable) {
+          this._nativeCurlEnabled = false;
+          console.warn(`WebDAV native transport unavailable, fallback to legacy transport: ${nativeErr}`);
+        } else if (!this.allowLegacyTransportFallback) {
           throw new Error(`native transport failed: ${nativeErr}`);
+        } else {
+          console.warn(`WebDAV native fallback enabled: ${nativeErr}`);
         }
-        console.warn(`WebDAV native fallback enabled: ${nativeErr}`);
       }
     }
-    if (!this.allowLegacyTransportFallback) {
+    if (!this._nativeCurlEnabled) {
+      console.warn('WebDAV native transport unavailable, fallback to legacy transport');
+    } else if (!this.allowLegacyTransportFallback) {
       throw new Error('legacy transport fallback disabled');
     }
     // ── 回退：现有 socket / http 实现 ──────────────────────────────────────
@@ -2395,5 +2412,3 @@ export class WebDAVClient {
     });
   }
 }
-
-

--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -311,7 +311,7 @@ export struct FileExplorerPage {
   }
 
   private changePath(newPath: string = '/') {
-    this.client.listDirectory(encodeURIComponent(newPath)).then(files => {
+    this.client.listDirectory(newPath).then(files => {
       files.shift()
       this.fileExplorerController.currentPath = newPath
       this.fileExplorerController.resources = files

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -378,14 +378,14 @@ export struct PlayerPage {
         this.videoPlayerController.saveProgressNow();
       });
 
-        let pageParam = context.pathInfo.param as PlayerPageParam
-        if (pageParam) {
-          if (pageParam.preferredBackend) {
-            this.videoPlayerController.setPreferredBackend(
-              pageParam.preferredBackend,
-              pageParam.strictPreferredBackend === true
-            );
-          }
+      let pageParam = context.pathInfo.param as PlayerPageParam
+      if (pageParam) {
+        if (pageParam.preferredBackend) {
+          this.videoPlayerController.setPreferredBackend(
+            pageParam.preferredBackend,
+            pageParam.strictPreferredBackend === true
+          );
+        }
         if (pageParam.unsupportedFormatFallback) {
           this.videoPlayerController.setUnsupportedFormatFallback(pageParam.unsupportedFormatFallback);
         }

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -33,6 +33,8 @@ export interface PlayerPageParam {
   episodeNumber?: number;
   /** 可选：强制指定播放后端（当前建议 avplayer / ijkplayer / native） */
   preferredBackend?: PlayerBackend;
+  /** 可选：严格锁定 preferredBackend，禁止运行时自动切换到其他后端（用于调试/对照验证） */
+  strictPreferredBackend?: boolean;
   /** 可选：AVPlayer 不支持格式时的自动回退后端 */
   unsupportedFormatFallback?: UnsupportedFormatFallback;
 }
@@ -50,12 +52,73 @@ export struct PlayerPage {
   private pendingSeekMs: number = -1
 
   private getBackendDebugText(): string {
-    const backendText = `backend=${this.videoPlayerController.backend}`;
+    const strictText = this.videoPlayerController.isStrictPreferredBackendLocked() ? ' [strict]' : '';
+    const backendText = `backend=${this.videoPlayerController.backend}${strictText}`;
     const reason = this.videoPlayerController.lastErrorMessage;
     if (reason.length === 0) {
       return backendText;
     }
     return `${backendText} | ${reason}`;
+  }
+
+  private switchBackend(targetBackend: PlayerBackend): void {
+    this.videoPlayerController.setPreferredBackend(targetBackend, true);
+  }
+
+  private isCurrentBackend(targetBackend: PlayerBackend): boolean {
+    return this.videoPlayerController.backend === targetBackend;
+  }
+
+  private getBackendButtonColor(targetBackend: PlayerBackend): string {
+    if (this.isCurrentBackend(targetBackend)) {
+      return '#1B78F2';
+    }
+    return '#333333';
+  }
+
+  @Builder
+  BackendDebugPanel() {
+    Column({ space: 8 }) {
+      Text(this.getBackendDebugText())
+        .fontSize(12)
+        .fontColor('#E6FFFFFF')
+        .backgroundColor('#66000000')
+        .padding({ left: 8, right: 8, top: 4, bottom: 4 })
+        .borderRadius(4)
+
+      Row({ space: 8 }) {
+        Button('AV')
+          .fontSize(11)
+          .fontColor(Color.White)
+          .backgroundColor(this.getBackendButtonColor('avplayer'))
+          .borderRadius(4)
+          .padding({ left: 10, right: 10, top: 4, bottom: 4 })
+          .onClick(() => {
+            this.switchBackend('avplayer')
+          })
+
+        Button('Native')
+          .fontSize(11)
+          .fontColor(Color.White)
+          .backgroundColor(this.getBackendButtonColor('native'))
+          .borderRadius(4)
+          .padding({ left: 10, right: 10, top: 4, bottom: 4 })
+          .onClick(() => {
+            this.switchBackend('native')
+          })
+
+        Button('IJK')
+          .fontSize(11)
+          .fontColor(Color.White)
+          .backgroundColor(this.getBackendButtonColor('ijkplayer'))
+          .borderRadius(4)
+          .padding({ left: 10, right: 10, top: 4, bottom: 4 })
+          .onClick(() => {
+            this.switchBackend('ijkplayer')
+          })
+      }
+    }
+    .alignItems(HorizontalAlign.Start)
   }
 
   static PAGE_NAME = 'player'
@@ -157,12 +220,9 @@ export struct PlayerPage {
 
         this.ResumeDialog()
 
-        Text(this.getBackendDebugText())
-          .fontSize(12)
-          .fontColor('#E6FFFFFF')
-          .backgroundColor('#66000000')
-          .padding({ left: 8, right: 8, top: 4, bottom: 4 })
-          .borderRadius(4)
+        Column() {
+          this.BackendDebugPanel()
+        }
           .alignRules({
             top: { anchor: '__container__', align: VerticalAlign.Top },
             left: { anchor: '__container__', align: HorizontalAlign.Start }
@@ -178,13 +238,14 @@ export struct PlayerPage {
         this.videoPlayerController.saveProgressNow();
       });
 
-      let pageParam = context.pathInfo.param as PlayerPageParam
-      if (pageParam) {
-        if (pageParam.preferredBackend) {
-          this.videoPlayerController.backend = pageParam.preferredBackend === 'ffmpeg'
-            ? 'ijkplayer'
-            : pageParam.preferredBackend;
-        }
+        let pageParam = context.pathInfo.param as PlayerPageParam
+        if (pageParam) {
+          if (pageParam.preferredBackend) {
+            this.videoPlayerController.setPreferredBackend(
+              pageParam.preferredBackend,
+              pageParam.strictPreferredBackend === true
+            );
+          }
         if (pageParam.unsupportedFormatFallback) {
           this.videoPlayerController.setUnsupportedFormatFallback(pageParam.unsupportedFormatFallback);
         }

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -10,6 +10,7 @@ import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { PlayProgressEntity } from "../../db/models/MediaEntity";
 import { millisecondsToTime } from "../../utils/TimeUtil";
 import { PlayerEvents } from "../../components/core/player/Constants";
+import { DeviceCapabilityUtil } from "../../utils/DeviceCapabilityUtil";
 import { emitter } from "@kit.BasicServicesKit";
 
 export interface PlayerPageParam {
@@ -61,6 +62,58 @@ export struct PlayerPage {
     return `${backendText} | ${reason}`;
   }
 
+  private getAudioCapabilityDebugText(): string {
+    const text = this.videoPlayerController.audioCapabilityText;
+    return text.length > 0 ? text : '音频能力: 暂无';
+  }
+
+  private getPresetAudioDebugText(): string {
+    const tracks = this.videoData?.presetAudioTracks;
+    if (!tracks || tracks.length === 0) {
+      return '预置音轨: 0';
+    }
+    const first = tracks[0];
+    const format = first.mimeType && first.mimeType.length > 0 ? first.mimeType : first.displayName;
+    return `预置音轨: ${tracks.length} | 首轨=${format}`;
+  }
+
+  private getRuntimeTrackDebugText(): string {
+    const audioCount = this.videoPlayerController.audioTracks.length;
+    const subtitleCount = this.videoPlayerController.allSubtitleTracks.length;
+    return `运行时轨道: audio=${audioCount} subtitle=${subtitleCount}`;
+  }
+
+  private getActiveAudioDebugText(): string {
+    const index = this.videoPlayerController.activeAudioIndex;
+    const tracks = this.videoPlayerController.audioTracks;
+    if (index < 0 || index >= tracks.length) {
+      return '当前音轨: 未选中';
+    }
+    const current = tracks[index];
+    return `当前音轨: ${current.displayName}`;
+  }
+
+  private getVideoCapabilityDebugText(codec: string, label: string): string {
+    const summary = DeviceCapabilityUtil.buildNativeVideoCapabilitySummary(codec);
+    if (!summary.supported) {
+      return `${label}: 不支持`;
+    }
+    const capabilityText = summary.isHardware ? '硬解' : '仅软解';
+    const detail = summary.message.replace(`视频能力: ${summary.codecLabel} | `, '');
+    return `${label}: ${capabilityText} | ${detail}`;
+  }
+
+  private dumpNativeVideoCapabilityMatrix(): void {
+    DeviceCapabilityUtil.logNativeVideoDecoderCapabilityMatrix();
+  }
+
+  private async runNativeSurfaceProbe(): Promise<void> {
+    const summaries = await this.videoPlayerController.runExclusiveNativeVideoDecoderSurfaceProbes(['h264', 'h265']);
+    for (let i = 0; i < summaries.length; i++) {
+      console.info(`[PlayerPage] surfaceProbe ${summaries[i]}`);
+    }
+  }
+
   private switchBackend(targetBackend: PlayerBackend): void {
     this.videoPlayerController.setPreferredBackend(targetBackend, true);
   }
@@ -82,6 +135,55 @@ export struct PlayerPage {
       Text(this.getBackendDebugText())
         .fontSize(12)
         .fontColor('#E6FFFFFF')
+        .backgroundColor('#66000000')
+        .padding({ left: 8, right: 8, top: 4, bottom: 4 })
+        .borderRadius(4)
+
+      Text(this.getAudioCapabilityDebugText())
+        .fontSize(11)
+        .fontColor('#CCFFFFFF')
+        .backgroundColor('#66000000')
+        .padding({ left: 8, right: 8, top: 4, bottom: 4 })
+        .borderRadius(4)
+
+      Text(this.getPresetAudioDebugText())
+        .fontSize(11)
+        .fontColor('#CCFFFFFF')
+        .backgroundColor('#66000000')
+        .padding({ left: 8, right: 8, top: 4, bottom: 4 })
+        .borderRadius(4)
+
+      Text(this.getRuntimeTrackDebugText())
+        .fontSize(11)
+        .fontColor('#CCFFFFFF')
+        .backgroundColor('#66000000')
+        .padding({ left: 8, right: 8, top: 4, bottom: 4 })
+        .borderRadius(4)
+
+      Text(this.getActiveAudioDebugText())
+        .fontSize(11)
+        .fontColor('#CCFFFFFF')
+        .backgroundColor('#66000000')
+        .padding({ left: 8, right: 8, top: 4, bottom: 4 })
+        .borderRadius(4)
+
+      Text(this.getVideoCapabilityDebugText('h264', 'H264'))
+        .fontSize(11)
+        .fontColor('#CCFFFFFF')
+        .backgroundColor('#66000000')
+        .padding({ left: 8, right: 8, top: 4, bottom: 4 })
+        .borderRadius(4)
+
+      Text(this.getVideoCapabilityDebugText('h265', 'H265'))
+        .fontSize(11)
+        .fontColor('#CCFFFFFF')
+        .backgroundColor('#66000000')
+        .padding({ left: 8, right: 8, top: 4, bottom: 4 })
+        .borderRadius(4)
+
+      Text(this.getVideoCapabilityDebugText('av1', 'AV1'))
+        .fontSize(11)
+        .fontColor('#CCFFFFFF')
         .backgroundColor('#66000000')
         .padding({ left: 8, right: 8, top: 4, bottom: 4 })
         .borderRadius(4)
@@ -115,6 +217,26 @@ export struct PlayerPage {
           .padding({ left: 10, right: 10, top: 4, bottom: 4 })
           .onClick(() => {
             this.switchBackend('ijkplayer')
+          })
+
+        Button('Probe')
+          .fontSize(11)
+          .fontColor(Color.White)
+          .backgroundColor('#5C3FB5')
+          .borderRadius(4)
+          .padding({ left: 10, right: 10, top: 4, bottom: 4 })
+          .onClick(() => {
+            this.dumpNativeVideoCapabilityMatrix()
+          })
+
+        Button('Surface')
+          .fontSize(11)
+          .fontColor(Color.White)
+          .backgroundColor('#9C4A1A')
+          .borderRadius(4)
+          .padding({ left: 10, right: 10, top: 4, bottom: 4 })
+          .onClick(() => {
+            this.runNativeSurfaceProbe()
           })
       }
     }
@@ -228,6 +350,24 @@ export struct PlayerPage {
             left: { anchor: '__container__', align: HorizontalAlign.Start }
           })
           .margin({ top: 20, left: 20 })
+
+        XComponent({
+          id: 'nativeProbeXComponent',
+          type: XComponentType.SURFACE,
+          libraryname: 'vidall_core_player_napi'
+        })
+          .onLoad((context: object) => {
+            this.videoPlayerController.setNativeProbeContext(context, 'nativeProbeXComponent')
+          })
+          .width(8)
+          .height(8)
+          .opacity(0.01)
+          .backgroundColor(Color.Transparent)
+          .alignRules({
+            bottom: { anchor: '__container__', align: VerticalAlign.Bottom },
+            right: { anchor: '__container__', align: HorizontalAlign.End }
+          })
+          .margin({ bottom: 4, right: 4 })
       }
       .height('100%')
       .width('100%')

--- a/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
+++ b/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
@@ -1,5 +1,26 @@
 import { media } from '@kit.MediaKit';
 import { BusinessError } from '@kit.BasicServicesKit';
+import * as VidAllCorePlayerNapiModule from 'libvidall_core_player_napi.so';
+
+interface NativeCapabilityBridge {
+  queryAudioDecoderCapability: (codecOrMime: string) => NativeAudioDecoderCapability;
+}
+
+interface NativeCapabilityBridgeModule {
+  default?: NativeCapabilityBridge;
+}
+
+function getNativeCapabilityBridge(): NativeCapabilityBridge {
+  const bridgeModule = VidAllCorePlayerNapiModule as NativeCapabilityBridgeModule | NativeCapabilityBridge | undefined;
+  if (bridgeModule === undefined) {
+    throw new Error('libvidall_core_player_napi.so 未加载');
+  }
+  const defaultBridge = (bridgeModule as NativeCapabilityBridgeModule).default;
+  if (defaultBridge !== undefined) {
+    return defaultBridge as NativeCapabilityBridge;
+  }
+  return bridgeModule as NativeCapabilityBridge;
+}
 
 // ─────────────────────────────────────────────
 // 常量定义（ArkTS 不支持 as const，用 namespace 替代）
@@ -145,12 +166,24 @@ export interface IjkHwDecodeSupport {
   h265: boolean;
 }
 
+export interface NativeAudioDecoderCapability {
+  capabilityKnown: boolean;
+  supported: boolean;
+  isHardware: boolean;
+  maxChannels: number;
+  decoderName: string;
+  mimeType: string;
+  errorMessage: string;
+}
+
 // ─────────────────────────────────────────────
 // 工具类
 // ─────────────────────────────────────────────
 
 export class DeviceCapabilityUtil {
   private static readonly TAG = '[DeviceCapability]';
+  private static readonly nativeAudioCapabilityCache: Map<string, NativeAudioDecoderCapability> =
+    new Map<string, NativeAudioDecoderCapability>();
 
   // ── 1. 静态规则查询 ──────────────────────────────────────────────
 
@@ -183,6 +216,103 @@ export class DeviceCapabilityUtil {
       supported,
       note: supported ? 'AVPlayer 已知支持' : '未在已知列表中，实际支持情况未知'
     };
+    return result;
+  }
+
+  static normalizeAudioCodecToMime(codecOrMime: string): string {
+    const normalized = (codecOrMime ?? '').trim().toLowerCase();
+    if (normalized.length === 0) {
+      return '';
+    }
+    if (normalized.startsWith('audio/')) {
+      return normalized;
+    }
+    if (normalized === 'aac' || normalized === 'mp4a' || normalized === 'mp4a-latm') {
+      return AUDIO_CODEC.AAC;
+    }
+    if (normalized === 'mp3' || normalized === 'mpeg' || normalized === 'mpga') {
+      return AUDIO_CODEC.MP3;
+    }
+    if (normalized === 'flac') {
+      return AUDIO_CODEC.FLAC;
+    }
+    if (normalized === 'vorbis') {
+      return AUDIO_CODEC.VORBIS;
+    }
+    if (normalized === 'opus') {
+      return AUDIO_CODEC.OPUS;
+    }
+    if (normalized === 'pcm' || normalized === 'pcm_s16le' || normalized === 'pcm_s24le' ||
+      normalized === 'pcm_s32le') {
+      return AUDIO_CODEC.PCM;
+    }
+    if (normalized === 'ac3' || normalized === 'ac-3') {
+      return AUDIO_CODEC.AC3;
+    }
+    if (normalized === 'eac3' || normalized === 'e-ac-3') {
+      return AUDIO_CODEC.EAC3;
+    }
+    if (normalized === 'dts') {
+      return AUDIO_CODEC.DTS;
+    }
+    if (normalized === 'dtshd' || normalized === 'dts-hd' || normalized === 'dts_hd') {
+      return AUDIO_CODEC.DTSHD;
+    }
+    if (normalized === 'truehd' || normalized === 'true-hd') {
+      return AUDIO_CODEC.TRUEHD;
+    }
+    return '';
+  }
+
+  static queryNativeAudioDecoderCapability(codecOrMime: string): NativeAudioDecoderCapability {
+    const normalizedKey = (codecOrMime ?? '').trim().toLowerCase();
+    if (normalizedKey.length === 0) {
+      const emptyResult: NativeAudioDecoderCapability = {
+        capabilityKnown: false,
+        supported: false,
+        isHardware: false,
+        maxChannels: 0,
+        decoderName: '',
+        mimeType: '',
+        errorMessage: 'empty codec'
+      };
+      return emptyResult;
+    }
+
+    const cached = DeviceCapabilityUtil.nativeAudioCapabilityCache.get(normalizedKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let result: NativeAudioDecoderCapability;
+    try {
+      const bridge = getNativeCapabilityBridge();
+      const nativeResult = bridge.queryAudioDecoderCapability(normalizedKey);
+      const typedResult: NativeAudioDecoderCapability = {
+        capabilityKnown: nativeResult.capabilityKnown,
+        supported: nativeResult.supported,
+        isHardware: nativeResult.isHardware,
+        maxChannels: nativeResult.maxChannels,
+        decoderName: nativeResult.decoderName,
+        mimeType: nativeResult.mimeType,
+        errorMessage: nativeResult.errorMessage
+      };
+      result = typedResult;
+    } catch (e) {
+      const err = e as BusinessError;
+      const fallback: NativeAudioDecoderCapability = {
+        capabilityKnown: false,
+        supported: false,
+        isHardware: false,
+        maxChannels: 0,
+        decoderName: '',
+        mimeType: DeviceCapabilityUtil.normalizeAudioCodecToMime(normalizedKey),
+        errorMessage: err.message ?? JSON.stringify(err)
+      };
+      result = fallback;
+    }
+
+    DeviceCapabilityUtil.nativeAudioCapabilityCache.set(normalizedKey, result);
     return result;
   }
 

--- a/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
+++ b/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
@@ -309,7 +309,7 @@ export class DeviceCapabilityUtil {
       return 'video/hevc';
     }
     if (normalized === 'av1' || normalized === 'av01') {
-      return 'video/av1';
+      return VIDEO_CODEC.AV1;
     }
     if (normalized === 'vp9') {
       return 'video/x-vnd.on2.vp9';
@@ -325,7 +325,7 @@ export class DeviceCapabilityUtil {
       return 'video/mpeg2';
     }
     if (normalized === 'vc1' || normalized === 'wvc1') {
-      return 'video/vc1';
+      return VIDEO_CODEC.VC1;
     }
     return '';
   }

--- a/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
+++ b/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
@@ -4,6 +4,7 @@ import * as VidAllCorePlayerNapiModule from 'libvidall_core_player_napi.so';
 
 interface NativeCapabilityBridge {
   queryAudioDecoderCapability: (codecOrMime: string) => NativeAudioDecoderCapability;
+  queryVideoDecoderCapability: (codecOrMime: string) => NativeVideoDecoderCapability;
 }
 
 interface NativeCapabilityBridgeModule {
@@ -176,6 +177,33 @@ export interface NativeAudioDecoderCapability {
   errorMessage: string;
 }
 
+export interface NativeVideoDecoderCapability {
+  capabilityKnown: boolean;
+  supported: boolean;
+  isHardware: boolean;
+  maxWidth: number;
+  maxHeight: number;
+  minWidth: number;
+  minHeight: number;
+  maxFrameRate: number;
+  minFrameRate: number;
+  widthAlignment: number;
+  heightAlignment: number;
+  maxInstances: number;
+  decoderName: string;
+  mimeType: string;
+  errorMessage: string;
+}
+
+export interface NativeVideoCapabilitySummary {
+  codecLabel: string;
+  mimeType: string;
+  supported: boolean;
+  isHardware: boolean;
+  decoderName: string;
+  message: string;
+}
+
 // ─────────────────────────────────────────────
 // 工具类
 // ─────────────────────────────────────────────
@@ -184,6 +212,8 @@ export class DeviceCapabilityUtil {
   private static readonly TAG = '[DeviceCapability]';
   private static readonly nativeAudioCapabilityCache: Map<string, NativeAudioDecoderCapability> =
     new Map<string, NativeAudioDecoderCapability>();
+  private static readonly nativeVideoCapabilityCache: Map<string, NativeVideoDecoderCapability> =
+    new Map<string, NativeVideoDecoderCapability>();
 
   // ── 1. 静态规则查询 ──────────────────────────────────────────────
 
@@ -264,6 +294,42 @@ export class DeviceCapabilityUtil {
     return '';
   }
 
+  static normalizeVideoCodecToMime(codecOrMime: string): string {
+    const normalized = (codecOrMime ?? '').trim().toLowerCase();
+    if (normalized.length === 0) {
+      return '';
+    }
+    if (normalized.startsWith('video/')) {
+      return normalized;
+    }
+    if (normalized === 'h264' || normalized === 'h.264' || normalized === 'avc' || normalized === 'x264') {
+      return 'video/avc';
+    }
+    if (normalized === 'h265' || normalized === 'h.265' || normalized === 'hevc' || normalized === 'x265') {
+      return 'video/hevc';
+    }
+    if (normalized === 'av1' || normalized === 'av01') {
+      return 'video/av1';
+    }
+    if (normalized === 'vp9') {
+      return 'video/x-vnd.on2.vp9';
+    }
+    if (normalized === 'vp8') {
+      return 'video/x-vnd.on2.vp8';
+    }
+    if (normalized === 'mpeg4' || normalized === 'mp4v' || normalized === 'mp4v-es' ||
+      normalized === 'divx' || normalized === 'xvid') {
+      return 'video/mp4v-es';
+    }
+    if (normalized === 'mpeg2' || normalized === 'mpeg-2') {
+      return 'video/mpeg2';
+    }
+    if (normalized === 'vc1' || normalized === 'wvc1') {
+      return 'video/vc1';
+    }
+    return '';
+  }
+
   static queryNativeAudioDecoderCapability(codecOrMime: string): NativeAudioDecoderCapability {
     const normalizedKey = (codecOrMime ?? '').trim().toLowerCase();
     if (normalizedKey.length === 0) {
@@ -314,6 +380,125 @@ export class DeviceCapabilityUtil {
 
     DeviceCapabilityUtil.nativeAudioCapabilityCache.set(normalizedKey, result);
     return result;
+  }
+
+  static queryNativeVideoDecoderCapability(codecOrMime: string): NativeVideoDecoderCapability {
+    const normalizedKey = (codecOrMime ?? '').trim().toLowerCase();
+    if (normalizedKey.length === 0) {
+      const emptyResult: NativeVideoDecoderCapability = {
+        capabilityKnown: false,
+        supported: false,
+        isHardware: false,
+        maxWidth: 0,
+        maxHeight: 0,
+        minWidth: 0,
+        minHeight: 0,
+        maxFrameRate: 0,
+        minFrameRate: 0,
+        widthAlignment: 0,
+        heightAlignment: 0,
+        maxInstances: 0,
+        decoderName: '',
+        mimeType: '',
+        errorMessage: 'empty codec'
+      };
+      return emptyResult;
+    }
+
+    const cached = DeviceCapabilityUtil.nativeVideoCapabilityCache.get(normalizedKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let result: NativeVideoDecoderCapability;
+    try {
+      const bridge = getNativeCapabilityBridge();
+      const nativeResult = bridge.queryVideoDecoderCapability(normalizedKey);
+      const typedResult: NativeVideoDecoderCapability = {
+        capabilityKnown: nativeResult.capabilityKnown,
+        supported: nativeResult.supported,
+        isHardware: nativeResult.isHardware,
+        maxWidth: nativeResult.maxWidth,
+        maxHeight: nativeResult.maxHeight,
+        minWidth: nativeResult.minWidth,
+        minHeight: nativeResult.minHeight,
+        maxFrameRate: nativeResult.maxFrameRate,
+        minFrameRate: nativeResult.minFrameRate,
+        widthAlignment: nativeResult.widthAlignment,
+        heightAlignment: nativeResult.heightAlignment,
+        maxInstances: nativeResult.maxInstances,
+        decoderName: nativeResult.decoderName,
+        mimeType: nativeResult.mimeType,
+        errorMessage: nativeResult.errorMessage
+      };
+      result = typedResult;
+    } catch (e) {
+      const err = e as BusinessError;
+      const fallback: NativeVideoDecoderCapability = {
+        capabilityKnown: false,
+        supported: false,
+        isHardware: false,
+        maxWidth: 0,
+        maxHeight: 0,
+        minWidth: 0,
+        minHeight: 0,
+        maxFrameRate: 0,
+        minFrameRate: 0,
+        widthAlignment: 0,
+        heightAlignment: 0,
+        maxInstances: 0,
+        decoderName: '',
+        mimeType: DeviceCapabilityUtil.normalizeVideoCodecToMime(normalizedKey),
+        errorMessage: err.message ?? JSON.stringify(err)
+      };
+      result = fallback;
+    }
+
+    DeviceCapabilityUtil.nativeVideoCapabilityCache.set(normalizedKey, result);
+    return result;
+  }
+
+  static buildNativeVideoCapabilitySummary(codecOrMime: string): NativeVideoCapabilitySummary {
+    const capability = DeviceCapabilityUtil.queryNativeVideoDecoderCapability(codecOrMime);
+    const normalizedMime = DeviceCapabilityUtil.normalizeVideoCodecToMime(codecOrMime);
+    const codecLabel = normalizedMime.length > 0
+      ? normalizedMime
+      : ((codecOrMime ?? '').trim().toLowerCase() || 'unknown');
+    let message = `视频能力: ${codecLabel} | `;
+    if (!capability.capabilityKnown) {
+      message += `未知 (${capability.errorMessage.length > 0 ? capability.errorMessage : '未建立映射'})`;
+    } else if (!capability.supported) {
+      message += '不支持';
+    } else {
+      message += capability.isHardware ? '硬解支持' : '仅软解支持';
+      if (capability.maxWidth > 0 && capability.maxHeight > 0) {
+        message += ` | 最大=${capability.maxWidth}x${capability.maxHeight}`;
+      }
+      if (capability.maxFrameRate > 0) {
+        message += ` | 最大帧率=${capability.maxFrameRate}`;
+      }
+      if (capability.decoderName.length > 0) {
+        message += ` | decoder=${capability.decoderName}`;
+      }
+    }
+    const summary: NativeVideoCapabilitySummary = {
+      codecLabel,
+      mimeType: capability.mimeType.length > 0 ? capability.mimeType : normalizedMime,
+      supported: capability.supported,
+      isHardware: capability.isHardware,
+      decoderName: capability.decoderName,
+      message
+    };
+    return summary;
+  }
+
+  static logNativeVideoDecoderCapabilityMatrix(): void {
+    console.info(`${DeviceCapabilityUtil.TAG} ===== Native 视频解码能力矩阵 =====`);
+    for (const entry of ALL_VIDEO_CODECS) {
+      const summary = DeviceCapabilityUtil.buildNativeVideoCapabilitySummary(entry.mime);
+      console.info(`${DeviceCapabilityUtil.TAG}   ${entry.key}: ${summary.message}`);
+    }
+    console.info(`${DeviceCapabilityUtil.TAG} ==================================`);
   }
 
   static logAllCodecSupport(): void {

--- a/entry/src/main/ets/utils/VideoPlayerUtil.ets
+++ b/entry/src/main/ets/utils/VideoPlayerUtil.ets
@@ -71,7 +71,7 @@ function classifyError(code: number, message: string): string {
   return 'PREPARE_ERROR';
 }
 
-function encodeUrlPath(url: string): string {
+export function encodeUrlPath(url: string): string {
   const protocolEnd = url.indexOf('://');
   if (protocolEnd < 0) {
     return url;
@@ -283,4 +283,3 @@ export class VideoPlayerUtil {
     });
   }
 }
-


### PR DESCRIPTION
## 概要

收口 `#51`：沉淀 HarmonyOS TV 硬解能力矩阵、VideoDecoder surface 探针能力，以及真机上的关键技术选型结论。

**本 PR 不代表硬解主路径已正式接入用户播放链路。**
当前仅完成调研/验证基础设施与真机可行性验证，为 `#50` 下一阶段主路径骨架实现提供依据。

## 本 PR 包含

- native 视频解码能力探测（H264/H265/AV1/VP9/VP8/MPEG4/MPEG2/VC1/DIVX）
- 调试面板能力摘要与 `Probe / Surface` 调试入口
- `VideoDecoder surface probe` NAPI
- 专用 `probe XComponent` 验证链路
- 真机验证结论：
  - `H264/H265` 专用 surface 成功绑定硬解
  - 复用当前播放 surface 不可行
  - 成功时序应为 `Create -> Configure -> SetSurface -> Prepare`

## 不包含

- 正式用户播放链路切换到硬解
- 硬解优先与软解回退的正式状态机接入
- 用户可感知的“硬解已上线”能力承诺

## 关键结论

- 当前设备：`H264/H265` 存在硬件解码器
- `AV1/VP9/VP8` 不支持，`MPEG4/MPEG2` 仅软解支持
- 正式硬解主路径应采用**专用 surface**，不能直接复用当前 `nativePlayerXComponent`
- `#50` 下一步应进入：**硬解优先 + 失败自动回退 FFmpeg 软解** 的正式骨架实现

Closes #51
Refs #50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native experimental backend for video playback with automatic FFmpeg fallback
  * Implemented backend selection control with strict locking
  * Added capability queries for audio and video decoders
  * Enhanced subtitle handling for native/FFmpeg hybrid mode
  * UI indicators for unsupported track switching

* **Documentation**
  * Updated README documenting native backend architecture and status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->