### PR TITLE
修复: SMB 播放路径补充轨道元信息注入，解决音轨/字幕轨列表不显示

### DIFF
--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -853,15 +853,32 @@ static std::string StripAssOverrideTags(const std::string &text) {
 // 从 ASS Dialogue 行提取纯文本（格式：Dialogue: layer,start,end,style,...,text）
 static std::string ParseAssDialogue(const char *ass) {
   if (ass == nullptr) return "";
-  // 跳过 9 个逗号分隔的字段到文本部分
+  // 支持两种合法格式：
+  //   1. 完整 Dialogue 行（FFmpeg ass 解码器输出）：
+  //      "Dialogue: Marked,Start,End,Style,Name,ML,MR,MV,Effect,Text"
+  //      → 9 个逗号后取文本
+  //   2. MKV ASS block 原始包（raw-pkt / 解码器 fallback）：
+  //      "ReadOrder,Layer,Style,Name,ML,MR,MV,Effect,Text"
+  //      → 8 个逗号后取文本
   int commas = 0;
   const char *p = ass;
+  const char *textAt8 = nullptr; // 指向第 8 个逗号之后的字符
   while (*p && commas < 9) {
-    if (*p == ',') commas++;
+    if (*p == ',') {
+      commas++;
+      if (commas == 8) textAt8 = p + 1;
+    }
     p++;
   }
-  if (commas < 9) return ""; // 格式不符，返回空串（不暴露原始乱码内容）
-  return StripAssOverrideTags(std::string(p));
+  if (commas == 9) {
+    // 完整 Dialogue 行：p 指向第 9 个逗号之后
+    return StripAssOverrideTags(std::string(p));
+  }
+  if (commas == 8 && textAt8 != nullptr) {
+    // MKV raw block：textAt8 指向第 8 个逗号之后
+    return StripAssOverrideTags(std::string(textAt8));
+  }
+  return ""; // 格式不符，返回空串
 }
 
 static void ExecuteExtractSubAsync(napi_env env, void *data) {
@@ -913,8 +930,9 @@ static void ExecuteExtractSubAsync(napi_env env, void *data) {
                               earlyId == AV_CODEC_ID_DVD_SUBTITLE ||
                               earlyId == AV_CODEC_ID_DVB_SUBTITLE);
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "ExtractSub",
-                   "extractSub early-check stream[%d] codec=%s imageBased=%d",
-                   earlySi, earlyName ? earlyName : "?", (int)earlyImageBased);
+                   "extractSub early-check stream[%d] codec_type=%d codec=%s imageBased=%d",
+                   earlySi, (int)formatCtx->streams[earlySi]->codecpar->codec_type,
+                   earlyName ? earlyName : "?", (int)earlyImageBased);
       if (earlyImageBased) {
         ctx->errorMessage = std::string("image-based subtitle not supported: ") +
                             (earlyName ? earlyName : "unknown");
@@ -993,6 +1011,10 @@ static void ExecuteExtractSubAsync(napi_env env, void *data) {
       }
     }
   }
+  OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "ExtractSub",
+               "extractSub codecCtx=%s extradata_size=%d",
+               codecCtx != nullptr ? "opened" : "NULL(raw-pkt-mode)",
+               subStream->codecpar->extradata_size);
 
   // Cues-based seek 策略（针对蓝光原盘等非交错封装 MKV）：
   // MKV Cues 元素记录了每条流各 Cluster 的字节偏移；FFmpeg 在 avformat_open_input 后
@@ -1072,11 +1094,34 @@ static void ExecuteExtractSubAsync(napi_env env, void *data) {
 
     std::string text;
 
+    // 诊断日志：前 3 个字幕包打印详情，帮助定位 entries=0 根因
+    bool diagLog = (subPkts <= 3);
+
     if (codecCtx != nullptr) {
       // 有解码器：走 avcodec_decode_subtitle2
       AVSubtitle sub = {};
       int gotSub = 0;
       int dr = avcodec_decode_subtitle2(codecCtx, &sub, &gotSub, pkt);
+
+      if (diagLog) {
+        OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "ExtractSub",
+                     "extractSub pkt#%lld decode dr=%d gotSub=%d num_rects=%u",
+                     (long long)subPkts, dr, gotSub,
+                     (unsigned)(gotSub ? sub.num_rects : 0u));
+        if (gotSub && sub.num_rects > 0 && sub.rects[0]->ass != nullptr) {
+          // 截取前 100 字节，替换 \0 为 '?' 保证 %s 安全
+          char assSnip[101] = {};
+          int assLen = (int)strlen(sub.rects[0]->ass);
+          int snipLen = assLen < 100 ? assLen : 100;
+          for (int ci = 0; ci < snipLen; ci++) {
+            assSnip[ci] = (sub.rects[0]->ass[ci] == '\0') ? '?' : sub.rects[0]->ass[ci];
+          }
+          OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "ExtractSub",
+                       "extractSub pkt#%lld ass[0](%d)=%{public}s",
+                       (long long)subPkts, assLen, assSnip);
+        }
+      }
+
       if (dr >= 0 && gotSub && sub.num_rects > 0) {
         for (unsigned int r = 0; r < sub.num_rects; r++) {
           if (sub.rects[r]->ass != nullptr) {
@@ -1088,8 +1133,34 @@ static void ExecuteExtractSubAsync(napi_env env, void *data) {
         }
       }
       avsubtitle_free(&sub);
+
+      // gotSub=0 降级：解码器未解出内容时，尝试将原始包当作 raw-pkt 解析
+      // 常见于 OHOS 上 extradata 为空导致 ass 解码器拒绝所有包
+      if (text.empty() && pkt->size > 0 && pkt->data != nullptr) {
+        if (diagLog) {
+          OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "ExtractSub",
+                       "extractSub pkt#%lld gotSub=0 fallback to raw-pkt",
+                       (long long)subPkts);
+        }
+        goto raw_pkt_parse; // 跳到 raw-pkt 路径；goto 仅在此处使用，清晰且无资源泄漏
+      }
     } else {
-      // 无解码器：subrip 在 MKV 中 pkt->data 可能是 ASS block 格式或纯 SRT 文本
+raw_pkt_parse:
+      // 无解码器（或 gotSub=0 降级）：
+      // subrip/ass 在 MKV 中 pkt->data 可能是 ASS block 格式或纯 SRT 文本
+      if (diagLog) {
+        // 截取前 200 字节，替换控制字符为 '?' 保证 %s 安全
+        size_t snipLen = std::min((size_t)200, (size_t)pkt->size);
+        char rawSnip[201] = {};
+        for (size_t ci = 0; ci < snipLen; ci++) {
+          unsigned char ch = pkt->data[ci];
+          rawSnip[ci] = (ch < 0x20 && ch != '\n' && ch != '\r') ? '?' : (char)ch;
+        }
+        OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "ExtractSub",
+                     "extractSub pkt#%lld raw(%d)=%{public}s",
+                     (long long)subPkts, pkt->size, rawSnip);
+      }
+
       text = std::string(reinterpret_cast<char *>(pkt->data),
                          static_cast<size_t>(pkt->size));
       // 检测 MKV ASS block 格式：readorder,layer,style,name,marginL,marginR,marginV,effect,text

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1023,8 +1023,17 @@ static void ExecuteExtractSubAsync(napi_env env, void *data) {
       // 重置超时，为从字幕起始位置做顺序读取提供完整时间窗口
       interruptCtx.startTimeUs = av_gettime_relative();
       interruptCtx.timeoutUs = ctx->timeoutMs > 0 ? ctx->timeoutMs * 1000 : 60LL * 1000000LL;
+    } else {
+      // Cues 无该字幕流索引条目，回退到从文件起始位置读取
+      // avformat_find_stream_info 可能已将文件指针推进到中段，需 seek 回 0
+      // 否则后续 av_read_frame 从中段顺序扫描，对大文件（4K SMB）需读 90000+ 包导致 30s 超时
+      OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "ExtractSub",
+                   "extractSub stream[%d] no cues-seek, seek to beginning", si);
+      av_seek_frame(formatCtx, -1, 0, AVSEEK_FLAG_BACKWARD);
+      // 重置超时时钟，为从起始位置完整读取提供完整时间窗口
+      interruptCtx.startTimeUs = av_gettime_relative();
+      interruptCtx.timeoutUs = ctx->timeoutMs > 0 ? ctx->timeoutMs * 1000 : 60LL * 1000000LL;
     }
