### PR TITLE
新增: 媒体级播放进度持久化，支持详情页跨会话续播

### DIFF
--- a/entry/src/main/ets/db/MediaProgressStore.ets
+++ b/entry/src/main/ets/db/MediaProgressStore.ets
@@ -12,8 +12,8 @@ import { MediaProgressEntry } from './models/MediaEntity';
  */
 export class MediaProgressStore {
   /** 构造剧集媒体进度 key */
-  static seriesKey(seriesProviderId: string): string {
-    return `media_progress_series_${seriesProviderId}`;
+  static seriesKey(seriesProviderId: string, provider: string = 'tmdb'): string {
+    return `media_progress_series_${provider}_${seriesProviderId}`;
   }
 
   /** 构造电影媒体进度 key */

--- a/entry/src/main/ets/db/MediaProgressStore.ets
+++ b/entry/src/main/ets/db/MediaProgressStore.ets
@@ -1,0 +1,74 @@
+import { FileSourceDatabase } from './files/FileSourceDatabase';
+import { MediaProgressEntry } from './models/MediaEntity';
+
+/**
+ * 媒体级播放进度读写工具类。
+ *
+ * Key 规则：
+ *   - 剧集：media_progress_series_<seriesProviderId>
+ *   - 电影：media_progress_movie_<movieId>
+ *
+ * 完播阈值：剩余时长 < 60 秒 或 已播比例 > 95%，由调用方判断后调用 clear()。
+ */
+export class MediaProgressStore {
+  /** 构造剧集媒体进度 key */
+  static seriesKey(seriesProviderId: string): string {
+    return `media_progress_series_${seriesProviderId}`;
+  }
+
+  /** 构造电影媒体进度 key */
+  static movieKey(movieId: string): string {
+    return `media_progress_movie_${movieId}`;
+  }
+
+  /**
+   * 判断当前播放位置是否达到完播阈值。
+   * 剩余时长 < 60 秒 或 已播比例 > 95% 视为完播。
+   */
+  static isNearEnd(positionMs: number, durationMs: number): boolean {
+    if (durationMs <= 0) {
+      return false;
+    }
+    return (durationMs - positionMs) < 60000 || positionMs > durationMs * 0.95;
+  }
+
+  /**
+   * 保存媒体级进度。
+   * @param key         由 seriesKey / movieKey 生成的存储键
+   * @param posMs       当前播放位置（毫秒）
+   * @param durMs       视频总时长（毫秒）
+   * @param seasonNumber  剧集：季号（电影传 0）
+   * @param episodeNumber 剧集：集号（电影传 0）
+   */
+  static async save(
+    key: string,
+    posMs: number,
+    durMs: number,
+    seasonNumber: number,
+    episodeNumber: number
+  ): Promise<void> {
+    const entry: MediaProgressEntry = {
+      mediaKey: key,
+      positionMs: posMs,
+      durationMs: durMs,
+      lastPlayedAt: Date.now(),
+      episodeNumber: episodeNumber,
+      seasonNumber: seasonNumber
+    };
+    await FileSourceDatabase.getInstance().upsertMediaProgress(entry);
+  }
+
+  /**
+   * 读取媒体级进度，不存在时返回 null。
+   */
+  static async get(key: string): Promise<MediaProgressEntry | null> {
+    return FileSourceDatabase.getInstance().getMediaProgress(key);
+  }
+
+  /**
+   * 清除媒体级进度（完播重置）。
+   */
+  static async clear(key: string): Promise<void> {
+    await FileSourceDatabase.getInstance().clearMediaProgress(key);
+  }
+}

--- a/entry/src/main/ets/db/MediaProgressStore.ets
+++ b/entry/src/main/ets/db/MediaProgressStore.ets
@@ -29,7 +29,7 @@ export class MediaProgressStore {
     if (durationMs <= 0) {
       return false;
     }
-    return (durationMs - positionMs) < 60000 || positionMs > durationMs * 0.95;
+    return (durationMs - positionMs) < 60000 || positionMs >= durationMs * 0.95;
   }
 
   /**

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -3,18 +3,18 @@ import { Context } from '@ohos.abilityAccessCtrl';
 import { FileSource, FileSourceDirectory, FileSourceType } from '../models/FileSourceEntity';
 import {
   VideoEntity, ScrapeInfoEntity, MovieEntity, TvSeriesEntity, TvSeasonEntity, TvEpisodeEntity,
-  MediaItem, MediaStats, SeriesGroup, DecadeGroup, MediaListItem, PlayProgressEntity
+  MediaItem, MediaStats, SeriesGroup, DecadeGroup, MediaListItem, PlayProgressEntity, MediaProgressEntry
 } from '../models/MediaEntity';
 import { CryptoUtil } from '../../utils/CryptoUtil';
 import { BusinessError, emitter } from "@kit.BasicServicesKit";
 
 /**
- * 文件源数据库管理类 — DB v5
+ * 文件源数据库管理类 — DB v6
  * 表结构：file_sources, file_source_directories, videos, scrape_info,
- *         movies, tv_series, tv_seasons, tv_episodes, play_progress
+ *         movies, tv_series, tv_seasons, tv_episodes, play_progress, media_progress
  */
 export class FileSourceDatabase {
-  private static readonly DB_VERSION = 5;
+  private static readonly DB_VERSION = 6;
   private static readonly DB_NAME = 'FILE_SOURCES_DB';
   private static readonly TABLE_FILE_SOURCES = 'file_sources';
   private static readonly TABLE_DIRECTORIES = 'file_source_directories';
@@ -25,6 +25,7 @@ export class FileSourceDatabase {
   private static readonly TABLE_TV_SEASONS = 'tv_seasons';
   private static readonly TABLE_TV_EPISODES = 'tv_episodes';
   private static readonly TABLE_PLAY_PROGRESS = 'play_progress';
+  private static readonly TABLE_MEDIA_PROGRESS = 'media_progress';
   private static readonly DATABASE_READY = 'FILE_SOURCES_DB_READY'
 
   // 单例实例
@@ -306,6 +307,19 @@ export class FileSourceDatabase {
       )
     `);
     console.info('FileSourceDatabase: v3 media tables created');
+
+    // media_progress（媒体级播放进度，以 media_key 为主键）
+    await rdbStore.executeSql(`
+      CREATE TABLE IF NOT EXISTS ${FileSourceDatabase.TABLE_MEDIA_PROGRESS} (
+        media_key TEXT PRIMARY KEY,
+        position_ms INTEGER NOT NULL DEFAULT 0,
+        duration_ms INTEGER NOT NULL DEFAULT 0,
+        last_played_at INTEGER NOT NULL,
+        episode_number INTEGER NOT NULL DEFAULT 0,
+        season_number INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+    console.info('FileSourceDatabase: media_progress table created');
   }
 
   /**
@@ -346,6 +360,20 @@ export class FileSourceDatabase {
           )
         `);
         console.info(`FileSourceDatabase: CREATE TABLE play_progress`);
+      }
+      if (oldVersion < 6) {
+        // v5 → v6：新增媒体级播放进度表
+        await rdbStore.executeSql(`
+          CREATE TABLE IF NOT EXISTS ${FileSourceDatabase.TABLE_MEDIA_PROGRESS} (
+            media_key TEXT PRIMARY KEY,
+            position_ms INTEGER NOT NULL DEFAULT 0,
+            duration_ms INTEGER NOT NULL DEFAULT 0,
+            last_played_at INTEGER NOT NULL,
+            episode_number INTEGER NOT NULL DEFAULT 0,
+            season_number INTEGER NOT NULL DEFAULT 0
+          )
+        `);
+        console.info(`FileSourceDatabase: CREATE TABLE media_progress`);
       }
       console.info('FileSourceDatabase: Upgrade complete');
     } catch (error) {
@@ -2258,7 +2286,99 @@ export class FileSourceDatabase {
       updatedAt: num('updated_at')
     };
   }
+
+  // ─────────────────────────────────────────────
+  // 媒体级播放进度（media_progress 表）
+  // ─────────────────────────────────────────────
+
+  /**
+   * 写入或更新媒体级播放进度（以 media_key 为主键，INSERT OR REPLACE）。
+   * 写入失败仅打 warn，不抛出异常，不阻塞调用方。
+   */
+  async upsertMediaProgress(entry: MediaProgressEntry): Promise<void> {
+    if (this.rdbStore === null) {
+      console.warn('[DB][upsertMediaProgress] DB 未初始化，跳过写入');
+      return;
+    }
+    try {
+      const sql = `
+        INSERT OR REPLACE INTO ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}
+          (media_key, position_ms, duration_ms, last_played_at, episode_number, season_number)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `;
+      const args: relationalStore.ValueType[] = [
+        entry.mediaKey,
+        entry.positionMs,
+        entry.durationMs,
+        entry.lastPlayedAt,
+        entry.episodeNumber,
+        entry.seasonNumber
+      ];
+      await this.rdbStore.executeSql(sql, args);
+      console.info(
+        `[DB][upsertMediaProgress] key=${entry.mediaKey} pos=${entry.positionMs}ms ` +
+        `s${entry.seasonNumber}e${entry.episodeNumber}`
+      );
+    } catch (error) {
+      const err = error as BusinessError;
+      console.warn(`[DB][upsertMediaProgress] 写入失败 code=${err.code} msg=${err.message}`);
+    }
+  }
+
+  /**
+   * 查询媒体级播放进度，不存在返回 null。
+   */
+  async getMediaProgress(mediaKey: string): Promise<MediaProgressEntry | null> {
+    if (this.rdbStore === null) {
+      return null;
+    }
+    try {
+      const pred = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_MEDIA_PROGRESS);
+      pred.equalTo('media_key', mediaKey);
+      const rs = await this.rdbStore.query(pred, [
+        'media_key', 'position_ms', 'duration_ms', 'last_played_at',
+        'episode_number', 'season_number'
+      ]);
+      if (!rs.goToFirstRow()) {
+        rs.close();
+        return null;
+      }
+      const entry: MediaProgressEntry = {
+        mediaKey: rs.getString(rs.getColumnIndex('media_key')),
+        positionMs: rs.getLong(rs.getColumnIndex('position_ms')),
+        durationMs: rs.getLong(rs.getColumnIndex('duration_ms')),
+        lastPlayedAt: rs.getLong(rs.getColumnIndex('last_played_at')),
+        episodeNumber: rs.getLong(rs.getColumnIndex('episode_number')),
+        seasonNumber: rs.getLong(rs.getColumnIndex('season_number'))
+      };
+      rs.close();
+      return entry;
+    } catch (error) {
+      const err = error as BusinessError;
+      console.warn(`[DB][getMediaProgress] 查询失败 code=${err.code} msg=${err.message}`);
+      return null;
+    }
+  }
+
+  /**
+   * 删除媒体级播放进度（完播重置）。
+   */
+  async clearMediaProgress(mediaKey: string): Promise<void> {
+    if (this.rdbStore === null) {
+      return;
+    }
+    try {
+      const pred = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_MEDIA_PROGRESS);
+      pred.equalTo('media_key', mediaKey);
+      await this.rdbStore.delete(pred);
+      console.info(`[DB][clearMediaProgress] key=${mediaKey} 已清除`);
+    } catch (error) {
+      const err = error as BusinessError;
+      console.warn(`[DB][clearMediaProgress] 删除失败 code=${err.code} msg=${err.message}`);
+    }
+  }
 }
+
 
 
 

--- a/entry/src/main/ets/db/models/MediaEntity.ets
+++ b/entry/src/main/ets/db/models/MediaEntity.ets
@@ -180,6 +180,26 @@ export interface PlayProgressEntity {
 }
 
 // ─────────────────────────────────────────────
+// 媒体级播放进度（跨季聚合，key 由 MediaProgressStore 构造）
+// ─────────────────────────────────────────────
+
+/** 媒体级播放进度实体（对应 media_progress 表） */
+export interface MediaProgressEntry {
+  /** 存储 key，格式 media_progress_series_<id> 或 media_progress_movie_<id> */
+  mediaKey: string;
+  /** 上次播放位置（毫秒） */
+  positionMs: number;
+  /** 视频总时长（毫秒） */
+  durationMs: number;
+  /** 最近播放时间戳 */
+  lastPlayedAt: number;
+  /** 剧集：集号（0 表示无） */
+  episodeNumber: number;
+  /** 剧集：季号（0 表示无） */
+  seasonNumber: number;
+}
+
+// ─────────────────────────────────────────────
 // UI 聚合视图
 // ─────────────────────────────────────────────
 

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -1,5 +1,6 @@
-import { MediaItem, PlayProgressEntity, MovieEntity } from '../../db/models/MediaEntity';
+import { MediaItem, PlayProgressEntity, MovieEntity, MediaProgressEntry } from '../../db/models/MediaEntity';
 import { PlayerPageParam, PlayerPage } from '../player/index';
+import { MediaProgressStore } from '../../db/MediaProgressStore';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntity';
 import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient';
@@ -95,7 +96,8 @@ export struct MovieDetailPage {
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
 
   @Local item: MediaItem | undefined = undefined;
-  @Local progress: PlayProgressEntity | null = null;
+  @Local mediaProgress: MediaProgressEntry | null = null;
+  @Local hasActiveProgress: boolean = false;
   @Local movieEntity: MovieEntity | null = null;
   /** 从 backdrop 提取的深色背景色，格式 #RRGGBB，提取失败保持默认 */
   @Local dominantBgColor: string = '#111111';
@@ -204,20 +206,19 @@ export struct MovieDetailPage {
 
   /** 是否有有效续播进度（大于 5 秒才算） */
   private hasProgress(): boolean {
-    const p = this.progress;
-    return p !== null && p.positionMs > 5000;
+    return this.hasActiveProgress && this.mediaProgress !== null && this.mediaProgress.positionMs > 5000;
   }
 
   /** 是否已看完（>= 95%） */
   private isWatched(): boolean {
-    const p = this.progress;
+    const p = this.mediaProgress;
     if (p === null || p.durationMs <= 0) { return false; }
     return p.positionMs / p.durationMs >= 0.95;
   }
 
   /** 播放进度百分比（0~1） */
   private getProgressPercent(): number {
-    const p = this.progress;
+    const p = this.mediaProgress;
     if (p === null || p.durationMs <= 0) { return 0; }
     return Math.min(1, p.positionMs / p.durationMs);
   }
@@ -318,11 +319,6 @@ export struct MovieDetailPage {
 
   private loadAuxData(item: MediaItem): void {
     const db = FileSourceDatabase.getInstance();
-    // 并行加载续播进度
-    db.getPlayProgress(item.id).then((p: PlayProgressEntity | null) => {
-      this.progress = p;
-    }).catch(() => {});
-
     const provider = item.provider;
     const providerId = item.providerId;
     if (provider !== undefined && provider.length > 0 &&
@@ -333,6 +329,12 @@ export struct MovieDetailPage {
         const backdropUrl = this.getBackdropUrl();
         if (backdropUrl.length > 0) { this.extractDominantColor(backdropUrl); }
       }).catch(() => {});
+      // 加载媒体级进度
+      const mKey = MediaProgressStore.movieKey(providerId);
+      MediaProgressStore.get(mKey).then((mp: MediaProgressEntry | null) => {
+        this.mediaProgress = mp;
+        this.hasActiveProgress = mp !== null && mp.positionMs > 0 && mp.durationMs > 0;
+      }).catch(() => {});
     } else {
       // 无刮削数据时直接尝试用 item.backdropUrl 提取
       const backdropUrl = this.getBackdropUrl();
@@ -340,12 +342,15 @@ export struct MovieDetailPage {
     }
   }
 
-  /** 返回播放器后刷新进度 */
-  private refreshProgress(item: MediaItem): void {
-    FileSourceDatabase.getInstance()
-      .getPlayProgress(item.id)
-      .then((p: PlayProgressEntity | null) => { this.progress = p; })
-      .catch(() => {});
+  /** 返回播放器后刷新媒体级进度 */
+  private refreshMovieProgress(): Promise<void> {
+    const providerId = this.item?.providerId ?? '';
+    if (providerId.length === 0) { return Promise.resolve(); }
+    const mKey = MediaProgressStore.movieKey(providerId);
+    return MediaProgressStore.get(mKey).then((mp: MediaProgressEntry | null) => {
+      this.mediaProgress = mp;
+      this.hasActiveProgress = mp !== null && mp.positionMs > 0 && mp.durationMs > 0;
+    });
   }
 
   /** 构建播放 URL 并跳转播放器 */
@@ -437,7 +442,7 @@ export struct MovieDetailPage {
         }
 
         // 右：信息区
-        if (this.hasProgress() && this.progress !== null) {
+        if (this.hasProgress() && this.mediaProgress !== null) {
           // ── 有续播进度 ────────────────────────────────
           Column({ space: 10 }) {
             // 时长标签 + 电影标题
@@ -486,7 +491,7 @@ export struct MovieDetailPage {
               })
               .onClick(() => { this.play(); })
 
-              Text(millisecondsToTime(this.progress.positionMs))
+              Text(millisecondsToTime(this.mediaProgress.positionMs))
                 .fontSize(12).fontColor('#888888')
             }
             .alignItems(VerticalAlign.Center)
@@ -867,7 +872,7 @@ export struct MovieDetailPage {
       }
     })
     .onShown(() => {
-      if (this.item !== undefined) { this.refreshProgress(this.item); }
+      if (this.item !== undefined) { this.refreshMovieProgress(); }
     })
     .onBackPressed(() => {
       if (this.showOverviewDialog) {

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -626,21 +626,15 @@ export struct MovieDetailPage {
           // 简介：超 100 字截断显示 + 「更多」按钮（独立 Text 可聚焦），不超出仅显示原文
           if (this.getOverview().length > 0) {
             if (this.isOverviewLong()) {
-              Row({ space: 4 }) {
-                Text(this.getOverviewShort())
+              Text() {
+                Span(this.getOverviewShort())
                   .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
-                  .constraintSize({ maxWidth: 640 })
-                Text('更多')
-                  .fontSize(14)
-                  .fontColor(this.focusMoreBtn ? '#FFFFFFFF' : '#1B78F2')
+                Span('更多')
+                  .fontSize(14).fontColor('#1B78F2')
                   .fontWeight(FontWeight.Medium)
-                  .focusable(true)
-                  .onFocus(() => { this.focusMoreBtn = true; })
-                  .onBlur(() => { this.focusMoreBtn = false; })
                   .onClick(() => { this.showOverviewDialog = true; })
               }
               .constraintSize({ maxWidth: 700 })
-              .alignItems(VerticalAlign.Bottom)
             } else {
               Text(this.getOverview())
                 .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
@@ -650,14 +644,6 @@ export struct MovieDetailPage {
         }
         .layoutWeight(1)
         .alignItems(HorizontalAlign.Start)
-
-        // 中间：海报封面（有数据时显示）
-        if (this.getPosterUrl().length > 0) {
-          Image(this.getPosterUrl())
-            .width(120).aspectRatio(2 / 3)
-            .objectFit(ImageFit.Cover)
-            .borderRadius(8)
-        }
 
         // 右侧：电影版续播卡片
         this.MovieWatchingCard()

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -1,4 +1,4 @@
-import { MediaItem, PlayProgressEntity, MovieEntity, MediaProgressEntry } from '../../db/models/MediaEntity';
+import { MediaItem, MovieEntity, MediaProgressEntry } from '../../db/models/MediaEntity';
 import { PlayerPageParam, PlayerPage } from '../player/index';
 import { MediaProgressStore } from '../../db/MediaProgressStore';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
@@ -402,6 +402,9 @@ export struct MovieDetailPage {
         return;
       }
 
+      const providerId = item.providerId ?? '';
+      const mKey = providerId.length > 0 ? MediaProgressStore.movieKey(providerId) : undefined;
+
       const param: PlayerPageParam = {
         videoId: item.id,
         url: fullUrl,
@@ -410,7 +413,8 @@ export struct MovieDetailPage {
         durationHintMs: item.durationMs,
         seriesProviderId: '',
         seasonNumber: 0,
-        episodeNumber: 0
+        episodeNumber: 0,
+        mediaKey: mKey
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
     } catch (e) {
@@ -872,7 +876,7 @@ export struct MovieDetailPage {
       }
     })
     .onShown(() => {
-      if (this.item !== undefined) { this.refreshMovieProgress(); }
+      this.refreshMovieProgress().catch(() => {});
     })
     .onBackPressed(() => {
       if (this.showOverviewDialog) {

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -896,13 +896,15 @@ export struct SeasonDetailPage {
         // 简介
         if (this.getOverview().length > 0) {
           if (this.isOverviewLong()) {
-            Text() {
-              Span(this.getOverviewShort())
+            Row({ space: 4 }) {
+              Text(this.getOverviewShort())
                 .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
-              Span('更多')
+              Text('更多')
                 .fontSize(14).fontColor('#1B78F2').fontWeight(FontWeight.Medium)
+                .focusable(true)
                 .onClick(() => { this.showOverviewDialog = true; })
             }
+            .alignItems(VerticalAlign.Bottom)
             .constraintSize({ maxWidth: 700 })
           } else {
             Text(this.getOverview())

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -2,6 +2,7 @@ import { SeriesGroup, TvSeriesEntity, TvSeasonEntity, TvEpisodeEntity, MediaItem
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase'
 import { ScrapeCredit } from '../../lib/ScrapeClient'
 import { PlayerPageParam, PlayerPage } from '../player/index'
+import { MediaProgressStore } from '../../db/MediaProgressStore'
 import http from '@ohos.net.http'
 import image from '@ohos.multimedia.image'
 import effectKit from '@ohos.effectKit'
@@ -799,6 +800,8 @@ export struct SeasonDetailPage {
       }
 
       const episodeName = await this.resolveEpisodeName(db, episode);
+      const seriesProviderId = this.seriesEntity?.providerId ?? '';
+      const mKey = seriesProviderId.length > 0 ? MediaProgressStore.seriesKey(seriesProviderId) : undefined;
       const param: PlayerPageParam = {
         // getFullUrl() 已编码，传给播放页时保持原值，避免二次编码。
         url: fullUrl,
@@ -806,11 +809,12 @@ export struct SeasonDetailPage {
         title: this.buildPlayerTitle(episode, episodeName),
         durationHintMs: durationHintMs > 0 ? durationHintMs : undefined,
         videoId: episode.id,
-        seriesProviderId: this.seriesEntity?.providerId ?? '',
+        seriesProviderId,
         seasonNumber: episode.seasonNumber ?? 0,
         episodeNumber: episode.episodeNumber ?? 0,
         presetAudioTracks: presetAudioTracks.length > 0 ? presetAudioTracks : undefined,
-        presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined
+        presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined,
+        mediaKey: mKey
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
     } catch (e) {

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -1024,12 +1024,13 @@ export struct SeriesDetailPage {
                 }
               })
               .onClick(() => {
+                const mKey = MediaProgressStore.seriesKey(this.seriesEntity?.providerId ?? '');
                 if (this.lastEpisode !== null) {
-                  this.playEpisode(this.lastEpisode);
+                  this.playEpisode(this.lastEpisode, mKey);
                   return;
                 }
                 const eps = this.group?.episodes ?? [];
-                if (eps.length > 0) { this.playEpisode(eps[0]); }
+                if (eps.length > 0) { this.playEpisode(eps[0], mKey); }
               })
             }
             .alignItems(VerticalAlign.Center)

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -134,8 +134,6 @@ export struct SeriesDetailPage {
   @Local selectedSeasonNumber: number = -1
   /** 播放进度映射（key = videoId，文件级，用于集列表进度条） */
   @Local progressMap: Map<number, PlayProgressEntity> = new Map()
-  /** 最新播放进度（文件级，保留以供 getResumeCardEpLabel 等辅助方法访问） */
-  @Local lastProgress: PlayProgressEntity | null = null
   /** 媒体级播放进度（用于 ContinueWatchingCard 续播入口） */
   @Local mediaProgress: MediaProgressEntry | null = null
   /** 最新播放集信息 */
@@ -344,7 +342,6 @@ export struct SeriesDetailPage {
       newMap.set(progress.videoId, progress);
     }
     this.progressMap = newMap;
-    this.lastProgress = progressList.length > 0 ? progressList[0] : null;
 
     // ── 媒体级进度：用于 ContinueWatchingCard 续播入口 ─────────────────────
     const mKey = MediaProgressStore.seriesKey(seriesProviderId);

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -964,7 +964,9 @@ export struct SeriesDetailPage {
               })
               .onClick(() => {
                 if (this.lastEpisode !== null) {
-                  const mKey = MediaProgressStore.seriesKey(this.seriesEntity?.providerId ?? '');
+                  const pid = this.seriesEntity?.providerId ?? '';
+                  if (pid.length === 0) { return; }
+                  const mKey = MediaProgressStore.seriesKey(pid);
                   this.playEpisode(this.lastEpisode, mKey);
                 }
               })
@@ -1024,7 +1026,9 @@ export struct SeriesDetailPage {
                 }
               })
               .onClick(() => {
-                const mKey = MediaProgressStore.seriesKey(this.seriesEntity?.providerId ?? '');
+                const pid = this.seriesEntity?.providerId ?? '';
+                if (pid.length === 0) { return; }
+                const mKey = MediaProgressStore.seriesKey(pid);
                 if (this.lastEpisode !== null) {
                   this.playEpisode(this.lastEpisode, mKey);
                   return;
@@ -1118,17 +1122,19 @@ export struct SeriesDetailPage {
           }
           .alignItems(VerticalAlign.Center)
 
-          // 简介：超100字截断显示 + 「更多」Span，不超出仅显示原文
+          // 简介：超100字截断显示 + 「更多」按钮（独立 Text，支持 TV 焦点）
           if (this.getOverview().length > 0) {
             if (this.isOverviewLong()) {
-              Text() {
-                Span(this.getOverviewShort())
+              Row({ space: 4 }) {
+                Text(this.getOverviewShort())
                   .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
-                Span('更多')
+                Text('更多')
                   .fontSize(14).fontColor('#1B78F2')
                   .fontWeight(FontWeight.Medium)
+                  .focusable(true)
                   .onClick(() => { this.showOverviewDialog = true; })
               }
+              .alignItems(VerticalAlign.Bottom)
               .constraintSize({ maxWidth: 700 })
             } else {
               Text(this.getOverview())

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -1,5 +1,6 @@
-import { SeriesGroup, TvSeriesEntity, TvEpisodeEntity, MediaItem, PlayProgressEntity } from '../../db/models/MediaEntity'
+import { SeriesGroup, TvSeriesEntity, TvEpisodeEntity, MediaItem, PlayProgressEntity, MediaProgressEntry } from '../../db/models/MediaEntity'
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase'
+import { MediaProgressStore } from '../../db/MediaProgressStore'
 import { ScrapeCredit } from '../../lib/ScrapeClient'
 import { SeasonDetailPage } from './SeasonDetailPage'
 import { AppPreferences, PrefKey } from '../../utils/AppPreferences'
@@ -131,10 +132,12 @@ export struct SeriesDetailPage {
   @Local dominantBgColor: string = '#111111'
   /** 当前选中显示的季号（-1 = 未选） */
   @Local selectedSeasonNumber: number = -1
-  /** 播放进度映射（key = videoId） */
+  /** 播放进度映射（key = videoId，文件级，用于集列表进度条） */
   @Local progressMap: Map<number, PlayProgressEntity> = new Map()
-  /** 最新播放进度（用于 ContinueWatchingCard） */
+  /** 最新播放进度（文件级，保留以供 getResumeCardEpLabel 等辅助方法访问） */
   @Local lastProgress: PlayProgressEntity | null = null
+  /** 媒体级播放进度（用于 ContinueWatchingCard 续播入口） */
+  @Local mediaProgress: MediaProgressEntry | null = null
   /** 最新播放集信息 */
   @Local lastEpisode: MediaItem | null = null
   /** 最新播放集详情（用于缩略图/标题） */
@@ -333,24 +336,29 @@ export struct SeriesDetailPage {
     }
 
     const db = FileSourceDatabase.getInstance();
+
+    // ── 文件级进度：仍用于集列表进度条（不受本 Issue 影响）────────────────
     const progressList = await db.getPlayProgressBySeries(seriesProviderId);
     const newMap = new Map<number, PlayProgressEntity>();
     for (const progress of progressList) {
       newMap.set(progress.videoId, progress);
     }
     this.progressMap = newMap;
+    this.lastProgress = progressList.length > 0 ? progressList[0] : null;
 
-    const latestRecord: PlayProgressEntity | null = progressList.length > 0 ? progressList[0] : null;
-
-    this.lastProgress = latestRecord;
-    this.hasActiveProgress = this.isValidProgress(latestRecord);
+    // ── 媒体级进度：用于 ContinueWatchingCard 续播入口 ─────────────────────
+    const mKey = MediaProgressStore.seriesKey(seriesProviderId);
+    const mp = await MediaProgressStore.get(mKey);
+    this.mediaProgress = mp;
+    this.hasActiveProgress = mp !== null && mp.positionMs > 0 && mp.durationMs > 0;
     this.lastEpisode = null;
     this.lastEpisodeEntity = null;
 
-    if (latestRecord === null) {
+    if (mp === null || !this.hasActiveProgress) {
       return;
     }
 
+    // 根据媒体级进度中的 seasonNumber + episodeNumber 定位集
     let allEpisodes = this.group?.episodes ?? [];
     if (allEpisodes.length === 0) {
       const seriesId = this.seriesEntity?.id;
@@ -360,15 +368,15 @@ export struct SeriesDetailPage {
     }
 
     for (const episode of allEpisodes) {
-      if (episode.id === latestRecord.videoId) {
+      if (episode.seasonNumber === mp.seasonNumber && episode.episodeNumber === mp.episodeNumber) {
         this.lastEpisode = episode;
         break;
       }
     }
 
     const seriesId = this.seriesEntity?.id;
-    if (seriesId !== undefined && latestRecord.episodeNumber > 0) {
-      const entity = await db.getTvEpisode(seriesId, latestRecord.seasonNumber, latestRecord.episodeNumber);
+    if (seriesId !== undefined && mp.episodeNumber > 0) {
+      const entity = await db.getTvEpisode(seriesId, mp.seasonNumber, mp.episodeNumber);
       if (entity !== null) {
         this.lastEpisodeEntity = entity;
       }
@@ -663,8 +671,10 @@ export struct SeriesDetailPage {
    * 点击集 → 导航到播放器
    * 构造 WebDAV 完整 URL + Authorization 请求头后传入 PlayerPageParam，
    * 同时从 DB / ffprobe 读取音轨和字幕轨元数据并注入，与文件浏览器行为一致。
+   * @param episode  要播放的集
+   * @param mediaKey 媒体级进度 key（仅"继续播放"入口传入，文件浏览器/集列表不传）
    */
-  private async playEpisode(episode: MediaItem): Promise<void> {
+  private async playEpisode(episode: MediaItem, mediaKey?: string): Promise<void> {
     try {
       const db = FileSourceDatabase.getInstance();
       const fileSource = await db.getFileSourceById(episode.sourceId);
@@ -809,7 +819,8 @@ export struct SeriesDetailPage {
         seasonNumber: episode.seasonNumber ?? 0,
         episodeNumber: episode.episodeNumber ?? 0,
         presetAudioTracks: presetAudioTracks.length > 0 ? presetAudioTracks : undefined,
-        presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined
+        presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined,
+        mediaKey: mediaKey
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
     } catch (e) {
@@ -827,6 +838,20 @@ export struct SeriesDetailPage {
   /** 是否已看完（≥95%） */
   private isEpisodeWatched(episode: MediaItem): boolean {
     return this.getEpisodeProgress(episode) >= 0.95;
+  }
+
+  /** 媒体级进度百分比（0~100），用于 ContinueWatchingCard 进度条 */
+  private getMediaProgressPercent(): number {
+    const mp = this.mediaProgress;
+    if (mp === null || mp.durationMs <= 0) { return 0; }
+    return Math.min(100, Math.round(mp.positionMs / mp.durationMs * 100));
+  }
+
+  /** 媒体级是否已达完播阈值（供 ContinueWatchingCard 按钮文案判断） */
+  private isMediaWatched(): boolean {
+    const mp = this.mediaProgress;
+    if (mp === null || mp.durationMs <= 0) { return false; }
+    return MediaProgressStore.isNearEnd(mp.positionMs, mp.durationMs);
   }
 
   private isContinueActionFocused(action: string): boolean {
@@ -890,12 +915,12 @@ export struct SeriesDetailPage {
         }
 
         // 信息部分
-        if (this.hasActiveProgress && this.lastProgress !== null && this.lastEpisode !== null) {
+        if (this.hasActiveProgress && this.mediaProgress !== null && this.lastEpisode !== null) {
           // ── 有播放记录 ──────────────────────────────────
           Column({ space: 10 }) {
             // 集号标签 + 标题
             Row({ space: 8 }) {
-              Text(`S${String(this.lastProgress.seasonNumber).padStart(2, '0')}:E${String(this.lastProgress.episodeNumber).padStart(2, '0')}`)
+              Text(`S${String(this.mediaProgress.seasonNumber).padStart(2, '0')}:E${String(this.mediaProgress.episodeNumber).padStart(2, '0')}`)
                 .fontSize(12)
                 .fontColor('#1B78F2')
                 .padding({ left: 7, right: 7, top: 2, bottom: 2 })
@@ -908,10 +933,10 @@ export struct SeriesDetailPage {
             }
             .alignItems(VerticalAlign.Center)
 
-            // 进度条
+            // 进度条（使用媒体级进度）
             Column() {
               Column()
-                .width(`${Math.round(this.getEpisodeProgress(this.lastEpisode) * 100)}%`)
+                .width(`${this.getMediaProgressPercent()}%`)
                 .height('100%')
                 .backgroundColor('#1B78F2').borderRadius(2)
                 .alignSelf(ItemAlign.Start)
@@ -924,7 +949,7 @@ export struct SeriesDetailPage {
             Row({ space: 10 }) {
               Row({ space: 6 }) {
                 Text('▶').fontSize(12).fontColor(Color.White)
-                Text(this.isEpisodeWatched(this.lastEpisode) ? '重新播放' : '继续播放')
+                Text(this.isMediaWatched() ? '重新播放' : '继续播放')
                   .fontSize(14).fontColor(Color.White).fontWeight(FontWeight.Bold)
               }
               .padding({ left: 12, right: 12, top: 6, bottom: 6 })
@@ -941,10 +966,13 @@ export struct SeriesDetailPage {
                 }
               })
               .onClick(() => {
-                if (this.lastEpisode !== null) { this.playEpisode(this.lastEpisode); }
+                if (this.lastEpisode !== null) {
+                  const mKey = MediaProgressStore.seriesKey(this.seriesEntity?.providerId ?? '');
+                  this.playEpisode(this.lastEpisode, mKey);
+                }
               })
 
-              Text(millisecondsToTime(this.lastProgress.positionMs))
+              Text(millisecondsToTime(this.mediaProgress.positionMs))
                 .fontSize(12).fontColor('#888888')
             }
             .alignItems(VerticalAlign.Center)

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -8,6 +8,7 @@ import {
 } from "../../components/core/player/VideoPlayerController";
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { PlayProgressEntity } from "../../db/models/MediaEntity";
+import { MediaProgressStore } from "../../db/MediaProgressStore";
 import { millisecondsToTime } from "../../utils/TimeUtil";
 import { PlayerEvents } from "../../components/core/player/Constants";
 import { emitter } from "@kit.BasicServicesKit";
@@ -35,6 +36,12 @@ export interface PlayerPageParam {
   preferredBackend?: PlayerBackend;
   /** 可选：AVPlayer 不支持格式时的自动回退后端 */
   unsupportedFormatFallback?: UnsupportedFormatFallback;
+  /**
+   * 媒体级进度 key（由 MediaProgressStore.seriesKey / movieKey 生成）。
+   * 设置后，播放器使用媒体级进度续播（直接 seek，不弹续播弹窗），
+   * 并在退出/切后台时回写媒体级进度，完播时自动清除。
+   */
+  mediaKey?: string;
 }
 
 @ComponentV2
@@ -48,6 +55,12 @@ export struct PlayerPage {
   @Local savedPositionMs: number = 0
   @Local totalDurationMs: number = 0
   private pendingSeekMs: number = -1
+  /** 媒体级进度 key（来自 PlayerPageParam.mediaKey） */
+  private currentMediaKey: string = '';
+  /** 媒体级进度：当前集季号 */
+  private currentMediaSeason: number = 0;
+  /** 媒体级进度：当前集号 */
+  private currentMediaEpisode: number = 0;
 
   private getBackendDebugText(): string {
     const proto = this.videoPlayerController.sourceProtocol;
@@ -183,6 +196,17 @@ export struct PlayerPage {
       // 订阅 App 切后台事件，确保进度立即落盘
       emitter.on(PlayerEvents.APP_BACKGROUND, () => {
         this.videoPlayerController.saveProgressNow();
+        // 媒体级进度：切后台时保存当前位置
+        if (this.currentMediaKey.length > 0) {
+          const posMs = this.videoPlayerController.currentTime;
+          const durMs = this.videoPlayerController.duration;
+          if (posMs > 0) {
+            MediaProgressStore.save(
+              this.currentMediaKey, posMs, durMs,
+              this.currentMediaSeason, this.currentMediaEpisode
+            ).catch(() => {});
+          }
+        }
       });
 
       let pageParam = context.pathInfo.param as PlayerPageParam
@@ -234,25 +258,44 @@ export struct PlayerPage {
           };
           this.videoPlayerController.progressContext = ctx;
 
-          // 播放器 prepared 后检查是否有已保存进度
-          emitter.once(PlayerEvents.PREPARED, () => {
-            const videoId = pageParam.videoId ?? 0;
-            FileSourceDatabase.getInstance().getPlayProgress(videoId).then((saved) => {
-              if (saved !== null && saved.positionMs > 0) {
-                const dur = this.videoPlayerController.duration;
-                const isWatched = dur > 0 && saved.positionMs >= dur * 0.95;
-                this.savedPositionMs = saved.positionMs;
-                this.totalDurationMs = dur > 0 ? dur : saved.durationMs;
-                if (isWatched) {
-                  // 视为看完，默认从头，仍弹提示
-                  this.pendingSeekMs = 0;
-                } else {
-                  this.pendingSeekMs = saved.positionMs;
+          const mKey = pageParam.mediaKey ?? '';
+          if (mKey.length > 0) {
+            // ── 媒体级入口：直接 seek，不弹续播弹窗 ──────────────────────
+            this.currentMediaKey = mKey;
+            this.currentMediaSeason = pageParam.seasonNumber ?? 0;
+            this.currentMediaEpisode = pageParam.episodeNumber ?? 0;
+            emitter.once(PlayerEvents.PREPARED, () => {
+              MediaProgressStore.get(this.currentMediaKey).then((saved) => {
+                if (saved !== null && saved.positionMs > 0) {
+                  const dur = this.videoPlayerController.duration;
+                  const isNearEnd = MediaProgressStore.isNearEnd(saved.positionMs, dur > 0 ? dur : saved.durationMs);
+                  if (!isNearEnd) {
+                    this.videoPlayerController.seek(saved.positionMs).catch(() => {});
+                  }
                 }
-                this.showResumeDialog = true;
-              }
-            }).catch(() => {});
-          });
+              }).catch(() => {});
+            });
+          } else {
+            // ── 文件级入口：显示续播弹窗（原有逻辑不变）────────────────────
+            emitter.once(PlayerEvents.PREPARED, () => {
+              const videoId = pageParam.videoId ?? 0;
+              FileSourceDatabase.getInstance().getPlayProgress(videoId).then((saved) => {
+                if (saved !== null && saved.positionMs > 0) {
+                  const dur = this.videoPlayerController.duration;
+                  const isWatched = dur > 0 && saved.positionMs >= dur * 0.95;
+                  this.savedPositionMs = saved.positionMs;
+                  this.totalDurationMs = dur > 0 ? dur : saved.durationMs;
+                  if (isWatched) {
+                    // 视为看完，默认从头，仍弹提示
+                    this.pendingSeekMs = 0;
+                  } else {
+                    this.pendingSeekMs = saved.positionMs;
+                  }
+                  this.showResumeDialog = true;
+                }
+              }).catch(() => {});
+            });
+          }
         }
       }
     })
@@ -272,6 +315,19 @@ export struct PlayerPage {
 
   aboutToDisappear(): void {
     emitter.off(PlayerEvents.APP_BACKGROUND.eventId)
+    // 媒体级进度：完播则清除，否则保存当前位置
+    if (this.currentMediaKey.length > 0) {
+      const posMs = this.videoPlayerController.currentTime;
+      const durMs = this.videoPlayerController.duration;
+      if (MediaProgressStore.isNearEnd(posMs, durMs)) {
+        MediaProgressStore.clear(this.currentMediaKey).catch(() => {});
+      } else if (posMs > 0) {
+        MediaProgressStore.save(
+          this.currentMediaKey, posMs, durMs,
+          this.currentMediaSeason, this.currentMediaEpisode
+        ).catch(() => {});
+      }
+    }
     this.videoPlayerController.saveProgressNow()
     this.videoPlayerController.release()
   }

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -200,7 +200,7 @@ export struct PlayerPage {
         if (this.currentMediaKey.length > 0) {
           const posMs = this.videoPlayerController.currentTime;
           const durMs = this.videoPlayerController.duration;
-          if (posMs > 0) {
+          if (posMs > 0 && durMs > 0) {
             MediaProgressStore.save(
               this.currentMediaKey, posMs, durMs,
               this.currentMediaSeason, this.currentMediaEpisode
@@ -319,13 +319,16 @@ export struct PlayerPage {
     if (this.currentMediaKey.length > 0) {
       const posMs = this.videoPlayerController.currentTime;
       const durMs = this.videoPlayerController.duration;
-      if (MediaProgressStore.isNearEnd(posMs, durMs)) {
-        MediaProgressStore.clear(this.currentMediaKey).catch(() => {});
-      } else if (posMs > 0) {
-        MediaProgressStore.save(
-          this.currentMediaKey, posMs, durMs,
-          this.currentMediaSeason, this.currentMediaEpisode
-        ).catch(() => {});
+      // duration 未就绪时跳过完播判断，避免 duration=0 误清除进度
+      if (durMs > 0) {
+        if (MediaProgressStore.isNearEnd(posMs, durMs)) {
+          MediaProgressStore.clear(this.currentMediaKey).catch(() => {});
+        } else if (posMs > 0) {
+          MediaProgressStore.save(
+            this.currentMediaKey, posMs, durMs,
+            this.currentMediaSeason, this.currentMediaEpisode
+          ).catch(() => {});
+        }
       }
     }
     this.videoPlayerController.saveProgressNow()

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -61,6 +61,8 @@ export struct PlayerPage {
   private currentMediaSeason: number = 0;
   /** 媒体级进度：当前集号 */
   private currentMediaEpisode: number = 0;
+  /** media_progress 周期写入定时器 ID，-1 表示未启动 */
+  private mediaProgressTimerId: number = -1;
 
   private getBackendDebugText(): string {
     const proto = this.videoPlayerController.sourceProtocol;
@@ -209,6 +211,20 @@ export struct PlayerPage {
         }
       });
 
+      // 每 10 秒写入一次 media_progress，避免退出时异步写与 onShown 读产生竞态
+      this.mediaProgressTimerId = setInterval(() => {
+        if (this.currentMediaKey.length > 0) {
+          const posMs: number = this.videoPlayerController.currentTime;
+          const durMs: number = this.videoPlayerController.duration;
+          if (posMs > 0 && durMs > 0) {
+            MediaProgressStore.save(
+              this.currentMediaKey, posMs, durMs,
+              this.currentMediaSeason, this.currentMediaEpisode
+            ).catch(() => {});
+          }
+        }
+      }, 10000);
+
       let pageParam = context.pathInfo.param as PlayerPageParam
       if (pageParam) {
         if (pageParam.preferredBackend) {
@@ -315,6 +331,10 @@ export struct PlayerPage {
 
   aboutToDisappear(): void {
     emitter.off(PlayerEvents.APP_BACKGROUND.eventId)
+    if (this.mediaProgressTimerId >= 0) {
+      clearInterval(this.mediaProgressTimerId);
+      this.mediaProgressTimerId = -1;
+    }
     // 媒体级进度：完播则清除，否则保存当前位置
     if (this.currentMediaKey.length > 0) {
       const posMs = this.videoPlayerController.currentTime;

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -287,6 +287,9 @@ export struct PlayerPage {
                   const isNearEnd = MediaProgressStore.isNearEnd(saved.positionMs, dur > 0 ? dur : saved.durationMs);
                   if (!isNearEnd) {
                     this.videoPlayerController.seek(saved.positionMs).catch(() => {});
+                  } else {
+                    // 进程被杀前已近结尾，清除残留进度避免详情页仍显示"继续播放"
+                    MediaProgressStore.clear(this.currentMediaKey).catch(() => {});
                   }
                 }
               }).catch(() => {});


### PR DESCRIPTION
## 功能说明

实现媒体级播放进度持久化，支持详情页"继续播放"跨会话精确恢复。

## 变更内容

- `MediaProgressEntry` 接口 + `media_progress` 数据库表（DB v6）
- `MediaProgressStore` 静态工具类（seriesKey / movieKey / save / get / clear / isNearEnd）
- 播放页：退出/切后台时保存媒体级进度，完播时清除
- 剧集详情页：续播卡片读取媒体级进度，点击直接 seek 到上次位置

## 行为说明

- **续播**：详情页继续播放直接 seek，不弹文件级续播弹窗
- **完播重置**：剩余 <60s 或 >95% 时清除媒体级进度
- **向下兼容**：文件浏览器入口仍走原文件级续播弹窗逻辑，不受影响

Closes #83


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media-level playback progress for series and movies — improved resume, updated Continue Watching behavior, and auto-resume (skips resume prompt when media-level progress is available). Periodic and background saves keep progress up to date.
  * Near-completion detection that clears progress when content is essentially finished.

* **Chores**
  * Added persistent media-level progress storage and database schema upgrade to support media progress entries.

* **Bug Fixes / UI**
  * Simplified movie detail overview layout; removed intermediate poster thumbnail and focus-based "More" highlight.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->