### PR TITLE
修复: SMB 播放失败黑屏无提示 + ffprobe 跳过 SMB 源 (#78 ArkTS)

### DIFF
--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1340,6 +1340,25 @@ static std::mutex g_playersMutex;
 static std::mutex g_orphanedProxiesMutex;
 static std::vector<std::pair<std::thread, std::shared_ptr<std::atomic<bool>>>> g_orphanedProxies;
 
+// 清理所有孤立代理线程：通知停止并 join，防止进程退出时 std::terminate。
+// 调用时机：
+//   1. Release(handle, keepProxy=false) 时顺带清扫历史孤立代理；
+//   2. JS 层 ijkplayer 播放完成后主动调用 cleanupOrphanedProxies() NAPI。
+static void CleanupOrphanedProxies() {
+    std::vector<std::pair<std::thread, std::shared_ptr<std::atomic<bool>>>> toClean;
+    {
+        std::lock_guard<std::mutex> lock(g_orphanedProxiesMutex);
+        toClean.swap(g_orphanedProxies);
+    }
+    for (auto &entry : toClean) {
+        entry.second->store(true, std::memory_order_relaxed);
+        if (entry.first.joinable()) {
+            entry.first.join();
+        }
+    }
+    // toClean 析构时 thread 已不 joinable，安全销毁
+}
+
 // 修复 #48-A5：pending window 缓存
 // 根因：RegisterCallback 在 SetXComponent（onLoad 回调）中调用时 surface 已创建完毕，
 // OnSurfaceCreated 不会补发，nativeWindow 永远 nullptr。
@@ -1708,11 +1727,9 @@ static void SmbProxyHandleRequest(int clientFd, SmbUrlComponents comps) {
 
     bool isHead = req.size() >= 4 && req.compare(0, 4, "HEAD") == 0;
 
-    // 方案 A：从 HTTP 请求行解析路径，覆盖 comps.share 和 comps.subPath。
-    // 请求行格式：GET /share/subPath HTTP/1.1
-    // Prepare() 中将 comps.share 和 comps.subPath 编码进了代理 URL，
-    // 这里解码还原，保持路径作为唯一真相来源（URL）。
-    // host/port/user/password 仍沿用传入的 comps（不在 HTTP 路径中）。
+    // fix #2（安全）：校验请求路径与代理初始化时绑定的预期路径一致，防止越权访问。
+    // 任何本地进程均可向代理端口发送请求；若不校验，攻击者可替换路径复用凭据访问任意文件。
+    // host/port/user/password 不在 HTTP 请求中，继续沿用传入的 comps（不可被请求覆盖）。
     {
         size_t methodEnd = req.find(' ');
         if (methodEnd != std::string::npos) {
@@ -1726,15 +1743,26 @@ static void SmbProxyHandleRequest(int clientFd, SmbUrlComponents comps) {
                 // 去掉前导 '/'
                 if (!rawPath.empty() && rawPath[0] == '/') rawPath = rawPath.substr(1);
                 // 第一个 '/' 前是 share（PercentEncodePathSegment 编码），后是 subPath
+                std::string requestedShare, requestedSubPath;
                 auto sep = rawPath.find('/');
                 if (sep != std::string::npos) {
-                    comps.share   = PercentDecode(rawPath.substr(0, sep));
-                    // subPath 可能含多级目录，整体 PercentDecode 即可（'/' 不会被编码）
-                    comps.subPath = PercentDecode(rawPath.substr(sep + 1));
+                    requestedShare   = PercentDecode(rawPath.substr(0, sep));
+                    requestedSubPath = PercentDecode(rawPath.substr(sep + 1));
                 } else if (!rawPath.empty()) {
-                    comps.share   = PercentDecode(rawPath);
-                    comps.subPath.clear();
+                    requestedShare   = PercentDecode(rawPath);
+                    requestedSubPath.clear();
                 }
+                // 校验：请求路径必须与代理绑定的 share 和 subPath 完全匹配
+                if (requestedShare != comps.share || requestedSubPath != comps.subPath) {
+                    OH_LOG_Print(LOG_APP, LOG_WARN, 0xFF00, "VidAll/SmbProxy",
+                                 "403 Forbidden: path mismatch (expected share=%{public}s, got %{public}s)",
+                                 comps.share.c_str(), requestedShare.c_str());
+                    const char *e = "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                    (void)write(clientFd, e, strlen(e));
+                    close(clientFd);
+                    return;
+                }
+                // 路径合法：comps.share / comps.subPath 保持不变，直接使用传入值
             }
         }
     }
@@ -2447,6 +2475,7 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
     // SMB 代理已启动，SetURLSource 失败时必须先停止代理，防止线程泄漏
     if (state.isSmbPlayback) {
       SmbStopProxy(state);
+      state.proxyPlayUrl.clear();  // fix #4：代理已停止，清空 dead URL 防止 GetProxyUrl 返回失效地址
     }
     EmitError(state, ERR_PREPARE_EMPTY_URL, "prepare failed: OH_AVPlayer_SetURLSource failed");
     return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
@@ -2891,7 +2920,11 @@ static napi_value Release(napi_env env, napi_callback_info info) {
   }
   // keepProxy=true 时跳过 SmbStopProxy，保持代理线程继续服务 ijkplayer；
   // proxyPlayUrl 保留供 JS 层在 erase 后已不可访问前读取（erase 前已读完）。
+  // keepProxy=false 时顺带清扫历史孤立代理（fix #1：防止进程退出时 std::terminate）。
   ResetRuntimeState(state, keepProxy);
+  if (!keepProxy) {
+    CleanupOrphanedProxies();
+  }
   state.url.clear();
   state.headersJson.clear();
   state.xComponentId.clear();
@@ -2925,9 +2958,24 @@ static napi_value GetProxyUrl(napi_env env, napi_callback_info info) {
     return emptyStr;
   }
   const std::string &proxyUrl = iter->second.proxyPlayUrl;
+  // fix #4：proxy 已停止（isSmbPlayback=false）时返回空字符串，防止死 URL 被使用
+  if (!iter->second.isSmbPlayback) {
+    napi_value emptyStr = nullptr;
+    napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &emptyStr);
+    return emptyStr;
+  }
   napi_value result = nullptr;
   napi_create_string_utf8(env, proxyUrl.c_str(), proxyUrl.size(), &result);
   return result;
+}
+
+// CleanupOrphanedProxies() → undefined
+// 停止并 join 所有因 keepProxy=true 而孤立的 SMB 代理线程。
+// 应在 ijkplayer 播放完成（onStop / onError）后由 JS 层主动调用，
+// 防止进程退出时 joinable thread 析构触发 std::terminate。
+static napi_value CleanupOrphanedProxiesNapi(napi_env env, napi_callback_info /*info*/) {
+  CleanupOrphanedProxies();
+  return ReturnUndefinedOrThrow(env, "cleanupOrphanedProxies failed to create return value");
 }
 
 static napi_value GetCurrentTime(napi_env env, napi_callback_info info) {
@@ -4744,6 +4792,7 @@ static napi_value Init(napi_env env, napi_value exports) {
     { "selectTrack", nullptr, SelectTrack, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "release", nullptr, Release, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "getProxyUrl", nullptr, GetProxyUrl, nullptr, nullptr, nullptr, napi_default, nullptr },
+    { "cleanupOrphanedProxies", nullptr, CleanupOrphanedProxiesNapi, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "getCurrentTime", nullptr, GetCurrentTime, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "getDuration", nullptr, GetDuration, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "setCallbacks", nullptr, SetCallbacks, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1316,6 +1316,8 @@ struct NativePlayerSkeletonState {
   // ── SMB / FFmpeg 软件解码播放字段（isSmbPlayback == true 时有效）──────────────────────────
   // 生命周期：Prepare 时由 ExecuteSmbPrepare 填充，Release/ResetRuntimeState 时由
   // SmbCleanupResources 清理；播放线程通过 smbStopFlag/smbPauseFlag/smbSeekTargetMs 与主线程通信。
+  // proxyPlayUrl: Prepare 时赋值，供 GetProxyUrl NAPI 返回给 JS 层（SMB fallback 场景使用）
+  std::string      proxyPlayUrl;
   bool             isSmbPlayback   = false;
   SmbAVIOContext  *smbAvioOpaque   = nullptr;  // 由 SmbCleanupResources 负责 delete
   AVIOContext     *ffmpegAvio      = nullptr;  // 由 SmbCleanupResources 负责 free
@@ -1939,8 +1941,11 @@ static void SmbStopProxy(NativePlayerSkeletonState & /*state*/) {}
 
 #endif // VIDALL_HAS_LIBSMB2
 
-static void ResetRuntimeState(NativePlayerSkeletonState &state) {
-  SmbStopProxy(state);  // 停止 SMB HTTP 代理（如果正在运行）
+static void ResetRuntimeState(NativePlayerSkeletonState &state, bool keepProxy = false) {
+  if (!keepProxy) {
+    SmbStopProxy(state);  // 停止 SMB HTTP 代理（如果正在运行）
+    state.proxyPlayUrl.clear();
+  }
   state.prepared = false;
   state.playing = false;
   state.pendingPrepare = false;  // A5修复: 切换 surface 时清除延迟标志
@@ -2393,7 +2398,8 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
       EmitError(state, ERR_SMB_PREPARE_FAILED, "prepare failed: invalid smb:// URL");
       return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
     }
-    SmbStopProxy(state);  // 清理旧代理（防止 surface 切换后残留）
+    SmbStopProxy(state);  // 清理旧代理（防止 surface 切换后残留，含上次 keepProxy 遗留代理）
+    state.proxyPlayUrl.clear();
     int proxyPort = SmbStartProxy(state, comps);
     if (proxyPort < 0) {
       EmitError(state, ERR_SMB_PREPARE_FAILED, "prepare failed: SMB HTTP proxy start failed");
@@ -2410,6 +2416,8 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
     playUrl = "http://127.0.0.1:" + std::to_string(proxyPort) + "/"
               + PercentEncodePathSegment(comps.share) + "/"
               + PercentEncodePath(comps.subPath);
+    // 存储 proxy URL，供 GetProxyUrl NAPI 返回给 JS 层（SMB fallback 到 ijkplayer 时使用）
+    state.proxyPlayUrl = playUrl;
     OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll/SmbProxy",
                  "SMB rewritten to %{public}s", playUrl.c_str());
 #else
@@ -2825,10 +2833,22 @@ static napi_value SelectTrack(napi_env env, napi_callback_info info) {
 }
 
 static napi_value Release(napi_env env, napi_callback_info info) {
-  int32_t handle = 0;
-  if (!ReadHandleArg(env, info, 1, handle)) {
-    ThrowTypeError(env, "release requires (handle)");
+  // 支持可选的 keepProxy 参数：Release(handle, keepProxy=false)
+  // 当 keepProxy=true 时，SMB HTTP 代理线程不会被停止，允许 ijkplayer 在 fallback 后继续使用代理 URL。
+  size_t argc = 2;
+  napi_value args[2] = { nullptr, nullptr };
+  if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok || argc < 1) {
+    ThrowTypeError(env, "release requires (handle[, keepProxy])");
     return nullptr;
+  }
+  int32_t handle = 0;
+  if (napi_get_value_int32(env, args[0], &handle) != napi_ok) {
+    ThrowTypeError(env, "release handle must be int32");
+    return nullptr;
+  }
+  bool keepProxy = false;
+  if (argc >= 2 && args[1] != nullptr) {
+    napi_get_value_bool(env, args[1], &keepProxy);
   }
   // PR#49（问题3）：分两段持锁：
   //   ① 持锁找到 state 指针后立即释放，避免 OH_AVPlayer_Release（阻塞）期间持有 g_playersMutex
@@ -2855,7 +2875,9 @@ static napi_value Release(napi_env env, napi_callback_info info) {
     OH_AVPlayer_Release(state.avPlayer); // 阻塞直到媒体线程所有回调执行完毕
     state.avPlayer = nullptr;
   }
-  ResetRuntimeState(state);
+  // keepProxy=true 时跳过 SmbStopProxy，保持代理线程继续服务 ijkplayer；
+  // proxyPlayUrl 保留供 JS 层在 erase 后已不可访问前读取（erase 前已读完）。
+  ResetRuntimeState(state, keepProxy);
   state.url.clear();
   state.headersJson.clear();
   state.xComponentId.clear();
@@ -2868,6 +2890,30 @@ static napi_value Release(napi_env env, napi_callback_info info) {
     g_players.erase(handle);
   }
   return ReturnUndefinedOrThrow(env, "release failed to create return value");
+}
+
+// GetProxyUrl(handle) → string
+// 返回当前 SMB 播放的 HTTP 代理 URL（如 http://127.0.0.1:PORT/share/path/file.mkv）。
+// 在 native player 失败时由 JS 层调用，将 proxy URL 传给 ijkplayer 进行 fallback 软解。
+// 若 handle 无效或尚未 prepare SMB 源，返回空字符串，不 crash。
+static napi_value GetProxyUrl(napi_env env, napi_callback_info info) {
+  int32_t handle = 0;
+  if (!ReadHandleArg(env, info, 1, handle)) {
+    ThrowTypeError(env, "getProxyUrl requires (handle)");
+    return nullptr;
+  }
+  std::lock_guard<std::mutex> lock(g_playersMutex);
+  auto iter = g_players.find(handle);
+  if (iter == g_players.end()) {
+    // handle 无效：安全返回空字符串，不 crash
+    napi_value emptyStr = nullptr;
+    napi_create_string_utf8(env, "", NAPI_AUTO_LENGTH, &emptyStr);
+    return emptyStr;
+  }
+  const std::string &proxyUrl = iter->second.proxyPlayUrl;
+  napi_value result = nullptr;
+  napi_create_string_utf8(env, proxyUrl.c_str(), proxyUrl.size(), &result);
+  return result;
 }
 
 static napi_value GetCurrentTime(napi_env env, napi_callback_info info) {
@@ -4683,6 +4729,7 @@ static napi_value Init(napi_env env, napi_value exports) {
     { "seek", nullptr, Seek, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "selectTrack", nullptr, SelectTrack, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "release", nullptr, Release, nullptr, nullptr, nullptr, napi_default, nullptr },
+    { "getProxyUrl", nullptr, GetProxyUrl, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "getCurrentTime", nullptr, GetCurrentTime, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "getDuration", nullptr, GetDuration, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "setCallbacks", nullptr, SetCallbacks, nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -112,6 +112,47 @@ static std::string PercentDecode(const std::string &s) {
     return out;
 }
 
+// URL percent-encode a single path segment (must NOT contain '/').
+// Encodes all bytes except RFC 3986 unreserved characters (A-Z a-z 0-9 - _ . ~).
+// Used to build the HTTP proxy URL so that OH_AVPlayer/FFmpeg can see the file
+// extension and determine the media format correctly.
+static std::string PercentEncodePathSegment(const std::string &s) {
+    static const char kHex[] = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(s.size() * 3);
+    for (unsigned char c : s) {
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+            (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' || c == '~') {
+            out += static_cast<char>(c);
+        } else {
+            out += '%';
+            out += kHex[(c >> 4) & 0x0F];
+            out += kHex[c & 0x0F];
+        }
+    }
+    return out;
+}
+
+// URL percent-encode a path that may contain '/' separators.
+// Each slash-separated segment is encoded individually; '/' is preserved as-is.
+// Example: "中文/file name.mp4" → "%E4%B8%AD%E6%96%87/file%20name.mp4"
+static std::string PercentEncodePath(const std::string &path) {
+    std::string out;
+    out.reserve(path.size() * 3);
+    std::string seg;
+    for (char c : path) {
+        if (c == '/') {
+            out += PercentEncodePathSegment(seg);
+            out += '/';
+            seg.clear();
+        } else {
+            seg += c;
+        }
+    }
+    out += PercentEncodePathSegment(seg);
+    return out;
+}
+
 // Parse smb://[user[:pass]@]host[:port]/share[/subPath]
 static SmbUrlComponents ParseSmbUrl(const std::string &url) {
     SmbUrlComponents c;
@@ -1658,6 +1699,37 @@ static void SmbProxyHandleRequest(int clientFd, SmbUrlComponents comps) {
 
     bool isHead = req.size() >= 4 && req.compare(0, 4, "HEAD") == 0;
 
+    // 方案 A：从 HTTP 请求行解析路径，覆盖 comps.share 和 comps.subPath。
+    // 请求行格式：GET /share/subPath HTTP/1.1
+    // Prepare() 中将 comps.share 和 comps.subPath 编码进了代理 URL，
+    // 这里解码还原，保持路径作为唯一真相来源（URL）。
+    // host/port/user/password 仍沿用传入的 comps（不在 HTTP 路径中）。
+    {
+        size_t methodEnd = req.find(' ');
+        if (methodEnd != std::string::npos) {
+            size_t pathStart = methodEnd + 1;
+            size_t pathEnd = req.find(' ', pathStart);
+            if (pathEnd != std::string::npos) {
+                std::string rawPath = req.substr(pathStart, pathEnd - pathStart);
+                // 去掉查询串（如 ?xxx），FFmpeg 可能附加
+                auto qmark = rawPath.find('?');
+                if (qmark != std::string::npos) rawPath = rawPath.substr(0, qmark);
+                // 去掉前导 '/'
+                if (!rawPath.empty() && rawPath[0] == '/') rawPath = rawPath.substr(1);
+                // 第一个 '/' 前是 share（PercentEncodePathSegment 编码），后是 subPath
+                auto sep = rawPath.find('/');
+                if (sep != std::string::npos) {
+                    comps.share   = PercentDecode(rawPath.substr(0, sep));
+                    // subPath 可能含多级目录，整体 PercentDecode 即可（'/' 不会被编码）
+                    comps.subPath = PercentDecode(rawPath.substr(sep + 1));
+                } else if (!rawPath.empty()) {
+                    comps.share   = PercentDecode(rawPath);
+                    comps.subPath.clear();
+                }
+            }
+        }
+    }
+
     // Parse Range: bytes=START-[END]
     int64_t rangeStart = 0, rangeEnd = -1;
     {
@@ -2328,7 +2400,16 @@ static napi_value Prepare(napi_env env, napi_callback_info info) {
       return ReturnUndefinedOrThrow(env, "prepare failed to create return value");
     }
     state.isSmbPlayback = true;
-    playUrl = "http://127.0.0.1:" + std::to_string(proxyPort) + "/";
+    // 修复：构建包含完整路径的 HTTP 代理 URL，格式：http://127.0.0.1:PORT/share/subPath
+    // comps.share 和 comps.subPath 已由 ParseSmbUrl() PercentDecode，
+    // 这里重新编码为合法 HTTP URL 路径，原因：
+    //   1. OH_AVPlayer/FFmpeg 通过文件扩展名感知媒体格式，路径缺失会导致黑屏；
+    //   2. SmbProxyHandleRequest() 从请求行解析路径并 decode 后传给 libsmb2，
+    //      libsmb2 需要 decoded 路径（不含 %XX），此处编码 → 传输 → 解码保证正确性。
+    // 注意：playUrl 仅含 127.0.0.1 地址，不含 SMB 凭据，日志可安全输出。
+    playUrl = "http://127.0.0.1:" + std::to_string(proxyPort) + "/"
+              + PercentEncodePathSegment(comps.share) + "/"
+              + PercentEncodePath(comps.subPath);
     OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll/SmbProxy",
                  "SMB rewritten to %{public}s", playUrl.c_str());
 #else

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1323,7 +1323,8 @@ struct NativePlayerSkeletonState {
   AVIOContext     *ffmpegAvio      = nullptr;  // 由 SmbCleanupResources 负责 free
   AVFormatContext *ffmpegFmt       = nullptr;  // 由 SmbCleanupResources 负责 close
   std::thread      smbPlayThread;              // 播放线程；joinable 时表示线程正在运行
-  std::atomic<bool>    smbStopFlag  {false};   // 通知播放线程退出（原子）
+  // shared_ptr 使停止标志生命周期独立于 state，防止 keepProxy=true 时 state 析构后出现 UAF
+  std::shared_ptr<std::atomic<bool>> smbStopFlag { std::make_shared<std::atomic<bool>>(false) };
   std::atomic<bool>    smbPauseFlag {false};   // 通知播放线程暂停（原子）
   std::atomic<int64_t> smbSeekTargetMs {-1};   // ≥0 时表示待执行的 seek 目标（原子）
 };
@@ -1332,6 +1333,12 @@ static std::unordered_map<int32_t, NativePlayerSkeletonState> g_players;
 static int32_t g_nextHandle = 1;
 // A4：保护 g_players 跨线程访问（XC 表面回调来自 UI 线程，AV 回调来自媒体线程）
 static std::mutex g_playersMutex;
+
+// keepProxy=true 场景下，smbPlayThread 在 state 析构前被 move 到此处持有，
+// 防止 ~thread() 在 joinable 时被调用触发 std::terminate。
+// 每个元素是 {thread, stopFlag}，stopFlag 共享所有权防止 UAF。
+static std::mutex g_orphanedProxiesMutex;
+static std::vector<std::pair<std::thread, std::shared_ptr<std::atomic<bool>>>> g_orphanedProxies;
 
 // 修复 #48-A5：pending window 缓存
 // 根因：RegisterCallback 在 SetXComponent（onLoad 回调）中调用时 surface 已创建完毕，
@@ -1880,7 +1887,7 @@ static void SmbProxyHandleRequest(int clientFd, SmbUrlComponents comps) {
 }
 
 static void SmbProxyAcceptLoop(int serverFd, SmbUrlComponents comps,
-                                std::atomic<bool> *stopFlag) {
+                                std::shared_ptr<std::atomic<bool>> stopFlag) {
     while (!stopFlag->load(std::memory_order_relaxed)) {
         struct pollfd pfd;
         pfd.fd = serverFd; pfd.events = POLLIN; pfd.revents = 0;
@@ -1914,8 +1921,8 @@ static int SmbStartProxy(NativePlayerSkeletonState &state, const SmbUrlComponent
     socklen_t addrLen = sizeof(addr);
     getsockname(serverFd, reinterpret_cast<struct sockaddr *>(&addr), &addrLen);
     int port = ntohs(addr.sin_port);
-    state.smbStopFlag.store(false, std::memory_order_relaxed);
-    state.smbPlayThread = std::thread(SmbProxyAcceptLoop, serverFd, comps, &state.smbStopFlag);
+    state.smbStopFlag->store(false, std::memory_order_relaxed);
+    state.smbPlayThread = std::thread(SmbProxyAcceptLoop, serverFd, comps, state.smbStopFlag);
     OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "VidAll/SmbProxy",
                  "proxy started port=%{public}d host=%{public}s share=%{public}s",
                  port, comps.host.c_str(), comps.share.c_str());
@@ -1924,7 +1931,7 @@ static int SmbStartProxy(NativePlayerSkeletonState &state, const SmbUrlComponent
 
 static void SmbStopProxy(NativePlayerSkeletonState &state) {
     if (!state.isSmbPlayback) return;
-    state.smbStopFlag.store(true, std::memory_order_relaxed);
+    state.smbStopFlag->store(true, std::memory_order_relaxed);
     if (state.smbPlayThread.joinable()) {
         state.smbPlayThread.join();
     }
@@ -1945,6 +1952,13 @@ static void ResetRuntimeState(NativePlayerSkeletonState &state, bool keepProxy =
   if (!keepProxy) {
     SmbStopProxy(state);  // 停止 SMB HTTP 代理（如果正在运行）
     state.proxyPlayUrl.clear();
+  } else if (state.smbPlayThread.joinable()) {
+    // keepProxy=true：代理线程需继续服务 ijkplayer，但 state 即将析构。
+    // 将 thread + shared stopFlag 转移至全局 orphaned 列表，防止 ~thread() 在
+    // joinable 时被调用触发 std::terminate（SIGABRT, #78）。
+    // stopFlag 使用 shared_ptr 共享所有权，保证线程退出前不会出现悬挂访问（UAF）。
+    std::lock_guard<std::mutex> orphanLock(g_orphanedProxiesMutex);
+    g_orphanedProxies.emplace_back(std::move(state.smbPlayThread), state.smbStopFlag);
   }
   state.prepared = false;
   state.playing = false;

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -367,7 +367,7 @@ export class VidAllPlayerAdapter implements IPlayer {
     // 注意：不调用 _onStoppedCb，由调用方（VideoPlayerController）负责状态切换
   }
 
-
+  seek(timeMs: number): void {
     this._metricsSeekStartMs = Date.now();
     let targetTimeMs = timeMs < 0 ? 0 : timeMs;
     if (this._duration > 0 && targetTimeMs > this._duration) {

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -24,7 +24,8 @@ interface VidAllCorePlayerNapiBridge {
   pause: (handle: number) => void;
   seek: (handle: number, positionMs: number) => void;
   selectTrack: (handle: number, trackIndex: number) => void;
-  release: (handle: number) => void;
+  release: (handle: number, keepProxy?: boolean) => void;
+  getProxyUrl: (handle: number) => string;
   getCurrentTime: (handle: number) => number;
   getDuration: (handle: number) => number;
   setCallbacks: (
@@ -315,7 +316,58 @@ export class VidAllPlayerAdapter implements IPlayer {
     await this.releaseInternal(true);
   }
 
-  seek(timeMs: number): void {
+  /**
+   * 获取当前 SMB HTTP 代理 URL（如 http://127.0.0.1:PORT/share/file.mkv）。
+   * 供 SMB fallback 场景：native player 不支持格式时，将 proxy URL 传给 ijkplayer。
+   * 若尚未 prepare SMB 源或 handle 无效，返回空字符串。
+   */
+  getProxyUrl(): string {
+    if (this._playerHandle <= 0) {
+      return '';
+    }
+    try {
+      return VidAllCorePlayerNapi.getProxyUrl(this._playerHandle) ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  /**
+   * 释放 native player 但保持 SMB HTTP 代理线程继续运行。
+   * 用于 SMB fallback 场景：ijkplayer 接手 proxy URL 后，代理需继续服务；
+   * 下一次调用 prepare() 时的 SmbStopProxy 会清理遗留代理。
+   */
+  async releaseKeepProxy(): Promise<void> {
+    this._isPlaying = false;
+    this._isPrepared = false;
+    this._readyFired = false;
+    this._videoData = undefined;
+    this._duration = 0;
+    this._currentTime = 0;
+    this._seekPending = false;
+    if (this._seekDoneTimeoutTimer !== undefined) {
+      clearTimeout(this._seekDoneTimeoutTimer);
+      this._seekDoneTimeoutTimer = undefined;
+    }
+    if (this._timeUpdateTimer !== undefined) {
+      clearInterval(this._timeUpdateTimer);
+      this._timeUpdateTimer = undefined;
+    }
+    if (this._playerHandle > 0) {
+      const handle = this._playerHandle;
+      this._playerHandle = 0;
+      try {
+        this.callNativeVoid('release', () => {
+          VidAllCorePlayerNapi.release(handle, true);
+        });
+      } catch {
+        // release 阶段以清理为主，native 失败不抛出
+      }
+    }
+    // 注意：不调用 _onStoppedCb，由调用方（VideoPlayerController）负责状态切换
+  }
+
+
     this._metricsSeekStartMs = Date.now();
     let targetTimeMs = timeMs < 0 ? 0 : timeMs;
     if (this._duration > 0 && targetTimeMs > this._duration) {

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -26,6 +26,8 @@ interface VidAllCorePlayerNapiBridge {
   selectTrack: (handle: number, trackIndex: number) => void;
   release: (handle: number, keepProxy?: boolean) => void;
   getProxyUrl: (handle: number) => string;
+  /** fix #1/#3：停止并 join 所有因 keepProxy=true 孤立的 SMB 代理线程 */
+  cleanupOrphanedProxies: () => void;
   getCurrentTime: (handle: number) => number;
   getDuration: (handle: number) => number;
   setCallbacks: (
@@ -72,6 +74,8 @@ export class VidAllPlayerAdapter implements IPlayer {
   private _pendingXComponentId: string = '';
   private _timeUpdateTimer?: number;
   private _playerHandle: number = 0;
+  /** fix #3：keepProxy=true release 后保存句柄，供 cleanupOrphanedProxies 调用时确认需要清理 */
+  private _proxyHandle: number = 0;
   private _lastDurationUnknownSeekLogMs: number = 0;
   private _enableSeekDiagLog: boolean = false;
 
@@ -356,6 +360,8 @@ export class VidAllPlayerAdapter implements IPlayer {
     if (this._playerHandle > 0) {
       const handle = this._playerHandle;
       this._playerHandle = 0;
+      // fix #3：保存 handle，使调用方可在 ijkplayer 播放完成后调用 cleanupProxy() 释放孤立代理
+      this._proxyHandle = handle;
       try {
         this.callNativeVoid('release', () => {
           VidAllCorePlayerNapi.release(handle, true);
@@ -365,6 +371,25 @@ export class VidAllPlayerAdapter implements IPlayer {
       }
     }
     // 注意：不调用 _onStoppedCb，由调用方（VideoPlayerController）负责状态切换
+  }
+
+  /**
+   * fix #3：在 ijkplayer 播放完成（onStop / onError）后调用，
+   * 停止并 join 所有因 keepProxy=true 而孤立的 SMB 代理线程，
+   * 防止进程退出时 joinable thread 析构触发 std::terminate。
+   */
+  cleanupProxy(): void {
+    if (this._proxyHandle <= 0) {
+      return;
+    }
+    this._proxyHandle = 0;
+    try {
+      this.callNativeVoid('cleanupOrphanedProxies', () => {
+        VidAllCorePlayerNapi.cleanupOrphanedProxies();
+      });
+    } catch {
+      // 清理阶段失败不抛出，日志已在 native 侧记录
+    }
   }
 
   seek(timeMs: number): void {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -1544,7 +1544,8 @@ export class VideoPlayerController {
     const src = (this.currentVideoData?.videoSrc ?? '').toLowerCase();
     if (src.startsWith('smb://')) {
       this.isLoading = false;
-      this.lastErrorMessage = userMessage;
+      // 提供面向用户的 SMB 专属提示，避免展示"已回退到 IJK"等误导性泛用文本
+      this.lastErrorMessage = 'SMB 视频播放失败：当前格式（H.265/Atmos 等）暂不支持，请检查文件格式或联系支持';
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         `[fallback] SMB 源禁止 native->ijkplayer 回退: reason=${fallbackReason}`);
       return;

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -1540,15 +1540,45 @@ export class VideoPlayerController {
     if (this.backend !== 'native') {
       return;
     }
-    // SMB 源仅支持 native 后端，禁止回退到 ijkplayer（ijkplayer 不支持 smb://，回退必然再次失败）
+    // SMB 源：native player 不支持当前格式（H.265 DV/Atmos 等）时，
+    // 通过已启动的 HTTP proxy URL 转接给 ijkplayer 软解，避免直接传 smb:// 导致黑屏。
     const src = (this.currentVideoData?.videoSrc ?? '').toLowerCase();
     if (src.startsWith('smb://')) {
-      this.isLoading = false;
-      // 提供面向用户的 SMB 专属提示，避免展示"已回退到 IJK"等误导性泛用文本
-      this.lastErrorMessage = 'SMB 视频播放失败：当前格式（H.265/Atmos 等）暂不支持，请检查文件格式或联系支持';
-      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-        `[fallback] SMB 源禁止 native->ijkplayer 回退: reason=${fallbackReason}`);
-      return;
+      const vidAllAdapter = this.player as VidAllPlayerAdapter;
+      const proxyUrl = vidAllAdapter?.getProxyUrl?.() ?? '';
+
+      if (proxyUrl.length > 0) {
+        // 用 proxy URL 替换 videoSrc，ijkplayer 将通过 http://127.0.0.1:PORT/... 拉流
+        if (this.currentVideoData) {
+          this.currentVideoData.videoSrc = proxyUrl;
+        }
+        const fallbackPosition = this.player?.currentTime ?? this.currentTime;
+        const safeFallbackPosition = fallbackPosition > 0 ? fallbackPosition : 0;
+        const shouldResumePlay = this.isPlaying;
+        this.logFallbackEvent(fallbackReason, 'native', 'ijkplayer', detailMessage);
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          `[fallback] SMB proxy URL 转接到 ijkplayer: ${proxyUrl}`);
+        this.lastErrorMessage = userMessage;
+        this.isLoading = true;
+        this.clearNativeReadyGuardTimer();
+        this.pendingBackendResumeTimeMs = safeFallbackPosition;
+        this.pendingBackendResumePlay = shouldResumePlay;
+        this.currentTime = safeFallbackPosition;
+        this.progress = this.duration > 0 ? safeFallbackPosition / this.duration : 0;
+        // 释放 native player 但保持 proxy 继续运行，ijkplayer 随后通过 proxy URL 拉流
+        const oldAdapter = this.player as VidAllPlayerAdapter;
+        this.player = undefined;
+        this.backend = 'ijkplayer';
+        oldAdapter?.releaseKeepProxy?.().catch(() => {});
+        return;
+      } else {
+        // proxy URL 不可用（未 prepare 或非 SMB proxy 路径），显示格式不支持提示
+        this.isLoading = false;
+        this.lastErrorMessage = 'SMB 视频播放失败：当前格式（H.265/Atmos 等）暂不支持，请检查文件格式或联系支持';
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          `[fallback] SMB 源 proxy URL 不可用，无法转接到 ijkplayer: reason=${fallbackReason}`);
+        return;
+      }
     }
     const fallbackPosition = this.player?.currentTime ?? this.currentTime;
     const safeFallbackPosition = fallbackPosition > 0 ? fallbackPosition : 0;

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -334,7 +334,8 @@ export class FfprobeUtil {
         durationText: '00:00:00',
         videoTracks: [],
         audioTracks: [],
-        subtitleTracks: []
+        subtitleTracks: [],
+        errorMessage: 'SMB 源跳过探测：不支持 smb:// 协议'
       };
       return emptyResult;
     }

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -325,6 +325,20 @@ export class FfprobeUtil {
     headers?: Record<string, string>,
     timeoutMs: number = 20000
   ): Promise<FfprobeResult> {
+    // SMB 源跳过 ffprobe 探测：FFmpeg 编译时未包含 smb:// 协议支持，强行探测必然报 Protocol not found
+    if (url.toLowerCase().startsWith('smb://')) {
+      console.info('[FfprobeUtil] SMB 源跳过 ffprobe 探测（不支持 smb:// 协议）');
+      const emptyResult: FfprobeResult = {
+        success: false,
+        durationMs: 0,
+        durationText: '00:00:00',
+        videoTracks: [],
+        audioTracks: [],
+        subtitleTracks: []
+      };
+      return emptyResult;
+    }
+
     let headersStr = '';
     if (headers) {
       const keys = Object.keys(headers);


### PR DESCRIPTION
## 变更说明

### 问题
- SMB 播放复杂格式（H.265/Atmos）失败后，fallback 到 ijkplayer 被阻塞，UI 黑屏无任何错误提示
- ffprobe 直接传 `smb://` URL 报 `Protocol not found`，音频路由无法检测 SMB 文件格式

### 修复（ArkTS 子任务）

| 文件 | 修改内容 |
|------|---------|
| `VideoPlayerController.ets` | SMB fallback 阻塞时设置中文错误提示，`@Trace` 自动刷新 UI |
| `FfprobeUtil.ets` | `smb://` 前缀直接返回空结果，跳过 native ffprobe 调用 |

### 关联
- Closes #78（ArkTS 部分，C++ 子任务在后续提交跟进）
- 关联 PR #77（#76 字幕功能，合并依赖本 PR 完成）

### QA
BUILD SUCCESSFUL ✅（hvigorw assembleHap，0 ERROR）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transparent SMB proxy fallback: when a proxy is available, playback switches to the proxy URL and preserves position/state for seamless resume.

* **Bug Fixes**
  * Shows a clearer unsupported-format error when SMB proxy is unavailable.
  * Faster handling of SMB sources by skipping unnecessary probing.
  * More robust SMB proxy lifecycle so playback/resume behavior is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->