### PR TITLE
优化: 收口 #53 native 硬解主路径与解码路径诊断

### DIFF
--- a/.github/agents/PM.agent.md
+++ b/.github/agents/PM.agent.md
@@ -3,7 +3,7 @@ name: 'SE: 产品经理'
 description: >-
   面向 GitHub Issue 创建、用户需求与业务价值对齐、数据驱动产品决策的产品管理指导
 model: GPT-5
-tools: [search/codebase, web/githubRepo, 'github/*', vscode.mermaid-chat-features/renderMermaidDiagram, github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest]
+tools: [read, edit, search/codebase, web/githubRepo, 'github/*', pencil/batch_get, pencil/find_empty_space_on_canvas, pencil/get_editor_state, pencil/get_guidelines, pencil/get_screenshot, pencil/get_style_guide, pencil/get_style_guide_tags, pencil/get_variables, pencil/open_document, pencil/search_all_unique_properties, pencil/snapshot_layout, vscode.mermaid-chat-features/renderMermaidDiagram, github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest, todo]
 ---
 # 产品经理顾问
 

--- a/.github/agents/PM.agent.md
+++ b/.github/agents/PM.agent.md
@@ -3,7 +3,7 @@ name: 'SE: 产品经理'
 description: >-
   面向 GitHub Issue 创建、用户需求与业务价值对齐、数据驱动产品决策的产品管理指导
 model: GPT-5
-tools: [read, edit, search/codebase, web/githubRepo, 'github/*', pencil/batch_get, pencil/find_empty_space_on_canvas, pencil/get_editor_state, pencil/get_guidelines, pencil/get_screenshot, pencil/get_style_guide, pencil/get_style_guide_tags, pencil/get_variables, pencil/open_document, pencil/search_all_unique_properties, pencil/snapshot_layout, vscode.mermaid-chat-features/renderMermaidDiagram, github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest, todo]
+tools: [search/codebase, web/githubRepo, 'github/*', vscode.mermaid-chat-features/renderMermaidDiagram, github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest]
 ---
 # 产品经理顾问
 

--- a/.github/agents/project-manager.agent.md
+++ b/.github/agents/project-manager.agent.md
@@ -3,6 +3,7 @@ name: "SE: 项目经理"
 description: "用于按指定 GitHub Issue 清单编排多子 Agent 执行、监督迭代与验收闭环。关键词：issue分发、任务协调、子agent、QA编译、迭代管理、里程碑。"
 user-invocable: true
 model: GPT-5
+tools: [vscode, execute, read, agent, edit, search, web, browser, 'github/*', 'io.github.upstash/context7/*', 'microsoft/markitdown/*', 'pencil/*', github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest, todo]
 ---
 
 # GitHub Issue 协调官

--- a/.github/agents/project-manager.agent.md
+++ b/.github/agents/project-manager.agent.md
@@ -3,7 +3,6 @@ name: "SE: 项目经理"
 description: "用于按指定 GitHub Issue 清单编排多子 Agent 执行、监督迭代与验收闭环。关键词：issue分发、任务协调、子agent、QA编译、迭代管理、里程碑。"
 user-invocable: true
 model: GPT-5
-tools: [vscode, execute, read, agent, edit, search, web, browser, 'github/*', 'io.github.upstash/context7/*', 'microsoft/markitdown/*', 'pencil/*', github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest, todo]
 ---
 
 # GitHub Issue 协调官

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -38,22 +38,21 @@ target_include_directories(vidall_core_player_napi PRIVATE
 
 # ---------------------------------------------------------------------------
 # B1：FFmpeg demux/decode 路径编译开关
-# 默认 ON；可通过 cmake -DVIDALL_ENABLE_FFMPEG=OFF 关闭（仅保留 OH_AVPlayer 路径）。
+# 默认 ON；当前 OFF 仅关闭编译期标记，不承诺完全裁剪 EGL/GLES/OH_Audio 依赖。
+# 为避免 OFF 配置下出现未解析符号，系统图形/音频库仍保持链接。
 # ---------------------------------------------------------------------------
 option(VIDALL_ENABLE_FFMPEG "Enable FFmpeg demux/decode path" ON)
+target_link_libraries(vidall_core_player_napi PRIVATE
+    libEGL.so
+    libGLESv2.so
+    libohaudio.so
+)
 if(VIDALL_ENABLE_FFMPEG)
     target_compile_definitions(vidall_core_player_napi PRIVATE VIDALL_ENABLE_FFMPEG=1)
     message(STATUS "VIDALL_ENABLE_FFMPEG=ON — FFmpeg demux path enabled")
-    # B3：OpenGL ES YUV 渲染管线需要 EGL 上下文与 GLES2 库
-    # B4：OH_AudioRenderer PCM 送显需要 libohaudio
-    target_link_libraries(vidall_core_player_napi PRIVATE
-        libEGL.so      # EGL 上下文（创建 window surface / context）
-        libGLESv2.so   # OpenGL ES 2.0（shader / texture / draw）
-        libohaudio.so  # B4：OH_AudioRenderer（PCM 音频送显）
-    )
 else()
     target_compile_definitions(vidall_core_player_napi PRIVATE VIDALL_ENABLE_FFMPEG=0)
-    message(STATUS "VIDALL_ENABLE_FFMPEG=OFF — FFmpeg demux path disabled")
+    message(STATUS "VIDALL_ENABLE_FFMPEG=OFF — FFmpeg demux path compile flag disabled, runtime dependencies still linked")
 endif()
 
 # ---------------------------------------------------------------------------

--- a/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
+++ b/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
@@ -1,4 +1,5 @@
 export const createPlayer: () => number;
+export const setPreferredDecodePath: (handle: number, path: string) => void;
 export const setSource: (handle: number, url: string) => void;
 export const setDurationHint: (handle: number, durationMs: number) => void;
 export const setHeaders: (handle: number, headersJson: string) => void;

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -878,6 +878,21 @@ struct FfmpegContext {
   }
 };
 
