### PR TITLE
新增: 媒体库电影详情页（MovieDetailPage）

### DIFF
--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -1903,7 +1903,7 @@ export class FileSourceDatabase {
                v.id AS vid, v.source_id, v.directory_path, v.file_path, v.file_name,
                v.file_size, v.duration_ms, v.width, v.height, v.video_codec,
                v.audio_tracks_json, v.scanned_at,
-               si.scraped_at
+               si.scraped_at, si.provider, si.provider_id, si.movie_id
         FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} si
         JOIN ${FileSourceDatabase.TABLE_MOVIES} m ON si.movie_id = m.id
         JOIN ${FileSourceDatabase.TABLE_VIDEOS} v ON si.video_id = v.id
@@ -1945,7 +1945,10 @@ export class FileSourceDatabase {
           posterUrl: str('poster_url'),
           posterLocalPath: str('poster_local_path'),
           backdropUrl: str('backdrop_url'),
-          rating: dbl('rating')
+          rating: dbl('rating'),
+          provider: str('provider'),
+          providerId: str('provider_id'),
+          movieId: num('movie_id')
         };
         const item: MediaListItem = { kind: 'video', video: mediaItem, sortTs: scrapedAt };
         movieItems.push(item);

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -6,6 +6,7 @@ import { PlayerPage } from './player/index';
 import { SettingsPage } from './settings/Index';
 import { SeriesDetailPage } from './detail/SeriesDetailPage';
 import { SeasonDetailPage } from './detail/SeasonDetailPage';