-    // 若 nb_index_entries == 0（Cues 无字幕条目），保持当前文件位置顺序读取
   }
 
   // 顺序读取 packet 并过滤字幕流

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -853,32 +853,20 @@ static std::string StripAssOverrideTags(const std::string &text) {
 // 从 ASS Dialogue 行提取纯文本（格式：Dialogue: layer,start,end,style,...,text）
 static std::string ParseAssDialogue(const char *ass) {
   if (ass == nullptr) return "";
-  // 支持两种合法格式：
-  //   1. 完整 Dialogue 行（FFmpeg ass 解码器输出）：
-  //      "Dialogue: Marked,Start,End,Style,Name,ML,MR,MV,Effect,Text"
-  //      → 9 个逗号后取文本
-  //   2. MKV ASS block 原始包（raw-pkt / 解码器 fallback）：
-  //      "ReadOrder,Layer,Style,Name,ML,MR,MV,Effect,Text"
-  //      → 8 个逗号后取文本
+  // MKV ASS block 格式（avcodec_decode_subtitle2 及 raw-pkt 均输出此格式）：
+  //   "ReadOrder,Layer,Style,Name,MarginL,MarginR,MarginV,Effect,Text"
+  //   共 8 个逗号分隔的字段，第 8 个逗号之后即为 Text 字段。
+  //
+  // 注意：Text 字段本身可包含逗号（如 \fad(500,1000) 内的逗号），
+  // 因此必须在恰好数到第 8 个逗号后立即停止，不得继续向后搜索。
   int commas = 0;
   const char *p = ass;
-  const char *textAt8 = nullptr; // 指向第 8 个逗号之后的字符
-  while (*p && commas < 9) {
-    if (*p == ',') {
-      commas++;
-      if (commas == 8) textAt8 = p + 1;
-    }
+  while (*p && commas < 8) {
+    if (*p == ',') commas++;
     p++;
   }
-  if (commas == 9) {
-    // 完整 Dialogue 行：p 指向第 9 个逗号之后
-    return StripAssOverrideTags(std::string(p));
-  }
-  if (commas == 8 && textAt8 != nullptr) {
-    // MKV raw block：textAt8 指向第 8 个逗号之后
-    return StripAssOverrideTags(std::string(textAt8));
-  }
-  return ""; // 格式不符，返回空串
+  if (commas < 8) return ""; // 字段不足，格式不符
+  return StripAssOverrideTags(std::string(p));
 }
 
 static void ExecuteExtractSubAsync(napi_env env, void *data) {
@@ -1241,19 +1229,21 @@ raw_pkt_parse:
                "extractSub done stream=%d totalPkts=%lld subPkts=%lld",
                si, (long long)totalPkts, (long long)subPkts);
 
-  if (readRet < 0 && readRet != AVERROR_EOF) {
+  if (!first) {
+    // 找到至少一条字幕条目——即使超时也以已有结果 resolve（partial results）
+    json += "]";
+    ctx->jsonResult = json;
+  } else if (readRet < 0 && readRet != AVERROR_EOF) {
+    // 无条目且读取中途出错（超时 / 网络断开等）
     ctx->errorMessage = "extractSub: read failed: " + FfmpegErrorToString(readRet) +
                         " totalPkts=" + std::to_string(totalPkts) +
                         " subPkts=" + std::to_string(subPkts);
-  } else if (first) {
-    // count=0：以错误形式 reject，让 ArkTS catch 能打印 codec/packet 诊断信息
+  } else {
+    // 无条目且正常结束（EOF 或空文件）
     ctx->errorMessage = "count=0 codec=" + std::string(subCodecName ? subCodecName : "?") +
                         " totalPkts=" + std::to_string(totalPkts) +
                         " subPkts=" + std::to_string(subPkts) +
                         " nbStreams=" + std::to_string(nbStreams);
-  } else {
-    json += "]";
-    ctx->jsonResult = json;
   }
 }
 

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1039,7 +1039,13 @@ static void ExecuteExtractSubAsync(napi_env env, void *data) {
       // 否则后续 av_read_frame 从中段顺序扫描，对大文件（4K SMB）需读 90000+ 包导致 30s 超时
       OH_LOG_Print(LOG_APP, LOG_INFO, 0xFF00, "ExtractSub",
                    "extractSub stream[%d] no cues-seek, seek to beginning", si);
-      av_seek_frame(formatCtx, -1, 0, AVSEEK_FLAG_BACKWARD);
+      const int seekRet = av_seek_frame(formatCtx, -1, 0, AVSEEK_FLAG_BACKWARD);
+      if (seekRet < 0) {
+        ctx->errorMessage = "extractSub: rewind failed: " + FfmpegErrorToString(seekRet);
+        if (codecCtx != nullptr) { avcodec_free_context(&codecCtx); }
+        avformat_close_input(&formatCtx);
+        return;
+      }
       // 重置超时时钟，为从起始位置完整读取提供完整时间窗口
       interruptCtx.startTimeUs = av_gettime_relative();
       interruptCtx.timeoutUs = ctx->timeoutMs > 0 ? ctx->timeoutMs * 1000 : 60LL * 1000000LL;

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -1046,9 +1046,16 @@ static void ExecuteExtractSubAsync(napi_env env, void *data) {
     }
   }
 
-  // 顺序读取 packet 并过滤字幕流
-  // 注意：不设 AVDISCARD_ALL——HTTP/WebDAV 场景下 AVDISCARD_ALL 会对每个 video/audio block
-  // 调用 avio_skip()，进而发起大量 HTTP Range 请求（每帧一次），高 RTT 下速度极慢。
+  // 丢弃所有非字幕流，减少 av_read_frame 返回的无效包数量。
+  // 对于 MKV 容器：demuxer 在找到 subtitle cluster 之前仍需顺序解析块头，
+  // 但设置 AVDISCARD_ALL 后 FFmpeg 会跳过这些包的解码，减少 CPU 开销。
+  // 对于 localhost SMB proxy（127.0.0.1）：额外的 avio_skip()/Range 请求
+  // 延迟可忽略不计（<1ms/请求），不存在 WebDAV 场景的高 RTT 问题。
+  for (unsigned int discardI = 0; discardI < formatCtx->nb_streams; discardI++) {
+    if ((int)discardI != si) {
+      formatCtx->streams[discardI]->discard = AVDISCARD_ALL;
+    }
+  }
 
   std::string json = "[";
   bool first = true;

--- a/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
@@ -188,6 +188,14 @@ function extractSmbLangLabel(fileName: string, baseName: string): string {
 export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
   /** 防止异步提取竞态：每次发起新切轨请求时递增，过期结果不写入 srtEntries */
   private subtitleSwitchGeneration: number = 0;
+  /** 缓存最新播放位置，用于提取完成后判断 entries 是否覆盖当前时间 */
+  private lastKnownPositionMs: number = 0;
+
+  override onTimeUpdate(currentTimeMs: number): void {
+    this.lastKnownPositionMs = currentTimeMs;
+    super.onTimeUpdate(currentTimeMs);
+  }
+
   protected async loadExternalTracks(): Promise<SubtitleTrackItem[]> {
     if (!this.videoData) {
       return [];
@@ -464,15 +472,31 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `[SmbSub] 内嵌字幕提取完成 stream=${internalIndex} entries=${entries.length}`);
 
-      // entries=0 说明内嵌字幕提取失败，尝试 fallback 到第一个外置字幕轨
-      if (entries.length === 0) {
+      // 判断是否需要 fallback 到外置字幕：
+      // 1. entries=0（提取失败）
+      // 2. entries 时间范围无法覆盖当前播放位置（典型场景：超时后只拿到片头动画字幕，
+      //    而播放已在片中，此时 entries 最大时间 < 当前位置）
+      let needFallback = entries.length === 0;
+      if (!needFallback && entries.length > 0) {
+        const maxEndMs: number = (entries as SrtEntry[]).reduce(
+          (maxVal: number, e: SrtEntry) => e.endMs > maxVal ? e.endMs : maxVal,
+          0
+        );
+        const curPos: number = this.lastKnownPositionMs;
+        if (curPos > 0 && maxEndMs < curPos) {
+          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+            `[SmbSub] 内嵌字幕仅覆盖到 ${maxEndMs}ms，当前播放 ${curPos}ms，需 fallback`);
+          needFallback = true;
+        }
+      }
+
+      if (needFallback) {
         const externalIndex: number = this.allSubtitleTracks.findIndex(
           (t: SubtitleTrackItem) => t.kind === 'external'
         );
         if (externalIndex >= 0) {
           hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-            `[SmbSub] 内嵌字幕提取失败，fallback 到外置字幕 index=${externalIndex}`);
-          // 调用父类 switchTrack：对 external 轨道直接从预加载的 srtEntries 赋值，不递归
+            `[SmbSub] 内嵌字幕不足，fallback 到外置字幕 index=${externalIndex}`);
           await super.switchTrack(externalIndex);
         }
       }

--- a/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
@@ -478,7 +478,18 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
       }
     } catch {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-        '[SmbSub] 内嵌字幕提取失败，降级无字幕');
+        '[SmbSub] 内嵌字幕提取失败，尝试 fallback 到外置字幕');
+      // generation 检查：若用户已切换到其他轨道，不干扰
+      if (currentGen === this.subtitleSwitchGeneration) {
+        const externalIdx: number = this.allSubtitleTracks.findIndex(
+          (t: SubtitleTrackItem) => t.kind === 'external'
+        );
+        if (externalIdx >= 0) {
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `[SmbSub] catch fallback 到外置字幕 index=${externalIdx}`);
+          await super.switchTrack(externalIdx);
+        }
+      }
     }
   }
 }

--- a/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
@@ -3,6 +3,9 @@ import { CommonConstants } from '../../../common/constants/CommonConstants';
 import { SMBClient, SMBClientConfig } from '../../../lib/SMBClient';
 import { BaseSubtitleBridgeAdapter, SubtitleTrackItem } from './SubtitleBridgeAdapter';
 import { AssFileParser, SrtEntry, SrtParser } from './SubtitleRenderer';