+enum class NativePreferredDecodePath {
+  HARDWARE_PREFERRED = 0,
+  FFMPEG_ONLY = 1
+};
+
+static const char *PreferredDecodePathToString(NativePreferredDecodePath path) {
+  switch (path) {
+    case NativePreferredDecodePath::FFMPEG_ONLY:
+      return "ffmpeg_only";
+    case NativePreferredDecodePath::HARDWARE_PREFERRED:
+    default:
+      return "hardware_preferred";
+  }
+}
+
 struct NativePlayerSkeletonState {
   std::string url;
   std::string headersJson;
@@ -915,6 +930,7 @@ struct NativePlayerSkeletonState {
   // PR#49 修复（问题6）：per-player mutex，保护 state 字段的跨线程读写
   // 注意：std::mutex 不可拷贝/移动；unordered_map 通过节点指针操作，不需要拷贝值
   std::mutex stateMutex;
+  NativePreferredDecodePath preferredDecodePath = NativePreferredDecodePath::HARDWARE_PREFERRED;
   // B1：FFmpeg 自研路径标志与上下文
   bool useFfmpegPath = false;  // OH_AVPlayer 报错后设为 true，切换到 FFmpeg 路径
   std::unique_ptr<FfmpegContext> ffmpegCtx;
@@ -1282,6 +1298,21 @@ static void ResetRuntimeState(NativePlayerSkeletonState &state) {
   state.lastRealtimeMs = 0;
 }
 
+static bool ParsePreferredDecodePath(
+  const std::string &rawPath,
+  NativePreferredDecodePath &preferredDecodePath
+) {
+  if (rawPath == "ffmpeg_only") {
+    preferredDecodePath = NativePreferredDecodePath::FFMPEG_ONLY;
+    return true;
+  }
+  if (rawPath == "hardware_preferred") {
+    preferredDecodePath = NativePreferredDecodePath::HARDWARE_PREFERRED;
+    return true;
+  }
+  return false;
+}
+
 static void JoinFfmpegFallbackThread(NativePlayerSkeletonState &state) {
   std::thread threadToJoin;
   {
@@ -1352,6 +1383,46 @@ static napi_value SetSource(napi_env env, napi_callback_info info) {
   ResetRuntimeState(*state);
   EmitTimeUpdate(*state);
   return ReturnUndefinedOrThrow(env, "setSource failed to create return value");
+}
+
+static napi_value SetPreferredDecodePath(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2] = { nullptr, nullptr };
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok) {
+    ThrowTypeError(env, "setPreferredDecodePath failed to read args");
+    return nullptr;
+  }
+  if (argc < 2) {
+    ThrowTypeError(env, "setPreferredDecodePath requires (handle, path)");
+    return nullptr;
+  }
+  int32_t handle = 0;
+  if (napi_get_value_int32(env, args[0], &handle) != napi_ok) {
+    ThrowTypeError(env, "setPreferredDecodePath handle must be int32");
+    return nullptr;
+  }
+  NativePlayerSkeletonState *state = FindPlayerOrThrow(env, handle);
+  if (state == nullptr) {
+    return nullptr;
+  }
+  std::string rawPath;
+  if (!ReadUtf8String(env, args[1], rawPath)) {
+    ThrowTypeError(env, "setPreferredDecodePath path must be string");
+    return nullptr;
+  }
+  NativePreferredDecodePath preferredDecodePath = NativePreferredDecodePath::HARDWARE_PREFERRED;
+  if (!ParsePreferredDecodePath(rawPath, preferredDecodePath)) {
+    ThrowTypeError(env, "setPreferredDecodePath path must be 'hardware_preferred' or 'ffmpeg_only'");
+    return nullptr;
+  }
+  {
+    std::lock_guard<std::mutex> lk(state->stateMutex);
+    state->preferredDecodePath = preferredDecodePath;
+  }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "SetPreferredDecodePath: handle=%d preferred=%s",
+               handle, PreferredDecodePathToString(preferredDecodePath));
+  return ReturnUndefinedOrThrow(env, "setPreferredDecodePath failed to create return value");
 }
 
 static napi_value SetDurationHint(napi_env env, napi_callback_info info) {
@@ -3804,6 +3875,33 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
     return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
   }
 
+  NativePreferredDecodePath preferredDecodePath = NativePreferredDecodePath::HARDWARE_PREFERRED;
+  {
+    std::lock_guard<std::mutex> lk(state.stateMutex);
+    preferredDecodePath = state.preferredDecodePath;
+  }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll",
+               "Prepare: preferredDecodePath=%s url=%s xComponentId=%s",
+               PreferredDecodePathToString(preferredDecodePath),
+               state.url.c_str(),
+               state.xComponentId.c_str());
+
+  if (preferredDecodePath == NativePreferredDecodePath::FFMPEG_ONLY) {
+    {
+      std::lock_guard<std::mutex> lk(state.stateMutex);
+      state.useFfmpegPath = true;
+      state.pendingPrepare = false;
+    }
+    EmitBufferingChange(state, true);
+    StartFfmpegDemux(&state, state.url);
+    return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(state.stateMutex);
+    state.useFfmpegPath = false;
+  }
+
   // A3：创建 OH_AVPlayer 实例（每次 prepare 前确保实例存在）
   if (state.avPlayer == nullptr) {
     state.avPlayer = OH_AVPlayer_Create();
@@ -5466,6 +5564,7 @@ static napi_value ProbeVideoDecoderSurface(napi_env env, napi_callback_info info
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     { "createPlayer", nullptr, CreatePlayer, nullptr, nullptr, nullptr, napi_default, nullptr },
+    { "setPreferredDecodePath", nullptr, SetPreferredDecodePath, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "setSource", nullptr, SetSource, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "setDurationHint", nullptr, SetDurationHint, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "setHeaders", nullptr, SetHeaders, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -704,8 +704,9 @@ export class VidAllPlayerAdapter implements IPlayer {
             preferredBufferDuration: 3,
             preferredHdr: true
           };
+          const sanitizedUrl = this.sanitizeProbeUrlForLog(encodedUrl);
           hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-            `probeTrackInfos 使用编码 URL 探测轨道: ${encodedUrl}`);
+            `probeTrackInfos 使用编码 URL 探测轨道: ${sanitizedUrl}`);
           try {
             player.setMediaSource(mediaSource, playbackStrategy);
           } catch (e) {
@@ -774,6 +775,11 @@ export class VidAllPlayerAdapter implements IPlayer {
       safeHeaders[key] = headers[key];
     }
     return JSON.stringify(safeHeaders);
+  }
+
+  private sanitizeProbeUrlForLog(rawUrl: string): string {
+    const withoutCredential = rawUrl.replace(/\/\/([^\/@]+)@/, '//***@');
+    return withoutCredential.replace(/[?#].*$/, '');
   }
 
   /**

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -60,6 +60,25 @@ interface VideoDecoderSurfaceProbeResult {
   errorMessage: string;
 }
 
+export type NativeDecodePath = 'hardware' | 'ffmpeg';
+export type NativeDecodePathState = 'hardware_active' | 'ffmpeg_switching' | 'ffmpeg_active';
+export type NativeBackendFatalErrorSource = 'runtime_callback' | 'napi_bridge';
+
+export interface NativeDecodePathStatus {
+  path: NativeDecodePath;
+  state: NativeDecodePathState;
+  reason: string;
+}
+
+export interface NativeBackendFatalError {
+  source: NativeBackendFatalErrorSource;
+  code: number;
+  message: string;
+  diagnostics: string;
+  path: NativeDecodePath;
+  state: NativeDecodePathState;
+}
+
 const playerBridgeModule = VidAllCorePlayerNapiModule as VidAllCorePlayerNapiBridgeModule | VidAllCorePlayerNapiBridge | undefined;
 const VidAllCorePlayerNapi: VidAllCorePlayerNapiBridge =
   playerBridgeModule !== undefined && (playerBridgeModule as VidAllCorePlayerNapiBridgeModule).default !== undefined
@@ -91,6 +110,11 @@ export class VidAllPlayerAdapter implements IPlayer {
   private _playerHandle: number = 0;
   private _lastDurationUnknownSeekLogMs: number = 0;
   private _enableSeekDiagLog: boolean = false;
+  private _decodePathStatus: NativeDecodePathStatus = {
+    path: 'hardware',
+    state: 'hardware_active',
+    reason: 'init'
+  };
 
   private _onReadyCb?: () => void;
   private _onPlayCb?: () => void;
@@ -103,9 +127,10 @@ export class VidAllPlayerAdapter implements IPlayer {
   private _onSeekDoneCb?: () => void;
   private _onSubtitleUpdateCb?: (info: SubtitleInfo) => void;
   private _onBufferingCb?: (isBuffering: boolean) => void;
+  private _onNativeDecodePathChangedCb?: (status: NativeDecodePathStatus) => void;
+  private _onNativeBackendFatalErrorCb?: (error: NativeBackendFatalError) => void;
   /** B6修复：FFmpeg 接管时通知上层重置 native 就绪守卫计时器 */
   private _onFfmpegSwitchingCb?: () => void;
-  private _usingFfmpegPath: boolean = false;
   private _probedTrackInfos?: TrackInfo[];
   private _probeTrackInfosPromise?: Promise<TrackInfo[]>;
   /** seek 完成确认门禁：true 表示有一次 seek 正在等待原生 seekDone 确认 */
@@ -122,7 +147,15 @@ export class VidAllPlayerAdapter implements IPlayer {
   }
 
   isUsingFfmpegPath(): boolean {
-    return this._usingFfmpegPath;
+    return this._decodePathStatus.path === 'ffmpeg';
+  }
+
+  getDecodePathStatus(): NativeDecodePathStatus {
+    return {
+      path: this._decodePathStatus.path,
+      state: this._decodePathStatus.state,
+      reason: this._decodePathStatus.reason
+    };
   }
 
   setPendingContext(context: object, xComponentId: string): void {
@@ -134,6 +167,14 @@ export class VidAllPlayerAdapter implements IPlayer {
 
   setSeekDiagEnabled(enabled: boolean): void {
     this._enableSeekDiagLog = enabled;
+  }
+
+  setNativeDecodePathChangedCallback(cb: (status: NativeDecodePathStatus) => void): void {
+    this._onNativeDecodePathChangedCb = cb;
+  }
+
+  setNativeBackendFatalErrorCallback(cb: (error: NativeBackendFatalError) => void): void {
+    this._onNativeBackendFatalErrorCb = cb;
   }
 
   /** B6修复：注册 FFmpeg 接管通知回调，由上层 VideoPlayerController 调用以重置守卫计时器 */
@@ -172,7 +213,11 @@ export class VidAllPlayerAdapter implements IPlayer {
     this._pendingXComponentId = pendingXComponentId;
     this._videoData = videoData;
     this._surfaceId = surfaceId;
-    this._usingFfmpegPath = false;
+    this._decodePathStatus = {
+      path: 'hardware',
+      state: 'hardware_active',
+      reason: 'init'
+    };
     this._probedTrackInfos = undefined;
     this._probeTrackInfosPromise = undefined;
     this._duration = 0;
@@ -245,6 +290,9 @@ export class VidAllPlayerAdapter implements IPlayer {
           }
           this._currentTime = this.silentNativeFallback('getCurrentTime', () =>
             VidAllCorePlayerNapi.getCurrentTime(currentHandle), 0);
+          if (this._decodePathStatus.state === 'ffmpeg_switching') {
+            this.updateDecodePathStatus('ffmpeg', 'ffmpeg_active', 'ffmpeg_prepared');
+          }
           hilog.info(CommonConstants.LOG_DOMAIN, TAG,
             `onPrepared: handle=${currentHandle} duration=${this._duration} position=${this._currentTime}`);
           this._onReadyCb?.();
@@ -259,7 +307,8 @@ export class VidAllPlayerAdapter implements IPlayer {
           const errorMessage = `[${code}] ${msg} (hint=${hint})`;
           hilog.error(CommonConstants.LOG_DOMAIN, TAG,
             `onError: handle=${currentHandle} code=${code} hint=${hint}`);
-          this._onErrorCb?.(new Error(errorMessage));
+          this.emitNativeBackendFatalError('runtime_callback', code, errorMessage);
+          this.emitGeneralErrorIfNeeded(new Error(errorMessage));
         },
         (posMs: number) => {
           // 状态门禁：同 onError。
@@ -303,7 +352,7 @@ export class VidAllPlayerAdapter implements IPlayer {
           // 避免 avformat_open_input（3-10s）期间 3.5s 守卫误触 fallbackNativeToIjk。
           hilog.info(CommonConstants.LOG_DOMAIN, TAG,
             `onFfmpegSwitching: handle=${currentHandle}, FFmpeg 接管，通知重置守卫计时器`);
-          this._usingFfmpegPath = true;
+          this.updateDecodePathStatus('ffmpeg', 'ffmpeg_switching', 'avplayer_error_handoff');
           this._onFfmpegSwitchingCb?.();
         },
         (info: SubtitleInfo) => {
@@ -437,7 +486,7 @@ export class VidAllPlayerAdapter implements IPlayer {
   }
 
   async getTrackInfos(): Promise<TrackInfo[]> {
-    if (!this._usingFfmpegPath) {
+    if (!this.isUsingFfmpegPath()) {
       const probedTracks = await this.probeAvPlayerTrackInfos();
       if (probedTracks.length > 0) {
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
@@ -768,7 +817,7 @@ export class VidAllPlayerAdapter implements IPlayer {
       this._onErrorCb?.(err);
       throw err;
     }
-    if (this._usingFfmpegPath) {
+    if (this.isUsingFfmpegPath()) {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         `selectTrack(${trackIndex}) 已跳过：native/FFmpeg 子路径暂不支持运行时切轨`);
       return;
@@ -837,7 +886,11 @@ export class VidAllPlayerAdapter implements IPlayer {
     this._isPrepared = false;
     this._readyFired = false;
     this._videoData = undefined;
-    this._usingFfmpegPath = false;
+    this._decodePathStatus = {
+      path: 'hardware',
+      state: 'hardware_active',
+      reason: 'released'
+    };
     this._probedTrackInfos = undefined;
     this._probeTrackInfosPromise = undefined;
     this._duration = 0;
@@ -926,8 +979,10 @@ export class VidAllPlayerAdapter implements IPlayer {
     try {
       fn();
     } catch (e) {
-      const err = this.wrapNativeError(action, e as BusinessError);
-      this._onErrorCb?.(err);
+      const nativeError = e as BusinessError;
+      const err = this.wrapNativeError(action, nativeError);
+      this.emitNativeBackendFatalError('napi_bridge', this.resolveBusinessErrorCode(nativeError), err.message);
+      this.emitGeneralErrorIfNeeded(err);
       throw err;
     }
   }
@@ -936,8 +991,10 @@ export class VidAllPlayerAdapter implements IPlayer {
     try {
       return fn();
     } catch (e) {
-      const err = this.wrapNativeError(action, e as BusinessError);
-      this._onErrorCb?.(err);
+      const nativeError = e as BusinessError;
+      const err = this.wrapNativeError(action, nativeError);
+      this.emitNativeBackendFatalError('napi_bridge', this.resolveBusinessErrorCode(nativeError), err.message);
+      this.emitGeneralErrorIfNeeded(err);
       throw err;
     }
   }
@@ -946,8 +1003,10 @@ export class VidAllPlayerAdapter implements IPlayer {
     try {
       return fn();
     } catch (e) {
-      const err = this.wrapNativeError(action, e as BusinessError);
-      this._onErrorCb?.(err);
+      const nativeError = e as BusinessError;
+      const err = this.wrapNativeError(action, nativeError);
+      this.emitNativeBackendFatalError('napi_bridge', this.resolveBusinessErrorCode(nativeError), err.message);
+      this.emitGeneralErrorIfNeeded(err);
       return fallback;
     }
   }
@@ -968,13 +1027,63 @@ export class VidAllPlayerAdapter implements IPlayer {
     }
   }
 
+  private updateDecodePathStatus(path: NativeDecodePath, state: NativeDecodePathState, reason: string): void {
+    const changed = this._decodePathStatus.path !== path ||
+      this._decodePathStatus.state !== state ||
+      this._decodePathStatus.reason !== reason;
+    this._decodePathStatus = {
+      path,
+      state,
+      reason
+    };
+    if (!changed) {
+      return;
+    }
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[native-decode-path] path=${path} state=${state} reason=${reason}`);
+    this._onNativeDecodePathChangedCb?.({
+      path,
+      state,
+      reason
+    });
+  }
+
+  private emitNativeBackendFatalError(
+    source: NativeBackendFatalErrorSource,
+    code: number,
+    message: string
+  ): void {
+    const fatalError: NativeBackendFatalError = {
+      source,
+      code,
+      message,
+      diagnostics: `path=${this._decodePathStatus.path}; state=${this._decodePathStatus.state}`,
+      path: this._decodePathStatus.path,
+      state: this._decodePathStatus.state
+    };
+    hilog.error(CommonConstants.LOG_DOMAIN, TAG,
+      `[native-backend-fatal] source=${source} code=${code} path=${fatalError.path} state=${fatalError.state} message=${message}`);
+    this._onNativeBackendFatalErrorCb?.(fatalError);
+  }
+
+  private emitGeneralErrorIfNeeded(error: Error): void {
+    if (this._onNativeBackendFatalErrorCb !== undefined) {
+      return;
+    }
+    this._onErrorCb?.(error);
+  }
+
   private wrapNativeError(action: string, nativeError: BusinessError): Error {
-    const code = nativeError.code;
+    const code = this.resolveBusinessErrorCode(nativeError);
     const message = nativeError.message ?? 'unknown native error';
     const hint = this.resolveNativeErrorHint(code);
     const error = new Error(`[NAPI/${action}] code=${code} msg=${message} hint=${hint}`);
     hilog.error(CommonConstants.LOG_DOMAIN, TAG, error.message);
     return error;
+  }
+
+  private resolveBusinessErrorCode(nativeError: BusinessError): number {
+    return typeof nativeError.code === 'number' ? nativeError.code : -1;
   }
 
   private resolveNativeErrorHint(code: number): string {

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -20,6 +20,7 @@ interface NativeXComponentFallbackContext {
 interface VidAllCorePlayerNapiBridge {
   probeVideoDecoderSurface: (handle: number, codecOrMime: string) => VideoDecoderSurfaceProbeResult;
   createPlayer: () => number;
+  setPreferredDecodePath: (handle: number, path: string) => void;
   setSource: (handle: number, url: string) => void;
   setDurationHint: (handle: number, durationMs: number) => void;
   setHeaders: (handle: number, headersJson: string) => void;
@@ -61,10 +62,27 @@ interface VideoDecoderSurfaceProbeResult {
 }
 
 export type NativeDecodePath = 'hardware' | 'ffmpeg';
-export type NativeDecodePathState = 'hardware_active' | 'ffmpeg_switching' | 'ffmpeg_active';
+export type NativeDecodeExpectation = 'hardware_preferred' | 'ffmpeg_only';
+export type NativeDecodePathState =
+  'hardware_preferred' |
+  'hardware_active' |
+  'ffmpeg_only' |
+  'ffmpeg_switching' |
+  'ffmpeg_active';
 export type NativeBackendFatalErrorSource = 'runtime_callback' | 'napi_bridge';
+type NativePrepareDecodePlan = 'system_default' | 'native_hw_preferred' | 'native_ffmpeg_only';
+
+interface NativePrepareDecodeSelection {
+  plan: NativePrepareDecodePlan;
+  expectedPath: NativeDecodeExpectation;
+  initialPath: NativeDecodePath;
+  initialState: NativeDecodePathState;
+  reason: string;
+  diagnostics: string;
+}
 
 export interface NativeDecodePathStatus {
+  expectedPath: NativeDecodeExpectation;
   path: NativeDecodePath;
   state: NativeDecodePathState;
   reason: string;
@@ -110,9 +128,18 @@ export class VidAllPlayerAdapter implements IPlayer {
   private _playerHandle: number = 0;
   private _lastDurationUnknownSeekLogMs: number = 0;
   private _enableSeekDiagLog: boolean = false;
+  private _prepareDecodeSelection: NativePrepareDecodeSelection = {
+    plan: 'system_default',
+    expectedPath: 'hardware_preferred',
+    initialPath: 'hardware',
+    initialState: 'hardware_preferred',
+    reason: 'default_prepare_plan',
+    diagnostics: 'plan=system_default'
+  };
   private _decodePathStatus: NativeDecodePathStatus = {
+    expectedPath: 'hardware_preferred',
     path: 'hardware',
-    state: 'hardware_active',
+    state: 'hardware_preferred',
     reason: 'init'
   };
 
@@ -152,6 +179,7 @@ export class VidAllPlayerAdapter implements IPlayer {
 
   getDecodePathStatus(): NativeDecodePathStatus {
     return {
+      expectedPath: this._decodePathStatus.expectedPath,
       path: this._decodePathStatus.path,
       state: this._decodePathStatus.state,
       reason: this._decodePathStatus.reason
@@ -180,6 +208,14 @@ export class VidAllPlayerAdapter implements IPlayer {
   /** B6修复：注册 FFmpeg 接管通知回调，由上层 VideoPlayerController 调用以重置守卫计时器 */
   setFfmpegSwitchingCallback(cb: () => void): void {
     this._onFfmpegSwitchingCb = cb;
+  }
+
+  setPrepareDecodePlan(plan: NativePrepareDecodePlan, reason: string, diagnostics: string): void {
+    this._prepareDecodeSelection = this.buildPrepareDecodeSelection(plan, reason, diagnostics);
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[native-prepare-plan] set plan=${this._prepareDecodeSelection.plan} expected=${this._prepareDecodeSelection.expectedPath} ` +
+      `initialPath=${this._prepareDecodeSelection.initialPath} initialState=${this._prepareDecodeSelection.initialState} ` +
+      `reason=${this._prepareDecodeSelection.reason} diagnostics=${this._prepareDecodeSelection.diagnostics}`);
   }
 
   async initWithContext(videoData: VideoData, surfaceId: string, context: object, xComponentId: string): Promise<void> {
@@ -214,8 +250,9 @@ export class VidAllPlayerAdapter implements IPlayer {
     this._videoData = videoData;
     this._surfaceId = surfaceId;
     this._decodePathStatus = {
-      path: 'hardware',
-      state: 'hardware_active',
+      expectedPath: this._prepareDecodeSelection.expectedPath,
+      path: this._prepareDecodeSelection.initialPath,
+      state: this._prepareDecodeSelection.initialState,
       reason: 'init'
     };
     this._probedTrackInfos = undefined;
@@ -240,6 +277,20 @@ export class VidAllPlayerAdapter implements IPlayer {
     }
 
     this._playerHandle = this.callNativeWithValue('createPlayer', () => VidAllCorePlayerNapi.createPlayer());
+    const prepareSelection = this._prepareDecodeSelection;
+    this.callNativeVoid('setPreferredDecodePath', () => {
+      VidAllCorePlayerNapi.setPreferredDecodePath(this._playerHandle, prepareSelection.expectedPath);
+    });
+    this.updateDecodePathStatus(
+      prepareSelection.initialPath,
+      prepareSelection.initialState,
+      `prepare_selected:${prepareSelection.reason}`
+    );
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[native-prepare-plan] handle=${this._playerHandle} plan=${prepareSelection.plan} ` +
+      `expected=${prepareSelection.expectedPath} initialPath=${prepareSelection.initialPath} ` +
+      `initialState=${prepareSelection.initialState} reason=${prepareSelection.reason} ` +
+      `diagnostics=${prepareSelection.diagnostics}`);
     // OH_AVPlayer_SetURLSource 不支持自定义 HTTP 头；将 Basic Auth 凭据嵌入 URL userinfo
     // （RFC 3986：http://user:pass@host/path），FFmpeg 底层会自动提取并发送 Authorization 头。
     const urlForNative = this.buildUrlWithAuth(videoData.videoSrc, videoData.httpHeader);
@@ -292,9 +343,15 @@ export class VidAllPlayerAdapter implements IPlayer {
             VidAllCorePlayerNapi.getCurrentTime(currentHandle), 0);
           if (this._decodePathStatus.state === 'ffmpeg_switching') {
             this.updateDecodePathStatus('ffmpeg', 'ffmpeg_active', 'ffmpeg_prepared');
+          } else if (this._decodePathStatus.state === 'ffmpeg_only') {
+            this.updateDecodePathStatus('ffmpeg', 'ffmpeg_active', 'ffmpeg_only_prepared');
+          } else if (this._decodePathStatus.state === 'hardware_preferred') {
+            this.updateDecodePathStatus('hardware', 'hardware_active', 'hardware_prepared');
           }
           hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-            `onPrepared: handle=${currentHandle} duration=${this._duration} position=${this._currentTime}`);
+            `onPrepared: handle=${currentHandle} expected=${this._decodePathStatus.expectedPath} ` +
+            `path=${this._decodePathStatus.path} state=${this._decodePathStatus.state} ` +
+            `duration=${this._duration} position=${this._currentTime}`);
           this._onReadyCb?.();
         },
         (code: number, msg: string) => {
@@ -887,8 +944,9 @@ export class VidAllPlayerAdapter implements IPlayer {
     this._readyFired = false;
     this._videoData = undefined;
     this._decodePathStatus = {
-      path: 'hardware',
-      state: 'hardware_active',
+      expectedPath: this._prepareDecodeSelection.expectedPath,
+      path: this._prepareDecodeSelection.initialPath,
+      state: this._prepareDecodeSelection.initialState,
       reason: 'released'
     };
     this._probedTrackInfos = undefined;
@@ -1028,10 +1086,12 @@ export class VidAllPlayerAdapter implements IPlayer {
   }
 
   private updateDecodePathStatus(path: NativeDecodePath, state: NativeDecodePathState, reason: string): void {
-    const changed = this._decodePathStatus.path !== path ||
+    const changed = this._decodePathStatus.expectedPath !== this._prepareDecodeSelection.expectedPath ||
+      this._decodePathStatus.path !== path ||
       this._decodePathStatus.state !== state ||
       this._decodePathStatus.reason !== reason;
     this._decodePathStatus = {
+      expectedPath: this._prepareDecodeSelection.expectedPath,
       path,
       state,
       reason
@@ -1040,8 +1100,9 @@ export class VidAllPlayerAdapter implements IPlayer {
       return;
     }
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `[native-decode-path] path=${path} state=${state} reason=${reason}`);
+      `[native-decode-path] expected=${this._decodePathStatus.expectedPath} path=${path} state=${state} reason=${reason}`);
     this._onNativeDecodePathChangedCb?.({
+      expectedPath: this._decodePathStatus.expectedPath,
       path,
       state,
       reason
@@ -1057,13 +1118,39 @@ export class VidAllPlayerAdapter implements IPlayer {
       source,
       code,
       message,
-      diagnostics: `path=${this._decodePathStatus.path}; state=${this._decodePathStatus.state}`,
+      diagnostics: `expected=${this._decodePathStatus.expectedPath}; path=${this._decodePathStatus.path}; state=${this._decodePathStatus.state}`,
       path: this._decodePathStatus.path,
       state: this._decodePathStatus.state
     };
     hilog.error(CommonConstants.LOG_DOMAIN, TAG,
-      `[native-backend-fatal] source=${source} code=${code} path=${fatalError.path} state=${fatalError.state} message=${message}`);
+      `[native-backend-fatal] source=${source} code=${code} expected=${this._decodePathStatus.expectedPath} ` +
+      `path=${fatalError.path} state=${fatalError.state} message=${message}`);
     this._onNativeBackendFatalErrorCb?.(fatalError);
+  }
+
+  private buildPrepareDecodeSelection(
+    plan: NativePrepareDecodePlan,
+    reason: string,
+    diagnostics: string
+  ): NativePrepareDecodeSelection {
+    if (plan === 'native_ffmpeg_only') {
+      return {
+        plan,
+        expectedPath: 'ffmpeg_only',
+        initialPath: 'ffmpeg',
+        initialState: 'ffmpeg_only',
+        reason,
+        diagnostics
+      };
+    }
+    return {
+      plan,
+      expectedPath: 'hardware_preferred',
+      initialPath: 'hardware',
+      initialState: 'hardware_preferred',
+      reason,
+      diagnostics
+    };
   }
 
   private emitGeneralErrorIfNeeded(error: Error): void {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -10,8 +10,8 @@ import { IjkPlayerAdapter } from "./IjkPlayerAdapter";
 import { VidAllPlayerAdapter } from "./VidAllPlayerAdapter";
 import { FileSourceDatabase } from "../../../db/files/FileSourceDatabase";
 import { PlayProgressEntity } from "../../../db/models/MediaEntity";
-import { FfprobeUtil } from "../../../utils/FfprobeUtil";
-import { DeviceCapabilityUtil } from "../../../utils/DeviceCapabilityUtil";
+import { FfprobeResult, FfprobeTrack, FfprobeUtil } from "../../../utils/FfprobeUtil";
+import { DeviceCapabilityUtil, NativeVideoDecoderCapability } from "../../../utils/DeviceCapabilityUtil";
 import { FfmpegVideoFrameUtil } from "../../../utils/FfmpegVideoFrameUtil";
 import {
   AvSubtitleBridgeAdapter,
@@ -76,6 +76,45 @@ interface AudioRoutingDecision {
   decoderIsHardware: boolean;
   precheckProbeFailed: boolean;
   precheckProbeError: string;
+}
+
+type NativeVideoPlan = 'system_default' | 'native_hw_preferred' | 'native_ffmpeg_only';
+type NativeFallbackLevel1 = 'native_ffmpeg';
+type NativeFallbackLevel2 = 'ijkplayer';
+type NativeErrorEscalationPolicy = 'controller_wide_for_now';
+type NativeErrorEscalationAction = 'fallback_to_ijkplayer';
+
+interface PlaybackPreflightSnapshot {
+  probeSucceeded: boolean;
+  probeError: string;
+  probeResult?: FfprobeResult;
+  primaryVideoTrack?: FfprobeTrack;
+  primaryAudioTrack?: FfprobeTrack;
+  videoCodecName: string;
+  videoCodecMime: string;
+  nativeVideoCapability: NativeVideoDecoderCapability;
+}
+
+interface PlaybackFallbackPlan {
+  avplayerUnsupportedFallback: UnsupportedFormatFallback;
+  nativeLevel1Fallback: NativeFallbackLevel1;
+  nativeLevel2Fallback: NativeFallbackLevel2;
+  nativeErrorEscalationPolicy: NativeErrorEscalationPolicy;
+  surfaceProbeIncluded: boolean;
+}
+
+interface PlaybackPlanDecision {
+  selectedBackend: PlayerBackend;
+  nativeVideoPlan: NativeVideoPlan;
+  fallbackPlan: PlaybackFallbackPlan;
+  decisionReason: string;
+  diagnostics: string;
+}
+
+interface NativeErrorEscalationDirective {
+  action: NativeErrorEscalationAction;
+  reason: string;
+  diagnostics: string;
 }
 
 interface PresetAudioHint {
@@ -170,6 +209,8 @@ export class VideoPlayerController {
   @Trace lastErrorMessage: string = ''
   /** 音频能力探测文案（用于 UI 展示） */
   @Trace audioCapabilityText: string = ''
+  /** 播放预检 / 播放计划摘要（用于日志与后续 UI/调试展示） */
+  @Trace playbackPlanSummary: string = ''
   /** ffmpeg 模式首帧预览图（file:// URI） */
   @Trace ffmpegPreviewUri: string = ''
   @Trace progress = 0
@@ -265,6 +306,7 @@ export class VideoPlayerController {
   private ffmpegLastEmptyQueueCatchupAtMs: number = 0;
   /** ffmpeg 连续预览：远程 chunk 不稳定时切到单帧模式 */
   private ffmpegSingleFrameMode: boolean = false;
+  private latestPlaybackPlan?: PlaybackPlanDecision;
 
   /**
    * 初始化播放器。
@@ -314,12 +356,14 @@ export class VideoPlayerController {
 
     // 先重置可展示状态，避免复用上次播放残留。
     this.audioCapabilityText = '';
+    this.playbackPlanSummary = '';
     this.ffmpegPreviewUri = '';
+    const preflight = await this.collectPlaybackPreflightSnapshot(videoData);
 
     // 若外部未显式锁定策略，则根据探测结果自动选择硬解/软解路由。
     if (!this.unsupportedFallbackLockedByUser) {
       const backendBeforeAutoRouting = this.backend;
-      const decision = await this.resolveAudioRoutingDecision(videoData);
+      const decision = await this.resolveAudioRoutingDecision(videoData, preflight);
       this.unsupportedFormatFallback = decision.fallback;
       videoData.ffmpegDecodeChannels = decision.preferredChannels;
       videoData.audioProbeSummary = decision.summary;
@@ -345,6 +389,14 @@ export class VideoPlayerController {
         'ffmpeg 播放后端已从主路径下线，自动回退到 ijkplayer');
       this.backend = 'ijkplayer';
     }
+
+    const playbackPlan = this.buildPlaybackPlanDecision(preflight);
+    this.latestPlaybackPlan = playbackPlan;
+    this.playbackPlanSummary =
+      `播放计划: backend=${playbackPlan.selectedBackend} | ` +
+      `nativePlan=${playbackPlan.nativeVideoPlan} | ` +
+      `fallback=${playbackPlan.fallbackPlan.nativeLevel1Fallback}->${playbackPlan.fallbackPlan.nativeLevel2Fallback}`;
+    this.logPlaybackPlan(playbackPlan);
 
     // 指标埋点：play_start — backend 已最终确定，记录本次播放启动意图
     hilog.info(CommonConstants.LOG_DOMAIN, METRICS_TAG,
@@ -551,7 +603,10 @@ export class VideoPlayerController {
       hilog.warn(CommonConstants.LOG_DOMAIN, METRICS_TAG,
         `{"event":"play_result","backend":"${this.backend}","video_id":${this.progressContext?.videoId ?? -1},"result":"error","error_code":"${error.message.substring(0, 80)}","elapsed_ms":${metricsElapsedOnError}}`);
       if (this.backend === 'native') {
-        this.fallbackNativeToIjk('native_error_callback', 'native 错误回调触发，已自动回退到 IJK 播放', error.message);
+        const directive = this.resolveNativeErrorEscalationDirective(error.message);
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          `[native-error-policy] action=${directive.action}, reason=${directive.reason}, diagnostics=${directive.diagnostics}`);
+        this.fallbackNativeToIjk(directive.reason, 'native 错误回调触发，已自动回退到 IJK 播放', error.message);
         return;
       }
       this.isLoading = false;
@@ -1387,7 +1442,48 @@ export class VideoPlayerController {
     return false;
   }
 
-  private async resolveAudioRoutingDecision(videoData: VideoData): Promise<AudioRoutingDecision> {
+  private async collectPlaybackPreflightSnapshot(videoData: VideoData): Promise<PlaybackPreflightSnapshot> {
+    let probeResult: FfprobeResult | undefined = undefined;
+    let probeSucceeded = false;
+    let probeError = '';
+
+    try {
+      const probe = await FfprobeUtil.probe(videoData.videoSrc, videoData.httpHeader, 9000);
+      if (probe.success) {
+        probeResult = probe;
+        probeSucceeded = true;
+      } else {
+        probeError = probe.errorMessage ?? 'ffprobe failed';
+      }
+    } catch (e) {
+      probeError = this.safeErrorMessage(e);
+    }
+
+    const primaryVideoTrack = probeResult?.videoTracks.length ? probeResult.videoTracks[0] : undefined;
+    const primaryAudioTrack = probeResult?.audioTracks.length ? probeResult.audioTracks[0] : undefined;
+    const videoCodecName = (primaryVideoTrack?.codecName ?? '').toLowerCase();
+    const videoCodecMime = DeviceCapabilityUtil.normalizeVideoCodecToMime(videoCodecName);
+    const nativeVideoCapability = videoCodecName.length > 0
+      ? DeviceCapabilityUtil.queryNativeVideoDecoderCapability(videoCodecName)
+      : this.buildEmptyNativeVideoCapability('video codec unavailable');
+
+    const snapshot: PlaybackPreflightSnapshot = {
+      probeSucceeded,
+      probeError,
+      probeResult,
+      primaryVideoTrack,
+      primaryAudioTrack,
+      videoCodecName,
+      videoCodecMime,
+      nativeVideoCapability
+    };
+    return snapshot;
+  }
+
+  private async resolveAudioRoutingDecision(
+    videoData: VideoData,
+    preflight?: PlaybackPreflightSnapshot
+  ): Promise<AudioRoutingDecision> {
     const defaultDecision: AudioRoutingDecision = {
       preferredBackend: 'avplayer',
       fallback: 'native',
@@ -1408,21 +1504,13 @@ export class VideoPlayerController {
     const presetHint = this.readPresetAudioHint(videoData);
     let codecName = presetHint.codecName;
     let channels = presetHint.channels;
-    let precheckProbeFailed = false;
-    let precheckProbeError = '';
+    const precheckProbeFailed = preflight !== undefined && !preflight.probeSucceeded;
+    const precheckProbeError = preflight?.probeError ?? '';
 
-    try {
-      // 优先用 ffprobe 读取真实流信息；失败时再退回 preset 提示。
-      const probe = await FfprobeUtil.probe(videoData.videoSrc, videoData.httpHeader, 9000);
-      if (probe.success && probe.audioTracks.length > 0) {
-        const first = probe.audioTracks[0];
-        codecName = first.codecName;
-        channels = first.channels ?? channels;
-      }
-    } catch (e) {
-      precheckProbeFailed = true;
-      precheckProbeError = this.safeErrorMessage(e);
-      // 探测失败时使用预置音轨提示继续决策。
+    const probedAudioTrack = preflight?.primaryAudioTrack;
+    if (probedAudioTrack !== undefined) {
+      codecName = probedAudioTrack.codecName;
+      channels = probedAudioTrack.channels ?? channels;
     }
 
     const normalizedCodec = (codecName ?? '').toLowerCase();
@@ -1457,6 +1545,77 @@ export class VideoPlayerController {
       precheckProbeError
     };
     return decision;
+  }
+
+  private buildPlaybackPlanDecision(preflight: PlaybackPreflightSnapshot): PlaybackPlanDecision {
+    const selectedBackend = this.backend;
+    let nativeVideoPlan: NativeVideoPlan = 'system_default';
+    let decisionReason = '未命中 native 硬解预检条件，保持 system_default 骨架';
+
+    if (preflight.videoCodecName.length === 0) {
+      decisionReason = preflight.probeSucceeded
+        ? 'ffprobe 未识别视频主轨 codec，native 暂保持 system_default'
+        : 'ffprobe 失败，native 暂保持 system_default';
+    } else if (this.isHwCandidateCodec(preflight.videoCodecMime)) {
+      if (preflight.nativeVideoCapability.capabilityKnown &&
+        preflight.nativeVideoCapability.supported &&
+        preflight.nativeVideoCapability.isHardware) {
+        nativeVideoPlan = 'native_hw_preferred';
+        decisionReason = `${preflight.videoCodecMime} 命中硬解主路径候选，设备存在原生硬解能力`;
+      } else {
+        nativeVideoPlan = 'native_ffmpeg_only';
+        decisionReason = `${preflight.videoCodecMime} 虽为硬解主路径候选，但设备无可用原生硬解能力`;
+      }
+    } else {
+      nativeVideoPlan = 'native_ffmpeg_only';
+      decisionReason = `${preflight.videoCodecName} 不在 H.264/H.265 硬解 MVP 范围内，native 仅保留 FFmpeg 子路径`;
+    }
+
+    const diagnosticsParts: string[] = [
+      `probeSucceeded=${preflight.probeSucceeded}`,
+      `probeError=${preflight.probeError.length > 0 ? preflight.probeError : 'none'}`,
+      `videoCodec=${preflight.videoCodecName.length > 0 ? preflight.videoCodecName : 'unknown'}`,
+      `videoMime=${preflight.videoCodecMime.length > 0 ? preflight.videoCodecMime : 'unknown'}`,
+      `videoTracks=${preflight.probeResult?.videoTracks.length ?? 0}`,
+      `audioTracks=${preflight.probeResult?.audioTracks.length ?? 0}`,
+      `format=${preflight.probeResult?.formatName ?? 'unknown'}`,
+      `capabilityKnown=${preflight.nativeVideoCapability.capabilityKnown}`,
+      `nativeSupported=${preflight.nativeVideoCapability.supported}`,
+      `nativeIsHardware=${preflight.nativeVideoCapability.isHardware}`,
+      `decoder=${preflight.nativeVideoCapability.decoderName.length > 0
+        ? preflight.nativeVideoCapability.decoderName
+        : 'unknown'}`
+    ];
+
+    const fallbackPlan: PlaybackFallbackPlan = {
+      avplayerUnsupportedFallback: this.unsupportedFormatFallback,
+      nativeLevel1Fallback: 'native_ffmpeg',
+      nativeLevel2Fallback: 'ijkplayer',
+      nativeErrorEscalationPolicy: 'controller_wide_for_now',
+      surfaceProbeIncluded: false
+    };
+
+    const decision: PlaybackPlanDecision = {
+      selectedBackend,
+      nativeVideoPlan,
+      fallbackPlan,
+      decisionReason,
+      diagnostics: diagnosticsParts.join(', ')
+    };
+    return decision;
+  }
+
+  private logPlaybackPlan(plan: PlaybackPlanDecision): void {
+    const message =
+      '[PlaybackPlan] ' +
+      `selectedBackend=${plan.selectedBackend}, ` +
+      `nativeVideoPlan=${plan.nativeVideoPlan}, ` +
+      `avplayerFallback=${plan.fallbackPlan.avplayerUnsupportedFallback}, ` +
+      `nativeFallback=${plan.fallbackPlan.nativeLevel1Fallback}->${plan.fallbackPlan.nativeLevel2Fallback}, ` +
+      `nativeErrorPolicy=${plan.fallbackPlan.nativeErrorEscalationPolicy}, ` +
+      `surfaceProbeIncluded=${plan.fallbackPlan.surfaceProbeIncluded}, ` +
+      `reason=${plan.decisionReason}, diagnostics=${plan.diagnostics}`;
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG, message);
   }
 
   private logAudioCapabilityReport(decision: AudioRoutingDecision): void {
@@ -1535,6 +1694,31 @@ export class VideoPlayerController {
       return 6;
     }
     return 2;
+  }
+
+  private isHwCandidateCodec(videoMime: string): boolean {
+    return videoMime === 'video/avc' || videoMime === 'video/hevc';
+  }
+
+  private buildEmptyNativeVideoCapability(errorMessage: string): NativeVideoDecoderCapability {
+    const capability: NativeVideoDecoderCapability = {
+      capabilityKnown: false,
+      supported: false,
+      isHardware: false,
+      maxWidth: 0,
+      maxHeight: 0,
+      minWidth: 0,
+      minHeight: 0,
+      maxFrameRate: 0,
+      minFrameRate: 0,
+      widthAlignment: 0,
+      heightAlignment: 0,
+      maxInstances: 0,
+      decoderName: '',
+      mimeType: '',
+      errorMessage
+    };
+    return capability;
   }
 
   private isLikelySystemHardDecodeSupported(codec: string): boolean {
@@ -1660,6 +1844,18 @@ export class VideoPlayerController {
     this.player = undefined;
     this.backend = 'ijkplayer';
     oldPlayer?.release().catch(() => {});
+  }
+
+  private resolveNativeErrorEscalationDirective(message: string): NativeErrorEscalationDirective {
+    const diagnostics = this.latestPlaybackPlan !== undefined
+      ? `${this.latestPlaybackPlan.nativeVideoPlan}; ${this.latestPlaybackPlan.diagnostics}; raw=${message}`
+      : `no-playback-plan; raw=${message}`;
+    const directive: NativeErrorEscalationDirective = {
+      action: 'fallback_to_ijkplayer',
+      reason: 'native_error_callback_wide_escalation',
+      diagnostics
+    };
+    return directive;
   }
 
   private logFallbackEvent(

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -1671,14 +1671,14 @@ export class VideoPlayerController {
       `systemSupported=${decision.systemSupported}, capabilityKnown=${decision.capabilityKnown}, ` +
       `decoder=${decision.decoderName.length > 0 ? decision.decoderName : 'unknown'}, ` +
       `decoderIsHardware=${decision.decoderIsHardware}, capabilityMime=${decision.capabilityMime.length > 0 ? decision.capabilityMime : 'unknown'}, ` +
-      `maxChannels=${decision.maxSupportedChannels}, route=${decision.preferredBackend}, fallback=${decision.fallback}, ` +
+      `maxChannels=${decision.maxSupportedChannels}, route=${this.backend}, fallback=${decision.fallback}, ` +
       `decodePlan=${currentDecodePlan}, videoCodec=${videoCodecLabel}, videoCapability=${videoCapabilityLabel}, videoDecode=${videoDecodeLabel}; ` +
       `channelHints=[${SUPPORTED_CHANNEL_LAYOUT_HINTS.join(', ')}]`;
 
     this.audioCapabilityText =
       `音频能力: 检测=${decision.detectedCodec} ${channelTag} | ` +
       `系统支持=${decision.systemSupported ? '是' : '否'} | ` +
-      `当前路由=${decision.preferredBackend} | ` +
+      `当前路由=${this.backend} | ` +
       `软解兜底=${decision.fallback} | ` +
       `视频信息=${videoCodecLabel}（${videoCapabilityLabel}） | 当前实际=${videoDecodeLabel}`;
 
@@ -1710,9 +1710,9 @@ export class VideoPlayerController {
       return '具备硬解能力';
     }
     if (capability.supported) {
-      return '具备解码能力';
+      return '仅软解支持';
     }
-    return '不具备硬解能力';
+    return '不支持';
   }
 
   private getCurrentVideoDecodeLabel(): string {
@@ -1725,13 +1725,8 @@ export class VideoPlayerController {
     if (this.backend === 'ijkplayer') {
       return '软解';
     }
-
-    const nativePlan = this.latestPlaybackPlan?.nativeVideoPlan;
-    if (nativePlan === 'native_ffmpeg_only') {
+    if (this.backend === 'ffmpeg') {
       return '软解';
-    }
-    if (nativePlan === 'native_hw_preferred') {
-      return '硬解';
     }
     return '系统解码';
   }

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -7,7 +7,12 @@ import { millisecondsToTime } from "../../../utils/TimeUtil";
 import { IPlayer, TrackInfo } from "./IPlayer";
 import { AVPlayerAdapter } from "./AVPlayerAdapter";
 import { IjkPlayerAdapter } from "./IjkPlayerAdapter";
-import { VidAllPlayerAdapter } from "./VidAllPlayerAdapter";
+import {
+  NativeBackendFatalError,
+  NativeDecodePathState,
+  NativeDecodePathStatus,
+  VidAllPlayerAdapter
+} from "./VidAllPlayerAdapter";
 import { FileSourceDatabase } from "../../../db/files/FileSourceDatabase";
 import { PlayProgressEntity } from "../../../db/models/MediaEntity";
 import { FfprobeResult, FfprobeTrack, FfprobeUtil } from "../../../utils/FfprobeUtil";
@@ -81,7 +86,7 @@ interface AudioRoutingDecision {
 type NativeVideoPlan = 'system_default' | 'native_hw_preferred' | 'native_ffmpeg_only';
 type NativeFallbackLevel1 = 'native_ffmpeg';
 type NativeFallbackLevel2 = 'ijkplayer';
-type NativeErrorEscalationPolicy = 'controller_wide_for_now';
+type NativeErrorEscalationPolicy = 'backend_fatal_only';
 type NativeErrorEscalationAction = 'fallback_to_ijkplayer';
 
 interface PlaybackPreflightSnapshot {
@@ -213,6 +218,10 @@ export class VideoPlayerController {
   @Trace playbackPlanSummary: string = ''
   /** ffmpeg 模式首帧预览图（file:// URI） */
   @Trace ffmpegPreviewUri: string = ''
+  /** native backend 内部当前 decode path（hardware / ffmpeg） */
+  @Trace nativeDecodePath: 'hardware' | 'ffmpeg' = 'hardware'
+  /** native backend 内部 decode path 状态（显式表达切换阶段） */
+  @Trace nativeDecodePathState: NativeDecodePathState = 'hardware_active'
   @Trace progress = 0
   /** 内嵌字幕轨道列表（来自 getTrackInfos） */
   @Trace subtitleTracks: TrackInfo[] = []
@@ -342,6 +351,8 @@ export class VideoPlayerController {
     this.ffmpegLastForceRestartAtMs = 0;
     this.ffmpegLastEmptyQueueCatchupAtMs = 0;
     this.ffmpegSingleFrameMode = false;
+    this.nativeDecodePath = 'hardware';
+    this.nativeDecodePathState = 'hardware_active';
     this.clearNativeReadyGuardTimer();
     const shouldPreserveBackendResume = this.backend === 'ijkplayer' && this.pendingBackendResumeTimeMs >= 0;
     if (!shouldPreserveBackendResume) {
@@ -462,16 +473,25 @@ export class VideoPlayerController {
         'initPlayer: 使用 VidAll Player Adapter，等待 UI 层调用 setNativeContext()');
       const nativeAdapter = new VidAllPlayerAdapter();
       nativeAdapter.setSeekDiagEnabled(this.nativeSeekDiagLogEnabled);
-      // B6修复：注册 FFmpeg 接管通知，FFmpeg 开始接管后将守卫计时器从 3.5s 延长到 15s，
-      // 防止 avformat_open_input 期间（最长 10s）提前触发 fallbackNativeToIjk。
       const capturedSessionId = currentSessionId;
-      nativeAdapter.setFfmpegSwitchingCallback(() => {
-        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-          `[session=${capturedSessionId}] FFmpeg 接管信号收到，重置就绪守卫计时器为 15s`);
-        if (capturedSessionId === this.playbackSessionId) {
-          this.startNativeReadyGuard(capturedSessionId, 15000);
-          void this.switchNativeSubtitleAdapterToExternalOnly(capturedSessionId);
+      nativeAdapter.setNativeDecodePathChangedCallback((status: NativeDecodePathStatus) => {
+        if (capturedSessionId !== this.playbackSessionId) {
+          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+            `[session=${capturedSessionId}] 忽略过期 native decode path 更新: ${status.state}`);
+          return;
         }
+        this.handleNativeDecodePathChanged(capturedSessionId, status);
+      });
+      nativeAdapter.setNativeBackendFatalErrorCallback((fatalError: NativeBackendFatalError) => {
+        if (capturedSessionId !== this.playbackSessionId) {
+          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+            `[session=${capturedSessionId}] 忽略过期 native backend fatal: ${fatalError.message}`);
+          return;
+        }
+        const directive = this.resolveNativeErrorEscalationDirective(fatalError);
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          `[native-error-policy] action=${directive.action}, reason=${directive.reason}, diagnostics=${directive.diagnostics}`);
+        this.fallbackNativeToIjk(directive.reason, 'native backend 致命错误，已自动回退到 IJK 播放', fatalError.message);
       });
       adapter = nativeAdapter;
       this.nativeSubtitleMode = 'av';
@@ -603,10 +623,9 @@ export class VideoPlayerController {
       hilog.warn(CommonConstants.LOG_DOMAIN, METRICS_TAG,
         `{"event":"play_result","backend":"${this.backend}","video_id":${this.progressContext?.videoId ?? -1},"result":"error","error_code":"${error.message.substring(0, 80)}","elapsed_ms":${metricsElapsedOnError}}`);
       if (this.backend === 'native') {
-        const directive = this.resolveNativeErrorEscalationDirective(error.message);
-        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-          `[native-error-policy] action=${directive.action}, reason=${directive.reason}, diagnostics=${directive.diagnostics}`);
-        this.fallbackNativeToIjk(directive.reason, 'native 错误回调触发，已自动回退到 IJK 播放', error.message);
+        // native 内部 Level 1 fallback（hardware -> ffmpeg）已通过专用 runtime callback 收口。
+        // 这里不再做 controller 宽升级，避免把可恢复错误一刀切回退到 ijkplayer。
+        this.lastErrorMessage = this.normalizePlayerError(error.message);
         return;
       }
       this.isLoading = false;
@@ -1591,7 +1610,7 @@ export class VideoPlayerController {
       avplayerUnsupportedFallback: this.unsupportedFormatFallback,
       nativeLevel1Fallback: 'native_ffmpeg',
       nativeLevel2Fallback: 'ijkplayer',
-      nativeErrorEscalationPolicy: 'controller_wide_for_now',
+      nativeErrorEscalationPolicy: 'backend_fatal_only',
       surfaceProbeIncluded: false
     };
 
@@ -1846,13 +1865,30 @@ export class VideoPlayerController {
     oldPlayer?.release().catch(() => {});
   }
 
-  private resolveNativeErrorEscalationDirective(message: string): NativeErrorEscalationDirective {
+  private handleNativeDecodePathChanged(sessionId: number, status: NativeDecodePathStatus): void {
+    this.nativeDecodePath = status.path;
+    this.nativeDecodePathState = status.state;
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[session=${sessionId}] [native-decode-path] path=${status.path}, state=${status.state}, reason=${status.reason}`);
+    if (status.state === 'ffmpeg_switching') {
+      // Level 1 fallback：仅 native 内部 hardware -> ffmpeg，不切 backend。
+      // FFmpeg 接管可能需要更长准备时间，因此把 native ready guard 延长到 15s。
+      this.startNativeReadyGuard(sessionId, 15000);
+      void this.switchNativeSubtitleAdapterToExternalOnly(sessionId);
+    }
+  }
+
+  private resolveNativeErrorEscalationDirective(fatalError: NativeBackendFatalError): NativeErrorEscalationDirective {
     const diagnostics = this.latestPlaybackPlan !== undefined
-      ? `${this.latestPlaybackPlan.nativeVideoPlan}; ${this.latestPlaybackPlan.diagnostics}; raw=${message}`
-      : `no-playback-plan; raw=${message}`;
+      ? `${this.latestPlaybackPlan.nativeVideoPlan}; ${this.latestPlaybackPlan.diagnostics}; ` +
+        `path=${fatalError.path}; state=${fatalError.state}; source=${fatalError.source}; raw=${fatalError.message}`
+      : `no-playback-plan; path=${fatalError.path}; state=${fatalError.state}; source=${fatalError.source}; raw=${fatalError.message}`;
+    const reason = fatalError.path === 'ffmpeg'
+      ? 'native_ffmpeg_backend_fatal'
+      : 'native_hardware_backend_fatal';
     const directive: NativeErrorEscalationDirective = {
       action: 'fallback_to_ijkplayer',
-      reason: 'native_error_callback_wide_escalation',
+      reason,
       diagnostics
     };
     return directive;

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -9,6 +9,7 @@ import { AVPlayerAdapter } from "./AVPlayerAdapter";
 import { IjkPlayerAdapter } from "./IjkPlayerAdapter";
 import {
   NativeBackendFatalError,
+  NativeDecodeExpectation,
   NativeDecodePathState,
   NativeDecodePathStatus,
   VidAllPlayerAdapter
@@ -220,8 +221,10 @@ export class VideoPlayerController {
   @Trace ffmpegPreviewUri: string = ''
   /** native backend 内部当前 decode path（hardware / ffmpeg） */
   @Trace nativeDecodePath: 'hardware' | 'ffmpeg' = 'hardware'
+  /** native backend 当前会话在 prepare 阶段确定的期望 decode path */
+  @Trace nativeDecodeExpectedPath: NativeDecodeExpectation = 'hardware_preferred'
   /** native backend 内部 decode path 状态（显式表达切换阶段） */
-  @Trace nativeDecodePathState: NativeDecodePathState = 'hardware_active'
+  @Trace nativeDecodePathState: NativeDecodePathState = 'hardware_preferred'
   @Trace progress = 0
   /** 内嵌字幕轨道列表（来自 getTrackInfos） */
   @Trace subtitleTracks: TrackInfo[] = []
@@ -352,7 +355,8 @@ export class VideoPlayerController {
     this.ffmpegLastEmptyQueueCatchupAtMs = 0;
     this.ffmpegSingleFrameMode = false;
     this.nativeDecodePath = 'hardware';
-    this.nativeDecodePathState = 'hardware_active';
+    this.nativeDecodeExpectedPath = 'hardware_preferred';
+    this.nativeDecodePathState = 'hardware_preferred';
     this.clearNativeReadyGuardTimer();
     const shouldPreserveBackendResume = this.backend === 'ijkplayer' && this.pendingBackendResumeTimeMs >= 0;
     if (!shouldPreserveBackendResume) {
@@ -473,6 +477,11 @@ export class VideoPlayerController {
         'initPlayer: 使用 VidAll Player Adapter，等待 UI 层调用 setNativeContext()');
       const nativeAdapter = new VidAllPlayerAdapter();
       nativeAdapter.setSeekDiagEnabled(this.nativeSeekDiagLogEnabled);
+      nativeAdapter.setPrepareDecodePlan(
+        playbackPlan.nativeVideoPlan,
+        playbackPlan.decisionReason,
+        playbackPlan.diagnostics
+      );
       const capturedSessionId = currentSessionId;
       nativeAdapter.setNativeDecodePathChangedCallback((status: NativeDecodePathStatus) => {
         if (capturedSessionId !== this.playbackSessionId) {
@@ -1244,9 +1253,10 @@ export class VideoPlayerController {
     const nativeAdapter = this.player as VidAllPlayerAdapter;
     this.cachedNativeContext = context;
     this.cachedNativeXComponentId = xComponentId;
+    const nativeReadyGuardMs = this.latestPlaybackPlan?.nativeVideoPlan === 'native_ffmpeg_only' ? 15000 : NATIVE_READY_GUARD_MS;
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `setNativeContext: 绑定 XComponent id=${xComponentId}，开始 native 骨架 init...`);
-    this.startNativeReadyGuard(this.playbackSessionId);
+      `setNativeContext: 绑定 XComponent id=${xComponentId}，开始 native 骨架 init... guardMs=${nativeReadyGuardMs}`);
+    this.startNativeReadyGuard(this.playbackSessionId, nativeReadyGuardMs);
     if (this.currentVideoData) {
       try {
         let safeContext: object = context;
@@ -1866,10 +1876,12 @@ export class VideoPlayerController {
   }
 
   private handleNativeDecodePathChanged(sessionId: number, status: NativeDecodePathStatus): void {
+    this.nativeDecodeExpectedPath = status.expectedPath;
     this.nativeDecodePath = status.path;
     this.nativeDecodePathState = status.state;
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `[session=${sessionId}] [native-decode-path] path=${status.path}, state=${status.state}, reason=${status.reason}`);
+      `[session=${sessionId}] [native-decode-path] expected=${status.expectedPath}, path=${status.path}, ` +
+      `state=${status.state}, reason=${status.reason}`);
     if (status.state === 'ffmpeg_switching') {
       // Level 1 fallback：仅 native 内部 hardware -> ffmpeg，不切 backend。
       // FFmpeg 接管可能需要更长准备时间，因此把 native ready guard 延长到 15s。

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -319,6 +319,8 @@ export class VideoPlayerController {
   /** ffmpeg 连续预览：远程 chunk 不稳定时切到单帧模式 */
   private ffmpegSingleFrameMode: boolean = false;
   private latestPlaybackPlan?: PlaybackPlanDecision;
+  private latestPreflightSnapshot?: PlaybackPreflightSnapshot;
+  private latestAudioRoutingDecision?: AudioRoutingDecision;
 
   /**
    * 初始化播放器。
@@ -373,12 +375,16 @@ export class VideoPlayerController {
     this.audioCapabilityText = '';
     this.playbackPlanSummary = '';
     this.ffmpegPreviewUri = '';
+    this.latestPreflightSnapshot = undefined;
+    this.latestAudioRoutingDecision = undefined;
     const preflight = await this.collectPlaybackPreflightSnapshot(videoData);
+    this.latestPreflightSnapshot = preflight;
 
     // 若外部未显式锁定策略，则根据探测结果自动选择硬解/软解路由。
     if (!this.unsupportedFallbackLockedByUser) {
       const backendBeforeAutoRouting = this.backend;
       const decision = await this.resolveAudioRoutingDecision(videoData, preflight);
+      this.latestAudioRoutingDecision = decision;
       this.unsupportedFormatFallback = decision.fallback;
       videoData.ffmpegDecodeChannels = decision.preferredChannels;
       videoData.audioProbeSummary = decision.summary;
@@ -396,7 +402,6 @@ export class VideoPlayerController {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `自动音频路由: backend=${this.backend}, fallback=${this.unsupportedFormatFallback}, ` +
         `ffmpegChannels=${videoData.ffmpegDecodeChannels}, summary=${decision.summary}`);
-      this.logAudioCapabilityReport(decision);
     }
 
     if (this.backend === 'ffmpeg') {
@@ -412,6 +417,9 @@ export class VideoPlayerController {
       `nativePlan=${playbackPlan.nativeVideoPlan} | ` +
       `fallback=${playbackPlan.fallbackPlan.nativeLevel1Fallback}->${playbackPlan.fallbackPlan.nativeLevel2Fallback}`;
     this.logPlaybackPlan(playbackPlan);
+    if (this.latestAudioRoutingDecision !== undefined) {
+      this.logAudioCapabilityReport(this.latestAudioRoutingDecision);
+    }
 
     // 指标埋点：play_start — backend 已最终确定，记录本次播放启动意图
     hilog.info(CommonConstants.LOG_DOMAIN, METRICS_TAG,
@@ -1653,6 +1661,9 @@ export class VideoPlayerController {
     const currentDecodePlan = decision.preferredBackend === 'avplayer'
       ? `system-harddecode-${channelTag}`
       : `${decision.preferredBackend}-fallback-${channelTag}`;
+    const videoCodecLabel = this.getCurrentVideoCodecLabel();
+    const videoCapabilityLabel = this.getCurrentVideoCapabilityLabel();
+    const videoDecodeLabel = this.getCurrentVideoDecodeLabel();
 
     const message =
       '[AudioCapability] ' +
@@ -1661,15 +1672,68 @@ export class VideoPlayerController {
       `decoder=${decision.decoderName.length > 0 ? decision.decoderName : 'unknown'}, ` +
       `decoderIsHardware=${decision.decoderIsHardware}, capabilityMime=${decision.capabilityMime.length > 0 ? decision.capabilityMime : 'unknown'}, ` +
       `maxChannels=${decision.maxSupportedChannels}, route=${decision.preferredBackend}, fallback=${decision.fallback}, ` +
-      `decodePlan=${currentDecodePlan}; channelHints=[${SUPPORTED_CHANNEL_LAYOUT_HINTS.join(', ')}]`;
+      `decodePlan=${currentDecodePlan}, videoCodec=${videoCodecLabel}, videoCapability=${videoCapabilityLabel}, videoDecode=${videoDecodeLabel}; ` +
+      `channelHints=[${SUPPORTED_CHANNEL_LAYOUT_HINTS.join(', ')}]`;
 
     this.audioCapabilityText =
       `音频能力: 检测=${decision.detectedCodec} ${channelTag} | ` +
       `系统支持=${decision.systemSupported ? '是' : '否'} | ` +
       `当前路由=${decision.preferredBackend} | ` +
-      `软解兜底=${decision.fallback}`;
+      `软解兜底=${decision.fallback} | ` +
+      `视频信息=${videoCodecLabel}（${videoCapabilityLabel}） | 当前实际=${videoDecodeLabel}`;
 
     hilog.info(CommonConstants.LOG_DOMAIN, TAG, message);
+  }
+
+  private getCurrentVideoCodecLabel(): string {
+    const codecMime = this.latestPreflightSnapshot?.videoCodecMime ?? '';
+    if (codecMime === 'video/avc') {
+      return 'H264';
+    }
+    if (codecMime === 'video/hevc') {
+      return 'H265';
+    }
+
+    const codecName = (this.latestPreflightSnapshot?.videoCodecName ?? '').toUpperCase();
+    if (codecName.length > 0) {
+      return codecName;
+    }
+    return '未知编码';
+  }
+
+  private getCurrentVideoCapabilityLabel(): string {
+    const capability = this.latestPreflightSnapshot?.nativeVideoCapability;
+    if (capability === undefined) {
+      return '能力未知';
+    }
+    if (capability.supported && capability.isHardware) {
+      return '具备硬解能力';
+    }
+    if (capability.supported) {
+      return '具备解码能力';
+    }
+    return '不具备硬解能力';
+  }
+
+  private getCurrentVideoDecodeLabel(): string {
+    if (this.backend === 'native') {
+      if (this.nativeDecodePathState === 'ffmpeg_switching') {
+        return '硬解→软解切换中';
+      }
+      return this.nativeDecodePath === 'ffmpeg' ? '软解' : '硬解';
+    }
+    if (this.backend === 'ijkplayer') {
+      return '软解';
+    }
+
+    const nativePlan = this.latestPlaybackPlan?.nativeVideoPlan;
+    if (nativePlan === 'native_ffmpeg_only') {
+      return '软解';
+    }
+    if (nativePlan === 'native_hw_preferred') {
+      return '硬解';
+    }
+    return '系统解码';
   }
 
   private getChannelTag(channels: number): string {
@@ -1879,6 +1943,9 @@ export class VideoPlayerController {
     this.nativeDecodeExpectedPath = status.expectedPath;
     this.nativeDecodePath = status.path;
     this.nativeDecodePathState = status.state;
+    if (this.latestAudioRoutingDecision !== undefined) {
+      this.logAudioCapabilityReport(this.latestAudioRoutingDecision);
+    }
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
       `[session=${sessionId}] [native-decode-path] expected=${status.expectedPath}, path=${status.path}, ` +
       `state=${status.state}, reason=${status.reason}`);

--- a/entry/src/main/ets/lib/WebDAVClient.ets
+++ b/entry/src/main/ets/lib/WebDAVClient.ets
@@ -446,7 +446,13 @@ export class WebDAVClient {
   ): Promise<HttpResponse> {
     // ── native libcurl 优先路径 ────────────────────────────────────────────
     const nativeCurlEnabled = this.checkNativeCurlEnabled();
-    const shouldTryNativeFirst = nativeCurlEnabled || this.isHttps;
+    const shouldTryNativeFirst = nativeCurlEnabled;
+    if (this.isHttps && !nativeCurlEnabled) {
+      if (!this.allowLegacyTransportFallback) {
+        throw new Error('native transport unavailable and legacy fallback disabled');
+      }
+      console.warn('WebDAV native transport unavailable before request, fallback to legacy transport');
+    }
     if (shouldTryNativeFirst) {
       try {
         const response = await this.sendViaNative(method, path, headers, body);
@@ -462,6 +468,9 @@ export class WebDAVClient {
           nativeErr.includes('is not a function');
         if (nativeUnavailable) {
           this._nativeCurlEnabled = false;
+          if (!this.allowLegacyTransportFallback) {
+            throw new Error(`native transport unavailable: ${nativeErr}`);
+          }
           console.warn(`WebDAV native transport unavailable, fallback to legacy transport: ${nativeErr}`);
         } else if (!this.allowLegacyTransportFallback) {
           throw new Error(`native transport failed: ${nativeErr}`);
@@ -470,7 +479,7 @@ export class WebDAVClient {
         }
       }
     }
-    if (shouldTryNativeFirst && !this._nativeCurlEnabled) {
+    if (shouldTryNativeFirst && !this._nativeCurlEnabled && this.allowLegacyTransportFallback) {
       console.warn('WebDAV native transport unavailable, fallback to legacy transport');
     }
     // ── 回退：现有 socket / http 实现 ──────────────────────────────────────

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -236,7 +236,9 @@ export struct PlayerPage {
           .borderRadius(4)
           .padding({ left: 10, right: 10, top: 4, bottom: 4 })
           .onClick(() => {
-            this.runNativeSurfaceProbe()
+            void this.runNativeSurfaceProbe().catch(() => {
+              this.videoPlayerController.lastErrorMessage = 'surface probe 执行失败';
+            })
           })
       }
     }


### PR DESCRIPTION
## 背景

收口 `#53`：`[Native硬解] H.264/H.265 硬解主路径与软解回退 MVP 实现`。

本 PR 基于 `feat/issue-53-decode-path-selection`，汇总了 issue #53 分支上的累计实现，用于把 native 硬解主路径的预检、选路、一级回退边界以及诊断信息整体合入。

另：HDR / Dolby Vision 已拆分为后续子 issue `#57`，不并入本 PR 的 MVP 范围。

## 主要改动

- 增加播放预检与播放计划骨架
  - 在控制层统一收口 `ffprobe`、能力探测与播放计划生成
  - 建立 `PlaybackPreflightSnapshot / PlaybackPlanDecision / PlaybackFallbackPlan` 等结构

- 前移 native 解码路径选择
  - 在 prepare 前显式设置 `preferred decode path`
  - 区分 `hardware_preferred / ffmpeg_only`
  - 在状态与日志中区分 expected path 与 actual path

- 收口 native 一级回退边界
  - native 内部优先处理 `AVPlayer -> FFmpeg` handoff
  - 控制层不再把所有 native 错误一刀切回退到 `ijkplayer`
  - 明确 Level 1 fallback：`native.hardware -> native.ffmpeg`
  - 明确 Level 2 fallback：`native -> ijkplayer`

- 增强诊断与展示文案
  - 在 `VideoPlayerController` 中增加视频编码、硬解能力、当前实际解码路径的展示文案
  - 将“设备具备硬解能力”和“本次实际走硬解/软解”区分开，避免误解

- 补充 native 能力探测与桥接
  - 完善 NAPI / ArkTS adapter / C++ native 之间的解码路径和回调衔接

## 影响文件

- `entry/src/main/ets/components/core/player/VideoPlayerController.ets`
- `entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets`
- `entry/src/main/cpp/vidall_core_player_napi.cpp`
- `entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts`
- `entry/src/main/ets/utils/DeviceCapabilityUtil.ets`
- 以及本分支关联的播放器辅助文件

## 验证说明

分支内历史子任务已分别完成 QA 验证：

- `hvigor sync`
- `assembleApp`
- `UnitTestBuild`

本次最后一条增量提交主要是展示文案与诊断信息调整，未单独追加构建验证。

## 关联 Issue

- Ref #53
- Ref #50
- Ref #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Native backend (experimental) with automatic FFmpeg fallback for improved hardware video decoding support
  * Added decoder capability detection and probing for video and audio formats
  * Added backend preference locking to control automatic switching behavior
  * Enhanced subtitle and audio track handling with runtime availability constraints

* **Improvements**
  * WebDAV native transport support with automatic fallback for improved file streaming performance
  * Playback preflight analysis for smarter backend selection based on device capabilities
  * Enhanced diagnostic UI and debug information for backend and decoder capabilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->