+import { MovieDetailPage } from './detail/MovieDetailPage';
 @Entry
 @ComponentV2
 struct Index {
@@ -24,6 +25,8 @@ struct Index {
       SmbFileExplorerPage();
     } else if (name === SeriesDetailPage.PAGE_NAME) {
       SeriesDetailPage();
+    } else if (name === MovieDetailPage.PAGE_NAME) {
+      MovieDetailPage();
     } else if (name === SeasonDetailPage.PAGE_NAME) {
       SeasonDetailPage();
     }

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -1,0 +1,266 @@
+import { MediaItem } from '../../db/models/MediaEntity';
+import { PlayerPageParam, PlayerPage } from '../player/index';
+
+// ─────────────────────────────────────────────
+// 工具函数
+// ─────────────────────────────────────────────
+
+function formatRuntime(ms: number | undefined): string {
+  if (ms === undefined || ms <= 0) {
+    return '未知';
+  }
+  const totalSeconds = Math.floor(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  if (h > 0) {
+    return h.toString() + ' 小时 ' + m.toString() + ' 分';
+  }
+  return m.toString() + ' 分钟';
+}
+
+function formatYear(date: string | undefined): string {
+  if (!date || date.length < 4) {
+    return '';
+  }
+  return date.substring(0, 4);
+}
+
+function parseGenresArr(json: string | undefined): string[] {
+  if (!json) {
+    return [];
+  }
+  try {
+    return JSON.parse(json) as string[];
+  } catch (e) {
+    return [];
+  }
+}
+
+// ─────────────────────────────────────────────
+// 电影详情页
+// ─────────────────────────────────────────────
+
+@ComponentV2
+export struct MovieDetailPage {
+  static readonly PAGE_NAME: string = 'movieDetail';
+
+  @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
+
+  @Local item: MediaItem | undefined = undefined;
+  @Local isHovered: boolean = false;
+
+  // ── 计算属性 ──
+
+  private getTitle(): string {
+    return this.item?.title ?? this.item?.fileName ?? '未知影片';
+  }
+
+  private getPoster(): string {
+    return this.item?.posterLocalPath ?? this.item?.posterUrl ?? '';
+  }
+
+  private hasPoster(): boolean {
+    const p = this.getPoster();
+    return p.length > 0;
+  }
+
+  private getYear(): string {
+    return formatYear(this.item?.releaseDate);
+  }
+
+  private getRating(): string {
+    const r = this.item?.rating;
+    if (r === undefined) {
+      return '';
+    }
+    return r.toFixed(1) + ' 分';
+  }
+
+  private getRuntime(): string {
+    return formatRuntime(this.item?.durationMs);
+  }
+
+  private getOverview(): string {
+    const ov = this.item?.overview;
+    if (!ov || ov.length === 0) {
+      return '暂无简介';
+    }
+    return ov;
+  }
+
+  private getGenres(): string[] {
+    return parseGenresArr(this.item?.genresJson);
+  }
+
+  // ── 播放 ──
+
+  private play(): void {
+    if (this.item === undefined) {
+      return;
+    }
+    const param: PlayerPageParam = {
+      videoId: this.item.id,
+      url: this.item.filePath,
+      title: this.getTitle(),
+      durationHintMs: this.item.durationMs,
+    };
+    this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
+  }
+
+  // ── 构建 ──
+
+  build() {
+    NavDestination() {
+      Stack({ alignContent: Alignment.TopStart }) {
+        // 背景：模糊横幅（若无海报则纯色）
+        if (this.hasPoster()) {
+          Image(this.getPoster())
+            .width('100%')
+            .height('50%')
+            .objectFit(ImageFit.Cover)
+            .blur(30)
+            .opacity(0.35)
+        }
+
+        // 顶部渐变遮罩
+        Column()
+          .width('100%')
+          .height('50%')
+          .linearGradient({
+            angle: 180,
+            colors: [['#00000000', 0.0], ['#FF1A1A1A', 1.0]]
+          })
+          .hitTestBehavior(HitTestMode.Transparent)
+
+        // 主体内容
+        Row({ space: 40 }) {
+          // 海报列
+          Column() {
+            if (this.hasPoster()) {
+              Image(this.getPoster())
+                .width(200)
+                .height(300)
+                .objectFit(ImageFit.Cover)
+                .borderRadius(8)
+                .shadow({ radius: 20, color: 'rgba(0,0,0,0.5)', offsetX: 0, offsetY: 8 })
+            } else {
+              Column() {
+                Text(this.getTitle())
+                  .fontSize(14)
+                  .fontColor('#CCCCCC')
+                  .textAlign(TextAlign.Center)
+                  .maxLines(4)
+                  .textOverflow({ overflow: TextOverflow.Ellipsis })
+                  .padding(12)
+              }
+              .width(200)
+              .height(300)
+              .backgroundColor('#2A2A2A')
+              .borderRadius(8)
+              .justifyContent(FlexAlign.Center)
+            }
+          }
+          .margin({ top: 60 })
+
+          // 信息列
+          Column({ space: 16 }) {
+            // 标题
+            Text(this.getTitle())
+              .fontSize(36)
+              .fontColor(Color.White)
+              .fontWeight(FontWeight.Bold)
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+
+            // 元数据行（年份 / 时长 / 评分）
+            Row({ space: 16 }) {
+              if (this.getYear().length > 0) {
+                Text(this.getYear())
+                  .fontSize(16)
+                  .fontColor('#AAAAAA')
+              }
+              if (this.getRuntime() !== '未知') {
+                Text(this.getRuntime())
+                  .fontSize(16)
+                  .fontColor('#AAAAAA')
+              }
+              if (this.getRating().length > 0) {
+                Text('★ ' + this.getRating())
+                  .fontSize(16)
+                  .fontColor('#FFA500')
+                  .fontWeight(FontWeight.Medium)
+              }
+            }
+
+            // 类型标签
+            if (this.getGenres().length > 0) {
+              Row({ space: 8 }) {
+                ForEach(this.getGenres(), (genre: string) => {
+                  Text(genre)
+                    .fontSize(13)
+                    .fontColor('#CCCCCC')
+                    .backgroundColor('rgba(255,255,255,0.12)')
+                    .padding({ left: 10, right: 10, top: 4, bottom: 4 })
+                    .borderRadius(4)
+                })
+              }
+            }
+
+            // 播放按钮
+            Button({ type: ButtonType.Normal }) {
+              Row({ space: 8 }) {
+                Text('▶')
+                  .fontSize(20)
+                  .fontColor(Color.White)
+                Text('立即播放')
+                  .fontSize(22)
+                  .fontColor(Color.White)
+                  .fontWeight(FontWeight.Medium)
+              }
+              .padding({ left: 8, right: 8 })
+            }
+            .width(220)
+            .height(60)
+            .backgroundColor('#2196F3')
+            .borderRadius(8)
+            .focusable(true)
+            .onClick(() => { this.play(); })
+
+            // 简介
+            Column({ space: 8 }) {
+              Text('简介')
+                .fontSize(18)
+                .fontColor('#FFFFFF')
+                .fontWeight(FontWeight.Medium)
+              Text(this.getOverview())
+                .fontSize(16)
+                .fontColor('#BBBBBB')
+                .lineHeight(26)
+                .maxLines(6)
+                .textOverflow({ overflow: TextOverflow.Ellipsis })
+                .width('100%')
+            }
+            .alignItems(HorizontalAlign.Start)
+            .margin({ top: 8 })
+          }
+          .layoutWeight(1)
+          .alignItems(HorizontalAlign.Start)
+          .margin({ top: 60 })
+        }
+        .width('100%')
+        .padding({ left: 60, right: 60, bottom: 40 })
+        .alignItems(VerticalAlign.Top)
+      }
+      .width('100%')
+      .height('100%')
+      .backgroundColor('#1A1A1A')
+    }
+    .onReady((context: NavDestinationContext) => {
+      const param = context.pathInfo.param as MediaItem;
+      if (param !== undefined && param !== null) {
+        this.item = param;
+      }
+    })
+    .hideTitleBar(true)
+  }
+}

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -100,6 +100,8 @@ export struct MovieDetailPage {
   /** 从 backdrop 提取的深色背景色，格式 #RRGGBB，提取失败保持默认 */
   @Local dominantBgColor: string = '#111111';
   @Local showOverviewDialog: boolean = false;
+  /** 简介「更多」按钮焦点状态，用于 TV 遥控器 D-Pad 焦点高亮 */
+  @Local focusMoreBtn: boolean = false;
   /** 播放按钮焦点/Hover 状态 key */
   @Local focusedActionKey: string = '';
   @Local hoveredActionKey: string = '';
@@ -407,7 +409,8 @@ export struct MovieDetailPage {
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
     } catch (e) {
-      console.error('[MovieDetailPage] play() 构建播放 URL 失败');
+      const err = e as BusinessError;
+      console.error('MovieDetailPage', `play() 构建播放 URL 失败: ${err.message}`);
     }
   }
 
@@ -628,9 +631,12 @@ export struct MovieDetailPage {
                   .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
                   .constraintSize({ maxWidth: 640 })
                 Text('更多')
-                  .fontSize(14).fontColor('#1B78F2')
+                  .fontSize(14)
+                  .fontColor(this.focusMoreBtn ? '#FFFFFFFF' : '#1B78F2')
                   .fontWeight(FontWeight.Medium)
                   .focusable(true)
+                  .onFocus(() => { this.focusMoreBtn = true; })
+                  .onBlur(() => { this.focusMoreBtn = false; })
                   .onClick(() => { this.showOverviewDialog = true; })
               }
               .constraintSize({ maxWidth: 700 })

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -3,72 +3,84 @@ import { PlayerPageParam, PlayerPage } from '../player/index';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntity';
 import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient';
+import http from '@ohos.net.http';
+import image from '@ohos.multimedia.image';
+import effectKit from '@ohos.effectKit';
+import { millisecondsToTime } from '../../utils/TimeUtil';
 
 // ─────────────────────────────────────────────
-// 辅助类型
+// TMDB 图片 URL 工具
 // ─────────────────────────────────────────────
 
+/**
+ * 按指定宽度档位构造 TMDB 图片 URL。
+ * width 取值：'w185' | 'w300' | 'w342' | 'w500' | 'w780' | 'w1280' | 'original'
+ */
+function tmdbImageUrl(path: string | undefined, width: string): string {
+  if (!path || path.length === 0) { return ''; }
+  return 'https://image.tmdb.org/t/p/' + width + path;
+}
+
+function formatYear(date: string | undefined): string {
+  if (!date || date.length < 4) { return ''; }
+  return date.substring(0, 4);
+}
+
+function parseGenresArr(json: string | undefined): string[] {
+  if (!json) { return []; }
+  try { return JSON.parse(json) as string[]; } catch (e) { return []; }
+}
+
+/**
+ * 将电影时长格式化为 h:mm:ss 字符串。
+ * 优先用 runtimeMinutes（TMDB 原始分钟数），其次用 durationMs（本地文件时长）。
+ */
+function formatMovieDuration(runtimeMinutes: number | undefined, durationMs: number | undefined): string {
+  let totalSeconds: number = 0;
+  if (runtimeMinutes !== undefined && runtimeMinutes > 0) {
+    totalSeconds = runtimeMinutes * 60;
+  } else if (durationMs !== undefined && durationMs > 0) {
+    totalSeconds = Math.floor(durationMs / 1000);
+  } else {
+    return '';
+  }
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  const mm = m.toString().padStart(2, '0');
+  const ss = s.toString().padStart(2, '0');
+  if (h > 0) {
+    return h.toString() + ':' + mm + ':' + ss;
+  }
+  return '0:' + mm + ':' + ss;
+}
+
+// ─────────────────────────────────────────────
+// 内部类型定义
+// ─────────────────────────────────────────────
+
+/** 演员原始数据结构（来自 movie.cast_json） */
 interface CastPerson {
   name: string;
   character?: string;
   profile_path?: string;
 }
 
-// ─────────────────────────────────────────────
-// 工具函数
-// ─────────────────────────────────────────────
-
-function formatRuntime(ms: number | undefined): string {
-  if (ms === undefined || ms <= 0) {
-    return '未知';
-  }
-  const totalSeconds = Math.floor(ms / 1000);
-  const h = Math.floor(totalSeconds / 3600);
-  const m = Math.floor((totalSeconds % 3600) / 60);
-  if (h > 0) {
-    return h.toString() + ' 小时 ' + m.toString() + ' 分';
-  }
-  return m.toString() + ' 分钟';
-}
-
-function formatYear(date: string | undefined): string {
-  if (!date || date.length < 4) {
-    return '';
-  }
-  return date.substring(0, 4);
-}
-
-function parseGenresArr(json: string | undefined): string[] {
-  if (!json) {
-    return [];
-  }
-  try {
-    return JSON.parse(json) as string[];
-  } catch (e) {
-    return [];
-  }
+/** 演职人员统一展示项（导演 + 演员合并列表） */
+interface CastCrewItem {
+  name: string;
+  role?: string;
+  profile_path?: string;
 }
 
 function parseCastArr(json: string | undefined): CastPerson[] {
-  if (!json) {
-    return [];
-  }
-  try {
-    return JSON.parse(json) as CastPerson[];
-  } catch (e) {
-    return [];
-  }
+  if (!json) { return []; }
+  try { return JSON.parse(json) as CastPerson[]; } catch (e) { return []; }
 }
 
 function parseDirectorsArr(json: string | undefined): string[] {
-  if (!json) {
-    return [];
-  }
-  try {
-    return JSON.parse(json) as string[];
-  } catch (e) {
-    return [];
-  }
+  if (!json) { return []; }
+  try { return JSON.parse(json) as string[]; } catch (e) { return []; }
 }
 
 // ─────────────────────────────────────────────
@@ -82,112 +94,255 @@ export struct MovieDetailPage {
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
 
   @Local item: MediaItem | undefined = undefined;
-  // Thread 2：续播进度
   @Local progress: PlayProgressEntity | null = null;
-  // Thread 3：电影详情（演员/导演）
   @Local movieEntity: MovieEntity | null = null;
+  /** 从 backdrop 提取的深色背景色，格式 #RRGGBB，提取失败保持默认 */
+  @Local dominantBgColor: string = '#111111';
+  @Local showOverviewDialog: boolean = false;
+  /** 播放按钮焦点/Hover 状态 key */
+  @Local focusedActionKey: string = '';
+  @Local hoveredActionKey: string = '';
 
-  // ── 数据加载 ──
+  // ── 属性计算方法 ──────────────────────────────────
+
+  /** 将 #RRGGBB 转为完全不透明的 #FFRRGGBB（ARGB 8位），用于渐变颜色 */
+  private toOpaqueColor(hex: string): string {
+    return '#FF' + hex.substring(1);
+  }
+
+  /**
+   * Backdrop URL（高清 w1280）。
+   * 优先级：TMDB backdropPath → backdropUrl（movieEntity/item）→ 海报降级
+   */
+  private getBackdropUrl(): string {
+    const path = this.movieEntity?.backdropPath;
+    if (path !== undefined && path.length > 0) { return tmdbImageUrl(path, 'w1280'); }
+    const url = this.movieEntity?.backdropUrl ?? this.item?.backdropUrl;
+    if (url !== undefined && url.length > 0) { return url; }
+    return this.item?.posterLocalPath ?? this.item?.posterUrl ?? '';
+  }
+
+  /**
+   * Backdrop 缩略图 URL（w300，用于 MovieWatchingCard 缩略图）。
+   * 与 getBackdropUrl 相同优先级，但尺寸为 w300。
+   */
+  private getBackdropThumbUrl(): string {
+    const path = this.movieEntity?.backdropPath;
+    if (path !== undefined && path.length > 0) { return tmdbImageUrl(path, 'w300'); }
+    const url = this.movieEntity?.backdropUrl ?? this.item?.backdropUrl;
+    if (url !== undefined && url.length > 0) { return url; }
+    return this.item?.posterLocalPath ?? this.item?.posterUrl ?? '';
+  }
+
+  /** 电影标题 */
+  private getTitle(): string {
+    return this.movieEntity?.title ?? this.item?.title ?? this.item?.fileName ?? '未知影片';
+  }
+
+  /** 上映年份（YYYY） */
+  private getYear(): string {
+    return formatYear(this.movieEntity?.releaseDate ?? this.item?.releaseDate);
+  }
+
+  /** 评分（可能为 undefined） */
+  private getRating(): number | undefined {
+    return this.movieEntity?.rating ?? this.item?.rating;
+  }
+
+  /** 完整简介文本 */
+  private getOverview(): string {
+    return this.movieEntity?.overview ?? this.item?.overview ?? '';
+  }
+
+  /** 简介是否超过 100 字 */
+  private isOverviewLong(): boolean { return this.getOverview().length > 100; }
+
+  /** 截断后的简介（前 100 字 + 省略号） */
+  private getOverviewShort(): string { return this.getOverview().substring(0, 100) + '...'; }
+
+  /** 类型标签数组 */
+  private getGenres(): string[] {
+    return parseGenresArr(this.movieEntity?.genresJson ?? this.item?.genresJson);
+  }
+
+  /** 类型标签文字，如 "剧情 / 动作" */
+  private getGenresText(): string {
+    const g = this.getGenres();
+    if (g.length === 0) { return ''; }
+    return g.slice(0, 3).join(' / ');
+  }
+
+  /** 片长文字，如 "2 小时 15 分" */
+  private getRuntimeText(): string {
+    const rt = this.movieEntity?.runtime;
+    if (rt !== undefined && rt > 0) {
+      const h = Math.floor(rt / 60);
+      const m = rt % 60;
+      if (h > 0) { return h.toString() + ' 小时 ' + m.toString() + ' 分'; }
+      return m.toString() + ' 分钟';
+    }
+    const ms = this.item?.durationMs;
+    if (ms !== undefined && ms > 0) {
+      const totalSeconds = Math.floor(ms / 1000);
+      const h2 = Math.floor(totalSeconds / 3600);
+      const m2 = Math.floor((totalSeconds % 3600) / 60);
+      if (h2 > 0) { return h2.toString() + ' 小时 ' + m2.toString() + ' 分'; }
+      return m2.toString() + ' 分钟';
+    }
+    return '';
+  }
+
+  /** 详情弹窗海报 URL */
+  private getPosterUrl(): string {
+    const path = this.movieEntity?.posterPath;
+    if (path !== undefined && path.length > 0) { return tmdbImageUrl(path, 'w342'); }
+    return this.movieEntity?.posterUrl ?? this.item?.posterLocalPath ?? this.item?.posterUrl ?? '';
+  }
+
+  /** 是否有有效续播进度（大于 5 秒才算） */
+  private hasProgress(): boolean {
+    const p = this.progress;
+    return p !== null && p.positionMs > 5000;
+  }
+
+  /** 是否已看完（>= 95%） */
+  private isWatched(): boolean {
+    const p = this.progress;
+    if (p === null || p.durationMs <= 0) { return false; }
+    return p.positionMs / p.durationMs >= 0.95;
+  }
+
+  /** 播放进度百分比（0~1） */
+  private getProgressPercent(): number {
+    const p = this.progress;
+    if (p === null || p.durationMs <= 0) { return 0; }
+    return Math.min(1, p.positionMs / p.durationMs);
+  }
+
+  /** 按钮背景色（焦点 > Hover > 默认） */
+  private getButtonBgColor(key: string): string {
+    if (this.focusedActionKey === key) { return '#3C8FF6'; }
+    if (this.hoveredActionKey === key) { return '#2E82EA'; }
+    return '#1B78F2';
+  }
+
+  /** 按钮边框色（焦点 > Hover > 透明） */
+  private getButtonBorderColor(key: string): string {
+    if (this.focusedActionKey === key) { return '#66A9D8FF'; }
+    if (this.hoveredActionKey === key) { return '#7FB7F4'; }
+    return '#00FFFFFF';
+  }
+
+  /**
+   * 构建导演 + 演员合并列表（导演在前，演员在后）。
+   * 用于 CastSection 渲染，最多取 15 人。
+   */
+  private buildCastCrewList(): CastCrewItem[] {
+    const result: CastCrewItem[] = [];
+    const directors = parseDirectorsArr(this.movieEntity?.directorsJson);
+    for (const d of directors) {
+      const ci: CastCrewItem = { name: d, role: '导演' };
+      result.push(ci);
+    }
+    const castList = parseCastArr(this.movieEntity?.castJson);
+    for (const c of castList) {
+      const ci: CastCrewItem = { name: c.name, role: c.character, profile_path: c.profile_path };
+      result.push(ci);
+    }
+    return result;
+  }
+
+  // ── 数据加载 ──────────────────────────────────
+
+  /**
+   * 下载 backdrop 图片并用 effectKit 提取最暗主色作为页面背景色。
+   * 提取失败时静默忽略，保持默认 #111111。
+   */
+  private async extractDominantColor(url: string): Promise<void> {
+    try {
+      const req = http.createHttp();
+      let buf: ArrayBuffer | undefined;
+      try {
+        const resp = await req.request(url, {
+          method: http.RequestMethod.GET,
+          expectDataType: http.HttpDataType.ARRAY_BUFFER,
+          connectTimeout: 8000,
+          readTimeout: 8000
+        });
+        req.destroy();
+        if (resp.responseCode !== 200) { return; }
+        buf = resp.result as ArrayBuffer;
+      } catch (e) {
+        req.destroy();
+        return;
+      }
+      if (buf === undefined || buf.byteLength === 0) { return; }
+
+      // 缩小尺寸加速：从 ArrayBuffer 创建 ImageSource，解码为小尺寸 PixelMap
+      const imgSrc = image.createImageSource(buf);
+      const pixelMap = await imgSrc.createPixelMap({
+        desiredSize: { width: 64, height: 36 },
+        desiredPixelFormat: image.PixelMapFormat.RGBA_8888
+      });
+      imgSrc.release();
+
+      // effectKit 提取主色
+      const picker = await effectKit.createColorPicker(pixelMap);
+      const mainColor = picker.getMainColorSync();
+      pixelMap.release();
+
+      // 将 RGB 分量各减暗 40%，保证背景色足够深
+      const darken = (v: number): number => Math.round(v * 0.4);
+      const toHex = (v: number): string => {
+        const h = v.toString(16);
+        return h.length < 2 ? '0' + h : h;
+      };
+      const r = darken(mainColor.red & 0xFF);
+      const g = darken(mainColor.green & 0xFF);
+      const b = darken(mainColor.blue & 0xFF);
+      this.dominantBgColor = '#' + toHex(r) + toHex(g) + toHex(b);
+    } catch (e) {
+      // 提取失败，保持默认色
+      console.warn('[MovieDetailPage] extractDominantColor failed', JSON.stringify(e));
+    }
+  }
 
   private loadAuxData(item: MediaItem): void {
     const db = FileSourceDatabase.getInstance();
-    // 加载续播进度
+    // 并行加载续播进度
     db.getPlayProgress(item.id).then((p: PlayProgressEntity | null) => {
       this.progress = p;
-    }).catch(() => {
-      this.progress = null;
-    });
-    // 加载电影详情（演员/导演），仅在已刮削时查询
+    }).catch(() => {});
+
     const provider = item.provider;
     const providerId = item.providerId;
     if (provider !== undefined && provider.length > 0 &&
         providerId !== undefined && providerId.length > 0) {
       db.getMovieByProviderId(provider, providerId).then((m: MovieEntity | null) => {
         this.movieEntity = m;
-      }).catch(() => {
-        this.movieEntity = null;
-      });
+        // movieEntity 加载后提取背景色
+        const backdropUrl = this.getBackdropUrl();
+        if (backdropUrl.length > 0) { this.extractDominantColor(backdropUrl); }
+      }).catch(() => {});
+    } else {
+      // 无刮削数据时直接尝试用 item.backdropUrl 提取
+      const backdropUrl = this.getBackdropUrl();
+      if (backdropUrl.length > 0) { this.extractDominantColor(backdropUrl); }
     }
   }
 