+import { PresetSubtitleTrack } from './VideoData';
+import { FfprobeUtil, EmbeddedSubEntry } from '../../../utils/FfprobeUtil';
+import { VidAllPlayerAdapter } from './VidAllPlayerAdapter';
 
 const TAG = '[SmbSubtitleBridgeAdapter]';
 
@@ -351,6 +354,102 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         '[外置字幕] SMB 字幕加载异常，返回空数组');
       return [];
+    }
+  }
+
+  /**
+   * 覆写内嵌轨道加载：从 videoData.presetSubtitleTracks 读取已由 ffprobe 探测到的字幕轨，
+   * 过滤掉 PGS / DVD subtitle 等图形格式，只保留可文本渲染的格式。
+   */
+  protected override async loadInternalTracks(): Promise<SubtitleTrackItem[]> {
+    const items: SubtitleTrackItem[] = [];
+    const presets = this.videoData?.presetSubtitleTracks;
+    if (!presets || presets.length === 0) {
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        '[SmbSub] 无 presetSubtitleTracks，跳过内嵌轨道加载');
+      return items;
+    }
+    // 只保留可文本渲染的格式，跳过 hdmv_pgs_subtitle、dvd_subtitle 等图形字幕
+    const TEXT_CODECS: string[] = ['subrip', 'srt', 'ass', 'ssa', 'webvtt', 'mov_text'];
+    for (let i = 0; i < presets.length; i++) {
+      const t: PresetSubtitleTrack = presets[i];
+      if (t.codecName && !TEXT_CODECS.includes(t.codecName)) {
+        continue;
+      }
+      const item: SubtitleTrackItem = {
+        kind: 'internal',
+        displayName: t.displayName,
+        internalIndex: t.trackIndex
+      };
+      items.push(item);
+    }
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[SmbSub] loadInternalTracks: preset=${presets.length} 可渲染文本字幕=${items.length}`);
+    return items;
+  }
+
+  /**
+   * 覆写轨道切换：内嵌字幕通过 FfprobeUtil.extractEmbeddedSubtitles 提取后走 SRT 渲染管线；
+   * 外置字幕交由父类处理（srtEntries 已在 loadExternalTracks 解析完毕）。
+   * SMB 视频通过 native player 的 HTTP 代理提供 ffprobe 可用的 URL。
+   */
+  override async switchTrack(allIndex: number): Promise<void> {
+    if (!this.player) {
+      return;
+    }
+    // allIndex < 0 表示取消选中，交由父类处理（重置状态 + selectTrack(-1)）
+    if (allIndex < 0) {
+      await super.switchTrack(allIndex);
+      return;
+    }
+
+    const target = this.allSubtitleTracks[allIndex];
+    if (!target) {
+      return;
+    }
+
+    if (target.kind === 'external') {
+      // 外置字幕 srtEntries 已预加载，直接交父类处理
+      await super.switchTrack(allIndex);
+      return;
+    }
+
+    // 内嵌字幕：实时提取字幕文本，走 SRT 渲染管线
+    const internalIndex = target.internalIndex ?? -1;
+    if (internalIndex < 0) {
+      return;
+    }
+
+    this.activeSubtitleIndex = allIndex;
+    this.srtEntries = [];
+    this.lastSrtText = '';
+    this.currentSubtitleText = '';
+    this.currentSubtitleTrack = internalIndex;
+
+    // 优先使用 native player 的 HTTP 代理 URL（native 后端已为 SMB 源建立代理）
+    // 回退到 videoData.videoSrc（ijkplayer fallback 后 videoSrc 已更新为代理 URL）
+    let videoSrc: string = this.videoData?.videoSrc ?? '';
+    const vidAllAdapter = this.player as VidAllPlayerAdapter;
+    const proxyUrl: string = vidAllAdapter?.getProxyUrl?.() ?? '';
+    if (proxyUrl.length > 0) {
+      videoSrc = proxyUrl;
+    }
+    if (videoSrc.length === 0) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        '[SmbSub] 无可用视频 URL，降级无字幕');
+      return;
+    }
+
+    try {
+      const entries: EmbeddedSubEntry[] = await FfprobeUtil.extractEmbeddedSubtitles(
+        videoSrc, undefined, internalIndex, 30000
+      );
+      this.srtEntries = entries as SrtEntry[];
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        `[SmbSub] 内嵌字幕提取完成 stream=${internalIndex} entries=${entries.length}`);
+    } catch {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        '[SmbSub] 内嵌字幕提取失败，降级无字幕');
     }
   }
 }

--- a/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
@@ -367,6 +367,21 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
     }
   }
 
+  /** SMB 源优先选外置字幕（已预加载，立即可用）；无外置字幕时才回落到内嵌字幕 */
+  protected override findPreferredTrackIndex(): number {
+    for (let i = 0; i < this.allSubtitleTracks.length; i++) {
+      if (this.allSubtitleTracks[i].kind === 'external') {
+        return i;
+      }
+    }
+    for (let i = 0; i < this.allSubtitleTracks.length; i++) {
+      if (this.allSubtitleTracks[i].kind === 'internal') {
+        return i;
+      }
+    }
+    return -1;
+  }
+
   /**
    * 覆写内嵌轨道加载：从 videoData.presetSubtitleTracks 读取已由 ffprobe 探测到的字幕轨，
    * 过滤掉 PGS / DVD subtitle 等图形格式，只保留可文本渲染的格式。

--- a/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
@@ -463,6 +463,19 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
       this.srtEntries = entries as SrtEntry[];
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `[SmbSub] 内嵌字幕提取完成 stream=${internalIndex} entries=${entries.length}`);
+
+      // entries=0 说明内嵌字幕提取失败，尝试 fallback 到第一个外置字幕轨
+      if (entries.length === 0) {
+        const externalIndex: number = this.allSubtitleTracks.findIndex(
+          (t: SubtitleTrackItem) => t.kind === 'external'
+        );
+        if (externalIndex >= 0) {
+          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+            `[SmbSub] 内嵌字幕提取失败，fallback 到外置字幕 index=${externalIndex}`);
+          // 调用父类 switchTrack：对 external 轨道直接从预加载的 srtEntries 赋值，不递归
+          await super.switchTrack(externalIndex);
+        }
+      }
     } catch {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         '[SmbSub] 内嵌字幕提取失败，降级无字幕');

--- a/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
@@ -1,7 +1,7 @@
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { CommonConstants } from '../../../common/constants/CommonConstants';
 import { SMBClient, SMBClientConfig } from '../../../lib/SMBClient';
-import { BaseSubtitleBridgeAdapter, SubtitleTrackItem } from './SubtitleBridgeAdapter';
+import { AvSubtitleBridgeAdapter, BaseSubtitleBridgeAdapter, SubtitleTrackItem } from './SubtitleBridgeAdapter';
 import { AssFileParser, SrtEntry, SrtParser } from './SubtitleRenderer';
 import { PresetSubtitleTrack } from './VideoData';
 import { FfprobeUtil, EmbeddedSubEntry } from '../../../utils/FfprobeUtil';
@@ -181,9 +181,147 @@ function extractSmbLangLabel(fileName: string, baseName: string): string {
 }
 
 /**
- * SMB 外置字幕适配器。
- * 在 `loadExternalTracks()` 中通过 SMB 协议枚举视频同名字幕文件并解析。
+ * 通过 SMB 协议加载视频同名外置字幕文件（可被多个适配器复用）。
  * 任何步骤失败均静默处理（catch 后返回空数组），不向上抛出异常。
+ */
+async function loadSmbExternalSubtitles(smbVideoUrl: string): Promise<SubtitleTrackItem[]> {
+  if (!smbVideoUrl.startsWith('smb://')) {
+    return [];
+  }
+  try {
+    const parsed: ParsedSmbVideoUrl | null = parseSmbVideoUrl(smbVideoUrl);
+    if (!parsed) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        '[外置字幕] SMB URL 解析失败，跳过字幕加载');
+      return [];
+    }
+
+    const clientConfig: SMBClientConfig = {
+      host: parsed.host,
+      port: parsed.port,
+      username: parsed.username,
+      password: parsed.password,
+      shareName: parsed.shareName
+    };
+    const client: SMBClient = new SMBClient(clientConfig);
+
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[外置字幕] 列举目录 host=${parsed.host} path=${parsed.listDirPath} baseName=${parsed.baseName}`);
+
+    const dirResult = await client.listDirectory(parsed.listDirPath);
+    if (dirResult.error && dirResult.files.length === 0) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `[外置字幕] 目录列举失败: ${dirResult.error}`);
+      return [];
+    }
+
+    const sharePrefix: string = '/' + parsed.shareName;
+    const lowerBaseName: string = parsed.baseName.toLowerCase();
+
+    const candidates: SubtitleCandidate[] = [];
+    for (let i = 0; i < dirResult.files.length; i++) {
+      const file = dirResult.files[i];
+      if (file.isDirectory) {
+        continue;
+      }
+      const lowerName: string = file.name.toLowerCase();
+      let isSubtitle: boolean = false;
+      let matchedExt: string = '';
+      for (let j = 0; j < SUBTITLE_EXTENSIONS.length; j++) {
+        if (lowerName.endsWith(SUBTITLE_EXTENSIONS[j])) {
+          isSubtitle = true;
+          matchedExt = SUBTITLE_EXTENSIONS[j];
+          break;
+        }
+      }
+      if (!isSubtitle) {
+        continue;
+      }
+      const nameWithoutExt: string = lowerName.substring(0, lowerName.length - matchedExt.length);
+      const strictMatch: boolean = nameWithoutExt === lowerBaseName
+        || nameWithoutExt.startsWith(`${lowerBaseName}.`);
+      if (!strictMatch) {
+        continue;
+      }
+      let filePath: string = file.path;
+      if (filePath.startsWith(sharePrefix)) {
+        filePath = filePath.substring(sharePrefix.length);
+      }
+      const candidate: SubtitleCandidate = { name: file.name, filePath, matchedExt };
+      candidates.push(candidate);
+    }
+
+    if (candidates.length === 0) {
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG, '[外置字幕探测完成] 找到 0 个 SMB 外置字幕');
+      return [];
+    }
+
+    const readWithTimeout = (p: Promise<string>, ms: number): Promise<string> => {
+      const timeoutP: Promise<string> = new Promise<string>((resolve) => {
+        setTimeout(() => resolve(''), ms);
+      });
+      return Promise.race([p, timeoutP]);
+    };
+    const contents: string[] = await Promise.all(
+      candidates.map((candidate) =>
+        readWithTimeout(client.readTextFile(candidate.filePath).catch(() => ''), 3000)
+      )
+    );
+
+    const found: SubtitleTrackItem[] = [];
+    for (let i = 0; i < candidates.length; i++) {
+      const content: string = contents[i];
+      if (content.length === 0) {
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          `[外置字幕] 读取超时或失败: ${candidates[i].name}`);
+        continue;
+      }
+      try {
+        const matchedExt: string = candidates[i].matchedExt;
+        let entries: SrtEntry[] = [];
+        let formatLabel: string = 'SRT';
+        if (matchedExt === '.ass' || matchedExt === '.ssa') {
+          entries = AssFileParser.parse(content);
+          formatLabel = 'ASS';
+        } else if (matchedExt === '.vtt') {
+          entries = SrtParser.parse(content);
+          formatLabel = 'VTT';
+        } else {
+          entries = SrtParser.parse(content);
+          formatLabel = 'SRT';
+        }
+        const langLabel: string = extractSmbLangLabel(candidates[i].name, parsed.baseName);
+        const displayName: string = langLabel.length > 0
+          ? `${langLabel} [外部·${formatLabel}]`
+          : `字幕 [外部·${formatLabel}]`;
+        if (entries.length === 0) {
+          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+            `[外置字幕] 解析结果为空，跳过: ${candidates[i].name}`);
+          continue;
+        }
+        const item: SubtitleTrackItem = { kind: 'external', displayName, srtEntries: entries };
+        found.push(item);
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          `[外置字幕] 加载成功: ${candidates[i].name} entries=${entries.length}`);
+      } catch (e) {
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          `[外置字幕] 解析失败: ${candidates[i].name}`);
+      }
+    }
+
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[外置字幕探测完成] 找到 ${found.length} 个 SMB 外置字幕`);
+    return found;
+  } catch (e) {
+    hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+      '[外置字幕] SMB 字幕加载异常，返回空数组');
+    return [];
+  }
+}
+
+/**
+ * SMB 外置字幕适配器（配合 native FFmpeg 后端使用）。
+ * 外置字幕通过 SMB 协议加载；内嵌字幕通过 FfprobeUtil.extractEmbeddedSubtitles 提取。
  */
 export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
   /** 防止异步提取竞态：每次发起新切轨请求时递增，过期结果不写入 srtEntries */
@@ -197,189 +335,7 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
   }
 
   protected async loadExternalTracks(): Promise<SubtitleTrackItem[]> {
-    if (!this.videoData) {
-      return [];
-    }
-
-    const videoUrl: string = this.videoData.videoSrc;
-    if (!videoUrl.startsWith('smb://')) {
-      return [];
-    }
-
-    try {
-      const parsed: ParsedSmbVideoUrl | null = parseSmbVideoUrl(videoUrl);
-      if (!parsed) {
-        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-          '[外置字幕] SMB URL 解析失败，跳过字幕加载');
-        return [];
-      }
-
-      const clientConfig: SMBClientConfig = {
-        host: parsed.host,
-        port: parsed.port,
-        username: parsed.username,
-        password: parsed.password,
-        shareName: parsed.shareName
-      };
-      const client: SMBClient = new SMBClient(clientConfig);
-
-      // 日志脱敏：不打印凭据，仅打印 host、路径和 baseName
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-        `[外置字幕] 列举目录 host=${parsed.host} path=${parsed.listDirPath} baseName=${parsed.baseName}`);
-
-      const dirResult = await client.listDirectory(parsed.listDirPath);
-      if (dirResult.error && dirResult.files.length === 0) {
-        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-          `[外置字幕] 目录列举失败: ${dirResult.error}`);
-        return [];
-      }
-
-      // SmbFileInfo.path 格式为 "/<shareName>/<subPath>/<name>"
-      // readTextFile 需要相对于 shareName 的路径，即去掉 "/<shareName>" 前缀
-      const sharePrefix: string = '/' + parsed.shareName;
-      const lowerBaseName: string = parsed.baseName.toLowerCase();
-
-      // Phase 1：过滤候选字幕文件（Fix 1：严格同名匹配）
-      const candidates: SubtitleCandidate[] = [];
-      for (let i = 0; i < dirResult.files.length; i++) {
-        const file = dirResult.files[i];
-        if (file.isDirectory) {
-          continue;
-        }
-
-        const lowerName: string = file.name.toLowerCase();
-
-        // 检查是否为支持的字幕扩展名
-        let isSubtitle: boolean = false;
-        let matchedExt: string = '';
-        for (let j = 0; j < SUBTITLE_EXTENSIONS.length; j++) {
-          if (lowerName.endsWith(SUBTITLE_EXTENSIONS[j])) {
-            isSubtitle = true;
-            matchedExt = SUBTITLE_EXTENSIONS[j];
-            break;
-          }
-        }
-        if (!isSubtitle) {
-          continue;
-        }
-
-        // Fix 1：严格匹配——完全相同，或以 "baseName." 开头（支持 movie.chs.srt 语言后缀格式）
-        const nameWithoutExt: string = lowerName.substring(0, lowerName.length - matchedExt.length);
-        const strictMatch: boolean = nameWithoutExt === lowerBaseName
-          || nameWithoutExt.startsWith(`${lowerBaseName}.`);
-        if (!strictMatch) {
-          continue;
-        }
-
-        // 构造 readTextFile 路径：去掉 "/<shareName>" 前缀
-        let filePath: string = file.path;
-        if (filePath.startsWith(sharePrefix)) {
-          filePath = filePath.substring(sharePrefix.length);
-        }
-
-        const candidate: SubtitleCandidate = {
-          name: file.name,
-          filePath,
-          matchedExt
-        };
-        candidates.push(candidate);
-      }
-
-      if (candidates.length === 0) {
-        hilog.info(CommonConstants.LOG_DOMAIN, TAG, '[外置字幕探测完成] 找到 0 个 SMB 外置字幕');
-        return [];
-      }
-
-      // Phase 2：逐文件并发读取，每个文件单独 3 秒超时（Fix F: 避免一文件超时丢弃其他结果）
-      const readWithTimeout = (p: Promise<string>, ms: number): Promise<string> => {
-        const timeoutP: Promise<string> = new Promise<string>((resolve) => {
-          setTimeout(() => resolve(''), ms);
-        });
-        return Promise.race([p, timeoutP]);
-      };
-      const contents: string[] = await Promise.all(
-        candidates.map((candidate) =>
-          readWithTimeout(client.readTextFile(candidate.filePath).catch(() => ''), 3000)
-        )
-      );
-
-      // Phase 3：解析每个读取结果
-      const found: SubtitleTrackItem[] = [];
-      for (let i = 0; i < candidates.length; i++) {
-        const content: string = contents[i];
-        if (content.length === 0) {
-          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-            `[外置字幕] 读取超时或失败: ${candidates[i].name}`);
-          continue;
-        }
-
-        try {
-          const matchedExt: string = candidates[i].matchedExt;
-          let entries: SrtEntry[] = [];
-          let formatLabel: string = 'SRT';
-          if (matchedExt === '.ass' || matchedExt === '.ssa') {
-            entries = AssFileParser.parse(content);
-            formatLabel = 'ASS';
-          } else if (matchedExt === '.vtt') {
-            entries = SrtParser.parse(content);
-            formatLabel = 'VTT';
-          } else {
-            entries = SrtParser.parse(content);
-            formatLabel = 'SRT';
-          }
-
-          const langLabel: string = extractSmbLangLabel(candidates[i].name, parsed.baseName);
-          const displayName: string = langLabel.length > 0
-            ? `${langLabel} [外部·${formatLabel}]`
-            : `字幕 [外部·${formatLabel}]`;
-
-          // Fix G: 空解析结果不加入字幕轨道，避免产生空字幕轨道
-          if (entries.length === 0) {
-            hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-              `[外置字幕] 解析结果为空，跳过: ${candidates[i].name}`);
-            continue;
-          }
-
-          const item: SubtitleTrackItem = {
-            kind: 'external',
-            displayName,
-            srtEntries: entries
-          };
-          found.push(item);
-
-          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-            `[外置字幕] 加载成功: ${candidates[i].name} entries=${entries.length}`);
-        } catch (e) {
-          // 单条字幕解析失败不中断整体流程
-          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-            `[外置字幕] 解析失败: ${candidates[i].name}`);
-        }
-      }
-
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-        `[外置字幕探测完成] 找到 ${found.length} 个 SMB 外置字幕`);
-      return found;
-    } catch (e) {
-      // 任何未预期的异常，静默处理，不影响播放流程
-      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-        '[外置字幕] SMB 字幕加载异常，返回空数组');
-      return [];
-    }
-  }
-
-  /** SMB 源优先选外置字幕（已预加载，立即可用）；无外置字幕时才回落到内嵌字幕 */
-  protected override findPreferredTrackIndex(): number {
-    for (let i = 0; i < this.allSubtitleTracks.length; i++) {
-      if (this.allSubtitleTracks[i].kind === 'external') {
-        return i;
-      }
-    }
-    for (let i = 0; i < this.allSubtitleTracks.length; i++) {
-      if (this.allSubtitleTracks[i].kind === 'internal') {
-        return i;
-      }
-    }
-    return -1;
+    return loadSmbExternalSubtitles(this.videoData?.videoSrc ?? '');
   }
 
   /**
@@ -394,7 +350,6 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
         '[SmbSub] 无 presetSubtitleTracks，跳过内嵌轨道加载');
       return items;
     }
-    // 只保留可文本渲染的格式，跳过 hdmv_pgs_subtitle、dvd_subtitle 等图形字幕
     const TEXT_CODECS: string[] = ['subrip', 'srt', 'ass', 'ssa', 'webvtt', 'mov_text'];
     for (let i = 0; i < presets.length; i++) {
       const t: PresetSubtitleTrack = presets[i];
@@ -416,51 +371,37 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
   /**
    * 覆写轨道切换：内嵌字幕通过 FfprobeUtil.extractEmbeddedSubtitles 提取后走 SRT 渲染管线；
    * 外置字幕交由父类处理（srtEntries 已在 loadExternalTracks 解析完毕）。
-   * SMB 视频通过 native player 的 HTTP 代理提供 ffprobe 可用的 URL。
    */
   override async switchTrack(allIndex: number): Promise<void> {
     if (!this.player) {
       return;
     }
-    // allIndex < 0 表示关闭字幕：先显式清除播放器轨，再交由父类重置状态
     if (allIndex < 0) {
       await this.player?.selectTrack(-1);
       await super.switchTrack(allIndex);
       return;
     }
-
     const target = this.allSubtitleTracks[allIndex];
     if (!target) {
       return;
     }
-
     if (target.kind === 'external') {
-      // 外置字幕 srtEntries 已预加载，直接交父类处理
       await super.switchTrack(allIndex);
       return;
     }
-
-    // 内嵌字幕：实时提取字幕文本，走 SRT 渲染管线
     const internalIndex = target.internalIndex ?? -1;
     if (internalIndex < 0) {
       return;
     }
-
-    // Major #4：切换内嵌字幕前先清除播放器层面旧轨，防止双轨叠加
     await this.player?.selectTrack(-1);
-
-    // Major #5：递增版本号，防止慢请求覆盖快请求的结果（竞态防护）
     this.subtitleSwitchGeneration += 1;
     const currentGen = this.subtitleSwitchGeneration;
-
     this.activeSubtitleIndex = allIndex;
     this.srtEntries = [];
     this.lastSrtText = '';
     this.currentSubtitleText = '';
     this.currentSubtitleTrack = internalIndex;
 
-    // 优先使用 native player 的 HTTP 代理 URL（native 后端已为 SMB 源建立代理）
-    // 回退到 videoData.videoSrc（ijkplayer fallback 后 videoSrc 已更新为代理 URL）
     let videoSrc: string = this.videoData?.videoSrc ?? '';
     const vidAllAdapter = this.player as VidAllPlayerAdapter;
     const proxyUrl: string = vidAllAdapter?.getProxyUrl?.() ?? '';
@@ -468,8 +409,7 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
       videoSrc = proxyUrl;
     }
     if (videoSrc.length === 0) {
-      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-        '[SmbSub] 无可用视频 URL，降级无字幕');
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG, '[SmbSub] 无可用视频 URL，降级无字幕');
       return;
     }
 
@@ -477,7 +417,6 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
       const entries: EmbeddedSubEntry[] = await FfprobeUtil.extractEmbeddedSubtitles(
         videoSrc, undefined, internalIndex, 90000
       );
-      // Major #5：写入前检查版本号，过期结果直接丢弃
       if (currentGen !== this.subtitleSwitchGeneration) {
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
           '[SmbSub] 字幕提取结果已过期，丢弃（generation 不匹配）');
@@ -487,10 +426,6 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `[SmbSub] 内嵌字幕提取完成 stream=${internalIndex} entries=${entries.length}`);
 
-      // 判断是否需要 fallback 到外置字幕：
-      // 1. entries=0（提取失败）
-      // 2. entries 时间范围无法覆盖当前播放位置（典型场景：超时后只拿到片头动画字幕，
-      //    而播放已在片中，此时 entries 最大时间 < 当前位置）
       let needFallback = entries.length === 0;
       if (!needFallback && entries.length > 0) {
         const maxEndMs: number = (entries as SrtEntry[]).reduce(
@@ -504,7 +439,6 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
           needFallback = true;
         }
       }
-
       if (needFallback) {
         const externalIndex: number = this.allSubtitleTracks.findIndex(
           (t: SubtitleTrackItem) => t.kind === 'external'
@@ -518,7 +452,6 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
     } catch {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         '[SmbSub] 内嵌字幕提取失败，尝试 fallback 到外置字幕');
-      // generation 检查：若用户已切换到其他轨道，不干扰
       if (currentGen === this.subtitleSwitchGeneration) {
         const externalIdx: number = this.allSubtitleTracks.findIndex(
           (t: SubtitleTrackItem) => t.kind === 'external'
@@ -530,5 +463,24 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
         }
       }
     }
+  }
+}
+
+/**
+ * SMB + AVPlayer 字幕适配器。
+ * 内嵌字幕通过 AVPlayer 原生 subtitleInfoUpdate 实时推送（继承 AvSubtitleBridgeAdapter）；
+ * 外置字幕通过 SMBClient 从原始 SMB URL 目录加载（覆写 loadExternalTracks）。
+ * 适用于 SMB 源切换到 AVPlayer 路径（通过 HTTP 代理拉流）的场景。
+ */
+export class SmbAvSubtitleBridgeAdapter extends AvSubtitleBridgeAdapter {
+  private readonly smbVideoUrl: string;
+
+  constructor(smbVideoUrl: string) {
+    super();
+    this.smbVideoUrl = smbVideoUrl;
+  }
+
+  protected override async loadExternalTracks(): Promise<SubtitleTrackItem[]> {
+    return loadSmbExternalSubtitles(this.smbVideoUrl);
   }
 }

--- a/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
@@ -186,6 +186,8 @@ function extractSmbLangLabel(fileName: string, baseName: string): string {
  * 任何步骤失败均静默处理（catch 后返回空数组），不向上抛出异常。
  */
 export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
+  /** 防止异步提取竞态：每次发起新切轨请求时递增，过期结果不写入 srtEntries */
+  private subtitleSwitchGeneration: number = 0;
   protected async loadExternalTracks(): Promise<SubtitleTrackItem[]> {
     if (!this.videoData) {
       return [];
@@ -397,8 +399,9 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
     if (!this.player) {
       return;
     }
-    // allIndex < 0 表示取消选中，交由父类处理（重置状态 + selectTrack(-1)）
+    // allIndex < 0 表示关闭字幕：先显式清除播放器轨，再交由父类重置状态
     if (allIndex < 0) {
+      await this.player?.selectTrack(-1);
       await super.switchTrack(allIndex);
       return;
     }
@@ -419,6 +422,13 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
     if (internalIndex < 0) {
       return;
     }
+
+    // Major #4：切换内嵌字幕前先清除播放器层面旧轨，防止双轨叠加
+    await this.player?.selectTrack(-1);
+
+    // Major #5：递增版本号，防止慢请求覆盖快请求的结果（竞态防护）
+    this.subtitleSwitchGeneration += 1;
+    const currentGen = this.subtitleSwitchGeneration;
 
     this.activeSubtitleIndex = allIndex;
     this.srtEntries = [];
@@ -444,6 +454,12 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
       const entries: EmbeddedSubEntry[] = await FfprobeUtil.extractEmbeddedSubtitles(
         videoSrc, undefined, internalIndex, 30000
       );
+      // Major #5：写入前检查版本号，过期结果直接丢弃
+      if (currentGen !== this.subtitleSwitchGeneration) {
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          '[SmbSub] 字幕提取结果已过期，丢弃（generation 不匹配）');
+        return;
+      }
       this.srtEntries = entries as SrtEntry[];
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `[SmbSub] 内嵌字幕提取完成 stream=${internalIndex} entries=${entries.length}`);

--- a/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SmbSubtitleBridgeAdapter.ets
@@ -452,7 +452,7 @@ export class SmbSubtitleBridgeAdapter extends BaseSubtitleBridgeAdapter {
 
     try {
       const entries: EmbeddedSubEntry[] = await FfprobeUtil.extractEmbeddedSubtitles(
-        videoSrc, undefined, internalIndex, 30000
+        videoSrc, undefined, internalIndex, 90000
       );
       // Major #5：写入前检查版本号，过期结果直接丢弃
       if (currentGen !== this.subtitleSwitchGeneration) {

--- a/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
@@ -384,11 +384,21 @@ export class BaseSubtitleBridgeAdapter implements ISubtitleBridgeAdapter {
 
     if (this.allSubtitleTracks.length > 0) {
       const preferredIndex = this.findPreferredTrackIndex();
-      await this.switchTrack(preferredIndex);
+      // 不 await：auto-select 的轨道切换可能包含长时间异步操作（如 SMB 内嵌字幕 30s 提取）
+      // fire-and-forget，初始化立即完成，字幕在提取完成后自动开始渲染
+      this.switchTrack(preferredIndex).catch(() => {
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          `[字幕指标] 自动选轨异常，降级无字幕`);
+      });
       const selected = this.allSubtitleTracks[preferredIndex];
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-        `[字幕指标] 初始化完成: 内嵌=${internalItems.length} 外置=${externalItems.length}` +
-        ` 自动选中[${preferredIndex}]=${selected.displayName}(${selected.kind})`);
+      if (selected) {
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          `[字幕指标] 初始化完成: 内嵌=${internalItems.length} 外置=${externalItems.length}` +
+          ` 自动选中[${preferredIndex}]=${selected.displayName}(${selected.kind})`);
+      } else {
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          `[字幕指标] 初始化完成: 内嵌=${internalItems.length} 外置=${externalItems.length} 轨道索引越界`);
+      }
     } else {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `[字幕指标] 初始化完成: 内嵌=0 外置=0 无字幕轨道`);

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -20,7 +20,7 @@ import {
   SubtitleBridgeState,
   SubtitleTrackItem
 } from "./SubtitleBridgeAdapter";
-import { SmbSubtitleBridgeAdapter } from "./SmbSubtitleBridgeAdapter";
+import { SmbAvSubtitleBridgeAdapter, SmbSubtitleBridgeAdapter } from "./SmbSubtitleBridgeAdapter";
 import { VpeEnhancerUtil, VpeQualityLevel } from "../../../utils/VpeEnhancerUtil";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
@@ -220,6 +220,8 @@ export class VideoPlayerController {
   private pendingBackendResumeTimeMs: number = -1;
   /** native 自动回退后，是否在 seek 完成后自动续播 */
   private pendingBackendResumePlay: boolean = false;
+  /** SMB 源原始 URL（smb://...），在 native→AVPlayer 切换完成前保留，供字幕适配器使用 */
+  private pendingSmbOriginalUrl: string = '';
   /** 一次性控制：本次 seek 完成后不自动恢复播放 */
   private suppressPlayAfterSeekOnce: boolean = false;
   /** ffmpeg 动态预览：当前是否正在抽帧 */
@@ -294,6 +296,8 @@ export class VideoPlayerController {
     this.ffmpegLastEmptyQueueCatchupAtMs = 0;
     this.ffmpegSingleFrameMode = false;
     this.clearNativeReadyGuardTimer();
+    // SMB 代理切换标记：native player 就绪后将 videoSrc 换为代理 URL 并重新 init，此时需跳过后端覆写
+    const isSmbProxySwitch = this.pendingSmbOriginalUrl.length > 0 && !videoData.videoSrc.startsWith('smb://');
     const shouldPreserveBackendResume = this.backend === 'ijkplayer' && this.pendingBackendResumeTimeMs >= 0;
     if (!shouldPreserveBackendResume) {
       this.pendingBackendResumeTimeMs = -1;
@@ -318,7 +322,7 @@ export class VideoPlayerController {
       videoData.ffmpegDecodeChannels = decision.preferredChannels;
       videoData.audioProbeSummary = decision.summary;
       videoData.videoCodec = decision.videoCodecName;
-      if (this.backend === 'avplayer' || this.backend === 'ffmpeg' || this.backend === 'native') {
+      if (!isSmbProxySwitch && (this.backend === 'avplayer' || this.backend === 'ffmpeg' || this.backend === 'native')) {
         this.backend = decision.preferredBackend;
       }
       if (decision.precheckProbeFailed && backendBeforeAutoRouting !== this.backend) {
@@ -346,6 +350,7 @@ export class VideoPlayerController {
     if (videoData.videoSrc.startsWith('smb://')) {
       this.backend = 'native';
       this.sourceProtocol = 'SMB';
+      this.pendingSmbOriginalUrl = videoData.videoSrc;
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         'SMB 源检测：已强制切换到 native FFmpeg 后端（smb:// 协议）');
     }
@@ -440,7 +445,13 @@ export class VideoPlayerController {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         'initPlayer: 使用 AVPlayerAdapter');
       adapter = new AVPlayerAdapter();
-      this.subtitleAdapter = new AvSubtitleBridgeAdapter();
+      if (isSmbProxySwitch) {
+        // SMB 代理切换：AVPlayer 内嵌字幕实时推送 + SMB 外置字幕加载
+        this.subtitleAdapter = new SmbAvSubtitleBridgeAdapter(this.pendingSmbOriginalUrl);
+        this.pendingSmbOriginalUrl = '';
+      } else {
+        this.subtitleAdapter = new AvSubtitleBridgeAdapter();
+      }
     }
 
     // 注册所有 IPlayer 事件回调
@@ -1466,6 +1477,12 @@ export class VideoPlayerController {
   /** prepared 后回调：读取 duration、加载字幕轨道和音轨 */
   private async onPlayerReady(): Promise<void> {
     this.clearNativeReadyGuardTimer();
+    // SMB 源：native player 已就绪（HTTP 代理已启动），立即切换到 AVPlayer 路径以获得实时字幕
+    if (this.backend === 'native' && this.pendingSmbOriginalUrl.length > 0) {
+      if (this.switchSmbToAvPlayer()) {
+        return;
+      }
+    }
     const playerDuration = this.player?.duration ?? 0;
     this.duration = playerDuration > 0
       ? playerDuration
@@ -1600,6 +1617,40 @@ export class VideoPlayerController {
     this.player = undefined;
     this.backend = 'ijkplayer';
     oldPlayer?.release().catch(() => {});
+  }
+
+  /**
+   * SMB → AVPlayer 两阶段切换。
+   * native player 就绪后调用：获取代理 URL → 释放 native 保留代理 → backend='avplayer' → UI 重建 XComponent。
+   * 返回 true 表示切换已启动（onPlayerReady 应立即 return）；false 表示代理不可用，继续使用 native。
+   */
+  private switchSmbToAvPlayer(): boolean {
+    if (this.backend !== 'native') {
+      return false;
+    }
+    const vidAllAdapter = this.player as VidAllPlayerAdapter;
+    const proxyUrl = vidAllAdapter?.getProxyUrl?.() ?? '';
+    if (proxyUrl.length === 0) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        '[SMB→AVPlayer] 代理 URL 不可用，继续 native 路径');
+      return false;
+    }
+    // 将 videoSrc 替换为代理 URL，后续 initPlayer 走 AVPlayer 路径
+    if (this.currentVideoData) {
+      this.currentVideoData.videoSrc = proxyUrl;
+    }
+    const resumePosition = this.player?.currentTime ?? this.currentTime;
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[SMB→AVPlayer] 切换: resumePos=${resumePosition}`);
+    this.isLoading = true;
+    this.pendingBackendResumeTimeMs = resumePosition > 0 ? resumePosition : 0;
+    this.pendingBackendResumePlay = true;
+    // 释放 native player 但保留代理线程，AVPlayer 通过代理 URL 拉流
+    const oldAdapter = this.player as VidAllPlayerAdapter;
+    this.player = undefined;
+    this.backend = 'avplayer'; // @Monitor 响应 → VideoPlayer.ets 重建 XComponent → initPlayer
+    oldAdapter?.releaseKeepProxy?.().catch(() => {});
+    return true;
   }
 
   private logFallbackEvent(

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -2,6 +2,8 @@ import { BusinessError } from '@kit.BasicServicesKit'
 import { SMBSourceConfig } from '../../db/models/FileSourceEntity'
 import { SMBClient, SmbFileInfo } from '../../lib/SMBClient'
 import { PlayerPage, PlayerPageParam } from '../player'
+import { FfprobeUtil } from '../../utils/FfprobeUtil'
+import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 对外导出的路由参数接口
@@ -195,12 +197,53 @@ export struct SmbFileExplorerPage {
     }
   }
 
