### PR TITLE
新增: VideoInfoUtil 支持 SMB URL，路由到 FfprobeUtil bridge

### DIFF
--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -6,6 +6,7 @@ import http from '@ohos.net.http'
 import image from '@ohos.multimedia.image'
 import effectKit from '@ohos.effectKit'
 import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient'
+import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntity'
 import { FfprobeUtil, FfprobeTrack } from '../../utils/FfprobeUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
 
@@ -677,18 +678,31 @@ export struct SeasonDetailPage {
         return;
       }
       const config = JSON.parse(fileSource.configJson) as Record<string, string>;
-      const protocol = config['protocol'] ?? 'http';
-      const host = config['url'] ?? '';
-      const port = config['port'] ?? (protocol === 'https' ? '443' : '80');
-      const rootPath = (config['rootPath'] ?? '').replace(/\/$/, '');
-      const baseUrl = `${protocol}://${host}:${port}${rootPath}`;
-      const webdavConfig: WebDAVConfig = {
-        baseUrl, username: config['username'] ?? '', password: config['password'] ?? '', timeout: 30000
-      };
-      const client = new WebDAVClient(webdavConfig);
-      const fullUrl = client.getFullUrl(episode.filePath);
-      const authHeader = client.getAuthHeaderPublic();
-      const httpHeader: Record<string, string> = authHeader ? { 'Authorization': authHeader } : {};
+
+      let fullUrl: string;
+      let httpHeader: Record<string, string>;
+
+      if (fileSource.type === FileSourceType.SMB) {
+        const smbConfig = JSON.parse(fileSource.configJson) as SMBSourceConfig;
+        const port = smbConfig.port ?? 445;
+        const user = encodeURIComponent(smbConfig.username);
+        const pass = encodeURIComponent(smbConfig.password);
+        fullUrl = `smb://${user}:${pass}@${smbConfig.host}:${port}${episode.filePath}`;
+        httpHeader = {};
+      } else {
+        const protocol = config['protocol'] ?? 'http';
+        const host = config['url'] ?? '';
+        const port = config['port'] ?? (protocol === 'https' ? '443' : '80');
+        const rootPath = (config['rootPath'] ?? '').replace(/\/$/, '');
+        const baseUrl = `${protocol}://${host}:${port}${rootPath}`;
+        const webdavConfig: WebDAVConfig = {
+          baseUrl, username: config['username'] ?? '', password: config['password'] ?? '', timeout: 30000
+        };
+        const client = new WebDAVClient(webdavConfig);
+        fullUrl = client.getFullUrl(episode.filePath);
+        const authHeader = client.getAuthHeaderPublic();
+        httpHeader = authHeader ? { 'Authorization': authHeader } : {};
+      }
 
       // ── 音轨 / 字幕轨 ──────────────────────────
       let presetAudioTracks: PresetAudioTrack[] = [];

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -687,7 +687,13 @@ export struct SeasonDetailPage {
         const port = smbConfig.port ?? 445;
         const user = encodeURIComponent(smbConfig.username);
         const pass = encodeURIComponent(smbConfig.password);
-        fullUrl = `smb://${user}:${pass}@${smbConfig.host}:${port}${episode.filePath}`;
+        const encodedPath = episode.filePath.split('/').map((seg: string): string => {
+          if (seg.length === 0) { return ''; }
+          let decoded: string = seg;
+          try { decoded = decodeURIComponent(seg); } catch { decoded = seg; }
+          return encodeURIComponent(decoded);
+        }).join('/');
+        fullUrl = `smb://${user}:${pass}@${smbConfig.host}:${port}${encodedPath}`;
         httpHeader = {};
       } else {
         const protocol = config['protocol'] ?? 'http';
@@ -1379,6 +1385,9 @@ export struct SeasonDetailPage {
           this.loadData(tvSeriesId, seasonNumber);
         }
       }