-  // ── 计算属性 ──
-
-  private getTitle(): string {
-    return this.item?.title ?? this.item?.fileName ?? '未知影片';
+  /** 返回播放器后刷新进度 */
+  private refreshProgress(item: MediaItem): void {
+    FileSourceDatabase.getInstance()
+      .getPlayProgress(item.id)
+      .then((p: PlayProgressEntity | null) => { this.progress = p; })
+      .catch(() => {});
   }
 
-  private getPoster(): string {
-    return this.item?.posterLocalPath ?? this.item?.posterUrl ?? '';
-  }
-
-  private hasPoster(): boolean {
-    const p = this.getPoster();
-    return p.length > 0;
-  }
-
-  private getYear(): string {
-    return formatYear(this.item?.releaseDate);
-  }
-
-  private getRating(): string {
-    const r = this.item?.rating;
-    if (r === undefined) {
-      return '';
-    }
-    return r.toFixed(1) + ' 分';
-  }
-
-  private getRuntime(): string {
-    return formatRuntime(this.item?.durationMs);
-  }
-
-  private getOverview(): string {
-    const ov = this.item?.overview;
-    if (!ov || ov.length === 0) {
-      return '暂无简介';
-    }
-    return ov;
-  }
-
-  private getGenres(): string[] {
-    return parseGenresArr(this.item?.genresJson);
-  }
-
-  // Thread 3：演员列表，最多5人
-  private getCast(): CastPerson[] {
-    return parseCastArr(this.movieEntity?.castJson).slice(0, 5);
-  }
-
-  // Thread 3：导演列表
-  private getDirectors(): string[] {
-    return parseDirectorsArr(this.movieEntity?.directorsJson);
-  }
-
-  // Thread 2：是否有续播进度（大于5秒才算）
-  private hasProgress(): boolean {
-    const p = this.progress;
-    return p !== null && p.positionMs > 5000;
-  }
-
-  private getProgressPercent(): number {
-    const p = this.progress;
-    if (p === null || p.durationMs <= 0) {
-      return 0;
-    }
-    return Math.min(1, p.positionMs / p.durationMs);
-  }
-
-  private getPlayButtonText(): string {
-    return this.hasProgress() ? '继续播放' : '立即播放';
-  }
-
-  // ── 播放（Thread 1：构建正确的 WebDAV/SMB URL）──
-
+  /** 构建播放 URL 并跳转播放器 */
   private async play(): Promise<void> {
     const item = this.item;
-    if (item === undefined) {
-      return;
-    }
+    if (item === undefined) { return; }
     try {
       const db = FileSourceDatabase.getInstance();
       const fileSource = await db.getFileSourceById(item.sourceId);
@@ -200,27 +355,19 @@ export struct MovieDetailPage {
       let httpHeader: Record<string, string>;
 
       if (fileSource.type === FileSourceType.SMB) {
-        // SMB 源：构建带认证的 smb:// URL
         const smbConfig = JSON.parse(fileSource.configJson) as SMBSourceConfig;
         const port = smbConfig.port ?? 445;
         const user = encodeURIComponent(smbConfig.username);
         const pass = encodeURIComponent(smbConfig.password);
         const encodedPath = item.filePath.split('/').map((seg: string): string => {
-          if (seg.length === 0) {
-            return '';
-          }
+          if (seg.length === 0) { return ''; }
           let decoded: string = seg;
-          try {
-            decoded = decodeURIComponent(seg);
-          } catch {
-            decoded = seg;
-          }
+          try { decoded = decodeURIComponent(seg); } catch { decoded = seg; }
           return encodeURIComponent(decoded);
         }).join('/');
         fullUrl = 'smb://' + user + ':' + pass + '@' + smbConfig.host + ':' + port.toString() + encodedPath;
         httpHeader = {};
       } else {
-        // WebDAV 源：使用 WebDAVClient 构建完整认证 URL
         const protocol = config['protocol'] ?? 'http';
         const host = config['url'] ?? '';
         const port = config['port'] ?? (protocol === 'https' ? '443' : '80');
@@ -230,7 +377,7 @@ export struct MovieDetailPage {
           baseUrl,
           username: config['username'] ?? '',
           password: config['password'] ?? '',
-          timeout: 30000,
+          timeout: 30000
         };
         const client = new WebDAVClient(webdavConfig);
         fullUrl = client.getFullUrl(item.filePath);
@@ -246,228 +393,452 @@ export struct MovieDetailPage {
         durationHintMs: item.durationMs,
         seriesProviderId: '',
         seasonNumber: 0,
-        episodeNumber: 0,
+        episodeNumber: 0
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
-    } catch {
+    } catch (e) {
       console.error('[MovieDetailPage] play() 构建播放 URL 失败');
     }
   }
 
-  // ── 构建 ──
+  // ── Builders ──────────────────────────────────
+
+  /** 电影版续播卡片（右侧，显示 backdrop 缩略图 + 进度 + 播放按钮） */
+  @Builder
+  MovieWatchingCard() {
+    Column() {
+      Row({ space: 14 }) {
+        // 左：Backdrop 缩略图 150x84（优先 w300 backdrop，降级海报，再降级占位深色块）
+        if (this.getBackdropThumbUrl().length > 0) {
+          Image(this.getBackdropThumbUrl())
+            .width(150).height(84)
+            .borderRadius(4)
+            .objectFit(ImageFit.Cover)
+            .border({ width: 1, color: '#2E2E2E' })
+        } else {
+          Column()
+            .width(150).height(84)
+            .backgroundColor('#1C1C1C')
+            .borderRadius(4)
+            .border({ width: 1, color: '#2E2E2E' })
+        }
+
+        // 右：信息区
+        if (this.hasProgress() && this.progress !== null) {
+          // ── 有续播进度 ────────────────────────────────
+          Column({ space: 10 }) {
+            // 时长标签 + 电影标题
+            Row({ space: 8 }) {
+              Text(formatMovieDuration(this.movieEntity?.runtime, this.item?.durationMs))
+                .fontSize(12)
+                .fontColor('#1B78F2')
+                .padding({ left: 7, right: 7, top: 2, bottom: 2 })
+                .backgroundColor('#192840')
+                .borderRadius(3)
+              Text(this.getTitle())
+                .fontSize(14).fontColor('#CCCCCC').fontWeight(FontWeight.Medium)
+                .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
+                .layoutWeight(1)
+            }
+            .alignItems(VerticalAlign.Center)
+
+            // 进度条
+            Column() {
+              Column()
+                .width(Math.round(this.getProgressPercent() * 100).toString() + '%')
+                .height('100%')
+                .backgroundColor('#1B78F2').borderRadius(2)
+                .alignSelf(ItemAlign.Start)
+            }
+            .alignItems(HorizontalAlign.Start)
+            .width('100%').height(4)
+            .backgroundColor('#2E2E2E').borderRadius(2)
+
+            // 播放按钮行
+            Row({ space: 10 }) {
+              Row({ space: 6 }) {
+                Text('▶').fontSize(12).fontColor(Color.White)
+                Text(this.isWatched() ? '重新播放' : '继续播放')
+                  .fontSize(14).fontColor(Color.White).fontWeight(FontWeight.Bold)
+              }
+              .padding({ left: 12, right: 12, top: 6, bottom: 6 })
+              .backgroundColor(this.getButtonBgColor('resume')).borderRadius(4)
+              .border({ width: 2, color: this.getButtonBorderColor('resume') })
+              .focusable(true)
+              .onFocus(() => { this.focusedActionKey = 'resume'; })
+              .onBlur(() => { if (this.focusedActionKey === 'resume') { this.focusedActionKey = ''; } })
+              .onHover((isHover: boolean) => {
+                if (isHover) { this.hoveredActionKey = 'resume'; }
+                else { if (this.hoveredActionKey === 'resume') { this.hoveredActionKey = ''; } }
+              })
+              .onClick(() => { this.play(); })
+
+              Text(millisecondsToTime(this.progress.positionMs))
+                .fontSize(12).fontColor('#888888')
+            }
+            .alignItems(VerticalAlign.Center)
+          }
+          .layoutWeight(1)
+          .alignItems(HorizontalAlign.Start)
+          .justifyContent(FlexAlign.SpaceBetween)
+          .height(84)
+        } else {
+          // ── 无续播进度，显示立即播放 ────────────────────────────────
+          Column({ space: 10 }) {
+            Row({ space: 8 }) {
+              Text(this.getTitle())
+                .fontSize(14).fontColor('#CCCCCC').fontWeight(FontWeight.Medium)
+                .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
+                .layoutWeight(1)
+            }
+            .alignItems(VerticalAlign.Center)
+
+            // 进度条（0%）
+            Column() {
+              Column()
+                .width('0%').height('100%')
+                .backgroundColor('#1B78F2').borderRadius(2)
+                .alignSelf(ItemAlign.Start)
+            }
+            .alignItems(HorizontalAlign.Start)
+            .width('100%').height(4)
+            .backgroundColor('#2E2E2E').borderRadius(2)
+
+            Row({ space: 6 }) {
+              Text('▶').fontSize(12).fontColor(Color.White)
+              Text('立即播放').fontSize(14).fontColor(Color.White).fontWeight(FontWeight.Bold)
+            }
+            .padding({ left: 12, right: 12, top: 6, bottom: 6 })
+            .backgroundColor(this.getButtonBgColor('start')).borderRadius(4)
+            .border({ width: 2, color: this.getButtonBorderColor('start') })
+            .focusable(true)
+            .onFocus(() => { this.focusedActionKey = 'start'; })
+            .onBlur(() => { if (this.focusedActionKey === 'start') { this.focusedActionKey = ''; } })
+            .onHover((isHover: boolean) => {
+              if (isHover) { this.hoveredActionKey = 'start'; }
+              else { if (this.hoveredActionKey === 'start') { this.hoveredActionKey = ''; } }
+            })
+            .onClick(() => { this.play(); })
+          }
+          .layoutWeight(1)
+          .alignItems(HorizontalAlign.Start)
+          .justifyContent(FlexAlign.SpaceBetween)
+          .height(84)
+        }
+      }
+      .alignItems(VerticalAlign.Center)
+    }
+    .padding({ left: 16, right: 20, top: 14, bottom: 14 })
+    .backgroundColor('#18FFFFFF')
+    .borderRadius(8)
+    .border({ width: 1, color: '#22FFFFFF' })
+    .width(500)
+  }
+
+  /** Hero 区域：全屏 backdrop + 双渐变遮罩 + 标题/元信息/简介 + 续播卡片 */
+  @Builder
+  HeroSection() {
+    Stack({ alignContent: Alignment.BottomStart }) {
+      // ── 背景图（w1280）/ 渐变占位 ─────────────────
+      if (this.getBackdropUrl().length > 0) {
+        Image(this.getBackdropUrl())
+          .width('100%').height('100%')
+          .objectFit(ImageFit.Cover)
+      } else {
+        Column()
+          .width('100%').height('100%')
+          .linearGradient({
+            angle: 135,
+            colors: [['#1A1A2E', 0.0], ['#16213E', 0.5], ['#0F3460', 1.0]]
+          })
+      }
+
+      // ── 底部渐变遮罩 ──────────────────────────────
+      Column()
+        .width('100%').height('68%')
+        .linearGradient({
+          angle: 180,
+          colors: [['#00000000', 0.0], [this.toOpaqueColor(this.dominantBgColor), 1.0]]
+        })
+        .position({ left: 0, bottom: 0 })
+        .hitTestBehavior(HitTestMode.Transparent)
+
+      // ── 左侧渐变遮罩 ──────────────────────────────
+      Column()
+        .width('55%').height('100%')
+        .linearGradient({
+          angle: 90,
+          colors: [[this.toOpaqueColor(this.dominantBgColor), 0.0], ['#00000000', 1.0]]
+        })
+        .position({ left: 0, top: 0 })
+        .hitTestBehavior(HitTestMode.Transparent)
+
+      // ── 底部内容行 ────────────────────────────────
+      Row({ space: 40 }) {
+        // 左侧：标题 / 元信息 / 简介
+        Column({ space: 14 }) {
+          Text(this.getTitle())
+            .fontSize(52).fontColor(Color.White).fontWeight(FontWeight.Bold)
+            .maxLines(2).textOverflow({ overflow: TextOverflow.Ellipsis })
+            .textShadow({ radius: 8, color: '#88000000', offsetX: 2, offsetY: 2 })
+            .constraintSize({ maxWidth: 720 })
+
+          // 元信息行：年份 + 时长 + 评分 + 类型标签（同行）
+          Row({ space: 12 }) {
+            if (this.getYear().length > 0) {
+              Text(this.getYear())
+                .fontSize(18).fontColor('#CCCCCC').fontWeight(FontWeight.Medium)
+            }
+            if (this.getRuntimeText().length > 0) {
+              Text(this.getRuntimeText())
+                .fontSize(18).fontColor('#CCCCCC').fontWeight(FontWeight.Medium)
+            }
+            if (this.getRating() !== undefined) {
+              Row({ space: 4 }) {
+                Text('★').fontSize(16).fontColor('#FFA500')
+                Text((this.getRating() as number).toFixed(1))
+                  .fontSize(18).fontColor('#FFA500').fontWeight(FontWeight.Bold)
+              }
+            }
+            ForEach(this.getGenres().slice(0, 3), (genre: string) => {
+              Text(genre)
+                .fontSize(14).fontColor('#CCCCCC')
+                .padding({ left: 10, right: 10, top: 4, bottom: 4 })
+                .borderRadius(4)
+                .border({ width: 1, color: '#55FFFFFF' })
+            }, (genre: string) => genre)
+          }
+          .alignItems(VerticalAlign.Center)
+
+          // 简介：超 100 字截断显示 + 「更多」Span，不超出仅显示原文
+          if (this.getOverview().length > 0) {
+            if (this.isOverviewLong()) {
+              Text() {
+                Span(this.getOverviewShort())
+                  .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
+                Span('更多')
+                  .fontSize(14).fontColor('#1B78F2')
+                  .fontWeight(FontWeight.Medium)
+                  .onClick(() => { this.showOverviewDialog = true; })
+              }
+              .constraintSize({ maxWidth: 700 })
+            } else {
+              Text(this.getOverview())
+                .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
+                .constraintSize({ maxWidth: 700 })
+            }
+          }
+        }
+        .layoutWeight(1)
+        .alignItems(HorizontalAlign.Start)
+
+        // 右侧：电影版续播卡片
+        this.MovieWatchingCard()
+      }
+      .width('100%')
+      .padding({ left: 80, right: 80, bottom: 52 })
+      .alignItems(VerticalAlign.Bottom)
+    }
+    .width('100%').aspectRatio(1.778)
+  }
+
+  /** 演职人员横向滚动列表（导演在前，演员在后，最多 15 人） */
+  @Builder
+  CastSection() {
+    if (this.buildCastCrewList().length > 0) {
+      Column({ space: 0 }) {
+        Text('演职人员')
+          .fontSize(26).fontColor(Color.White).fontWeight(FontWeight.Bold)
+          .padding({ left: 80, top: 36, bottom: 20 })
+
+        Scroll() {
+          Row({ space: 24 }) {
+            ForEach(this.buildCastCrewList().slice(0, 15), (c: CastCrewItem) => {
+              Column({ space: 8 }) {
+                // 人物照片（长方形）
+                if (c.profile_path !== undefined && c.profile_path.length > 0) {
+                  Image(tmdbImageUrl(c.profile_path, 'w185'))
+                    .width(110).aspectRatio(2 / 3)
+                    .objectFit(ImageFit.Cover).borderRadius(6)
+                    .hoverEffect(HoverEffect.Scale)
+                } else {
+                  Column() {
+                    Text((c.name != null && c.name.length > 0) ? c.name.substring(0, 1) : '?')
+                      .fontSize(30).fontColor(Color.White).fontWeight(FontWeight.Bold)
+                  }
+                  .width(110).aspectRatio(2 / 3).borderRadius(6)
+                  .backgroundColor('#2A2A2A')
+                  .justifyContent(FlexAlign.Center).alignItems(HorizontalAlign.Center)
+                  .hoverEffect(HoverEffect.Scale)
+                }
+                // 姓名
+                Text(c.name ?? '')
+                  .fontSize(14).fontColor(Color.White)
+                  .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
+                  .width(110).textAlign(TextAlign.Center)
+                // 角色 / 职位
+                if (c.role !== undefined && c.role.length > 0) {
+                  Text(c.role)
+                    .fontSize(12).fontColor('#777777')
+                    .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
+                    .width(110).textAlign(TextAlign.Center)
+                }
+              }
+              .width(110).alignItems(HorizontalAlign.Center)
+            }, (c: CastCrewItem) => c.name ?? '')
+          }
+          .padding({ left: 80, right: 80 })
+        }
+        .scrollable(ScrollDirection.Horizontal)
+        .scrollBar(BarState.Off)
+        .edgeEffect(EdgeEffect.None)
+
+        Column().height(36)
+      }
+      .width('100%').alignItems(HorizontalAlign.Start)
+      .backgroundColor(this.dominantBgColor)
+    }
+  }
+
+  /** 简介全文弹窗覆盖层（点击「更多」时展开，双面板布局） */
+  @Builder
+  OverviewDialog() {
+    if (this.showOverviewDialog) {
+      Stack({ alignContent: Alignment.Center }) {
+        // 半透明遮罩
+        Column()
+          .width('100%').height('100%')
+          .backgroundColor('#BB000000')
+          .onClick(() => { this.showOverviewDialog = false; })
+
+        // 卡片主体
+        Column() {
+          // ── 标题栏 ──────────────────────────────
+          Row() {
+            Text('简介')
+              .fontSize(26).fontColor('#F0F0F0').fontWeight(FontWeight.Bold)
+              .layoutWeight(1).textAlign(TextAlign.Center)
+            Text('✕')
+              .fontSize(20).fontColor('#888892')
+              .width(48).height(48)
+              .textAlign(TextAlign.Center)
+              .borderRadius(24)
+              .backgroundColor('#2A2A2E')
+              .onClick(() => { this.showOverviewDialog = false; })
+          }
+          .alignItems(VerticalAlign.Center)
+          .padding({ left: 24, right: 24, top: 0, bottom: 0 })
+          .height(80)
+          .width('100%')
+          .backgroundColor('#1E1E22')
+
+          // 分隔线
+          Divider().color('#2E2E34').strokeWidth(1)
+
+          // ── 内容区（左右双面板）────────────────────
+          Row() {
+            // 左面板：海报 + 元数据
+            Column({ space: 20 }) {
+              Image(this.getPosterUrl())
+                .width(124).height(174)
+                .borderRadius(6)
+                .objectFit(ImageFit.Cover)
+                .backgroundColor('#2A2A2E')
+
+              Text(this.getTitle())
+                .fontSize(22).fontWeight(FontWeight.Bold).fontColor('#F0F0F0')
+                .maxLines(3).textOverflow({ overflow: TextOverflow.Ellipsis })
+                .lineHeight(32)
+                .width('100%')
+
+              Column({ space: 8 }) {
+                if (this.getGenresText().length > 0) {
+                  Text('风格：' + this.getGenresText())
+                    .fontSize(18).fontColor('#AAAAAA')
+                }
+                if (this.getRuntimeText().length > 0) {
+                  Text('片长：' + this.getRuntimeText())
+                    .fontSize(18).fontColor('#AAAAAA')
+                }
+                if (this.getYear().length > 0) {
+                  Text(this.getYear())
+                    .fontSize(18).fontColor('#AAAAAA')
+                }
+              }
+              .alignItems(HorizontalAlign.Start).width('100%')
+            }
+            .width('28%')
+            .padding({ left: 48, right: 32, top: 48, bottom: 48 })
+            .alignItems(HorizontalAlign.Start)
+
+            // 垂直分隔线
+            Divider().vertical(true).color('#2A2A2E').strokeWidth(1).height('100%')
+
+            // 右面板：全文简介
+            Scroll() {
+              Text(this.getOverview())
+                .fontSize(20).fontColor('#C8C8D0').lineHeight(36)
+                .width('100%')
+            }
+            .scrollable(ScrollDirection.Vertical)
+            .scrollBar(BarState.Auto)
+            .scrollBarColor('#555560')
+            .layoutWeight(1)
+            .padding({ left: 40, right: 40, top: 48, bottom: 48 })
+          }
+          .alignItems(VerticalAlign.Top)
+          .layoutWeight(1)
+        }
+        .width('85%').height('88%')
+        .backgroundColor('#18181C')
+        .borderRadius(16)
+        .border({ width: 1, color: '#2A2A2E' })
+        .clip(true)
+      }
+      .width('100%').height('100%')
+    }
+  }
+
+  // ── 构建 ──────────────────────────────────────
 
   build() {
     NavDestination() {
       Stack({ alignContent: Alignment.TopStart }) {
-        // 背景：模糊横幅（若无海报则纯色）
-        if (this.hasPoster()) {
-          Image(this.getPoster())
-            .width('100%')
-            .height('50%')
-            .objectFit(ImageFit.Cover)
-            .blur(30)
-            .opacity(0.35)
-        }
-
-        // 顶部渐变遮罩
-        Column()
-          .width('100%')
-          .height('50%')
-          .linearGradient({
-            angle: 180,
-            colors: [['#00000000', 0.0], ['#FF1A1A1A', 1.0]]
-          })
-          .hitTestBehavior(HitTestMode.Transparent)
-
-        // 主体内容
-        Row({ space: 40 }) {
-          // 海报列
+        // 主体滚动内容
+        Scroll() {
           Column() {
-            if (this.hasPoster()) {
-              Image(this.getPoster())
-                .width(200)
-                .height(300)
-                .objectFit(ImageFit.Cover)
-                .borderRadius(8)
-                .shadow({ radius: 20, color: 'rgba(0,0,0,0.5)', offsetX: 0, offsetY: 8 })
-            } else {
-              Column() {
-                Text(this.getTitle())
-                  .fontSize(14)
-                  .fontColor('#CCCCCC')
-                  .textAlign(TextAlign.Center)
-                  .maxLines(4)
-                  .textOverflow({ overflow: TextOverflow.Ellipsis })
-                  .padding(12)
-              }
-              .width(200)
-              .height(300)
-              .backgroundColor('#2A2A2A')
-              .borderRadius(8)
-              .justifyContent(FlexAlign.Center)
-            }
+            this.HeroSection()
+            // 无 SeasonsSection（电影无季集结构）
+            this.CastSection()
+            Column().height(80)
           }
-          .margin({ top: 60 })
+          .width('100%')
+          .backgroundColor(this.dominantBgColor)
+        }
+        .width('100%').height('100%')
+        .scrollBar(BarState.Off)
+        .edgeEffect(EdgeEffect.None)
 
-          // 信息列
-          Column({ space: 16 }) {
-            // 标题
-            Text(this.getTitle())
-              .fontSize(36)
-              .fontColor(Color.White)
-              .fontWeight(FontWeight.Bold)
-              .maxLines(2)
-              .textOverflow({ overflow: TextOverflow.Ellipsis })
+        // 简介全文弹窗
+        this.OverviewDialog()
 
-            // 元数据行（年份 / 时长 / 评分）
-            Row({ space: 16 }) {
-              if (this.getYear().length > 0) {
-                Text(this.getYear())
-                  .fontSize(16)
-                  .fontColor('#AAAAAA')
-              }
-              if (this.getRuntime() !== '未知') {
-                Text(this.getRuntime())
-                  .fontSize(16)
-                  .fontColor('#AAAAAA')
-              }
-              if (this.getRating().length > 0) {
-                Text('★ ' + this.getRating())
-                  .fontSize(16)
-                  .fontColor('#FFA500')
-                  .fontWeight(FontWeight.Medium)
-              }
-            }
-
-            // 类型标签
-            if (this.getGenres().length > 0) {
-              Row({ space: 8 }) {
-                ForEach(this.getGenres(), (genre: string) => {
-                  Text(genre)
-                    .fontSize(13)
-                    .fontColor('#CCCCCC')
-                    .backgroundColor('rgba(255,255,255,0.12)')
-                    .padding({ left: 10, right: 10, top: 4, bottom: 4 })
-                    .borderRadius(4)
-                })
-              }
-            }
-
-            // Thread 2：播放按钮（含续播进度）
-            Column({ space: 8 }) {
-              Button({ type: ButtonType.Normal }) {
-                Row({ space: 8 }) {
-                  Text('▶')
-                    .fontSize(20)
-                    .fontColor(Color.White)
-                  Text(this.getPlayButtonText())
-                    .fontSize(22)
-                    .fontColor(Color.White)
-                    .fontWeight(FontWeight.Medium)
-                }
-                .padding({ left: 8, right: 8 })
-              }
-              .width(220)
-              .height(60)
-              .backgroundColor('#2196F3')
-              .borderRadius(8)
-              .focusable(true)
-              .onClick(() => { this.play(); })
-
-              // Thread 2：续播进度条
-              if (this.hasProgress()) {
-                Column({ space: 4 }) {
-                  Progress({ value: this.getProgressPercent() * 100, total: 100, type: ProgressType.Linear })
-                    .width(220)
-                    .height(4)
-                    .color('#2196F3')
-                    .backgroundColor('rgba(255,255,255,0.2)')
-                  Text('已观看 ' + Math.round(this.getProgressPercent() * 100).toString() + '%')
-                    .fontSize(12)
-                    .fontColor('#AAAAAA')
-                }
-                .alignItems(HorizontalAlign.Start)
-              }
-            }
-            .alignItems(HorizontalAlign.Start)
-
-            // Thread 3：导演信息
-            if (this.getDirectors().length > 0) {
-              Row({ space: 8 }) {
-                Text('导演：')
-                  .fontSize(15)
-                  .fontColor('#AAAAAA')
-                Text(this.getDirectors().join('、'))
-                  .fontSize(15)
-                  .fontColor('#CCCCCC')
-                  .maxLines(1)
-                  .textOverflow({ overflow: TextOverflow.Ellipsis })
-              }
-            }
-
-            // 简介
-            Column({ space: 8 }) {
-              Text('简介')
-                .fontSize(18)
-                .fontColor('#FFFFFF')
-                .fontWeight(FontWeight.Medium)
-              Text(this.getOverview())
-                .fontSize(16)
-                .fontColor('#BBBBBB')
-                .lineHeight(26)
-                .maxLines(6)
-                .textOverflow({ overflow: TextOverflow.Ellipsis })
-                .width('100%')
-            }
-            .alignItems(HorizontalAlign.Start)
-            .margin({ top: 8 })
-
-            // Thread 3：演员列表（最多5人）
-            if (this.getCast().length > 0) {
-              Column({ space: 8 }) {
-                Text('演员')
-                  .fontSize(18)
-                  .fontColor('#FFFFFF')
-                  .fontWeight(FontWeight.Medium)
-                Row({ space: 12 }) {
-                  ForEach(this.getCast(), (person: CastPerson) => {
-                    Column({ space: 4 }) {
-                      Text(person.name)
-                        .fontSize(13)
-                        .fontColor('#CCCCCC')
-                        .maxLines(1)
-                        .textOverflow({ overflow: TextOverflow.Ellipsis })
-                        .width(80)
-                        .textAlign(TextAlign.Center)
-                      if (person.character !== undefined && person.character.length > 0) {
-                        Text(person.character)
-                          .fontSize(11)
-                          .fontColor('#888888')
-                          .maxLines(1)
-                          .textOverflow({ overflow: TextOverflow.Ellipsis })
-                          .width(80)
-                          .textAlign(TextAlign.Center)
-                      }
-                    }
-                    .width(80)
-                  })
-                }
-              }
-              .alignItems(HorizontalAlign.Start)
-              .margin({ top: 8 })
-            }
-          }
-          .layoutWeight(1)
-          .alignItems(HorizontalAlign.Start)
-          .margin({ top: 60 })
+        // 顶部浮动返回按钮
+        Row() {
+          Text('←')
+            .fontSize(30).fontColor(Color.White).fontWeight(FontWeight.Bold)
+            .textShadow({ radius: 6, color: '#88000000', offsetX: 1, offsetY: 1 })
+            .padding(20)
+            .onClick(() => { this.pageStack.pop(); })
         }
         .width('100%')
-        .padding({ left: 60, right: 60, bottom: 40 })
-        .alignItems(VerticalAlign.Top)
+        .padding({ left: 16, top: 8 })
+        .linearGradient({
+          angle: 180,
+          colors: [['#AA000000', 0.0], ['#00000000', 1.0]]
+        })
       }
-      .width('100%')
-      .height('100%')
-      .backgroundColor('#1A1A1A')
+      .width('100%').height('100%')
+      .backgroundColor(this.dominantBgColor)
     }
     .onReady((context: NavDestinationContext) => {
       const param = context.pathInfo.param as MediaItem;
@@ -475,6 +846,16 @@ export struct MovieDetailPage {
         this.item = param;
         this.loadAuxData(param);
       }
+    })
+    .onShown(() => {
+      if (this.item !== undefined) { this.refreshProgress(this.item); }
+    })
+    .onBackPressed(() => {
+      if (this.showOverviewDialog) {
+        this.showOverviewDialog = false;
+        return true;
+      }
+      return false;
     })
     .hideTitleBar(true)
   }

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -1,5 +1,18 @@
-import { MediaItem } from '../../db/models/MediaEntity';
+import { MediaItem, PlayProgressEntity, MovieEntity } from '../../db/models/MediaEntity';
 import { PlayerPageParam, PlayerPage } from '../player/index';
+import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
+import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntity';
+import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient';
+
+// ─────────────────────────────────────────────
+// 辅助类型
+// ─────────────────────────────────────────────
+
+interface CastPerson {
+  name: string;
+  character?: string;
+  profile_path?: string;
+}
 
 // ─────────────────────────────────────────────
 // 工具函数
@@ -36,6 +49,28 @@ function parseGenresArr(json: string | undefined): string[] {
   }
 }
 
+function parseCastArr(json: string | undefined): CastPerson[] {
+  if (!json) {
+    return [];
+  }
+  try {
+    return JSON.parse(json) as CastPerson[];
+  } catch (e) {
+    return [];
+  }
+}
+
+function parseDirectorsArr(json: string | undefined): string[] {
+  if (!json) {
+    return [];
+  }
+  try {
+    return JSON.parse(json) as string[];
+  } catch (e) {
+    return [];
+  }
+}
+
 // ─────────────────────────────────────────────
 // 电影详情页
 // ─────────────────────────────────────────────
@@ -47,7 +82,33 @@ export struct MovieDetailPage {
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
 
   @Local item: MediaItem | undefined = undefined;
-  @Local isHovered: boolean = false;
+  // Thread 2：续播进度
+  @Local progress: PlayProgressEntity | null = null;
+  // Thread 3：电影详情（演员/导演）
+  @Local movieEntity: MovieEntity | null = null;
+
+  // ── 数据加载 ──
+
+  private loadAuxData(item: MediaItem): void {
+    const db = FileSourceDatabase.getInstance();
+    // 加载续播进度
+    db.getPlayProgress(item.id).then((p: PlayProgressEntity | null) => {
+      this.progress = p;
+    }).catch(() => {
+      this.progress = null;
+    });
+    // 加载电影详情（演员/导演），仅在已刮削时查询
+    const provider = item.provider;
+    const providerId = item.providerId;
+    if (provider !== undefined && provider.length > 0 &&
+        providerId !== undefined && providerId.length > 0) {
+      db.getMovieByProviderId(provider, providerId).then((m: MovieEntity | null) => {
+        this.movieEntity = m;
+      }).catch(() => {
+        this.movieEntity = null;
+      });
+    }
+  }
 
   // ── 计算属性 ──
 
@@ -92,19 +153,105 @@ export struct MovieDetailPage {
     return parseGenresArr(this.item?.genresJson);
   }
 
-  // ── 播放 ──
+  // Thread 3：演员列表，最多5人
+  private getCast(): CastPerson[] {
+    return parseCastArr(this.movieEntity?.castJson).slice(0, 5);
+  }
 
-  private play(): void {
-    if (this.item === undefined) {
+  // Thread 3：导演列表
+  private getDirectors(): string[] {
+    return parseDirectorsArr(this.movieEntity?.directorsJson);
+  }
+
+  // Thread 2：是否有续播进度（大于5秒才算）
+  private hasProgress(): boolean {
+    const p = this.progress;
+    return p !== null && p.positionMs > 5000;
+  }
+
+  private getProgressPercent(): number {
+    const p = this.progress;
+    if (p === null || p.durationMs <= 0) {
+      return 0;
+    }
+    return Math.min(1, p.positionMs / p.durationMs);
+  }
+
+  private getPlayButtonText(): string {
+    return this.hasProgress() ? '继续播放' : '立即播放';
+  }
+
+  // ── 播放（Thread 1：构建正确的 WebDAV/SMB URL）──
+
+  private async play(): Promise<void> {
+    const item = this.item;
+    if (item === undefined) {
       return;
     }
-    const param: PlayerPageParam = {
-      videoId: this.item.id,
-      url: this.item.filePath,
-      title: this.getTitle(),
-      durationHintMs: this.item.durationMs,
-    };
-    this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
+    try {
+      const db = FileSourceDatabase.getInstance();
+      const fileSource = await db.getFileSourceById(item.sourceId);
+      if (fileSource === null) {
+        console.warn('[MovieDetailPage] 找不到文件源 sourceId=' + item.sourceId.toString());
+        return;
+      }
+      const config = JSON.parse(fileSource.configJson) as Record<string, string>;
+      let fullUrl: string;
+      let httpHeader: Record<string, string>;
+
+      if (fileSource.type === FileSourceType.SMB) {
+        // SMB 源：构建带认证的 smb:// URL
+        const smbConfig = JSON.parse(fileSource.configJson) as SMBSourceConfig;
+        const port = smbConfig.port ?? 445;
+        const user = encodeURIComponent(smbConfig.username);
+        const pass = encodeURIComponent(smbConfig.password);
+        const encodedPath = item.filePath.split('/').map((seg: string): string => {
+          if (seg.length === 0) {
+            return '';
+          }
+          let decoded: string = seg;
+          try {
+            decoded = decodeURIComponent(seg);
+          } catch {
+            decoded = seg;
+          }
+          return encodeURIComponent(decoded);
+        }).join('/');
+        fullUrl = 'smb://' + user + ':' + pass + '@' + smbConfig.host + ':' + port.toString() + encodedPath;
+        httpHeader = {};
+      } else {
+        // WebDAV 源：使用 WebDAVClient 构建完整认证 URL
+        const protocol = config['protocol'] ?? 'http';
+        const host = config['url'] ?? '';
+        const port = config['port'] ?? (protocol === 'https' ? '443' : '80');
+        const rootPath = (config['rootPath'] ?? '').replace(/\/$/, '');
+        const baseUrl = protocol + '://' + host + ':' + port + rootPath;
+        const webdavConfig: WebDAVConfig = {
+          baseUrl,
+          username: config['username'] ?? '',
+          password: config['password'] ?? '',
+          timeout: 30000,
+        };
+        const client = new WebDAVClient(webdavConfig);
+        fullUrl = client.getFullUrl(item.filePath);
+        const authHeader = client.getAuthHeaderPublic();
+        httpHeader = authHeader.length > 0 ? { 'Authorization': authHeader } : {};
+      }
+
+      const param: PlayerPageParam = {
+        videoId: item.id,
+        url: fullUrl,
+        httpHeader,
+        title: this.getTitle(),
+        durationHintMs: item.durationMs,
+        seriesProviderId: '',
+        seasonNumber: 0,
+        episodeNumber: 0,
+      };
+      this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
+    } catch {
+      console.error('[MovieDetailPage] play() 构建播放 URL 失败');
+    }
   }
 
   // ── 构建 ──
@@ -206,25 +353,57 @@ export struct MovieDetailPage {
               }
             }
 
-            // 播放按钮
-            Button({ type: ButtonType.Normal }) {
-              Row({ space: 8 }) {
-                Text('▶')
-                  .fontSize(20)
-                  .fontColor(Color.White)
-                Text('立即播放')
-                  .fontSize(22)
-                  .fontColor(Color.White)
-                  .fontWeight(FontWeight.Medium)
+            // Thread 2：播放按钮（含续播进度）
+            Column({ space: 8 }) {
+              Button({ type: ButtonType.Normal }) {
+                Row({ space: 8 }) {
+                  Text('▶')
+                    .fontSize(20)
+                    .fontColor(Color.White)
+                  Text(this.getPlayButtonText())
+                    .fontSize(22)
+                    .fontColor(Color.White)
+                    .fontWeight(FontWeight.Medium)
+                }
+                .padding({ left: 8, right: 8 })
               }
-              .padding({ left: 8, right: 8 })
+              .width(220)
+              .height(60)
+              .backgroundColor('#2196F3')
+              .borderRadius(8)
+              .focusable(true)
+              .onClick(() => { this.play(); })
+
+              // Thread 2：续播进度条
+              if (this.hasProgress()) {
+                Column({ space: 4 }) {
+                  Progress({ value: this.getProgressPercent() * 100, total: 100, type: ProgressType.Linear })
+                    .width(220)
+                    .height(4)
+                    .color('#2196F3')
+                    .backgroundColor('rgba(255,255,255,0.2)')
+                  Text('已观看 ' + Math.round(this.getProgressPercent() * 100).toString() + '%')
+                    .fontSize(12)
+                    .fontColor('#AAAAAA')
+                }
+                .alignItems(HorizontalAlign.Start)
+              }
             }
-            .width(220)
-            .height(60)
-            .backgroundColor('#2196F3')
-            .borderRadius(8)
-            .focusable(true)
-            .onClick(() => { this.play(); })
+            .alignItems(HorizontalAlign.Start)
+
+            // Thread 3：导演信息
+            if (this.getDirectors().length > 0) {
+              Row({ space: 8 }) {
+                Text('导演：')
+                  .fontSize(15)
+                  .fontColor('#AAAAAA')
+                Text(this.getDirectors().join('、'))
+                  .fontSize(15)
+                  .fontColor('#CCCCCC')
+                  .maxLines(1)
+                  .textOverflow({ overflow: TextOverflow.Ellipsis })
+              }
+            }
 
             // 简介
             Column({ space: 8 }) {
@@ -242,6 +421,41 @@ export struct MovieDetailPage {
             }
             .alignItems(HorizontalAlign.Start)
             .margin({ top: 8 })
+
+            // Thread 3：演员列表（最多5人）
+            if (this.getCast().length > 0) {
+              Column({ space: 8 }) {
+                Text('演员')
+                  .fontSize(18)
+                  .fontColor('#FFFFFF')
+                  .fontWeight(FontWeight.Medium)
+                Row({ space: 12 }) {
+                  ForEach(this.getCast(), (person: CastPerson) => {
+                    Column({ space: 4 }) {
+                      Text(person.name)
+                        .fontSize(13)
+                        .fontColor('#CCCCCC')
+                        .maxLines(1)
+                        .textOverflow({ overflow: TextOverflow.Ellipsis })
+                        .width(80)
+                        .textAlign(TextAlign.Center)
+                      if (person.character !== undefined && person.character.length > 0) {
+                        Text(person.character)
+                          .fontSize(11)
+                          .fontColor('#888888')
+                          .maxLines(1)
+                          .textOverflow({ overflow: TextOverflow.Ellipsis })
+                          .width(80)
+                          .textAlign(TextAlign.Center)
+                      }
+                    }
+                    .width(80)
+                  })
+                }
+              }
+              .alignItems(HorizontalAlign.Start)
+              .margin({ top: 8 })
+            }
           }
           .layoutWeight(1)
           .alignItems(HorizontalAlign.Start)
@@ -259,6 +473,7 @@ export struct MovieDetailPage {
       const param = context.pathInfo.param as MediaItem;
       if (param !== undefined && param !== null) {
         this.item = param;
+        this.loadAuxData(param);
       }
     })
     .hideTitleBar(true)

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -7,6 +7,7 @@ import http from '@ohos.net.http';
 import image from '@ohos.multimedia.image';
 import effectKit from '@ohos.effectKit';
 import { millisecondsToTime } from '../../utils/TimeUtil';
+import { BusinessError } from '@kit.BasicServicesKit';
 
 // ─────────────────────────────────────────────
 // TMDB 图片 URL 工具
@@ -279,31 +280,37 @@ export struct MovieDetailPage {
       if (buf === undefined || buf.byteLength === 0) { return; }
 
       // 缩小尺寸加速：从 ArrayBuffer 创建 ImageSource，解码为小尺寸 PixelMap
-      const imgSrc = image.createImageSource(buf);
-      const pixelMap = await imgSrc.createPixelMap({
-        desiredSize: { width: 64, height: 36 },
-        desiredPixelFormat: image.PixelMapFormat.RGBA_8888
-      });
-      imgSrc.release();
+      let imgSrc: image.ImageSource | undefined;
+      let pixelMap: image.PixelMap | undefined;
+      try {
+        imgSrc = image.createImageSource(buf);
+        pixelMap = await imgSrc.createPixelMap({
+          desiredSize: { width: 64, height: 36 },
+          desiredPixelFormat: image.PixelMapFormat.RGBA_8888
+        });
 
-      // effectKit 提取主色
-      const picker = await effectKit.createColorPicker(pixelMap);
-      const mainColor = picker.getMainColorSync();
-      pixelMap.release();
+        // effectKit 提取主色
+        const picker = await effectKit.createColorPicker(pixelMap);
+        const mainColor = picker.getMainColorSync();
 
-      // 将 RGB 分量各减暗 40%，保证背景色足够深
-      const darken = (v: number): number => Math.round(v * 0.4);
-      const toHex = (v: number): string => {
-        const h = v.toString(16);
-        return h.length < 2 ? '0' + h : h;
-      };
-      const r = darken(mainColor.red & 0xFF);
-      const g = darken(mainColor.green & 0xFF);
-      const b = darken(mainColor.blue & 0xFF);
-      this.dominantBgColor = '#' + toHex(r) + toHex(g) + toHex(b);
+        // 将 RGB 分量各减暗 40%，保证背景色足够深
+        const darken = (v: number): number => Math.round(v * 0.4);
+        const toHex = (v: number): string => {
+          const h = v.toString(16);
+          return h.length < 2 ? '0' + h : h;
+        };
+        const r = darken(mainColor.red & 0xFF);
+        const g = darken(mainColor.green & 0xFF);
+        const b = darken(mainColor.blue & 0xFF);
+        this.dominantBgColor = '#' + toHex(r) + toHex(g) + toHex(b);
+      } finally {
+        pixelMap?.release();
+        imgSrc?.release();
+      }
     } catch (e) {
       // 提取失败，保持默认色
-      console.warn('[MovieDetailPage] extractDominantColor failed', JSON.stringify(e));
+      const err = e as BusinessError;
+      console.warn('[MovieDetailPage]', `extractDominantColor failed: ${err.message}`);
     }
   }
 
@@ -367,7 +374,7 @@ export struct MovieDetailPage {
         }).join('/');
         fullUrl = 'smb://' + user + ':' + pass + '@' + smbConfig.host + ':' + port.toString() + encodedPath;
         httpHeader = {};
-      } else {
+      } else if (fileSource.type === FileSourceType.WEBDAV) {
         const protocol = config['protocol'] ?? 'http';
         const host = config['url'] ?? '';
         const port = config['port'] ?? (protocol === 'https' ? '443' : '80');
@@ -383,6 +390,9 @@ export struct MovieDetailPage {
         fullUrl = client.getFullUrl(item.filePath);
         const authHeader = client.getAuthHeaderPublic();
         httpHeader = authHeader.length > 0 ? { 'Authorization': authHeader } : {};
+      } else {
+        console.warn('[MovieDetailPage]', `不支持的文件源类型: ${fileSource.type}`);
+        return;
       }
 
       const param: PlayerPageParam = {
@@ -610,18 +620,21 @@ export struct MovieDetailPage {
           }
           .alignItems(VerticalAlign.Center)
 
-          // 简介：超 100 字截断显示 + 「更多」Span，不超出仅显示原文
+          // 简介：超 100 字截断显示 + 「更多」按钮（独立 Text 可聚焦），不超出仅显示原文
           if (this.getOverview().length > 0) {
             if (this.isOverviewLong()) {
-              Text() {
-                Span(this.getOverviewShort())
+              Row({ space: 4 }) {
+                Text(this.getOverviewShort())
                   .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
-                Span('更多')
+                  .constraintSize({ maxWidth: 640 })
+                Text('更多')
                   .fontSize(14).fontColor('#1B78F2')
                   .fontWeight(FontWeight.Medium)
+                  .focusable(true)
                   .onClick(() => { this.showOverviewDialog = true; })
               }
               .constraintSize({ maxWidth: 700 })
+              .alignItems(VerticalAlign.Bottom)
             } else {
               Text(this.getOverview())
                 .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
@@ -631,6 +644,14 @@ export struct MovieDetailPage {
         }
         .layoutWeight(1)
         .alignItems(HorizontalAlign.Start)
+
+        // 中间：海报封面（有数据时显示）
+        if (this.getPosterUrl().length > 0) {
+          Image(this.getPosterUrl())
+            .width(120).aspectRatio(2 / 3)
+            .objectFit(ImageFit.Cover)
+            .borderRadius(8)
+        }
 
         // 右侧：电影版续播卡片
         this.MovieWatchingCard()
@@ -828,7 +849,13 @@ export struct MovieDetailPage {
             .fontSize(30).fontColor(Color.White).fontWeight(FontWeight.Bold)
             .textShadow({ radius: 6, color: '#88000000', offsetX: 1, offsetY: 1 })
             .padding(20)
-            .onClick(() => { this.pageStack.pop(); })
+            .onClick(() => {
+              if (this.showOverviewDialog) {
+                this.showOverviewDialog = false;
+              } else {
+                this.pageStack.pop();
+              }
+            })
         }
         .width('100%')
         .padding({ left: 16, top: 8 })

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -63,14 +63,14 @@ function formatMovieDuration(runtimeMinutes: number | undefined, durationMs: num
 interface CastPerson {
   name: string;
   character?: string;
-  profile_path?: string;
+  profilePath?: string;
 }
 
 /** 演职人员统一展示项（导演 + 演员合并列表） */
 interface CastCrewItem {
   name: string;
   role?: string;
-  profile_path?: string;
+  profilePath?: string;
 }
 
 function parseCastArr(json: string | undefined): CastPerson[] {
@@ -246,7 +246,7 @@ export struct MovieDetailPage {
     }
     const castList = parseCastArr(this.movieEntity?.castJson);
     for (const c of castList) {
-      const ci: CastCrewItem = { name: c.name, role: c.character, profile_path: c.profile_path };
+      const ci: CastCrewItem = { name: c.name, role: c.character, profilePath: c.profilePath };
       result.push(ci);
     }
     return result;
@@ -656,8 +656,8 @@ export struct MovieDetailPage {
             ForEach(this.buildCastCrewList().slice(0, 15), (c: CastCrewItem) => {
               Column({ space: 8 }) {
                 // 人物照片（长方形）
-                if (c.profile_path !== undefined && c.profile_path.length > 0) {
-                  Image(tmdbImageUrl(c.profile_path, 'w185'))
+                if (c.profilePath !== undefined && c.profilePath.length > 0) {
+                  Image(tmdbImageUrl(c.profilePath, 'w185'))
                     .width(110).aspectRatio(2 / 3)
                     .objectFit(ImageFit.Cover).borderRadius(6)
                     .hoverEffect(HoverEffect.Scale)

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -10,6 +10,7 @@ import { FileSourceType } from "../../../db/models/FileSourceEntity"
 import promptAction from '@ohos.promptAction';
 import { SeriesDetailPage } from "../../detail/SeriesDetailPage"
 import { SeasonDetailPage } from "../../detail/SeasonDetailPage"
+import { MovieDetailPage } from "../../detail/MovieDetailPage"
 import { FfprobeUtil } from "../../../utils/FfprobeUtil"
 import { WebDAVClient, WebDAVConfig } from "../../../lib/WebDAVClient"
 
@@ -77,6 +78,7 @@ interface SourceRuntimeConfig {
 struct PosterCard {
   @Require @Param item: MediaItem
   @Local isHovered: boolean = false
+  @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
   private getTitle(): string { return displayTitle(this.item); }
   private getPoster(): string { return posterSrc(this.item); }
   private hasPosterImg(): boolean { return hasPoster(this.item); }
@@ -165,11 +167,13 @@ struct PosterCard {
     }
     .width(POSTER_WIDTH)
     .alignItems(HorizontalAlign.Start)
+    .onClick(() => {
+      if (this.item.mediaType === 'movie') {
+        this.pageStack.pushPathByName(MovieDetailPage.PAGE_NAME, this.item);
+      }
+    })
   }
 }
-
-// ─────────────────────────────────────────────
-// 合集卡片（电视剧/综艺）
 // ─────────────────────────────────────────────
 @ComponentV2
 struct SeriesCard {


### PR DESCRIPTION
## 功能说明

新增电影详情页（MovieDetailPage），媒体库电影卡片点击可跳转查看详情与播放。

## 变更内容

- 新建 `MovieDetailPage.ets`：模糊横幅背景 + 标题/时长/评分 + 播放按钮 + 简介区域，支持遥控器焦点导航
- `Index.ets`：PageBuilder 注册 `MovieDetailPage.PAGE_NAME` 路由
- `MediaLibraryTab.ets`：电影卡片 `onClick` 跳转电影详情页

## 验证

- 媒体库电影卡片点击 → 详情页
- 播放按钮跳转播放页
- 遥控器可操作

Closes #82


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a movie detail screen showing title, year, rating, genres, runtime, cast, directors and full overview (expandable modal).
  * Dynamic backdrop with adaptive dark tint derived from artwork.
  * Tracks and refreshes movie play progress; shows resume vs start actions.
  * Supports playback from multiple file sources with URL/authorization handling.
  * Tapping a movie card now navigates to the movie detail screen.
  * Recently-added list now includes source/provider and movie linkage metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->