### PR TITLE
新增: 文件浏览器支持 SMB 文件源

### DIFF
--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -3418,7 +3418,8 @@ static void ExecuteSmbListDirectory(napi_env /*env*/, void *data) {
         smb2_destroy_context(smb2);
         return;
     }
-    const char *dirPath = ctx->path.empty() ? "/" : ctx->path.c_str();
+    // 空字符串表示 share 根目录（libsmb2 期望 ""，传 "/" 会触发 Windows STATUS_INVALID_PARAMETER）
+    const char *dirPath = ctx->path.c_str();
     struct smb2dir *dir = smb2_opendir(smb2, dirPath);
     if (!dir) {
         const char *errStr = smb2_get_error(smb2);

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -583,23 +583,24 @@ export class FileSourceDatabase {
     if (this.rdbStore === null) {
       throw new Error('Database not initialized');
     }
-    this.rdbStore.beginTransaction();
+    const store = this.rdbStore;
+    await store.executeSql('BEGIN TRANSACTION');
     try {
       const predicates = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_DIRECTORIES);
       predicates.equalTo('source_id', sourceId);
-      await this.rdbStore.delete(predicates);
+      await store.delete(predicates);
       for (const dir of directories) {
         const valueBucket: relationalStore.ValuesBucket = {
           source_id: sourceId,
           directory_path: dir.directoryPath,
           custom_name: dir.customName ?? null
         };
-        await this.rdbStore.insert(FileSourceDatabase.TABLE_DIRECTORIES, valueBucket);
+        await store.insert(FileSourceDatabase.TABLE_DIRECTORIES, valueBucket);
       }
-      this.rdbStore.commit();
+      await store.executeSql('COMMIT');
       console.info(`FileSourceDatabase: Saved ${directories.length} directory(ies) for source ${sourceId}`);
     } catch (error) {
-      this.rdbStore.rollback();
+      await store.executeSql('ROLLBACK');
       console.error('FileSourceDatabase: saveDirectoriesForSource failed, rollback', JSON.stringify(error));
       throw new Error('Failed to save directories: ' + JSON.stringify(error));
     }

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -577,6 +577,35 @@ export class FileSourceDatabase {
   }
 
   /**
+   * 原子性替换指定文件源的目录关联（先删后插，在同一事务内完成，避免部分失败导致数据丢失）
+   */
+  async saveDirectoriesForSource(sourceId: number, directories: FileSourceDirectory[]): Promise<void> {
+    if (this.rdbStore === null) {
+      throw new Error('Database not initialized');
+    }
+    this.rdbStore.beginTransaction();
+    try {
+      const predicates = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_DIRECTORIES);
+      predicates.equalTo('source_id', sourceId);
+      await this.rdbStore.delete(predicates);
+      for (const dir of directories) {
+        const valueBucket: relationalStore.ValuesBucket = {
+          source_id: sourceId,
+          directory_path: dir.directoryPath,
+          custom_name: dir.customName ?? null
+        };
+        await this.rdbStore.insert(FileSourceDatabase.TABLE_DIRECTORIES, valueBucket);
+      }
+      this.rdbStore.commit();
+      console.info(`FileSourceDatabase: Saved ${directories.length} directory(ies) for source ${sourceId}`);
+    } catch (error) {
+      this.rdbStore.rollback();
+      console.error('FileSourceDatabase: saveDirectoriesForSource failed, rollback', JSON.stringify(error));
+      throw new Error('Failed to save directories: ' + JSON.stringify(error));
+    }
+  }
+
+  /**
    * 查询指定文件源的所有目录关联
    */
   async getDirectoriesBySourceId(sourceId: number): Promise<FileSourceDirectory[]> {

--- a/entry/src/main/ets/lib/SMBClient.ets
+++ b/entry/src/main/ets/lib/SMBClient.ets
@@ -235,6 +235,9 @@ export class SMBClient {
    */
   private async listDirectoryInShare(shareName: string, subPath: string): Promise<SmbListDirectoryResult> {
     try {
+      // smb2_opendir 在连接 share 后期望路径不含前导 "/"（如 "Movies" 而非 "/Movies"）
+      // 空字符串由 native 层自动处理为 share 根目录
+      const nativePath = subPath.startsWith('/') ? subPath.substring(1) : subPath;
       const raw = await getModule().smbListDirectory(
         this.host,
         this.port,
@@ -242,7 +245,7 @@ export class SMBClient {
         this.password,
         this.domain,
         shareName,
-        subPath,
+        nativePath,
         this.timeoutMs
       ) as Record<string, Object>;
 

--- a/entry/src/main/ets/lib/SMBClient.ets
+++ b/entry/src/main/ets/lib/SMBClient.ets
@@ -238,6 +238,7 @@ export class SMBClient {
       // smb2_opendir 在连接 share 后期望路径不含前导 "/"（如 "Movies" 而非 "/Movies"）
       // 空字符串由 native 层自动处理为 share 根目录
       const nativePath = subPath.startsWith('/') ? subPath.substring(1) : subPath;
+      console.info('[SMBClient] listDirectoryInShare shareName=' + shareName + ' subPath=' + subPath + ' nativePath=' + nativePath);
       const raw = await getModule().smbListDirectory(
         this.host,
         this.port,
@@ -250,6 +251,11 @@ export class SMBClient {
       ) as Record<string, Object>;
 
       const filesRaw = raw['files'] as Object[];
+      if (raw['error']) {
+        console.error('[SMBClient] native error shareName=' + shareName + ' nativePath=' + nativePath + ' err=' + (raw['error'] as string));
+      } else {
+        console.info('[SMBClient] native ok shareName=' + shareName + ' nativePath=' + nativePath + ' count=' + filesRaw.length.toString());
+      }
       // 构造全路径：/<shareName>/<subPath去尾斜杠>/<name>
       let cleanSub = subPath;
       while (cleanSub.endsWith('/')) {

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -1,5 +1,6 @@
 import { SidebarStore } from '../stores/sidebar/SidebarStore';
 import { FileExplorerPage } from './files';
+import { SmbFileExplorerPage } from './files/SmbFileExplorerPage';
 import { HomePage } from './home';
 import { PlayerPage } from './player/index';
 import { SettingsPage } from './settings/Index';
@@ -19,6 +20,8 @@ struct Index {
       SettingsPage();
     } else if (name === FileExplorerPage.PAGE_NAME) {
       FileExplorerPage();
+    } else if (name === SmbFileExplorerPage.PAGE_NAME) {
+      SmbFileExplorerPage();
     } else if (name === SeriesDetailPage.PAGE_NAME) {
       SeriesDetailPage();
     } else if (name === SeasonDetailPage.PAGE_NAME) {

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -1,3 +1,4 @@
+import { BusinessError } from '@kit.BasicServicesKit'
 import { SMBSourceConfig } from '../../db/models/FileSourceEntity'
 import { SMBClient, SmbFileInfo } from '../../lib/SMBClient'
 import { PlayerPage, PlayerPageParam } from '../player'
@@ -107,7 +108,15 @@ export struct SmbFileExplorerPage {
     })
   }
 
+  // ── 脱敏辅助：隐藏 URL 中的用户名与密码，仅用于日志输出 ─────────────────
+
+  private maskSmbUrl(url: string): string {
+    return url.replace(/smb:\/\/[^@]+@/, 'smb://***@')
+  }
+
   // ── 构造 SMB 播放 URL（内嵌凭据供播放器使用）──────────────────────────────
+  // 注意：凭据仅用于 libsmb2 认证，不得将完整 URL 记录到日志。
+  //       日志输出请统一使用 maskSmbUrl() 脱敏后的版本。
 
   private buildPlaybackUrl(filePath: string): string {
     const host = this.config.host
@@ -136,6 +145,7 @@ export struct SmbFileExplorerPage {
 
   private playVideo(file: SmbFileInfo): void {
     const url = this.buildPlaybackUrl(file.path)
+    console.info('SmbFileExplorerPage', `播放视频: ${this.maskSmbUrl(url)}`)
     const pageParam: PlayerPageParam = {
       url: url,
       title: file.name

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -53,6 +53,9 @@ export struct SmbFileExplorerPage {
   @Local private currentPath: string = '/'
   @Local private isLoading: boolean = false
   @Local private errorMessage: string = ''
+  @Local private sortField: string = 'name'
+  @Local private sortAscending: boolean = true
+  @Local private showHiddenFiles: boolean = false
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack()
 
   private config: SMBSourceConfig = DEFAULT_SMB_CONFIG
@@ -88,6 +91,43 @@ export struct SmbFileExplorerPage {
       items.push({ name: parts[i], path: accumulated })
     }
     return items
+  }
+
+  @Computed
+  get sortedFiles(): SmbFileInfo[] {
+    let filtered = this.files
+    if (!this.showHiddenFiles) {
+      filtered = this.files.filter((f: SmbFileInfo) => !f.name.startsWith('.'))
+    }
+    const sorted = filtered.slice()
+    sorted.sort((a: SmbFileInfo, b: SmbFileInfo) => {
+      if (a.isDirectory && !b.isDirectory) return -1
+      if (!a.isDirectory && b.isDirectory) return 1
+      let cmp = 0
+      if (this.sortField === 'name') {
+        cmp = a.name.localeCompare(b.name)
+      } else if (this.sortField === 'size') {
+        cmp = a.size - b.size
+      } else if (this.sortField === 'date') {
+        cmp = a.lastModifiedMs - b.lastModifiedMs
+      }
+      return this.sortAscending ? cmp : -cmp
+    })
+    return sorted
+  }
+
+  private getSortIcon(field: string): string {
+    if (this.sortField !== field) return ''
+    return this.sortAscending ? '↑' : '↓'
+  }
+
+  private changeSortField(field: string): void {
+    if (this.sortField === field) {
+      this.sortAscending = !this.sortAscending
+    } else {
+      this.sortField = field
+      this.sortAscending = true
+    }
   }
 
   // ── 列举目录 ────────────────────────────────────────────────────────────────
@@ -241,12 +281,27 @@ export struct SmbFileExplorerPage {
   build() {
     NavDestination() {
       Column() {
-        // ── 标题栏 ────────────────────────────────────────────────────────────
+        // ── 工具栏（返回 / 隐藏文件 / 文件计数 / 加载指示）────────────────────
         Row() {
-          Text('SMB 文件浏览器')
-            .fontSize(18)
-            .fontWeight(FontWeight.Bold)
-            .fontColor(this.COLORS.primaryText)
+          Button('返回')
+            .fontSize(16)
+            .height(40)
+            .backgroundColor(this.COLORS.button)
+            .fontColor(this.COLORS.accent)
+            .onClick(() => { this.handleBack() })
+            .margin({ right: 10 })
+
+          Button(this.showHiddenFiles ? '隐藏隐藏文件' : '显示隐藏文件')
+            .fontSize(16)
+            .height(40)
+            .backgroundColor(this.COLORS.button)
+            .fontColor(this.showHiddenFiles ? this.COLORS.accent : this.COLORS.secondaryText)
+            .onClick(() => { this.showHiddenFiles = !this.showHiddenFiles })
+            .margin({ right: 10 })
+
+          Text('文件：' + this.sortedFiles.length.toString())
+            .fontSize(14)
+            .fontColor(this.COLORS.tertiaryText)
             .layoutWeight(1)
 
           if (this.isLoading) {
@@ -299,24 +354,30 @@ export struct SmbFileExplorerPage {
         Divider()
           .color(this.COLORS.divider)
 
-        // ── 排序栏头 ──────────────────────────────────────────────────────────
+        // ── 排序栏头（可点击切换排序字段和升降序）──────────────────────────────
         Row() {
-          Text('名称')
+          Text('名称 ' + this.getSortIcon('name'))
             .fontSize(13)
-            .fontColor(this.COLORS.tertiaryText)
+            .fontColor(this.sortField === 'name' ? this.COLORS.accent : this.COLORS.tertiaryText)
+            .fontWeight(this.sortField === 'name' ? FontWeight.Medium : FontWeight.Normal)
             .layoutWeight(3)
+            .onClick(() => { this.changeSortField('name') })
 
-          Text('大小')
+          Text('大小 ' + this.getSortIcon('size'))
             .fontSize(13)
-            .fontColor(this.COLORS.tertiaryText)
+            .fontColor(this.sortField === 'size' ? this.COLORS.accent : this.COLORS.tertiaryText)
+            .fontWeight(this.sortField === 'size' ? FontWeight.Medium : FontWeight.Normal)
             .layoutWeight(2)
             .textAlign(TextAlign.End)
+            .onClick(() => { this.changeSortField('size') })
 
-          Text('修改日期')
+          Text('修改日期 ' + this.getSortIcon('date'))
             .fontSize(13)
-            .fontColor(this.COLORS.tertiaryText)
+            .fontColor(this.sortField === 'date' ? this.COLORS.accent : this.COLORS.tertiaryText)
+            .fontWeight(this.sortField === 'date' ? FontWeight.Medium : FontWeight.Normal)
             .layoutWeight(2)
             .textAlign(TextAlign.End)
+            .onClick(() => { this.changeSortField('date') })
         }
         .width('100%')
         .padding({ left: 16, right: 16, top: 8, bottom: 8 })
@@ -338,7 +399,7 @@ export struct SmbFileExplorerPage {
         }
 
         // ── 文件列表 ──────────────────────────────────────────────────────────
-        if (this.files.length === 0 && !this.isLoading) {
+        if (this.sortedFiles.length === 0 && !this.isLoading) {
           Column() {
             Text('📂')
               .fontSize(48)
@@ -354,17 +415,17 @@ export struct SmbFileExplorerPage {
           .backgroundColor(this.COLORS.background)
         } else {
           List({ space: 0 }) {
-            ForEach(this.files, (file: SmbFileInfo, index: number) => {
+            ForEach(this.sortedFiles, (file: SmbFileInfo, index: number) => {
               ListItem() {
                 Row() {
                   // 图标 + 文件名
                   Row({ space: 12 }) {
                     Text(this.getFileIcon(file))
-                      .fontSize(20)
+                      .fontSize($r('app.float.font_h6_title_large'))
 
                     Column() {
                       Text(file.name)
-                        .fontSize(15)
+                        .fontSize($r('app.float.font_h7_title_small'))
                         .maxLines(1)
                         .textOverflow({ overflow: TextOverflow.MARQUEE })
                         .fontColor(file.isDirectory

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -1,0 +1,421 @@
+import { SMBSourceConfig } from '../../db/models/FileSourceEntity'
+import { SMBClient, SmbFileInfo } from '../../lib/SMBClient'
+import { PlayerPage, PlayerPageParam } from '../player'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 对外导出的路由参数接口
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface SmbFileExplorerPageParam {
+  config: SMBSourceConfig
+  /** 初始目录路径，默认 "/" 列举所有共享 */
+  initialPath?: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部辅助类型
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface PathItem {
+  name: string
+  path: string
+}
+
+interface ColorsInterface {
+  background: string
+  surface: string
+  surfaceVariant: string
+  primaryText: string
+  secondaryText: string
+  tertiaryText: string
+  accent: string
+  divider: string
+  button: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SmbFileExplorerPage
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 占位用默认配置，真实配置在 onReady 中替换
+const DEFAULT_SMB_CONFIG: SMBSourceConfig = {
+  host: '',
+  username: '',
+  password: ''
+}
+
+@ComponentV2
+export struct SmbFileExplorerPage {
+  static PAGE_NAME = 'smbFileExplorerPage'
+
+  @Local private files: SmbFileInfo[] = []
+  @Local private currentPath: string = '/'
+  @Local private isLoading: boolean = false
+  @Local private errorMessage: string = ''
+  @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack()
+
+  private config: SMBSourceConfig = DEFAULT_SMB_CONFIG
+  private client: SMBClient = SMBClient.fromSourceConfig(DEFAULT_SMB_CONFIG)
+
+  private readonly COLORS: ColorsInterface = {
+    background: '#000000',
+    surface: '#1C1C1E',
+    surfaceVariant: '#2C2C2E',
+    primaryText: '#FFFFFF',
+    secondaryText: '#EBEBF5',
+    tertiaryText: '#98989D',
+    accent: '#0A84FF',
+    divider: '#38383A',
+    button: '#48484A'
+  }
+
+  // ── 路径面包屑 ──────────────────────────────────────────────────────────────
+
+  @Computed
+  get pathItems(): PathItem[] {
+    const items: PathItem[] = []
+    items.push({ name: '根目录', path: '/' })
+
+    if (this.currentPath === '/') {
+      return items
+    }
+
+    const parts = this.currentPath.split('/').filter(p => p.length > 0)
+    let accumulated = ''
+    for (let i = 0; i < parts.length; i++) {
+      accumulated += '/' + parts[i]
+      items.push({ name: parts[i], path: accumulated })
+    }
+    return items
+  }
+
+  // ── 列举目录 ────────────────────────────────────────────────────────────────
+
+  private loadDirectory(path: string): void {
+    this.isLoading = true
+    this.errorMessage = ''
+    this.client.listDirectory(path).then((result) => {
+      this.isLoading = false
+      if (result.error) {
+        this.errorMessage = result.error
+      }
+      this.files = result.files
+      this.currentPath = path
+    }).catch(() => {
+      this.isLoading = false
+      this.errorMessage = '加载目录失败'
+    })
+  }
+
+  // ── 构造 SMB 播放 URL（内嵌凭据供播放器使用）──────────────────────────────
+
+  private buildPlaybackUrl(filePath: string): string {
+    const host = this.config.host
+    const port = this.config.port ?? 445
+    const username = encodeURIComponent(this.config.username)
+    const password = encodeURIComponent(this.config.password)
+
+    // filePath 格式：/<shareName>/sub/path/file.mkv
+    let normalized = filePath
+    if (!normalized.startsWith('/')) {
+      normalized = '/' + normalized
+    }
+
+    return `smb://${username}:${password}@${host}:${port}${normalized}`
+  }
+
+  // ── 文件点击处理 ────────────────────────────────────────────────────────────
+
+  private handleFileClick(file: SmbFileInfo): void {
+    if (file.isDirectory) {
+      this.loadDirectory(file.path)
+    } else if (this.isVideoFile(file.name)) {
+      this.playVideo(file)
+    }
+  }
+
+  private playVideo(file: SmbFileInfo): void {
+    const url = this.buildPlaybackUrl(file.path)
+    const pageParam: PlayerPageParam = {
+      url: url,
+      title: file.name
+    }
+    this.pageStack.pushPath({
+      name: PlayerPage.PAGE_NAME,
+      param: pageParam
+    })
+  }
+
+  // ── 返回导航 ────────────────────────────────────────────────────────────────
+
+  private handleBack(): boolean {
+    if (this.currentPath === '/') {
+      this.pageStack.pop(true)
+      return true
+    }
+    const lastSlash = this.currentPath.lastIndexOf('/')
+    const parentPath = lastSlash > 0 ? this.currentPath.substring(0, lastSlash) : '/'
+    this.loadDirectory(parentPath)
+    return true
+  }
+
+  // ── 格式化辅助 ──────────────────────────────────────────────────────────────
+
+  private formatFileSize(bytes: number): string {
+    if (bytes <= 0) {
+      return '-'
+    }
+    if (bytes < 1024) {
+      return `${bytes} B`
+    } else if (bytes < 1024 * 1024) {
+      return `${(bytes / 1024).toFixed(1)} KB`
+    } else if (bytes < 1024 * 1024 * 1024) {
+      return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+    }
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+  }
+
+  private formatDate(ms: number): string {
+    if (ms <= 0) {
+      return '-'
+    }
+    const d = new Date(ms)
+    const y = d.getFullYear()
+    const mo = String(d.getMonth() + 1).padStart(2, '0')
+    const day = String(d.getDate()).padStart(2, '0')
+    return `${y}-${mo}-${day}`
+  }
+
+  private getFileIcon(file: SmbFileInfo): string {
+    if (file.isDirectory) {
+      return '📁'
+    }
+    const name = file.name.toLowerCase()
+    if (this.isVideoFile(name)) {
+      return '🎬'
+    }
+    if (this.isAudioFile(name)) {
+      return '🎵'
+    }
+    if (this.isImageFile(name)) {
+      return '🖼️'
+    }
+    return '📄'
+  }
+
+  private isVideoFile(name: string): boolean {
+    const exts = ['.mp4', '.avi', '.mkv', '.mov', '.wmv', '.flv', '.webm', '.m4v', '.ts', '.m2ts']
+    const lower = name.toLowerCase()
+    return exts.some(ext => lower.endsWith(ext))
+  }
+
+  private isAudioFile(name: string): boolean {
+    const exts = ['.mp3', '.flac', '.aac', '.ogg', '.wav', '.m4a']
+    const lower = name.toLowerCase()
+    return exts.some(ext => lower.endsWith(ext))
+  }
+
+  private isImageFile(name: string): boolean {
+    const exts = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp']
+    const lower = name.toLowerCase()
+    return exts.some(ext => lower.endsWith(ext))
+  }
+
+  // ── UI ──────────────────────────────────────────────────────────────────────
+
+  build() {
+    NavDestination() {
+      Column() {
+        // ── 标题栏 ────────────────────────────────────────────────────────────
+        Row() {
+          Text('SMB 文件浏览器')
+            .fontSize(18)
+            .fontWeight(FontWeight.Bold)
+            .fontColor(this.COLORS.primaryText)
+            .layoutWeight(1)
+
+          if (this.isLoading) {
+            LoadingProgress()
+              .width(24)
+              .height(24)
+              .color(this.COLORS.accent)
+          }
+        }
+        .width('100%')
+        .padding({ left: 16, right: 16, top: 12, bottom: 12 })
+        .backgroundColor(this.COLORS.surface)
+
+        // ── 路径面包屑 ────────────────────────────────────────────────────────
+        Scroll() {
+          Row() {
+            ForEach(this.pathItems, (item: PathItem, index: number) => {
+              Row() {
+                Text(item.name)
+                  .fontSize(14)
+                  .fontColor(index === this.pathItems.length - 1
+                    ? this.COLORS.primaryText
+                    : this.COLORS.accent)
+                  .fontWeight(index === this.pathItems.length - 1
+                    ? FontWeight.Bold
+                    : FontWeight.Normal)
+                  .onClick(() => {
+                    if (index !== this.pathItems.length - 1) {
+                      this.loadDirectory(item.path)
+                    }
+                  })
+
+                if (index < this.pathItems.length - 1) {
+                  Text(' / ')
+                    .fontSize(14)
+                    .fontColor(this.COLORS.tertiaryText)
+                    .margin({ left: 4, right: 4 })
+                }
+              }
+            }, (item: PathItem) => item.path)
+          }
+          .padding({ left: 16, right: 16 })
+        }
+        .scrollable(ScrollDirection.Horizontal)
+        .scrollBar(BarState.Off)
+        .width('100%')
+        .height(40)
+        .backgroundColor(this.COLORS.surfaceVariant)
+
+        Divider()
+          .color(this.COLORS.divider)
+
+        // ── 排序栏头 ──────────────────────────────────────────────────────────
+        Row() {
+          Text('名称')
+            .fontSize(13)
+            .fontColor(this.COLORS.tertiaryText)
+            .layoutWeight(3)
+
+          Text('大小')
+            .fontSize(13)
+            .fontColor(this.COLORS.tertiaryText)
+            .layoutWeight(2)
+            .textAlign(TextAlign.End)
+
+          Text('修改日期')
+            .fontSize(13)
+            .fontColor(this.COLORS.tertiaryText)
+            .layoutWeight(2)
+            .textAlign(TextAlign.End)
+        }
+        .width('100%')
+        .padding({ left: 16, right: 16, top: 8, bottom: 8 })
+        .backgroundColor(this.COLORS.surface)
+
+        Divider()
+          .color(this.COLORS.divider)
+
+        // ── 错误提示 ──────────────────────────────────────────────────────────
+        if (this.errorMessage.length > 0) {
+          Row() {
+            Text('⚠️  ' + this.errorMessage)
+              .fontSize(14)
+              .fontColor('#FF6B6B')
+              .padding({ left: 16, right: 16, top: 8, bottom: 8 })
+          }
+          .width('100%')
+          .backgroundColor(this.COLORS.surface)
+        }
+
+        // ── 文件列表 ──────────────────────────────────────────────────────────
+        if (this.files.length === 0 && !this.isLoading) {
+          Column() {
+            Text('📂')
+              .fontSize(48)
+              .margin({ bottom: 12 })
+
+            Text('此文件夹为空')
+              .fontSize(16)
+              .fontColor(this.COLORS.tertiaryText)
+          }
+          .width('100%')
+          .layoutWeight(1)
+          .justifyContent(FlexAlign.Center)
+          .backgroundColor(this.COLORS.background)
+        } else {
+          List({ space: 0 }) {
+            ForEach(this.files, (file: SmbFileInfo, index: number) => {
+              ListItem() {
+                Row() {
+                  // 图标 + 文件名
+                  Row({ space: 12 }) {
+                    Text(this.getFileIcon(file))
+                      .fontSize(20)
+
+                    Column() {
+                      Text(file.name)
+                        .fontSize(15)
+                        .maxLines(1)
+                        .textOverflow({ overflow: TextOverflow.MARQUEE })
+                        .fontColor(file.isDirectory
+                          ? this.COLORS.accent
+                          : this.COLORS.primaryText)
+                        .width('100%')
+                    }
+                    .alignItems(HorizontalAlign.Start)
+                    .layoutWeight(1)
+                  }
+                  .layoutWeight(3)
+                  .alignItems(VerticalAlign.Center)
+
+                  // 大小
+                  Text(file.isDirectory ? '-' : this.formatFileSize(file.size))
+                    .fontSize(13)
+                    .fontColor(this.COLORS.tertiaryText)
+                    .layoutWeight(2)
+                    .textAlign(TextAlign.End)
+                    .maxLines(1)
+
+                  // 修改日期
+                  Text(this.formatDate(file.lastModifiedMs))
+                    .fontSize(13)
+                    .fontColor(this.COLORS.tertiaryText)
+                    .layoutWeight(2)
+                    .textAlign(TextAlign.End)
+                    .maxLines(1)
+                }
+                .width('100%')
+                .padding({ left: 16, right: 16, top: 12, bottom: 12 })
+                .backgroundColor(index % 2 === 0
+                  ? this.COLORS.background
+                  : this.COLORS.surface)
+              }
+              .onClick(() => {
+                this.handleFileClick(file)
+              })
+            }, (file: SmbFileInfo) => file.path)
+          }
+          .width('100%')
+          .layoutWeight(1)
+          .backgroundColor(this.COLORS.background)
+          .divider({
+            strokeWidth: 0.5,
+            color: this.COLORS.divider,
+            startMargin: 16,
+            endMargin: 16
+          })
+        }
+      }
+      .width('100%')
+      .height('100%')
+      .backgroundColor(this.COLORS.background)
+    }
+    .onReady((context) => {
+      const param = context.pathInfo.param as SmbFileExplorerPageParam
+      this.config = param.config
+      this.client = SMBClient.fromSourceConfig(param.config)
+      const startPath = param.initialPath ?? '/'
+      this.loadDirectory(startPath)
+    })
+    .onBackPressed(() => {
+      return this.handleBack()
+    })
+    .mode(NavDestinationMode.DIALOG)
+    .hideTitleBar(true)
+  }
+}

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -93,18 +93,23 @@ export struct SmbFileExplorerPage {
   // ── 列举目录 ────────────────────────────────────────────────────────────────
 
   private loadDirectory(path: string): void {
+    console.info('[SmbExplorer] loadDirectory path=' + path)
     this.isLoading = true
     this.errorMessage = ''
     this.client.listDirectory(path).then((result) => {
       this.isLoading = false
       if (result.error) {
+        console.error('[SmbExplorer] listDirectory error path=' + path + ' err=' + result.error)
         this.errorMessage = result.error
+      } else {
+        console.info('[SmbExplorer] listDirectory ok path=' + path + ' count=' + result.files.length.toString())
       }
       this.files = result.files
       this.currentPath = path
     }).catch(() => {
       this.isLoading = false
       this.errorMessage = '加载目录失败'
+      console.error('[SmbExplorer] listDirectory catch path=' + path)
     })
   }
 

--- a/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
@@ -1,4 +1,5 @@
 import { LengthMetrics } from "@kit.ArkUI"
+import { BusinessError } from '@kit.BasicServicesKit'
 import { WebDAVConfig } from "../../../lib/WebDAVClient"
 import { FileExplorerPage } from "../../files"
 import { SmbFileExplorerPage, SmbFileExplorerPageParam } from "../../files/SmbFileExplorerPage"
@@ -65,7 +66,8 @@ export struct FileSourceTab {
         message: '刷新成功'
       } as promptAction.ShowToastOptions)
     } catch (error) {
-      console.error('FileSourceTab: Refresh failed', JSON.stringify(error))
+      const err = error as BusinessError
+      console.error('FileSourceTab', `刷新失败: code=${err.code} msg=${err.message}`)
     }
   }
 
@@ -109,7 +111,8 @@ export struct FileSourceTab {
         timeout: 10000
       }
     } catch (error) {
-      console.error('FileSourceTab: Failed to build WebDAV config', JSON.stringify(error))
+      const err = error as BusinessError
+      console.error('FileSourceTab', `构造 WebDAV 配置失败: code=${err.code} msg=${err.message}`)
       return null
     }
   }
@@ -138,7 +141,11 @@ export struct FileSourceTab {
           param: param
         }, false)
       } catch (e) {
-        console.error('FileSourceTab: 解析 SMB 配置失败', JSON.stringify(e))
+        const err = e as BusinessError
+        console.error('FileSourceTab', `解析 SMB 配置失败: code=${err.code} msg=${err.message}`)
+        this.getUIContext().getPromptAction().showToast({
+          message: '解析 SMB 配置失败'
+        } as promptAction.ShowToastOptions)
       }
     } else {
       console.warn('FileSourceTab: Unsupported file source type', item.fileSource.type)

--- a/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
@@ -1,8 +1,9 @@
 import { LengthMetrics } from "@kit.ArkUI"
 import { WebDAVConfig } from "../../../lib/WebDAVClient"
 import { FileExplorerPage } from "../../files"
+import { SmbFileExplorerPage, SmbFileExplorerPageParam } from "../../files/SmbFileExplorerPage"
 import promptAction from '@ohos.promptAction'
-import { FileSource, FileSourceType, WebDAVSourceConfig } from "../../../db/models/FileSourceEntity"
+import { FileSource, FileSourceType, WebDAVSourceConfig, SMBSourceConfig } from "../../../db/models/FileSourceEntity"
 import { FileSourceStore } from "../../../stores/files/FileSourceStore"
 import { DirectoryItem, FileSourceModel } from "../../../stores/files/FileSourceModel"
 import { FileSourceDatabase } from "../../../db/files/FileSourceDatabase"
@@ -124,6 +125,20 @@ export struct FileSourceTab {
           name: FileExplorerPage.PAGE_NAME,
           param: config as WebDAVConfig
         }, false)
+      }
+    } else if (item.fileSource.type === FileSourceType.SMB) {
+      try {
+        const smbConfig = JSON.parse(item.fileSource.configJson) as SMBSourceConfig
+        const param: SmbFileExplorerPageParam = {
+          config: smbConfig,
+          initialPath: item.directoryPath && item.directoryPath !== '/' ? item.directoryPath : '/'
+        }
+        this.pageStack.pushPath({
+          name: SmbFileExplorerPage.PAGE_NAME,
+          param: param
+        }, false)
+      } catch (e) {
+        console.error('FileSourceTab: 解析 SMB 配置失败', JSON.stringify(e))
       }
     } else {
       console.warn('FileSourceTab: Unsupported file source type', item.fileSource.type)

--- a/entry/src/main/ets/pages/settings/Index.ets
+++ b/entry/src/main/ets/pages/settings/Index.ets
@@ -6,6 +6,7 @@ import { VideoServerSettingBuilder } from "./builders/VideoServerSettingBuilder"
 import { WebDAVConfigBuilder } from "./builders/WebDAVConfigBuilder"
 import { SMBConfigBuilder } from "./builders/SMBConfigBuilder"
 import { DirectorySelectorBuilder } from "./builders/DirectorySelectorBuilder"
+import { SmbDirectorySelectorBuilder } from "./builders/SmbDirectorySelectorBuilder"
 import { SettingsController } from "./SettingsController"
 import SettingType from "./SettingType"
 
@@ -55,6 +56,9 @@ export struct SettingsPage {
             }
             if (this.controller.type === SettingType.DIRECTORY_SELECTOR) {
               DirectorySelectorBuilder()
+            }
+            if (this.controller.type === SettingType.SMB_DIRECTORY_SELECTOR) {
+              SmbDirectorySelectorBuilder()
             }
             if (this.controller.type === SettingType.VIDEO_SERVER) {
               VideoServerSettingBuilder()

--- a/entry/src/main/ets/pages/settings/SettingType.ets
+++ b/entry/src/main/ets/pages/settings/SettingType.ets
@@ -7,6 +7,5 @@ export default class SettingType {
   static WEBDAV_CONFIG = "webdavConfig" // WebDAV 配置
   static SMB_CONFIG = "smbConfig" // SMB 配置
   static DIRECTORY_SELECTOR = "directorySelector" // WebDAV 文件夹选择器
-  static SMB_DIRECTORY_SELECTOR = "smbDirectorySelector" // SMB 文件夹选择器（WebDAV）
   static SMB_DIRECTORY_SELECTOR = "smbDirectorySelector" // SMB 文件夹选择器
 }

--- a/entry/src/main/ets/pages/settings/SettingType.ets
+++ b/entry/src/main/ets/pages/settings/SettingType.ets
@@ -6,5 +6,7 @@ export default class SettingType {
   static ADD_FILE_SOURCE = "addFileSource" // 添加文件源
   static WEBDAV_CONFIG = "webdavConfig" // WebDAV 配置
   static SMB_CONFIG = "smbConfig" // SMB 配置
-  static DIRECTORY_SELECTOR = "directorySelector" // 文件夹选择器
+  static DIRECTORY_SELECTOR = "directorySelector" // WebDAV 文件夹选择器
+  static SMB_DIRECTORY_SELECTOR = "smbDirectorySelector" // SMB 文件夹选择器（WebDAV）
+  static SMB_DIRECTORY_SELECTOR = "smbDirectorySelector" // SMB 文件夹选择器
 }

--- a/entry/src/main/ets/pages/settings/builders/FileSourceSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/FileSourceSettingBuilder.ets
@@ -15,12 +15,14 @@ import {
 } from "./IconBuilders";
 import promptAction from '@ohos.promptAction';
 import { FileSourceStore } from "../../../stores/files/FileSourceStore";
-import { FileSource, FileSourceType, WebDAVSourceConfig } from "../../../db/models/FileSourceEntity";
+import { FileSource, FileSourceType, WebDAVSourceConfig, SMBSourceConfig } from "../../../db/models/FileSourceEntity"
+import { SmbFileExplorerPage, SmbFileExplorerPageParam } from "../../files/SmbFileExplorerPage";
 import { FileSourceModel } from "../../../stores/files/FileSourceModel";
 
 @ComponentV2
 struct FileSourceSettingBuilderComponent {
   @Consumer('settingsController') controller: SettingsController = new SettingsController()
+  @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack()
   @Local fileSourceModel: FileSourceModel = FileSourceStore.getState()
   @Local isLoading: boolean = false
 
@@ -190,6 +192,23 @@ struct FileSourceSettingBuilderComponent {
         console.error('FileSourceSettingBuilder: Failed to parse config', JSON.stringify(error))
         promptAction.showToast({
           message: '解析配置失败'
+        } as promptAction.ShowToastOptions)
+      }
+    } else if (fileSource.type === FileSourceType.SMB) {
+      try {
+        const config = JSON.parse(fileSource.configJson) as SMBSourceConfig
+        const param: SmbFileExplorerPageParam = {
+          config: config,
+          initialPath: '/'
+        }
+        this.pageStack.pushPath({
+          name: SmbFileExplorerPage.PAGE_NAME,
+          param: param
+        })
+      } catch (e) {
+        console.error('FileSourceSettingBuilder: Failed to parse SMB config', JSON.stringify(e))
+        promptAction.showToast({
+          message: '解析 SMB 配置失败'
         } as promptAction.ShowToastOptions)
       }
     } else {

--- a/entry/src/main/ets/pages/settings/builders/FileSourceSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/FileSourceSettingBuilder.ets
@@ -16,13 +16,11 @@ import {
 import promptAction from '@ohos.promptAction';
 import { FileSourceStore } from "../../../stores/files/FileSourceStore";
 import { FileSource, FileSourceType, WebDAVSourceConfig, SMBSourceConfig } from "../../../db/models/FileSourceEntity"
-import { SmbFileExplorerPage, SmbFileExplorerPageParam } from "../../files/SmbFileExplorerPage";
 import { FileSourceModel } from "../../../stores/files/FileSourceModel";
 
 @ComponentV2
 struct FileSourceSettingBuilderComponent {
   @Consumer('settingsController') controller: SettingsController = new SettingsController()
-  @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack()
   @Local fileSourceModel: FileSourceModel = FileSourceStore.getState()
   @Local isLoading: boolean = false
 
@@ -196,14 +194,14 @@ struct FileSourceSettingBuilderComponent {
     } else if (fileSource.type === FileSourceType.SMB) {
       try {
         const config = JSON.parse(fileSource.configJson) as SMBSourceConfig
-        const param: SmbFileExplorerPageParam = {
-          config: config,
-          initialPath: '/'
-        }
-        this.pageStack.pushPath({
-          name: SmbFileExplorerPage.PAGE_NAME,
-          param: param
-        })
+        const params: ESObject = {}
+        params['sourceId'] = fileSource.id as Object
+        params['host'] = config.host as Object
+        params['username'] = config.username as Object
+        params['password'] = (config.password ?? '') as Object
+        params['port'] = (config.port ?? 445) as Object
+        params['domain'] = (config.domain ?? '') as Object
+        this.controller.pushType(SettingType.SMB_DIRECTORY_SELECTOR, params as Record<string, Object>)
       } catch (e) {
         console.error('FileSourceSettingBuilder: Failed to parse SMB config', JSON.stringify(e))
         promptAction.showToast({

--- a/entry/src/main/ets/pages/settings/builders/FileSourceSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/FileSourceSettingBuilder.ets
@@ -147,7 +147,6 @@ struct FileSourceSettingBuilderComponent {
       return
     }
 
-    // 目前只支持 WebDAV 类型
     if (fileSource.type === FileSourceType.WEBDAV) {
       try {
         // 解析配置

--- a/entry/src/main/ets/pages/settings/builders/SmbDirectorySelectorBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/SmbDirectorySelectorBuilder.ets
@@ -1,6 +1,6 @@
 import { SettingContainer } from "../SettingContainer"
 import { SettingsController } from "../SettingsController"
-import { SMBClient, SmbFileInfo } from "../../../lib/SMBClient"
+import { SMBClient, SmbFileInfo, SMBClientConfig } from "../../../lib/SMBClient"
 import promptAction from '@ohos.promptAction'
 import { FileSourceDatabase } from "../../../db/files/FileSourceDatabase"
 import { FileSourceDirectory } from "../../../db/models/FileSourceEntity"
@@ -68,7 +68,15 @@ struct SmbDirectorySelectorBuilderComponent {
         return
       }
 
-      this.smbClient = new SMBClient(host, port, username, password, domain, 10000)
+      const clientConfig: SMBClientConfig = {
+        host: host,
+        port: port,
+        username: username,
+        password: password,
+        domain: domain,
+        timeoutMs: 10000
+      }
+      this.smbClient = new SMBClient(clientConfig)
       await this.loadSelectedDirectories()
       await this.loadCurrentDirectory()
     } catch (e) {

--- a/entry/src/main/ets/pages/settings/builders/SmbDirectorySelectorBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/SmbDirectorySelectorBuilder.ets
@@ -38,6 +38,7 @@ struct SmbDirectorySelectorBuilderComponent {
   private sourceId: number = 0
   private smbClient: SMBClient | null = null
   private previousSelectedMap: Map<string, string> = new Map()
+  private directoryLoadSeq: number = 0
   private uncheckedMap: Map<string, string> = new Map()
 
   aboutToAppear(): void {
@@ -109,11 +110,16 @@ struct SmbDirectorySelectorBuilderComponent {
       this.errorMessage = 'SMB 客户端未初始化'
       return
     }
+    const seq = ++this.directoryLoadSeq
+    const requestPath = this.currentPath
     this.isLoading = true
     this.errorMessage = ''
     try {
-      console.info('[SmbDirSelector] 加载目录:', this.currentPath)
-      const result = await this.smbClient.listDirectory(this.currentPath)
+      console.info('[SmbDirSelector] 加载目录:', requestPath)
+      const result = await this.smbClient.listDirectory(requestPath)
+      if (seq !== this.directoryLoadSeq || requestPath !== this.currentPath) {
+        return
+      }
       if (result.error && result.files.length === 0) {
         this.errorMessage = result.error
       } else {
@@ -127,12 +133,17 @@ struct SmbDirectorySelectorBuilderComponent {
       }
       console.info(`[SmbDirSelector] 找到 ${this.directories.length} 个文件夹`)
     } catch (e) {
+      if (seq !== this.directoryLoadSeq) {
+        return
+      }
       const err = e as BusinessError
       const errMsg = err.message ?? String(e)
       console.error('[SmbDirSelector] 加载目录失败', errMsg)
       this.errorMessage = errMsg
     } finally {
-      this.isLoading = false
+      if (seq === this.directoryLoadSeq) {
+        this.isLoading = false
+      }
     }
   }
 
@@ -194,7 +205,6 @@ struct SmbDirectorySelectorBuilderComponent {
     this.isSaving = true
     try {
       const database = FileSourceDatabase.getInstance()
-      await database.deleteDirectoriesBySourceId(this.sourceId)
       const dirEntries: FileSourceDirectory[] = []
       this.selectedMap.forEach((customName: string, path: string) => {
         const entry: FileSourceDirectory = {
@@ -204,7 +214,7 @@ struct SmbDirectorySelectorBuilderComponent {
         }
         dirEntries.push(entry)
       })
-      await database.insertDirectories(this.sourceId, dirEntries)
+      await database.saveDirectoriesForSource(this.sourceId, dirEntries)
       await this.fileSourceModel.loadFileSources(true)
       this.uncheckedMap.clear()
       console.info(`[SmbDirSelector] 保存 ${dirEntries.length} 个目录`)
@@ -288,7 +298,7 @@ struct SmbDirectorySelectorBuilderComponent {
       this.isAllSelected = false
     } else {
       this.previousSelectedMap = new Map(this.selectedMap)
-      this.selectedMap = new Map([[' /', '']])
+      this.selectedMap = new Map([['/', '']])
       this.isAllSelected = true
     }
   }

--- a/entry/src/main/ets/pages/settings/builders/SmbDirectorySelectorBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/SmbDirectorySelectorBuilder.ets
@@ -1,0 +1,534 @@
+import { SettingContainer } from "../SettingContainer"
+import { SettingsController } from "../SettingsController"
+import { SMBClient, SmbFileInfo } from "../../../lib/SMBClient"
+import promptAction from '@ohos.promptAction'
+import { FileSourceDatabase } from "../../../db/files/FileSourceDatabase"
+import { FileSourceDirectory } from "../../../db/models/FileSourceEntity"
+import { FileSourceModel } from "../../../stores/files/FileSourceModel"
+import { FileSourceStore } from "../../../stores/files/FileSourceStore"
+import { BusinessError } from '@kit.BasicServicesKit'
+
+interface BreadcrumbItem {
+  name: string
+  path: string
+}
+
+@ComponentV2
+struct SmbDirectorySelectorBuilderComponent {
+  @Consumer('settingsController') controller: SettingsController = new SettingsController()
+
+  @Local directories: SmbFileInfo[] = []
+  @Local isLoading: boolean = false
+  @Local isSaving: boolean = false
+  @Local errorMessage: string = ''
+  @Local currentPath: string = '/'
+  // path -> customName（空字符串表示使用默认名）
+  @Local selectedMap: Map<string, string> = new Map()
+  @Local isAllSelected: boolean = false
+  fileSourceModel: FileSourceModel = FileSourceStore.getState()
+
+  // 命名弹窗状态
+  @Local showNameDialog: boolean = false
+  @Local pendingPath: string = ''
+  @Local pendingDefaultName: string = ''
+  @Local inputCustomName: string = ''
+  private nameInputController: TextInputController = new TextInputController()
+
+  private pathHistory: string[] = ['/']
+  private sourceId: number = 0
+  private smbClient: SMBClient | null = null
+  private previousSelectedMap: Map<string, string> = new Map()
+  private uncheckedMap: Map<string, string> = new Map()
+
+  aboutToAppear(): void {
+    this.controller.setBackHandler(() => this.handleBackPressed())
+    this.initializeSelector()
+  }
+
+  aboutToDisappear(): void {
+    this.controller.setBackHandler(null)
+  }
+
+  private async initializeSelector(): Promise<void> {
+    try {
+      const params = this.controller.params
+      if (!params) {
+        this.errorMessage = '缺少必要参数'
+        return
+      }
+      this.sourceId = params['sourceId'] as number
+      const host = params['host'] as string
+      const username = params['username'] as string
+      const password = params['password'] as string
+      const port = (params['port'] as number) || 445
+      const domain = (params['domain'] as string) || ''
+
+      if (!this.sourceId || !host) {
+        this.errorMessage = '配置参数不完整'
+        return
+      }
+
+      this.smbClient = new SMBClient(host, port, username, password, domain, 10000)
+      await this.loadSelectedDirectories()
+      await this.loadCurrentDirectory()
+    } catch (e) {
+      const err = e as BusinessError
+      const errMsg = err.message ?? String(e)
+      console.error('[SmbDirSelector] 初始化失败', errMsg)
+      this.errorMessage = '初始化失败：' + errMsg
+    }
+  }
+
+  private async loadSelectedDirectories(): Promise<void> {
+    try {
+      const database = FileSourceDatabase.getInstance()
+      const dirs = await database.getDirectoriesBySourceId(this.sourceId)
+      dirs.forEach((dir: FileSourceDirectory) => {
+        this.selectedMap.set(dir.directoryPath, dir.customName ?? '')
+      })
+      if (this.selectedMap.has('/') && this.selectedMap.size === 1) {
+        this.isAllSelected = true
+      }
+      console.info(`[SmbDirSelector] 已加载 ${this.selectedMap.size} 个已选目录`)
+    } catch (e) {
+      const err = e as BusinessError
+      console.error('[SmbDirSelector] 加载已选目录失败', err.message ?? String(e))
+    }
+  }
+
+  private async loadCurrentDirectory(): Promise<void> {
+    if (!this.smbClient) {
+      this.errorMessage = 'SMB 客户端未初始化'
+      return
+    }
+    this.isLoading = true
+    this.errorMessage = ''
+    try {
+      console.info('[SmbDirSelector] 加载目录:', this.currentPath)
+      const result = await this.smbClient.listDirectory(this.currentPath)
+      if (result.error && result.files.length === 0) {
+        this.errorMessage = result.error
+      } else {
+        this.directories = result.files.filter((item: SmbFileInfo) => item.isDirectory)
+        if (this.directories.length === 0 && !result.error) {
+          this.errorMessage = '此目录下没有文件夹'
+        }
+        if (result.error) {
+          console.warn('[SmbDirSelector] 部分错误:', result.error)
+        }
+      }
+      console.info(`[SmbDirSelector] 找到 ${this.directories.length} 个文件夹`)
+    } catch (e) {
+      const err = e as BusinessError
+      const errMsg = err.message ?? String(e)
+      console.error('[SmbDirSelector] 加载目录失败', errMsg)
+      this.errorMessage = errMsg
+    } finally {
+      this.isLoading = false
+    }
+  }
+
+  private handleEnterDirectory(directory: SmbFileInfo): void {
+    this.pathHistory.push(this.currentPath)
+    this.currentPath = directory.path
+    console.info('[SmbDirSelector] 进入目录:', this.currentPath)
+    this.loadCurrentDirectory()
+  }
+
+  private handleGoBack(): void {
+    if (this.pathHistory.length <= 1) {
+      return
+    }
+    const previousPath = this.pathHistory.pop()
+    if (previousPath) {
+      this.currentPath = previousPath
+      console.info('[SmbDirSelector] 返回:', this.currentPath)
+      this.loadCurrentDirectory()
+    }
+  }
+
+  private handleCheckboxChange(directory: SmbFileInfo): void {
+    const path = directory.path
+    if (this.selectedMap.has(path)) {
+      const savedName = this.selectedMap.get(path) ?? ''
+      this.uncheckedMap.set(path, savedName)
+      this.selectedMap.delete(path)
+      this.selectedMap = new Map(this.selectedMap)
+    } else {
+      this.pendingPath = path
+      this.pendingDefaultName = directory.name
+      this.inputCustomName = this.uncheckedMap.get(path) ?? directory.name
+      this.showNameDialog = true
+    }
+  }
+
+  private confirmNameDialog(): void {
+    const finalName = this.inputCustomName.trim().length > 0
+      ? this.inputCustomName.trim()
+      : this.pendingDefaultName
+    this.selectedMap.set(this.pendingPath, finalName)
+    this.selectedMap = new Map(this.selectedMap)
+    this.uncheckedMap.delete(this.pendingPath)
+    this.showNameDialog = false
+  }
+
+  private cancelNameDialog(): void {
+    this.showNameDialog = false
+    this.pendingPath = ''
+    this.inputCustomName = ''
+  }
+
+  private isSelected(directory: SmbFileInfo): boolean {
+    return this.selectedMap.has(directory.path)
+  }
+
+  private async handleComplete(): Promise<void> {
+    this.isSaving = true
+    try {
+      const database = FileSourceDatabase.getInstance()
+      await database.deleteDirectoriesBySourceId(this.sourceId)
+      const dirEntries: FileSourceDirectory[] = []
+      this.selectedMap.forEach((customName: string, path: string) => {
+        const entry: FileSourceDirectory = {
+          sourceId: this.sourceId,
+          directoryPath: path,
+          customName: customName.length > 0 ? customName : undefined
+        }
+        dirEntries.push(entry)
+      })
+      await database.insertDirectories(this.sourceId, dirEntries)
+      await this.fileSourceModel.loadFileSources(true)
+      this.uncheckedMap.clear()
+      console.info(`[SmbDirSelector] 保存 ${dirEntries.length} 个目录`)
+      this.getUIContext().getPromptAction().showToast({
+        message: '保存成功'
+      } as promptAction.ShowToastOptions)
+      this.controller.popType()
+    } catch (e) {
+      const err = e as BusinessError
+      const errMsg = err.message ?? String(e)
+      console.error('[SmbDirSelector] 保存失败', errMsg)
+      AlertDialog.show({
+        title: '保存失败',
+        message: '保存目录选择失败：' + errMsg,
+        primaryButton: {
+          value: '确定',
+          action: () => {}
+        }
+      })
+    } finally {
+      this.isSaving = false
+    }
+  }
+
+  private handleCancel(): void {
+    if (this.pathHistory.length > 1) {
+      this.handleGoBack()
+    } else {
+      this.controller.popType()
+    }
+  }
+
+  private handleBackPressed(): boolean {
+    if (this.pathHistory.length > 1) {
+      this.handleGoBack()
+      return true
+    }
+    return false
+  }
+
+  private getBreadcrumbs(): BreadcrumbItem[] {
+    const breadcrumbs: BreadcrumbItem[] = []
+    const rootItem: BreadcrumbItem = { name: '共享列表', path: '/' }
+    breadcrumbs.push(rootItem)
+    if (this.currentPath !== '/') {
+      const segments = this.currentPath.split('/').filter((seg: string) => seg.length > 0)
+      let accumulatedPath = ''
+      segments.forEach((segment: string) => {
+        accumulatedPath += '/' + segment
+        const item: BreadcrumbItem = { name: segment, path: accumulatedPath }
+        breadcrumbs.push(item)
+      })
+    }
+    return breadcrumbs
+  }
+
+  private handleBreadcrumbClick(targetPath: string): void {
+    if (targetPath === this.currentPath) {
+      return
+    }
+    const targetIndex = this.pathHistory.indexOf(targetPath)
+    if (targetIndex !== -1) {
+      this.pathHistory = this.pathHistory.slice(0, targetIndex + 1)
+    } else {
+      const segments = targetPath.split('/').filter((seg: string) => seg.length > 0)
+      this.pathHistory = ['/']
+      let accumulatedPath = ''
+      segments.forEach((segment: string) => {
+        accumulatedPath += '/' + segment
+        this.pathHistory.push(accumulatedPath)
+      })
+    }
+    this.currentPath = targetPath
+    console.info('[SmbDirSelector] 面包屑跳转:', targetPath)
+    this.loadCurrentDirectory()
+  }
+
+  private handleSelectAll(): void {
+    if (this.isAllSelected) {
+      this.selectedMap = new Map(this.previousSelectedMap)
+      this.isAllSelected = false
+    } else {
+      this.previousSelectedMap = new Map(this.selectedMap)
+      this.selectedMap = new Map([[' /', '']])
+      this.isAllSelected = true
+    }
+  }
+
+  private getCustomName(directory: SmbFileInfo): string {
+    return this.selectedMap.get(directory.path) ?? ''
+  }
+
+  private hasCustomName(directory: SmbFileInfo): boolean {
+    return this.getCustomName(directory).length > 0
+  }
+
+  build() {
+    Stack() {
+      SettingContainer({ title: "选择文件夹" }) {
+        Column() {
+          // 顶部导航区
+          Column() {
+            if (this.pathHistory.length > 1) {
+              Row() {
+                Button("← 返回")
+                  .fontSize(14)
+                  .height(32)
+                  .backgroundColor($r('sys.color.ohos_id_color_button_normal'))
+                  .fontColor($r('sys.color.ohos_id_color_text_primary_contrary'))
+                  .onClick(() => this.handleGoBack())
+                  .enabled(!this.isLoading && !this.isSaving)
+              }
+              .width('100%')
+              .margin({ bottom: 8 })
+            }
+
+            // 面包屑导航
+            Scroll() {
+              Row({ space: 4 }) {
+                ForEach(this.getBreadcrumbs(), (breadcrumb: BreadcrumbItem, index: number) => {
+                  Row({ space: 4 }) {
+                    Text(breadcrumb.name)
+                      .fontSize(14)
+                      .fontColor(breadcrumb.path === this.currentPath ?
+                        $r('sys.color.ohos_id_color_emphasize') :
+                        $r('sys.color.ohos_id_color_text_secondary'))
+                      .fontWeight(breadcrumb.path === this.currentPath ? FontWeight.Medium : FontWeight.Normal)
+                      .padding({ left: 8, right: 8, top: 4, bottom: 4 })
+                      .borderRadius(4)
+                      .backgroundColor(breadcrumb.path === this.currentPath ?
+                        $r('sys.color.ohos_id_color_click_effect') :
+                        Color.Transparent)
+                      .onClick(() => {
+                        if (!this.isLoading && !this.isSaving) {
+                          this.handleBreadcrumbClick(breadcrumb.path)
+                        }
+                      })
+                      .enabled(!this.isLoading && !this.isSaving)
+
+                    if (index < this.getBreadcrumbs().length - 1) {
+                      Text('/')
+                        .fontSize(14)
+                        .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                    }
+                  }
+                }, (breadcrumb: BreadcrumbItem) => breadcrumb.path)
+              }
+              .padding({ left: 4, right: 4 })
+            }
+            .width('100%')
+            .scrollable(ScrollDirection.Horizontal)
+            .scrollBar(BarState.Off)
+          }
+          .width('100%')
+          .padding(12)
+          .backgroundColor($r('sys.color.ohos_id_color_background'))
+
+          // 内容区
+          Column() {
+            if (this.isLoading) {
+              Row() {
+                LoadingProgress()
+                  .width(30).height(30)
+                  .color($r('sys.color.ohos_id_color_emphasize'))
+              }
+              .width('100%').padding({ top: 40 })
+              .justifyContent(FlexAlign.Center)
+            } else if (this.errorMessage.length > 0) {
+              Row() {
+                Text(this.errorMessage)
+                  .fontSize(14)
+                  .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+              }
+              .width('100%').padding({ top: 40 })
+              .justifyContent(FlexAlign.Center)
+            } else {
+              Scroll() {
+                Column({ space: 0 }) {
+                  // 全部文件夹选项
+                  Row() {
+                    Text('📂').fontSize(24).margin({ right: 12 })
+                    Text('全部文件夹')
+                      .fontSize(16)
+                      .fontColor($r('sys.color.ohos_id_color_emphasize'))
+                      .fontWeight(FontWeight.Medium)
+                      .layoutWeight(1)
+                    Checkbox()
+                      .select(this.isAllSelected)
+                      .selectedColor($r('sys.color.ohos_id_color_emphasize'))
+                      .onChange(() => { this.handleSelectAll() })
+                  }
+                  .width('100%').height(56)
+                  .padding({ left: 16, right: 16 })
+                  .border({ width: { bottom: 2 }, color: $r('sys.color.ohos_id_color_emphasize') })
+
+                  // 目录列表
+                  ForEach(this.directories, (directory: SmbFileInfo) => {
+                    Row() {
+                      Text('📁').fontSize(24).margin({ right: 12 })
+                      Column() {
+                        Text(directory.name)
+                          .fontSize(16)
+                          .fontColor($r('sys.color.ohos_id_color_text_primary'))
+                          .maxLines(1)
+                          .textOverflow({ overflow: TextOverflow.Ellipsis })
+                        if (this.isSelected(directory) && this.hasCustomName(directory)) {
+                          Text('别名：' + this.getCustomName(directory))
+                            .fontSize(12)
+                            .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+                            .maxLines(1)
+                            .textOverflow({ overflow: TextOverflow.Ellipsis })
+                        }
+                      }
+                      .layoutWeight(1)
+                      .alignItems(HorizontalAlign.Start)
+
+                      if (!this.isAllSelected) {
+                        Checkbox()
+                          .select(this.isSelected(directory))
+                          .selectedColor($r('sys.color.ohos_id_color_emphasize'))
+                          .onChange(() => { this.handleCheckboxChange(directory) })
+                      }
+                    }
+                    .width('100%').height(56)
+                    .padding({ left: 16, right: 16 })
+                    .onClick(() => {
+                      if (!this.isAllSelected) {
+                        this.handleEnterDirectory(directory)
+                      }
+                    })
+                    .border({ width: { bottom: 1 }, color: $r('sys.color.ohos_id_color_list_separator') })
+                    .opacity(this.isAllSelected ? 0.5 : 1)
+                  }, (directory: SmbFileInfo) => directory.path)
+                }
+              }
+              .width('100%')
+              .layoutWeight(1)
+              .scrollBar(BarState.Auto)
+              .align(Alignment.Top)
+            }
+          }
+          .layoutWeight(1)
+          .alignItems(HorizontalAlign.Start)
+
+          // 底部操作栏
+          Row({ space: 12 }) {
+            Button('取消')
+              .fontSize(16)
+              .backgroundColor($r('sys.color.ohos_id_color_button_normal'))
+              .fontColor($r('sys.color.ohos_id_color_text_primary_contrary'))
+              .layoutWeight(1)
+              .onClick(() => this.handleCancel())
+              .enabled(!this.isSaving)
+
+            Button('完成')
+              .fontSize(16)
+              .backgroundColor($r('sys.color.ohos_id_color_emphasize'))
+              .fontColor($r('sys.color.ohos_id_color_text_primary_contrary'))
+              .layoutWeight(1)
+              .onClick(() => this.handleComplete())
+              .enabled(!this.isSaving)
+          }
+          .width('100%')
+          .padding(16)
+        }
+        .width('100%').height('100%')
+      }
+
+      // 自定义命名弹窗
+      if (this.showNameDialog) {
+        Column() {
+          Column({ space: 16 }) {
+            Text('自定义文件夹名称')
+              .fontSize(18)
+              .fontWeight(FontWeight.Bold)
+              .fontColor($r('sys.color.ohos_id_color_text_primary'))
+
+            Text('文件夹：' + this.pendingDefaultName)
+              .fontSize(13)
+              .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+              .maxLines(1)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+
+            TextInput({
+              placeholder: this.pendingDefaultName,
+              text: this.inputCustomName,
+              controller: this.nameInputController
+            })
+              .onChange((val: string) => { this.inputCustomName = val })
+              .onAppear(() => {
+                this.nameInputController.caretPosition(this.inputCustomName.length)
+                focusControl.requestFocus('smbNameInput')
+              })
+              .id('smbNameInput')
+              .defaultFocus(true)
+              .fontSize(16)
+              .borderRadius(8)
+
+            Row({ space: 12 }) {
+              Button('取消')
+                .layoutWeight(1)
+                .backgroundColor($r('sys.color.ohos_id_color_button_normal'))
+                .fontColor($r('sys.color.ohos_id_color_text_primary_contrary'))
+                .onClick(() => { this.cancelNameDialog() })
+              Button('确定')
+                .layoutWeight(1)
+                .backgroundColor($r('sys.color.ohos_id_color_emphasize'))
+                .fontColor($r('sys.color.ohos_id_color_text_primary_contrary'))
+                .onClick(() => { this.confirmNameDialog() })
+            }
+            .width('100%')
+          }
+          .width('80%')
+          .padding(24)
+          .borderRadius(16)
+          .backgroundColor($r('sys.color.ohos_id_color_background'))
+          .shadow({ radius: 20, color: '#33000000', offsetX: 0, offsetY: 4 })
+        }
+        .width('100%')
+        .height('100%')
+        .justifyContent(FlexAlign.Center)
+        .alignItems(HorizontalAlign.Center)
+        .backgroundColor('#80000000')
+        .onClick(() => {})
+      }
+    }
+    .width('100%')
+    .height('100%')
+  }
+}
+
+@Builder
+export function SmbDirectorySelectorBuilder() {
+  SmbDirectorySelectorBuilderComponent()
+}


### PR DESCRIPTION
## 关联 Issue
closes 部分 #68

## 变更说明
- 新增 `SmbFileExplorerPage.ets`：SMB 文件浏览页，支持根路径枚举共享、子路径递归列举、视频跳转播放
- `Index.ets`：注册 `smbFileExplorerPage` 路由
- `FileSourceTab.ets`：增加 SMB 文件源入口分支

## QA 验证
BUILD SUCCESSFUL（assembleHap，14s，HEAD: 101a3fd）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SMB shared directory browser (dialog) with breadcrumb navigation, folder traversal, listings (icons, size, modified) and video playback via SMB.
  * SMB folder selector in Settings to choose and alias persisted folders.
  * Quick entry to SMB browser from file source lists and settings.

* **Bug Fixes**
  * More reliable SMB path handling for directory listings.
  * Improved error messages, toasts and loading/empty-folder UX for SMB operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->