+    })
+    .onShown(() => {
+      this.refreshProgressState().catch(() => {});
     })
     .onBackPressed(() => {
       if (this.showOverviewDialog) {

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -8,6 +8,7 @@ import http from '@ohos.net.http'
 import image from '@ohos.multimedia.image'
 import effectKit from '@ohos.effectKit'
 import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient'
+import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntity'
 import { millisecondsToTime } from '../../utils/TimeUtil'
 import { FfprobeUtil, FfprobeTrack } from '../../utils/FfprobeUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
@@ -673,21 +674,34 @@ export struct SeriesDetailPage {
       }
 
       const config = JSON.parse(fileSource.configJson) as Record<string, string>;
-      const protocol = config['protocol'] ?? 'http';
-      const host = config['url'] ?? '';
-      const port = config['port'] ?? (protocol === 'https' ? '443' : '80');
-      const rootPath = (config['rootPath'] ?? '').replace(/\/$/, '');
-      const baseUrl = `${protocol}://${host}:${port}${rootPath}`;
-      const webdavConfig: WebDAVConfig = {
-        baseUrl,
-        username: config['username'] ?? '',
-        password: config['password'] ?? '',
-        timeout: 30000
-      };
-      const client = new WebDAVClient(webdavConfig);
-      const fullUrl = client.getFullUrl(episode.filePath);
-      const authHeader = client.getAuthHeaderPublic();
-      const httpHeader: Record<string, string> = authHeader ? { 'Authorization': authHeader } : {};
+
+      let fullUrl: string;
+      let httpHeader: Record<string, string>;
+
+      if (fileSource.type === FileSourceType.SMB) {
+        const smbConfig = JSON.parse(fileSource.configJson) as SMBSourceConfig;
+        const port = smbConfig.port ?? 445;
+        const user = encodeURIComponent(smbConfig.username);
+        const pass = encodeURIComponent(smbConfig.password);
+        fullUrl = `smb://${user}:${pass}@${smbConfig.host}:${port}${episode.filePath}`;
+        httpHeader = {};
+      } else {
+        const protocol = config['protocol'] ?? 'http';
+        const host = config['url'] ?? '';
+        const port = config['port'] ?? (protocol === 'https' ? '443' : '80');
+        const rootPath = (config['rootPath'] ?? '').replace(/\/$/, '');
+        const baseUrl = `${protocol}://${host}:${port}${rootPath}`;
+        const webdavConfig: WebDAVConfig = {
+          baseUrl,
+          username: config['username'] ?? '',
+          password: config['password'] ?? '',
+          timeout: 30000
+        };
+        const client = new WebDAVClient(webdavConfig);
+        fullUrl = client.getFullUrl(episode.filePath);
+        const authHeader = client.getAuthHeaderPublic();
+        httpHeader = authHeader ? { 'Authorization': authHeader } : {};
+      }
 
       // ── 音轨 / 字幕轨 ──────────────────────────
       let presetAudioTracks: PresetAudioTrack[] = [];

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -683,7 +683,13 @@ export struct SeriesDetailPage {
         const port = smbConfig.port ?? 445;
         const user = encodeURIComponent(smbConfig.username);
         const pass = encodeURIComponent(smbConfig.password);
-        fullUrl = `smb://${user}:${pass}@${smbConfig.host}:${port}${episode.filePath}`;
+        const encodedPath = episode.filePath.split('/').map((seg: string): string => {
+          if (seg.length === 0) { return ''; }
+          let decoded: string = seg;
+          try { decoded = decodeURIComponent(seg); } catch { decoded = seg; }
+          return encodeURIComponent(decoded);
+        }).join('/');
+        fullUrl = `smb://${user}:${pass}@${smbConfig.host}:${port}${encodedPath}`;
         httpHeader = {};
       } else {
         const protocol = config['protocol'] ?? 'http';
@@ -1476,6 +1482,9 @@ export struct SeriesDetailPage {
           this.loadData(param.tvSeriesId);
         }
       }
+    })
+    .onShown(() => {
+      this.refreshPlaybackState().catch(() => {});
     })
     .onBackPressed(() => {
       if (this.showOverviewDialog) {

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -268,6 +268,26 @@ export interface EmbeddedSubEntry {
   text: string;
 }
 
+// ─────────────────────────────────────────────
+// 日志脱敏
+// ─────────────────────────────────────────────
+
+/**
+ * 对日志输出中的 SMB URL 做凭据脱敏：
+ *   smb://user:secret@host/share → smb://***@host/share
+ * 非 SMB URL 原样返回。
+ */
+function maskUrlForLog(url: string): string {
+  if (!url.toLowerCase().startsWith('smb://')) {
+    return url;
+  }
+  const atIdx: number = url.indexOf('@');
+  if (atIdx < 0) { return url; }
+  const protoEnd: number = url.indexOf('://');
+  if (protoEnd < 0 || atIdx < protoEnd) { return url; }
+  return `${url.substring(0, protoEnd + 3)}***${url.substring(atIdx)}`;
+}
+
 export class FfprobeUtil {
   private static readonly MAX_CONCURRENT_PROBES: number = 2;
   private static activeProbeCount: number = 0;
@@ -327,7 +347,7 @@ export class FfprobeUtil {
 
     commands.push('-i', url);
 
-    console.info(`[FfprobeUtil] 开始探测: ${url}`);
+    console.info(`[FfprobeUtil] 开始探测: ${maskUrlForLog(url)}`);
     const safeCommands = commands.map((c) => {
       if (typeof c === 'string' && c.toLowerCase().includes('authorization:')) {
         return c.replace(/Authorization:[^\r\n]*/gi, 'Authorization: ***');

--- a/entry/src/main/ets/utils/VideoInfoUtil.ets
+++ b/entry/src/main/ets/utils/VideoInfoUtil.ets
@@ -5,7 +5,7 @@
  *
  * 路由逻辑：
  *   - smb:// URL → FfprobeUtil.probe()（AVPlayer 不支持 SMB 协议）
- *   - http/https URL → FfprobeUtil.probe()（与 VideoScannerUtil 行为一致）
+ *   - http/https URL → AVPlayer prepare 路径（原有机制，保持与 VideoPlayerUtil 一致）
  *
  * SMB 认证说明：
  *   libsmb2 / FFmpeg 通过 URL 内嵌凭据识别 SMB 鉴权：
@@ -18,25 +18,243 @@
  *   与 VideoScannerUtil（WebDAV 路径）保持完全一致。
  */
 
-import { FfprobeUtil, FfprobeResult } from './FfprobeUtil';
+import { media } from '@kit.MediaKit';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { FfprobeUtil, FfprobeResult, FfprobeTrack } from './FfprobeUtil';
 
 /**
  * VideoInfo 是 FfprobeResult 的类型别名。
- * 两条路径（HTTP 与 SMB）均返回相同结构，调用方无需区分来源。
+ * 两条路径（AVPlayer 与 SMB）均返回相同结构，调用方无需区分来源。
  */
 export type VideoInfo = FfprobeResult;
 
 // 重新导出 FfprobeTrack，方便调用方访问轨道类型
 export { FfprobeTrack } from './FfprobeUtil';
 
+// ─────────────────────────────────────────────
+// 内部辅助函数
+// ─────────────────────────────────────────────
+
+/** 毫秒 → HH:MM:SS */
+function formatDuration(ms: number): string {
+  if (ms <= 0) { return '00:00:00'; }
+  const totalSeconds = Math.floor(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+}
+
+/**
+ * MIME 类型 → 简短 codec 名（e.g. "video/hevc" → "hevc"，"audio/mp4a-latm" → "aac"）
+ */
+function mimeToCodecName(mime: string): string {
+  if (!mime) { return ''; }
+  const slash: number = mime.indexOf('/');
+  if (slash < 0) { return mime.toLowerCase(); }
+  const sub: string = mime.substring(slash + 1).toLowerCase();
+  if (sub === 'avc' || sub === 'h264') { return 'h264'; }
+  if (sub === 'hevc' || sub === 'h265') { return 'hevc'; }
+  if (sub === 'mp4a-latm' || sub === 'mp4a') { return 'aac'; }
+  return sub;
+}
+
+/**
+ * 对 URL 路径段做安全编码（与 VideoPlayerUtil 保持一致）。
+ */
+function encodeUrlPath(url: string): string {
+  const protocolEnd: number = url.indexOf('://');
+  if (protocolEnd < 0) { return url; }
+  const afterProtocol: string = url.substring(protocolEnd + 3);
+  const slashIdx: number = afterProtocol.indexOf('/');
+  if (slashIdx < 0) { return url; }
+  const hostPart: string = url.substring(0, protocolEnd + 3 + slashIdx);
+  const pathAndQuery: string = afterProtocol.substring(slashIdx);
+  const queryIdx: number = pathAndQuery.indexOf('?');
+  const pathOnly: string = queryIdx >= 0 ? pathAndQuery.substring(0, queryIdx) : pathAndQuery;
+  const query: string = queryIdx >= 0 ? pathAndQuery.substring(queryIdx) : '';
+  const encodedPath: string = pathOnly
+    .split('/')
+    .map((seg: string): string => {
+      if (seg.length === 0) { return ''; }
+      let decoded: string = seg;
+      try { decoded = decodeURIComponent(seg); } catch { decoded = seg; }
+      return encodeURIComponent(decoded);
+    })
+    .join('/');
+  return hostPart + encodedPath + query;
+}
+
+function buildErrorResult(errorMessage: string): VideoInfo {
+  const result: VideoInfo = {
+    success: false,
+    durationMs: 0,
+    durationText: '00:00:00',
+    videoTracks: [],
+    audioTracks: [],
+    subtitleTracks: [],
+    errorMessage,
+  };
+  return result;
+}
+
+/**
+ * 将 AVPlayer.getTrackDescription() 返回的描述转换为 FfprobeTrack 列表。
+ */
+function buildTracksFromDescs(
+  descs: media.MediaDescription[],
+  videoOut: FfprobeTrack[],
+  audioOut: FfprobeTrack[],
+  subtitleOut: FfprobeTrack[]
+): void {
+  for (const desc of descs) {
+    const rawType: number = desc[media.MediaDescriptionKey.MD_KEY_TRACK_TYPE] as number;
+    const mime: string = (desc[media.MediaDescriptionKey.MD_KEY_CODEC_MIME] as string) ?? '';
+    const lang: string = (desc[media.MediaDescriptionKey.MD_KEY_LANGUAGE] as string) ?? '';
+    const index: number = (desc[media.MediaDescriptionKey.MD_KEY_TRACK_INDEX] as number) ?? 0;
+    const codecName: string = mimeToCodecName(mime);
+
+    if (rawType === media.MediaType.MEDIA_TYPE_VID) {
+      const track: FfprobeTrack = {
+        index,
+        type: 'video',
+        codecName,
+        codecLongName: codecName,
+        language: lang,
+        width: desc[media.MediaDescriptionKey.MD_KEY_WIDTH] as number | undefined,
+        height: desc[media.MediaDescriptionKey.MD_KEY_HEIGHT] as number | undefined,
+        bitrate: desc[media.MediaDescriptionKey.MD_KEY_BITRATE] as number | undefined,
+      };
+      videoOut.push(track);
+    } else if (rawType === media.MediaType.MEDIA_TYPE_AUD) {
+      const track: FfprobeTrack = {
+        index,
+        type: 'audio',
+        codecName,
+        codecLongName: codecName,
+        language: lang,
+        channels: desc[media.MediaDescriptionKey.MD_KEY_CHANNEL_COUNT] as number | undefined,
+        sampleRate: desc[media.MediaDescriptionKey.MD_KEY_SAMPLE_RATE] as number | undefined,
+        bitrate: desc[media.MediaDescriptionKey.MD_KEY_BITRATE] as number | undefined,
+      };
+      audioOut.push(track);
+    } else if (rawType === media.MediaType.MEDIA_TYPE_SUBTITLE) {
+      const track: FfprobeTrack = {
+        index,
+        type: 'subtitle',
+        codecName,
+        codecLongName: codecName,
+        language: lang,
+      };
+      subtitleOut.push(track);
+    }
+  }
+}
+
+/**
+ * 使用 AVPlayer prepare 路径探测 HTTP/HTTPS 视频信息。
+ * 与 VideoPlayerUtil.checkSupport 同源，额外在 prepared 状态提取 duration + 轨道描述。
+ */
+function probeViaAvPlayer(
+  url: string,
+  headers: Record<string, string> | undefined,
+  timeoutMs: number
+): Promise<VideoInfo> {
+  return media.createAVPlayer().then((player: media.AVPlayer) => {
+    return new Promise<VideoInfo>((resolve) => {
+      let settled: boolean = false;
+
+      const finish = (r: VideoInfo): void => {
+        if (settled) { return; }
+        settled = true;
+        clearTimeout(timer);
+        player.release().catch(() => {});
+        resolve(r);
+      };
+
+      const timer: number = setTimeout(() => {
+        console.warn(`[VideoInfoUtil] AVPlayer prepare 超时 ${timeoutMs}ms`);
+        finish(buildErrorResult(`AVPlayer prepare 超时（${timeoutMs}ms）`));
+      }, timeoutMs);
+
+      // error 事件：携带详细 code，优先于 stateChange('error')
+      player.on('error', (err: BusinessError) => {
+        console.error(`[VideoInfoUtil] AVPlayer error: code=${err.code} msg=${err.message}`);
+        finish(buildErrorResult(`AVPlayer error ${err.code}: ${err.message}`));
+      });
+
+      // stateChange 驱动：initialized → prepare → prepared → 提取信息
+      player.on('stateChange', (state: media.AVPlayerState) => {
+        console.info(`[VideoInfoUtil] AVPlayer stateChange: ${state}`);
+        if (state === 'initialized') {
+          player.prepare().catch((e: BusinessError) => {
+            finish(buildErrorResult(`AVPlayer prepare 失败: ${e.message}`));
+          });
+        } else if (state === 'prepared') {
+          const durationMs: number = player.duration > 0 ? player.duration : 0;
+
+          // 提取轨道描述；失败时仍返回 success=true（时长已知）
+          const doExtract = async (): Promise<void> => {
+            const videoTracks: FfprobeTrack[] = [];
+            const audioTracks: FfprobeTrack[] = [];
+            const subtitleTracks: FfprobeTrack[] = [];
+            try {
+              const descs: media.MediaDescription[] = await player.getTrackDescription();
+              buildTracksFromDescs(descs, videoTracks, audioTracks, subtitleTracks);
+            } catch {
+              console.warn('[VideoInfoUtil] getTrackDescription 失败，轨道列表为空');
+            }
+            console.info(
+              `[VideoInfoUtil] AVPlayer 探测完成 — 时长=${formatDuration(durationMs)} | ` +
+              `视频轨=${videoTracks.length} 音轨=${audioTracks.length} 字幕轨=${subtitleTracks.length}`
+            );
+            const result: VideoInfo = {
+              success: true,
+              durationMs,
+              durationText: formatDuration(durationMs),
+              videoTracks,
+              audioTracks,
+              subtitleTracks,
+            };
+            finish(result);
+          };
+          doExtract().catch(() => {
+            finish(buildErrorResult('轨道提取意外失败'));
+          });
+        } else if (state === 'error') {
+          // error 事件已处理，此处兜底
+          finish(buildErrorResult('AVPlayer 进入 error 状态'));
+        }
+      });
+
+      // 设置媒体源（触发 stateChange → initialized）
+      const encoded: string = encodeUrlPath(url);
+      if (headers) {
+        const ms: media.MediaSource = media.createMediaSourceWithUrl(encoded, headers);
+        player.setMediaSource(ms).catch((e: BusinessError) => {
+          finish(buildErrorResult(`setMediaSource 失败: ${e.message}`));
+        });
+      } else {
+        player.url = encoded;
+      }
+    });
+  }).catch((e: BusinessError) => {
+    console.error(`[VideoInfoUtil] createAVPlayer 失败: ${e.code} ${e.message}`);
+    return buildErrorResult(`createAVPlayer 失败: ${e.message}`);
+  });
+}
+
+// ─────────────────────────────────────────────
+// 公开工具类
+// ─────────────────────────────────────────────
+
 export class VideoInfoUtil {
   /**
    * 获取视频轨道信息（分辨率、编码、音轨列表、字幕列表等）。
    *
    * @param url       视频 URL
-   *   - HTTP/HTTPS：如 "http://192.168.1.1:5005/dav/movie.mkv"
-   *   - SMB：如 "smb://user:pass@192.168.1.100/Movies/movie.mkv"
-   *     （认证信息需由调用方嵌入 URL）
+   *   - HTTP/HTTPS：如 "http://192.168.1.1:5005/dav/movie.mkv"（走 AVPlayer prepare）
+   *   - SMB：如 "smb://user:pass@192.168.1.100/Movies/movie.mkv"（走 FfprobeUtil）
    * @param headers   HTTP 请求头，仅对 http/https 生效；SMB 路径忽略此参数
    * @param timeoutMs 探测超时时间（毫秒），默认 20000
    * @returns         VideoInfo（即 FfprobeResult），包含 success 标志与轨道列表
@@ -46,19 +264,16 @@ export class VideoInfoUtil {
     headers?: Record<string, string>,
     timeoutMs: number = 20000
   ): Promise<VideoInfo> {
-    const isSmbUrl: boolean = url.toLowerCase().startsWith('smb://');
-
-    if (isSmbUrl) {
-      // SMB 路径：AVPlayer 不支持 smb:// 协议，直接走 FfprobeUtil
-      // 认证凭据应已嵌入 URL（smb://user:pass@host/share/path），
-      // HTTP headers 对 SMB 无效，不传入。
+    if (url.startsWith('smb://')) {
+      // SMB：AVPlayer 不支持 smb:// 协议，走 FfprobeUtil
+      // 日志脱敏：smb://user:pass@host → smb://***@host
       console.info(`[VideoInfoUtil] SMB URL → FfprobeUtil: ${VideoInfoUtil.maskSmbCredentials(url)}`);
       return FfprobeUtil.probe(url, undefined, timeoutMs);
     }
 
-    // HTTP/HTTPS 路径：透传 headers（Authorization 等），与 VideoScannerUtil 行为保持一致
-    console.info(`[VideoInfoUtil] HTTP URL → FfprobeUtil: ${url}`);
-    return FfprobeUtil.probe(url, headers, timeoutMs);
+    // HTTP/HTTPS：保持原有 AVPlayer prepare 路径
+    console.info('[VideoInfoUtil] HTTP/HTTPS URL → AVPlayer prepare');
+    return probeViaAvPlayer(url, headers, timeoutMs);
   }
 
   /**
@@ -66,15 +281,10 @@ export class VideoInfoUtil {
    *   smb://user:secret@host/share → smb://***@host/share
    */
   private static maskSmbCredentials(url: string): string {
-    // 匹配 smb://user:pass@host 或 smb://user@host 格式
     const atIdx: number = url.indexOf('@');
-    if (atIdx < 0) {
-      return url;
-    }
+    if (atIdx < 0) { return url; }
     const protoEnd: number = url.indexOf('://');
-    if (protoEnd < 0 || atIdx < protoEnd) {
-      return url;
-    }
+    if (protoEnd < 0 || atIdx < protoEnd) { return url; }
     const proto: string = url.substring(0, protoEnd + 3); // "smb://"
     const rest: string = url.substring(atIdx);             // "@host/share/..."
     return `${proto}***${rest}`;

--- a/entry/src/main/ets/utils/VideoInfoUtil.ets
+++ b/entry/src/main/ets/utils/VideoInfoUtil.ets
@@ -1,0 +1,82 @@
+/**
+ * VideoInfoUtil.ets
+ *
+ * 统一的视频轨道信息获取工具。
+ *
+ * 路由逻辑：
+ *   - smb:// URL → FfprobeUtil.probe()（AVPlayer 不支持 SMB 协议）
+ *   - http/https URL → FfprobeUtil.probe()（与 VideoScannerUtil 行为一致）
+ *
+ * SMB 认证说明：
+ *   libsmb2 / FFmpeg 通过 URL 内嵌凭据识别 SMB 鉴权：
+ *     smb://username:password@host/share/path
+ *   调用方（如 SMBAdapter）负责将用户名密码拼入 URL；
+ *   本工具不额外处理 SMB 凭据，直接将 URL 透传给 FfprobeUtil。
+ *
+ * 返回类型：
+ *   VideoInfo = FfprobeResult，包含 videoTracks / audioTracks / subtitleTracks 等字段，
+ *   与 VideoScannerUtil（WebDAV 路径）保持完全一致。
+ */
+
+import { FfprobeUtil, FfprobeResult } from './FfprobeUtil';
+
+/**
+ * VideoInfo 是 FfprobeResult 的类型别名。
+ * 两条路径（HTTP 与 SMB）均返回相同结构，调用方无需区分来源。
+ */
+export type VideoInfo = FfprobeResult;
+
+// 重新导出 FfprobeTrack，方便调用方访问轨道类型
+export { FfprobeTrack } from './FfprobeUtil';
+
+export class VideoInfoUtil {
+  /**
+   * 获取视频轨道信息（分辨率、编码、音轨列表、字幕列表等）。
+   *
+   * @param url       视频 URL
+   *   - HTTP/HTTPS：如 "http://192.168.1.1:5005/dav/movie.mkv"
+   *   - SMB：如 "smb://user:pass@192.168.1.100/Movies/movie.mkv"
+   *     （认证信息需由调用方嵌入 URL）
+   * @param headers   HTTP 请求头，仅对 http/https 生效；SMB 路径忽略此参数
+   * @param timeoutMs 探测超时时间（毫秒），默认 20000
+   * @returns         VideoInfo（即 FfprobeResult），包含 success 标志与轨道列表
+   */
+  static async getVideoInfo(
+    url: string,
+    headers?: Record<string, string>,
+    timeoutMs: number = 20000
+  ): Promise<VideoInfo> {
+    const isSmbUrl: boolean = url.toLowerCase().startsWith('smb://');
+
+    if (isSmbUrl) {
+      // SMB 路径：AVPlayer 不支持 smb:// 协议，直接走 FfprobeUtil
+      // 认证凭据应已嵌入 URL（smb://user:pass@host/share/path），
+      // HTTP headers 对 SMB 无效，不传入。
+      console.info(`[VideoInfoUtil] SMB URL → FfprobeUtil: ${VideoInfoUtil.maskSmbCredentials(url)}`);
+      return FfprobeUtil.probe(url, undefined, timeoutMs);
+    }
+
+    // HTTP/HTTPS 路径：透传 headers（Authorization 等），与 VideoScannerUtil 行为保持一致
+    console.info(`[VideoInfoUtil] HTTP URL → FfprobeUtil: ${url}`);
+    return FfprobeUtil.probe(url, headers, timeoutMs);
+  }
+
+  /**
+   * 对日志输出中的 SMB URL 做凭据脱敏：
+   *   smb://user:secret@host/share → smb://***@host/share
+   */
+  private static maskSmbCredentials(url: string): string {
+    // 匹配 smb://user:pass@host 或 smb://user@host 格式
+    const atIdx: number = url.indexOf('@');
+    if (atIdx < 0) {
+      return url;
+    }
+    const protoEnd: number = url.indexOf('://');
+    if (protoEnd < 0 || atIdx < protoEnd) {
+      return url;
+    }
+    const proto: string = url.substring(0, protoEnd + 3); // "smb://"
+    const rest: string = url.substring(atIdx);             // "@host/share/..."
+    return `${proto}***${rest}`;
+  }
+}

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -486,21 +486,56 @@ export class WebDAVAdapter implements ISourceAdapter {
 export class SMBAdapter implements ISourceAdapter {
   private client: SMBClient;
   private fileSource: FileSource;
+  private config: SMBSourceConfig;
+  private scrapeClient?: ScrapeClient;
 
-  constructor(fileSource: FileSource) {
+  constructor(fileSource: FileSource, scrapeClient?: ScrapeClient) {
     this.fileSource = fileSource;
-    const config = JSON.parse(fileSource.configJson) as SMBSourceConfig;
-    this.client = SMBClient.fromSourceConfig(config);
+    this.config = JSON.parse(fileSource.configJson) as SMBSourceConfig;
+    this.client = SMBClient.fromSourceConfig(this.config);
+    this.scrapeClient = scrapeClient;
+  }
+
+  /** 构建完整 smb:// 播放 URL（凭据内嵌，用于 FFmpeg 播放与刮削） */
+  private buildSmbUrl(filePath: string): string {
+    const port = this.config.port ?? 445;
+    const user = encodeURIComponent(this.config.username);
+    const pass = encodeURIComponent(this.config.password);
+    // filePath 形如 /Videos/TV Series/xxx/yyy.mkv，首段即 shareName
+    return `smb://${user}:${pass}@${this.config.host}:${port}${filePath}`;
+  }
+
+  /** 日志脱敏：smb://user:pass@host → smb://***@host */
+  private maskUrl(url: string): string {
+    const atIdx = url.indexOf('@');
+    if (atIdx < 0) {
+      return url;
+    }
+    const protoEnd = url.indexOf('://');
+    if (protoEnd < 0) {
+      return url;
+    }
+    return `${url.substring(0, protoEnd + 3)}***${url.substring(atIdx)}`;
+  }
+
+  /** 增量跳过判断（对照 WebDAVAdapter.canSkipIncrementalProcessing） */
+  private canSkip(existing: VideoEntity | null, info: VideoFileInfo): boolean {
+    if (!existing) {
+      return false;
+    }
+    if (!existing.lastModified || !info.lastModified) {
+      return false;
+    }
+    return existing.lastModified === info.lastModified;
   }
 
   async scan(directoryPath: string, options: ScanOptions): Promise<VideoFileInfo[]> {
-    // 若目录路径为空或"/"，从根目录开始（listDirectory("/"）会自动枚举所有磁盘共享）
     const rootPath = (directoryPath.trim().length === 0 || directoryPath.trim() === '/') ? '/' : directoryPath;
-    console.info(
-      `[VideoScanner][SMB] 开始扫描: ${rootPath} 最大深度: ${options.maxDepth}`
-    );
+    console.info(`[VideoScanner][SMB] 开始扫描: ${rootPath} 最大深度: ${options.maxDepth}`);
     const results: VideoFileInfo[] = [];
-    await this.scanDir(rootPath, rootPath, 0, options.maxDepth, results);
+    const processingTasks: Promise<void>[] = [];
+    await this.scanDir(rootPath, rootPath, 0, options.maxDepth, options.incremental, results, processingTasks);
+    await Promise.allSettled(processingTasks);
     return results;
   }
 
@@ -509,7 +544,9 @@ export class SMBAdapter implements ISourceAdapter {
     dirPath: string,
     currentDepth: number,
     maxDepth: number,
-    results: VideoFileInfo[]
+    incremental: boolean,
+    results: VideoFileInfo[],
+    processingTasks: Promise<void>[]
   ): Promise<void> {
     if (currentDepth > maxDepth) {
       return;
@@ -518,30 +555,209 @@ export class SMBAdapter implements ISourceAdapter {
     const listResult = await this.client.listDirectory(dirPath);
 
     if (listResult.error) {
-      // 跳过无权访问或不存在的目录，继续扫描其他路径（对齐 WebDAVAdapter 策略）
       console.warn(`[SMBAdapter] 跳过目录: ${listResult.error} (path=${dirPath})`);
       return;
     }
 
     for (const file of listResult.files) {
       if (file.isDirectory) {
-        await this.scanDir(rootPath, file.path, currentDepth + 1, maxDepth, results);
+        await this.scanDir(rootPath, file.path, currentDepth + 1, maxDepth, incremental, results, processingTasks);
       } else if (isVideoFile(file.name)) {
         const info: VideoFileInfo = {
           sourceId: this.fileSource.id ?? 0,
           sourceName: this.fileSource.name,
           sourceType: this.fileSource.type,
           directoryPath: rootPath,
-          filePath: file.path,           // 相对路径，与 WebDAVAdapter 保持一致
+          filePath: file.path,
           fileName: file.name,
           fileSize: file.size,
           lastModified: file.lastModifiedMs > 0 ? new Date(file.lastModifiedMs).toISOString() : undefined,
-          wasProcessed: false            // 未实现处理链前保持 false
+          wasProcessed: true
         };
         console.info(
           `[VideoScanner][SMB] 文件源=${this.fileSource.name} | 路径=${file.path} | 文件名=${file.name} | 大小=${file.size} bytes`
         );
         results.push(info);
+
+        // 增量跳过：文件未变化则仅更新 updated_at，不重新处理
+        if (incremental) {
+          let existing: VideoEntity | null = null;
+          try {
+            existing = await FileSourceDatabase.getInstance().getVideoByPath(file.path);
+          } catch {
+            // 查询失败视为新文件
+          }
+          if (this.canSkip(existing, info)) {
+            info.wasProcessed = false;
+            try {
+              await FileSourceDatabase.getInstance().markVideoUpdatedByPath(file.path);
+            } catch {
+              // 标记失败不阻断扫描
+            }
+            console.info(`[VideoScanner][SMB][INCREMENTAL] 跳过未变化文件: ${file.name}`);
+            continue;
+          }
+        }
+
+        // 异步处理：媒体信息抓取 + 入库 + 刮削
+        const capturedInfo = info;
+        const capturedScrapeClient = this.scrapeClient;
+        const smbUrl = this.buildSmbUrl(file.path);
+        const maskedUrl = this.maskUrl(smbUrl);
+
+        const task: Promise<void> = FfprobeUtil.probe(smbUrl).then(async (videoInfo) => {
+          if (videoInfo.success) {
+            const mainVideo = videoInfo.videoTracks.length > 0 ? videoInfo.videoTracks[0] : undefined;
+            console.info(
+              `[VideoScanner][SMB][MEDIA] ${capturedInfo.fileName} | ` +
+              `时长=${videoInfo.durationText} | ` +
+              `分辨率=${mainVideo?.width ?? '?'}x${mainVideo?.height ?? '?'} | ` +
+              `编码=${mainVideo?.codecName ?? '?'}`
+            );
+          } else {
+            console.warn(`[VideoScanner][SMB][MEDIA] 媒体信息抓取失败（将无媒体元数据入库）: ${capturedInfo.fileName} — ${videoInfo.errorMessage ?? ''}`);
+          }
+
+          const mainVideo = videoInfo.success && videoInfo.videoTracks.length > 0
+            ? videoInfo.videoTracks[0] : undefined;
+
+          const videoEntity: VideoEntity = {
+            sourceId: capturedInfo.sourceId,
+            directoryPath: capturedInfo.directoryPath,
+            filePath: capturedInfo.filePath,
+            fileName: capturedInfo.fileName,
+            fileSize: capturedInfo.fileSize,
+            lastModified: capturedInfo.lastModified,
+            contentType: undefined,
+            durationMs: videoInfo.success ? videoInfo.durationMs : undefined,
+            width: videoInfo.success ? mainVideo?.width : undefined,
+            height: videoInfo.success ? mainVideo?.height : undefined,
+            frameRate: videoInfo.success ? mainVideo?.frameRate : undefined,
+            videoCodec: videoInfo.success ? mainVideo?.codecName : undefined,
+            audioTracksJson: videoInfo.success ? JSON.stringify(videoInfo.audioTracks) : undefined,
+            subtitleTracksJson: videoInfo.success ? JSON.stringify(videoInfo.subtitleTracks) : undefined,
+            scannedAt: Date.now()
+          };
+
+          let videoId: number = -1;
+          try {
+            videoId = await FileSourceDatabase.getInstance().upsertVideo(videoEntity);
+            console.info(`[VideoScanner][SMB][DB] 落库成功 videoId=${videoId} fileName=${capturedInfo.fileName} url=${maskedUrl}`);
+          } catch (dbErr) {
+            console.warn(`[VideoScanner][SMB][DB] 落库失败 fileName=${capturedInfo.fileName}: ${JSON.stringify(dbErr)}`);
+            return;
+          }
+
+          if (!capturedScrapeClient) {
+            return;
+          }
+          try {
+            const existing = await FileSourceDatabase.getInstance().getScrapeInfoByVideoId(videoId);
+            if (existing) {
+              console.info(`[VideoScanner][SMB][SCRAPE] 已有刮削记录，跳过 fileName=${capturedInfo.fileName}`);
+              return;
+            }
+          } catch {
+            // 查询失败继续刮削
+          }
+
+          console.info(`[VideoScanner][SMB][SCRAPE] 开始刮削 fileName=${capturedInfo.fileName}`);
+          const parsed = parseFileName(capturedInfo.fileName);
+
+          if (parsed.mediaType === 'movie') {
+            try {
+              const result = await capturedScrapeClient.searchMovie(parsed.title ?? capturedInfo.fileName);
+              if (!result) {
+                return;
+              }
+              const movieEntity: MovieEntity = {
+                tmdbId: result.id,
+                title: result.title,
+                originalTitle: result.originalTitle,
+                overview: result.overview,
+                posterPath: result.posterPath,
+                backdropPath: result.backdropPath,
+                releaseDate: result.releaseDate,
+                rating: result.voteAverage,
+                rawJson: result.rawJson,
+                scrapedAt: Date.now()
+              };
+              const movieId = await FileSourceDatabase.getInstance().upsertMovie(movieEntity);
+              const scrapeInfo: ScrapeInfoEntity = {
+                videoId,
+                type: 'movie',
+                movieId,
+                scrapedAt: Date.now()
+              };
+              await FileSourceDatabase.getInstance().upsertScrapeInfo(scrapeInfo);
+              console.info(`[VideoScanner][SMB][SCRAPE] movie scrape_info 落库 videoId=${videoId} movieId=${movieId}`);
+            } catch (e) {
+              console.warn(`[VideoScanner][SMB][SCRAPE] movie 刮削失败 fileName=${capturedInfo.fileName}: ${JSON.stringify(e)}`);
+            }
+          } else if (parsed.mediaType === 'tv') {
+            try {
+              const result: TvSeriesScrapeResult | null = await capturedScrapeClient.searchTvSeries(
+                parsed.title ?? capturedInfo.fileName,
+                parsed.seasonNumber,
+                parsed.episodeNumber
+              );
+              if (!result) {
+                return;
+              }
+              const seriesEntity: TvSeriesEntity = {
+                tmdbId: result.series.id,
+                title: result.series.title,
+                originalTitle: result.series.originalTitle,
+                overview: result.series.overview,
+                posterPath: result.series.posterPath,
+                backdropPath: result.series.backdropPath,
+                firstAirDate: result.series.firstAirDate,
+                rating: result.series.voteAverage,
+                rawJson: result.series.rawJson,
+                scrapedAt: Date.now()
+              };
+              const tvSeriesId = await FileSourceDatabase.getInstance().upsertTvSeries(seriesEntity);
+              const seasonEntity: TvSeasonEntity = {
+                tvSeriesId,
+                seasonNumber: result.season.seasonNumber,
+                name: result.season.name,
+                overview: result.season.overview,
+                posterPath: result.season.posterPath,
+                airDate: result.season.airDate,
+                rawJson: result.season.rawJson,
+                scrapedAt: Date.now()
+              };
+              const tvSeasonId = await FileSourceDatabase.getInstance().upsertTvSeason(seasonEntity);
+              const episodeEntity: TvEpisodeEntity = {
+                tvSeasonId,
+                episodeNumber: result.episode.episodeNumber,
+                name: result.episode.name,
+                overview: result.episode.overview,
+                stillPath: result.episode.stillPath,
+                airDate: result.episode.airDate,
+                rating: result.episode.voteAverage,
+                rawJson: result.episode.rawJson,
+                scrapedAt: Date.now()
+              };
+              const tvEpisodeId = await FileSourceDatabase.getInstance().upsertTvEpisode(episodeEntity);
+              const scrapeInfo: ScrapeInfoEntity = {
+                videoId,
+                type: 'episode',
+                tvSeriesId,
+                tvSeasonId,
+                tvEpisodeId,
+                scrapedAt: Date.now()
+              };
+              await FileSourceDatabase.getInstance().upsertScrapeInfo(scrapeInfo);
+              console.info(
+                `[VideoScanner][SMB][SCRAPE] tv scrape_info 落库 videoId=${videoId} S${parsed.seasonNumber ?? '?'}E${parsed.episodeNumber ?? '?'}`
+              );
+            } catch (e) {
+              console.warn(`[VideoScanner][SMB][SCRAPE] tv 刮削失败 fileName=${capturedInfo.fileName}: ${JSON.stringify(e)}`);
+            }
+          }
+        });
+        processingTasks.push(task);
       }
     }
   }
@@ -578,7 +794,7 @@ function createAdapter(fileSource: FileSource, scrapeClient?: ScrapeClient): ISo
     case FileSourceType.WEBDAV:
       return new WebDAVAdapter(fileSource, scrapeClient);
     case FileSourceType.SMB:
-      return new SMBAdapter(fileSource);
+      return new SMBAdapter(fileSource, scrapeClient);
     default:
       return new UnsupportedAdapter(fileSource.name, fileSource.type);
   }

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -668,7 +668,7 @@ export class SMBAdapter implements ISourceAdapter {
 
           if (parsed.mediaType === 'movie') {
             try {
-              const movie = await capturedScrapeClient.searchMovie(parsed.title ?? fileName);
+              const movie = await capturedScrapeClient.autoScrapeMovie(fileName);
               if (!movie) {
                 console.warn(`[VideoScanner][SMB][SCRAPE] 电影刮削无结果 ${fileName}`);
                 return;

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -683,6 +683,24 @@ export class SMBAdapter implements ISourceAdapter {
               const existingMovie = await db.getMovieByProviderId(movie.provider, movie.providerId);
               if (existingMovie && existingMovie.id !== undefined) {
                 movieId = existingMovie.id;
+                console.info(`[VideoScanner][SMB][SCRAPE] 电影复用已有记录 movieId=${movieId} title="${movie.title}" 已有posterUrl=${existingMovie.posterUrl ? 'Y' : 'null'}`);
+                if (!existingMovie.posterUrl && movie.posterUrl) {
+                  const updateEntity: MovieEntity = {
+                    id: existingMovie.id,
+                    provider: movie.provider, providerId: movie.providerId,
+                    title: movie.title, originalTitle: movie.originalTitle,
+                    overview: movie.overview, releaseDate: movie.releaseDate,
+                    rating: movie.rating, voteCount: movie.voteCount,
+                    posterPath: movie.posterPath, backdropPath: movie.backdropPath,
+                    posterUrl: movie.posterUrl, backdropUrl: movie.backdropUrl,
+                    genresJson: movie.genresJson, castJson: movie.castJson,
+                    directorsJson: movie.directorsJson, runtime: movie.runtime,
+                    originalLanguage: movie.originalLanguage, rawJson: movie.rawJson,
+                    scrapedAt: Date.now()
+                  };
+                  await db.upsertMovie(updateEntity);
+                  console.info(`[VideoScanner][SMB][SCRAPE] 电影复用更新 posterUrl movieId=${movieId}`);
+                }
               } else {
                 const movieEntity: MovieEntity = {
                   provider: movie.provider, providerId: movie.providerId,
@@ -795,6 +813,8 @@ export class SMBAdapter implements ISourceAdapter {
               console.warn(`[VideoScanner][SMB][SCRAPE] 剧集刮削异常 ${fileName}: ${err.message}`);
             }
           }
+        }).catch((e) => {
+          console.warn(`[VideoScanner][SMB][TASK] 未处理异常 fileName=${capturedInfo.fileName}: ${(e as Error).message ?? String(e)}`);
         });
         processingTasks.push(task);
       }

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -496,13 +496,19 @@ export class SMBAdapter implements ISourceAdapter {
     this.scrapeClient = scrapeClient;
   }
 
-  /** 构建完整 smb:// 播放 URL（凭据内嵌，用于 FFmpeg 播放与刮削） */
+  /** 构建完整 smb:// 播放 URL（凭据内嵌，路径段编码，用于 FFmpeg 播放与刮削） */
   private buildSmbUrl(filePath: string): string {
     const port = this.config.port ?? 445;
     const user = encodeURIComponent(this.config.username);
     const pass = encodeURIComponent(this.config.password);
-    // filePath 形如 /Videos/TV Series/xxx/yyy.mkv，首段即 shareName
-    return `smb://${user}:${pass}@${this.config.host}:${port}${filePath}`;
+    // filePath 形如 /Videos/TV Series/xxx/yyy.mkv，对每段路径做 URI 编码（保留斜杠）
+    const encodedPath = filePath.split('/').map((seg: string): string => {
+      if (seg.length === 0) { return ''; }
+      let decoded: string = seg;
+      try { decoded = decodeURIComponent(seg); } catch { decoded = seg; }
+      return encodeURIComponent(decoded);
+    }).join('/');
+    return `smb://${user}:${pass}@${this.config.host}:${port}${encodedPath}`;
   }
 
   /** 日志脱敏：smb://user:pass@host → smb://***@host */

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -813,8 +813,8 @@ export class SMBAdapter implements ISourceAdapter {
               console.warn(`[VideoScanner][SMB][SCRAPE] 剧集刮削异常 ${fileName}: ${err.message}`);
             }
           }
-        }).catch((e) => {
-          console.warn(`[VideoScanner][SMB][TASK] 未处理异常 fileName=${capturedInfo.fileName}: ${(e as Error).message ?? String(e)}`);
+        }).catch((e: Error) => {
+          console.warn(`[VideoScanner][SMB][TASK] 未处理异常 fileName=${capturedInfo.fileName}: ${e.message ?? String(e)}`);
         });
         processingTasks.push(task);
       }

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -663,97 +663,130 @@ export class SMBAdapter implements ISourceAdapter {
 
           console.info(`[VideoScanner][SMB][SCRAPE] 开始刮削 fileName=${capturedInfo.fileName}`);
           const parsed = parseFileName(capturedInfo.fileName);
+          const fileName = capturedInfo.fileName;
+          const db = FileSourceDatabase.getInstance();
 
           if (parsed.mediaType === 'movie') {
             try {
-              const result = await capturedScrapeClient.searchMovie(parsed.title ?? capturedInfo.fileName);
-              if (!result) {
+              const movie = await capturedScrapeClient.searchMovie(parsed.title ?? fileName);
+              if (!movie) {
+                console.warn(`[VideoScanner][SMB][SCRAPE] 电影刮削无结果 ${fileName}`);
                 return;
               }
-              const movieEntity: MovieEntity = {
-                tmdbId: result.id,
-                title: result.title,
-                originalTitle: result.originalTitle,
-                overview: result.overview,
-                posterPath: result.posterPath,
-                backdropPath: result.backdropPath,
-                releaseDate: result.releaseDate,
-                rating: result.voteAverage,
-                rawJson: result.rawJson,
-                scrapedAt: Date.now()
-              };
-              const movieId = await FileSourceDatabase.getInstance().upsertMovie(movieEntity);
+              let movieId: number;
+              const existingMovie = await db.getMovieByProviderId(movie.provider, movie.providerId);
+              if (existingMovie && existingMovie.id !== undefined) {
+                movieId = existingMovie.id;
+              } else {
+                const movieEntity: MovieEntity = {
+                  provider: movie.provider, providerId: movie.providerId,
+                  title: movie.title, originalTitle: movie.originalTitle,
+                  overview: movie.overview, releaseDate: movie.releaseDate,
+                  rating: movie.rating, voteCount: movie.voteCount,
+                  posterPath: movie.posterPath, backdropPath: movie.backdropPath,
+                  posterUrl: movie.posterUrl, backdropUrl: movie.backdropUrl,
+                  genresJson: movie.genresJson, castJson: movie.castJson,
+                  directorsJson: movie.directorsJson, runtime: movie.runtime,
+                  originalLanguage: movie.originalLanguage, rawJson: movie.rawJson,
+                  scrapedAt: Date.now()
+                };
+                movieId = await db.upsertMovie(movieEntity);
+              }
               const scrapeInfo: ScrapeInfoEntity = {
-                videoId,
-                type: 'movie',
-                movieId,
-                scrapedAt: Date.now()
+                videoId, provider: movie.provider, providerId: movie.providerId,
+                mediaType: 'movie', title: movie.title, originalTitle: movie.originalTitle,
+                movieId, scrapedAt: Date.now()
               };
-              await FileSourceDatabase.getInstance().upsertScrapeInfo(scrapeInfo);
+              await db.upsertScrapeInfo(scrapeInfo);
               console.info(`[VideoScanner][SMB][SCRAPE] movie scrape_info 落库 videoId=${videoId} movieId=${movieId}`);
             } catch (e) {
-              console.warn(`[VideoScanner][SMB][SCRAPE] movie 刮削失败 fileName=${capturedInfo.fileName}: ${JSON.stringify(e)}`);
+              const err = e as Error;
+              console.warn(`[VideoScanner][SMB][SCRAPE] 电影刮削异常 ${fileName}: ${err.message}`);
             }
-          } else if (parsed.mediaType === 'tv') {
+          } else {
             try {
-              const result: TvSeriesScrapeResult | null = await capturedScrapeClient.searchTvSeries(
-                parsed.title ?? capturedInfo.fileName,
-                parsed.seasonNumber,
-                parsed.episodeNumber
-              );
-              if (!result) {
+              const result = await capturedScrapeClient.autoScrapeTvEpisode(fileName);
+              if (!result.series) {
+                console.warn(`[VideoScanner][SMB][SCRAPE] 剧集刮削无结果 ${fileName}`);
                 return;
               }
-              const seriesEntity: TvSeriesEntity = {
-                tmdbId: result.series.id,
-                title: result.series.title,
-                originalTitle: result.series.originalTitle,
-                overview: result.series.overview,
-                posterPath: result.series.posterPath,
-                backdropPath: result.series.backdropPath,
-                firstAirDate: result.series.firstAirDate,
-                rating: result.series.voteAverage,
-                rawJson: result.series.rawJson,
-                scrapedAt: Date.now()
-              };
-              const tvSeriesId = await FileSourceDatabase.getInstance().upsertTvSeries(seriesEntity);
-              const seasonEntity: TvSeasonEntity = {
-                tvSeriesId,
-                seasonNumber: result.season.seasonNumber,
-                name: result.season.name,
-                overview: result.season.overview,
-                posterPath: result.season.posterPath,
-                airDate: result.season.airDate,
-                rawJson: result.season.rawJson,
-                scrapedAt: Date.now()
-              };
-              const tvSeasonId = await FileSourceDatabase.getInstance().upsertTvSeason(seasonEntity);
-              const episodeEntity: TvEpisodeEntity = {
-                tvSeasonId,
-                episodeNumber: result.episode.episodeNumber,
-                name: result.episode.name,
-                overview: result.episode.overview,
-                stillPath: result.episode.stillPath,
-                airDate: result.episode.airDate,
-                rating: result.episode.voteAverage,
-                rawJson: result.episode.rawJson,
-                scrapedAt: Date.now()
-              };
-              const tvEpisodeId = await FileSourceDatabase.getInstance().upsertTvEpisode(episodeEntity);
+              const series: TvSeriesScrapeResult = result.series;
+              const season = result.season;
+              const episode = result.episode;
+
+              let seriesId: number;
+              const existingSeries = await db.getTvSeriesByProviderId(series.provider, series.providerId);
+              if (existingSeries && existingSeries.id !== undefined) {
+                seriesId = existingSeries.id;
+              } else {
+                const seriesEntity: TvSeriesEntity = {
+                  provider: series.provider, providerId: series.providerId,
+                  title: series.title, originalTitle: series.originalTitle,
+                  overview: series.overview, firstAirDate: series.firstAirDate,
+                  rating: series.rating, voteCount: series.voteCount,
+                  posterPath: series.posterPath, backdropPath: series.backdropPath,
+                  posterUrl: series.posterUrl, backdropUrl: series.backdropUrl,
+                  genresJson: series.genresJson, castJson: series.castJson,
+                  numberOfSeasons: series.numberOfSeasons,
+                  originalLanguage: series.originalLanguage, rawJson: series.rawJson,
+                  scrapedAt: Date.now()
+                };
+                seriesId = await db.upsertTvSeries(seriesEntity);
+              }
+
+              let seasonId: number | undefined;
+              if (season) {
+                const existingSeason = await db.getTvSeason(seriesId, season.seasonNumber);
+                if (existingSeason && existingSeason.id !== undefined) {
+                  seasonId = existingSeason.id;
+                } else {
+                  const seasonEntity: TvSeasonEntity = {
+                    seriesId, provider: season.provider, providerId: season.providerId,
+                    seasonNumber: season.seasonNumber, title: season.title,
+                    overview: season.overview, airDate: season.airDate,
+                    episodeCount: season.episodeCount, posterPath: season.posterPath,
+                    posterUrl: season.posterUrl, rawJson: season.rawJson,
+                    scrapedAt: Date.now()
+                  };
+                  seasonId = await db.upsertTvSeason(seasonEntity);
+                }
+              }
+
+              let episodeId: number | undefined;
+              if (episode) {
+                const existingEp = await db.getTvEpisode(seriesId, episode.seasonNumber, episode.episodeNumber);
+                if (existingEp && existingEp.id !== undefined) {
+                  episodeId = existingEp.id;
+                } else {
+                  const epEntity: TvEpisodeEntity = {
+                    seriesId, seasonId, provider: episode.provider, providerId: episode.providerId,
+                    seasonNumber: episode.seasonNumber, episodeNumber: episode.episodeNumber,
+                    title: episode.title, overview: episode.overview, airDate: episode.airDate,
+                    runtime: episode.runtime, rating: episode.rating,
+                    stillPath: episode.stillPath, stillUrl: episode.stillUrl,
+                    rawJson: episode.rawJson, scrapedAt: Date.now()
+                  };
+                  episodeId = await db.upsertTvEpisode(epEntity);
+                }
+              }
+
+              const mediaType = episodeId !== undefined ? 'episode' : 'tv';
               const scrapeInfo: ScrapeInfoEntity = {
-                videoId,
-                type: 'episode',
-                tvSeriesId,
-                tvSeasonId,
-                tvEpisodeId,
+                videoId, provider: series.provider,
+                providerId: episodeId !== undefined ? (episode?.providerId ?? series.providerId) : series.providerId,
+                mediaType, title: episode?.title ?? series.title,
+                originalTitle: series.originalTitle,
+                tvSeriesId: seriesId, episodeId,
+                seasonNumber: parsed.seasonNumber, episodeNumber: parsed.episodeNumber,
                 scrapedAt: Date.now()
               };
-              await FileSourceDatabase.getInstance().upsertScrapeInfo(scrapeInfo);
+              await db.upsertScrapeInfo(scrapeInfo);
               console.info(
                 `[VideoScanner][SMB][SCRAPE] tv scrape_info 落库 videoId=${videoId} S${parsed.seasonNumber ?? '?'}E${parsed.episodeNumber ?? '?'}`
               );
             } catch (e) {
-              console.warn(`[VideoScanner][SMB][SCRAPE] tv 刮削失败 fileName=${capturedInfo.fileName}: ${JSON.stringify(e)}`);
+              const err = e as Error;
+              console.warn(`[VideoScanner][SMB][SCRAPE] 剧集刮削异常 ${fileName}: ${err.message}`);
             }
           }
         });


### PR DESCRIPTION
## 变更内容

### 1. VideoInfoUtil SMB 路由（原始功能）
- `smb://` URL 路由到 `FfprobeUtil.probe()`，不走 AVPlayer
- 日志脱敏：`maskSmbCredentials()` 隐藏 URL 中的凭据

### 2. SMBAdapter 入库与刮削处理链（来自 PR #74 合并）
- 完整重写 `SMBAdapter`，补全 `upsertVideo()` + 刮削调用
- 对齐 WebDAVAdapter 的 `autoScrapeMovie` / `autoScrapeTvEpisode`
- `createAdapter()` 工厂补传 `scrapeClient`

### 3. SeriesDetailPage / SeasonDetailPage SMB 播放修复
- `playEpisode` 按 `fileSource.type` 分支，SMB 构建 `smb://user:pass@host:port/path`
- 修复前：SMB 文件源的 `configJson` 被当 WebDAV 解析，URL 构建失败，抛异常被 catch 吞掉

## QA 验证
BUILD SUCCESSFUL（commit dba1c0d）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified video probing for SMB and HTTP sources
  * Automatic media scraping and upsert for discovered videos

* **Improvements**
  * Full SMB file source support for playback with encoded path/credential handling
  * Incremental scanning with asynchronous processing to avoid reprocessing unchanged files
  * Enhanced playback/progress refresh on detail pages
  * Masked credentials in logs for safer diagnostics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->