-  private playVideo(file: SmbFileInfo): void {
+  private async playVideo(file: SmbFileInfo): Promise<void> {
     const url = this.buildPlaybackUrl(file.path)
-    console.info('SmbFileExplorerPage', `播放视频: ${this.maskSmbUrl(url)}`)
+    console.info('[SmbExplorer] 播放视频: ' + this.maskSmbUrl(url))
+
+    // ── 探测音轨/字幕轨信息（失败时降级为空轨道，不阻断播放主流程）────────────
+    let presetAudioTracks: PresetAudioTrack[] = []
+    let presetSubtitleTracks: PresetSubtitleTrack[] = []
+    try {
+      const probeResult = await FfprobeUtil.probeSmb(url, 15000)
+      if (probeResult.success) {
+        console.info(
+          '[SmbExplorer] 轨道探测成功: 音轨=' + probeResult.audioTracks.length.toString() +
+          ' 字幕轨=' + probeResult.subtitleTracks.length.toString()
+        )
+        for (let i = 0; i < probeResult.audioTracks.length; i++) {
+          const t = probeResult.audioTracks[i]
+          const item: PresetAudioTrack = {
+            trackIndex: t.index,
+            displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
+            language: t.language,
+            mimeType: t.codecName
+          }
+          presetAudioTracks.push(item)
+        }
+        for (let i = 0; i < probeResult.subtitleTracks.length; i++) {
+          const t = probeResult.subtitleTracks[i]
+          const item: PresetSubtitleTrack = {
+            trackIndex: t.index,
+            displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),
+            language: t.language,
+            codecName: t.codecName
+          }
+          presetSubtitleTracks.push(item)
+        }
+      } else {
+        console.warn('[SmbExplorer] 轨道探测未成功（降级为空轨道）: ' + (probeResult.errorMessage ?? '(未知原因)'))
+      }
+    } catch (e) {
+      const err = e as BusinessError
+      console.warn('[SmbExplorer] 轨道探测异常，不阻断播放: ' + (err.message ? err.message : JSON.stringify(e)))
+    }
+
     const pageParam: PlayerPageParam = {
       url: url,
-      title: file.name
+      title: file.name,
+      presetAudioTracks: presetAudioTracks.length > 0 ? presetAudioTracks : undefined,
+      presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined
     }
     this.pageStack.pushPath({
       name: PlayerPage.PAGE_NAME,

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -217,7 +217,7 @@ export struct SmbFileExplorerPage {
             trackIndex: t.index,
             displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
             language: t.language,
-            mimeType: t.codecName
+            mimeType: undefined   // codec 名不是 MIME type，下游用 codecName 匹配即可
           }
           presetAudioTracks.push(item)
         }

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -526,11 +526,12 @@ export class FfprobeUtil {
   ): Promise<FfprobeResult> {
     console.info(`[FfprobeUtil] SMB probe via HTTP proxy: ${maskUrlForLog(smbUrl)}`);
 
-    let playerHandle: number = 0;
-    let proxyUrl: string = '';
+    // ── 先拿并发槽位，防止多文件快速滑动时代理并发创建失控 ─────────────────
+    await FfprobeUtil.acquireProbeSlot();
 
-    // ── 阶段 1：启动 SMB HTTP 代理（native player prepare 同步触发）──────────
+    let playerHandle: number = 0;
     try {
+      // ── 阶段 1：启动 SMB HTTP 代理（native player prepare 异步回调）──────────
       const napi = getSmbProbeNapi();
       playerHandle = napi.createPlayer();
       napi.setSource(playerHandle, smbUrl);
@@ -539,11 +540,11 @@ export class FfprobeUtil {
       const dummyCtx: SmbProbeOnlyContext = {};
       napi.setXComponent(playerHandle, dummyCtx as Object, 'smb-probe-only');
 
-      // prepare() 是同步调用：onPrepared 在 prepare() 内部同步触发，代理随之启动
+      // prepare() 是非阻塞调用：onPrepared 通过异步回调触发，代理随之启动
       const h = playerHandle;
       napi.setCallbacks(
         h,
-        () => { /* onPrepared: prepare() 同步触发，代理已启动，无需额外操作 */ },
+        () => { /* onPrepared: prepare() 异步回调，代理已启动，无需额外操作 */ },
         (code: number, msg: string) => {
           console.warn(`[FfprobeUtil] SMB probe player error: code=${code} msg=${msg}`);
         },
@@ -559,12 +560,33 @@ export class FfprobeUtil {
 
       napi.prepare(h);
 
-      proxyUrl = napi.getProxyUrl(h) ?? '';
+      const proxyUrl = napi.getProxyUrl(h) ?? '';
       console.info(`[FfprobeUtil] SMB proxy URL: ${proxyUrl.length > 0 ? proxyUrl : '(空)'}`);
+
+      if (proxyUrl.length === 0) {
+        console.warn(`[FfprobeUtil] SMB proxy URL 为空，跳过探测（可能 prepare 未成功或非 SMB 源）`);
+        return FfprobeUtil.buildErrorResult(maskUrlForLog(smbUrl), 'SMB proxy URL 为空');
+      }
+
+      // ── 阶段 2：通过 HTTP proxy URL 直接调用 ffprobe NAPI（槽位已持有）────
+      try {
+        const outputJson = await getVidAllCorePlayerNapi().ffprobe(proxyUrl, '', timeoutMs);
+        console.info(`[FfprobeUtil] SMB probe 完成，输出长度=${outputJson.length}`);
+        return FfprobeUtil.parseOutput(proxyUrl, outputJson);
+      } catch (e) {
+        const err = e as BusinessError;
+        const msg = err.message ? err.message : JSON.stringify(e);
+        console.error(`[FfprobeUtil] SMB probe 探测失败: ${msg}`);
+        return FfprobeUtil.buildErrorResult(maskUrlForLog(smbUrl), msg);
+      }
     } catch (e) {
       const err = e as BusinessError;
       const msg = err.message ? err.message : JSON.stringify(e);
       console.warn(`[FfprobeUtil] SMB proxy 启动失败，跳过探测: ${msg}`);
+      return FfprobeUtil.buildErrorResult(maskUrlForLog(smbUrl), `SMB proxy 启动失败: ${msg}`);
+    } finally {
+      // 无论成功/失败，始终释放并发槽位与临时 player（代理随之停止）
+      FfprobeUtil.releaseProbeSlot();
       if (playerHandle > 0) {
         try {
           getSmbProbeNapi().release(playerHandle);
@@ -572,32 +594,7 @@ export class FfprobeUtil {
           /* 释放失败不抛出 */
         }
       }
-      return FfprobeUtil.buildErrorResult(maskUrlForLog(smbUrl), `SMB proxy 启动失败: ${msg}`);
     }
-
-    if (proxyUrl.length === 0) {
-      console.warn(`[FfprobeUtil] SMB proxy URL 为空，跳过探测（可能 prepare 未成功或非 SMB 源）`);
-      try {
-        getSmbProbeNapi().release(playerHandle);
-      } catch {
-        /* 释放失败不抛出 */
-      }
-      return FfprobeUtil.buildErrorResult(maskUrlForLog(smbUrl), 'SMB proxy URL 为空');
-    }
-
-    // ── 阶段 2：通过 HTTP proxy URL 调用 ffprobe，完成后释放 player ──────────
-    let probeResult: FfprobeResult;
-    try {
-      probeResult = await FfprobeUtil.probe(proxyUrl, {}, timeoutMs);
-    } finally {
-      // 无论探测成功/失败都释放临时 player，代理随之停止
-      try {
-        getSmbProbeNapi().release(playerHandle);
-      } catch {
-        /* 释放失败不抛出 */
-      }
-    }
-    return probeResult;
   }
 
   /**

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -843,27 +843,36 @@ export class FfprobeUtil {
 
   /**
    * 构建字幕轨显示名称
-   * e.g. "中文 (SRT)", "英语 (ASS)", "字幕 1"
+   * 格式：N 语言(编码)，例如：
+   *   "1 中文(ASS)"、"2 中文(SRT)"、"3 英语(ASS)"
+   *   "4 中文(ASS) 简体"（tier3 语义标签保留）
+   *   "5 字幕"（无语言无编码时的兜底）
    */
   static buildSubtitleTrackDisplayName(track: FfprobeTrack, index: number): string {
+    const num = index + 1;
     const langName = track.language
       ? FfprobeUtil.getLanguageDisplayName(track.language)
-      : `字幕 ${index + 1}`;
+      : '';
     const codecDisplay = track.codecName
       ? FfprobeUtil.getCodecDisplayName(track.codecName)
       : '';
     const tier3 = FfprobeUtil.getSubtitleTier3Label(track, index);
+    const isSemanticTier3 = tier3.length > 0 && tier3 !== '未标注' && !tier3.startsWith('轨道');
 
-    if (codecDisplay) {
-      // 有编解码显示名称时：语言 (编码)，与 buildAudioTrackDisplayName 风格一致
-      // tier3 为语义标签（简体/繁体/香港）时追加，通用兜底（'未标注'/'轨道N'）时省略
-      const isSemanticTier3 = tier3.length > 0 && tier3 !== '未标注' && !tier3.startsWith('轨道');
-      if (isSemanticTier3) {
-        return `${langName} (${codecDisplay}) ${tier3}`;
-      }
-      return `${langName} (${codecDisplay})`;
+    let label = '';
+    if (langName && codecDisplay) {
+      label = isSemanticTier3
+        ? `${langName}(${codecDisplay}) ${tier3}`
+        : `${langName}(${codecDisplay})`;
+    } else if (langName) {
+      label = langName;
+    } else if (codecDisplay) {
+      label = `字幕(${codecDisplay})`;
+    } else {
+      label = '字幕';
     }
-    return langName;
+
+    return `${num} ${label}`;
   }
 }
 

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -26,6 +26,49 @@ function getVidAllCorePlayerNapi(): FfprobeNapiBridge {
 }
 
 // ─────────────────────────────────────────────
+// SMB 代理探测所需的 NAPI 桥接（与 libvidall_core_player_napi.so 共模块）
+// ─────────────────────────────────────────────
+
+/** probeSmb() 创建临时 player 时传入的 XComponent 占位上下文（无实际渲染需求） */
+interface SmbProbeOnlyContext {
+}
+
+/** SMB 代理探测所需的 native player 管理方法子集 */
+interface SmbProbeNapiBridge {
+  createPlayer: () => number;
+  setSource: (handle: number, url: string) => void;
+  setXComponent: (handle: number, context: Object, xComponentId: string) => void;
+  setCallbacks: (
+    handle: number,
+    onPrepared: () => void,
+    onError: (code: number, msg: string) => void,
+    onTimeUpdate: (posMs: number) => void,
+    onCompleted: () => void,
+    onBufferingChange: (isBuffering: boolean) => void,
+    onSeekDone: () => void
+  ) => void;
+  prepare: (handle: number) => void;
+  getProxyUrl: (handle: number) => string;
+  release: (handle: number, keepProxy?: boolean) => void;
+}
+
+interface SmbProbeNapiBridgeModule {
+  default?: SmbProbeNapiBridge;
+}
+
+function getSmbProbeNapi(): SmbProbeNapiBridge {
+  const bridgeModule = VidAllCorePlayerNapiModule as SmbProbeNapiBridgeModule | SmbProbeNapiBridge | undefined;
+  if (bridgeModule === undefined) {
+    throw new Error('libvidall_core_player_napi.so 未加载');
+  }
+  const defaultBridge = (bridgeModule as SmbProbeNapiBridgeModule).default;
+  if (defaultBridge !== undefined) {
+    return defaultBridge as SmbProbeNapiBridge;
+  }
+  return bridgeModule as SmbProbeNapiBridge;
+}
+
+// ─────────────────────────────────────────────
 // 数据结构
 // ─────────────────────────────────────────────
 
@@ -460,6 +503,101 @@ export class FfprobeUtil {
       errorMessage,
     };
     return result;
+  }
+
+  /**
+   * 通过 SMB HTTP 代理探测 SMB 视频文件的轨道信息。
+   *
+   * 流程：
+   *   1. 创建临时 native player → prepare() 同步启动 SMB HTTP 代理
+   *   2. 获取代理 URL（http://127.0.0.1:PORT/share/path/file.mkv）
+   *   3. 用代理 URL 调用 ffprobe 探测轨道
+   *   4. ffprobe 完成后释放临时 player（代理随之停止）
+   *
+   * 若代理启动或 ffprobe 失败，返回 success=false 的结果，不抛出异常，
+   * 由调用方决定是否阻断播放（降级策略：失败时空轨道、正常播放）。
+   *
+   * @param smbUrl   smb://user:pass@host:port/share/path 格式的完整 SMB URL
+   * @param timeoutMs ffprobe 超时，默认 15000ms
+   */
+  static async probeSmb(
+    smbUrl: string,
+    timeoutMs: number = 15000
+  ): Promise<FfprobeResult> {
+    console.info(`[FfprobeUtil] SMB probe via HTTP proxy: ${maskUrlForLog(smbUrl)}`);
+
+    let playerHandle: number = 0;
+    let proxyUrl: string = '';
+
+    // ── 阶段 1：启动 SMB HTTP 代理（native player prepare 同步触发）──────────
+    try {
+      const napi = getSmbProbeNapi();
+      playerHandle = napi.createPlayer();
+      napi.setSource(playerHandle, smbUrl);
+
+      // probe 不需要实际渲染；XComponent 传 dummy 值（C++ 骨架阶段仅存储 id，不立即绑定 surface）
+      const dummyCtx: SmbProbeOnlyContext = {};
+      napi.setXComponent(playerHandle, dummyCtx as Object, 'smb-probe-only');
+
+      // prepare() 是同步调用：onPrepared 在 prepare() 内部同步触发，代理随之启动
+      const h = playerHandle;
+      napi.setCallbacks(
+        h,
+        () => { /* onPrepared: prepare() 同步触发，代理已启动，无需额外操作 */ },
+        (code: number, msg: string) => {
+          console.warn(`[FfprobeUtil] SMB probe player error: code=${code} msg=${msg}`);
+        },
+        (posMs: number) => {
+          console.debug(`[FfprobeUtil] SMB probe time update: ${posMs}`);
+        },
+        () => { /* onCompleted: probe 阶段不播放，忽略 */ },
+        (isBuffering: boolean) => {
+          console.debug(`[FfprobeUtil] SMB probe buffering: ${isBuffering}`);
+        },
+        () => { /* onSeekDone: probe 阶段无 seek，忽略 */ }
+      );
+
+      napi.prepare(h);
+
+      proxyUrl = napi.getProxyUrl(h) ?? '';
+      console.info(`[FfprobeUtil] SMB proxy URL: ${proxyUrl.length > 0 ? proxyUrl : '(空)'}`);
+    } catch (e) {
+      const err = e as BusinessError;
+      const msg = err.message ? err.message : JSON.stringify(e);
+      console.warn(`[FfprobeUtil] SMB proxy 启动失败，跳过探测: ${msg}`);
+      if (playerHandle > 0) {
+        try {
+          getSmbProbeNapi().release(playerHandle);
+        } catch {
+          /* 释放失败不抛出 */
+        }
+      }
+      return FfprobeUtil.buildErrorResult(maskUrlForLog(smbUrl), `SMB proxy 启动失败: ${msg}`);
+    }
+
+    if (proxyUrl.length === 0) {
+      console.warn(`[FfprobeUtil] SMB proxy URL 为空，跳过探测（可能 prepare 未成功或非 SMB 源）`);
+      try {
+        getSmbProbeNapi().release(playerHandle);
+      } catch {
+        /* 释放失败不抛出 */
+      }
+      return FfprobeUtil.buildErrorResult(maskUrlForLog(smbUrl), 'SMB proxy URL 为空');
+    }
+
+    // ── 阶段 2：通过 HTTP proxy URL 调用 ffprobe，完成后释放 player ──────────
+    let probeResult: FfprobeResult;
+    try {
+      probeResult = await FfprobeUtil.probe(proxyUrl, {}, timeoutMs);
+    } finally {
+      // 无论探测成功/失败都释放临时 player，代理随之停止
+      try {
+        getSmbProbeNapi().release(playerHandle);
+      } catch {
+        /* 释放失败不抛出 */
+      }
+    }
+    return probeResult;
   }
 
   /**

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -548,13 +548,9 @@ export class FfprobeUtil {
         (code: number, msg: string) => {
           console.warn(`[FfprobeUtil] SMB probe player error: code=${code} msg=${msg}`);
         },
-        (posMs: number) => {
-          console.debug(`[FfprobeUtil] SMB probe time update: ${posMs}`);
-        },
+        () => { /* onTimeUpdate: probe 阶段不播放，忽略 */ },
         () => { /* onCompleted: probe 阶段不播放，忽略 */ },
-        (isBuffering: boolean) => {
-          console.debug(`[FfprobeUtil] SMB probe buffering: ${isBuffering}`);
-        },
+        () => { /* onBufferingChange: probe 阶段不播放，忽略 */ },
         () => { /* onSeekDone: probe 阶段无 seek，忽略 */ }
       );
 

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -857,7 +857,9 @@ export class FfprobeUtil {
       ? FfprobeUtil.getCodecDisplayName(track.codecName)
       : '';
     const tier3 = FfprobeUtil.getSubtitleTier3Label(track, index);
-    const isSemanticTier3 = tier3.length > 0 && tier3 !== '未标注' && !tier3.startsWith('轨道');
+    // 只保留短语义标签（简体/繁体/香港等），过滤 MKV track title 长字符串
+    const SEMANTIC_TIER3_KEYWORDS: string[] = ['简体', '繁体', '香港', '台湾', 'Simplified', 'Traditional', 'HK', 'TW'];
+    const isSemanticTier3 = SEMANTIC_TIER3_KEYWORDS.some((kw: string) => tier3.includes(kw));
 
     let label = '';
     if (langName && codecDisplay) {


### PR DESCRIPTION
## 问题

SMB 文件浏览器播放视频时，播放页音轨和内置字幕轨选择列表为空，无法切换。

## 根因

`SmbFileExplorerPage.playVideo()` 只构造了 URL+title，未调用 ffprobe 探测轨道，导致播放器无 presetAudioTracks/presetSubtitleTracks 可用。AVPlayer 不支持 `smb://` 协议，fallback getTrackInfos() 路径不可靠。

## 修复方案

- `FfprobeUtil` 新增 `probeSmb(smbUrl, timeoutMs)` 静态方法：创建临时 native player 启动 HTTP 代理 → 通过代理 URL 调用现有 ffprobe 链路探测轨道 → finally 释放临时 player
- `SmbFileExplorerPage.playVideo()` 改为 async，播放前调用 `FfprobeUtil.probeSmb()`，成功则注入 preset 轨道，失败则降级继续播放

## 验证

- SMB 播放包含多音轨/字幕轨的 MKV，轨道选择列表正常显示
- 探测失败时播放页仍正常打开（降级）
- 凭据脱敏日志

Closes #81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playback probes SMB media before start to auto-detect and preset audio and subtitle tracks.
  * On-demand extraction of embedded text subtitles with filtered internal-track loading.

* **Bug Fixes / Reliability**
  * Probe failures gracefully fall back to normal playback without presets.
  * Subtitle switching and auto-selection hardened to avoid stale async results and initialization hangs; extraction fallbacks added.

* **Other**
  * Playback logging prefix clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->