### PR TITLE
新增: 演职人员详情页 CastDetailPage（Issue #97）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /.ai
 /docs
 /scripts
+.worktrees/

--- a/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
@@ -539,7 +539,11 @@ export class IjkPlayerAdapter implements IPlayer {
       this._videoCodec.includes('h265') ||
       this._videoCodec.includes('265');
 
-    const useH264Hw = !isHevc && hwSupport.h264;
+    // codec 未知时（videoCodec 为空，如 SMB fallback 场景 ffprobe 未能传入），
+    // 无法确认是 H264，不得开启 all-videos（会附带开启 H265 硬解导致花屏），
+    // 安全回退为全软解。
+    const isCodecKnown = this._videoCodec.length > 0;
+    const useH264Hw = isCodecKnown && !isHevc && hwSupport.h264;
     // HEVC 硬解始终关闭（花屏根因），H265 能力留着但不使用
     const useH265Hw = false;
 

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -1242,8 +1242,10 @@ export class VideoPlayerController {
           hilog.info(CommonConstants.LOG_DOMAIN, TAG,
             `[setIjkContext] SMB fallback 重启代理成功: ${newProxyUrl}`);
         } else {
+          // 代理重启失败：回退到原始 smb:// URL，不保留已停止代理的死 URL
+          this.currentVideoData.videoSrc = this.smbOriginalSrc;
           hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-            `[setIjkContext] SMB fallback 代理重启失败，backend=${this.backend} 将使用缓存 URL`);
+            `[setIjkContext] SMB fallback 代理重启失败，已回退到原始 SMB URL: ${this.smbOriginalSrc}`);
         }
       }
       try {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -224,6 +224,8 @@ export class VideoPlayerController {
   private pendingBackendResumePlay: boolean = false;
   /** SMB 源当前是否通过 HTTP 代理运行（用于 release 时触发 cleanupOrphanedProxies） */
   private smbProxyActive: boolean = false;
+  /** 保存原始 smb:// URL，供 avplayer→ijkplayer fallback 时重新启动代理 */
+  private smbOriginalSrc: string = '';
   /** 一次性控制：本次 seek 完成后不自动恢复播放 */
   private suppressPlayAfterSeekOnce: boolean = false;
   /** ffmpeg 动态预览：当前是否正在抽帧 */
@@ -369,14 +371,19 @@ export class VideoPlayerController {
       if (proxyUrl.length > 0) {
         videoData.videoSrc = proxyUrl;
         this.smbProxyActive = true;
+        this.smbOriginalSrc = smbOriginalUrl;  // 保存原始 smb:// URL，供 fallback 时重启代理
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
           `SMB 源已通过代理 URL 转交 ${this.backend}（proxy started → rewritten to ${proxyUrl}）`);
       } else {
         // 代理启动失败，保留原始 smb:// URL（ijkplayer 会尝试直连，大概率失败）
         smbOriginalUrl = '';
+        this.smbOriginalSrc = '';  // 代理未启动，清空缓存
         hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
           `SMB 代理启动失败，backend=${this.backend} 将使用原始 smb:// URL`);
       }
+    } else {
+      // 非 SMB 源，清空缓存，防止前一次 SMB 播放残留
+      this.smbOriginalSrc = '';
     }
 
     // 指标埋点：play_start — backend 已最终确定，记录本次播放启动意图
@@ -1224,6 +1231,19 @@ export class VideoPlayerController {
     // 把 context 传给 adapter，由 adapter 的 init() 内部在 native_setup 前调用 setContext
     ijkAdapter.setPendingContext(context, xComponentId);
     if (this.currentVideoData) {
+      // SMB fallback：avplayer release 时会停止代理，若原始源是 SMB 则需重新启动
+      if (this.smbOriginalSrc.length > 0) {
+        const newProxyUrl = VidAllPlayerAdapter.startSmbProxy(this.smbOriginalSrc);
+        if (newProxyUrl.length > 0) {
+          this.currentVideoData.videoSrc = newProxyUrl;
+          this.smbProxyActive = true;
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `[setIjkContext] SMB fallback 重启代理成功: ${newProxyUrl}`);
+        } else {
+          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+            `[setIjkContext] SMB fallback 代理重启失败，backend=${this.backend} 将使用缓存 URL`);
+        }
+      }
       try {
         await ijkAdapter.init(this.currentVideoData, this.surfaceId);
       } catch (e) {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -381,8 +381,10 @@ export class VideoPlayerController {
         hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
           `SMB 代理启动失败，backend=${this.backend} 将使用原始 smb:// URL`);
       }
-    } else {
-      // 非 SMB 源，清空缓存，防止前一次 SMB 播放残留
+    } else if (!videoData.videoSrc.startsWith('http://127.0.0.1')) {
+      // 非 SMB、非本地代理 URL（即真正的非 SMB 播放源），才清空缓存。
+      // fallback 场景下第二次 initPlayer() 收到的是上一次代理的 http://127.0.0.1:PORT/... URL，
+      // 不能清空 smbOriginalSrc，否则 setIjkContext() 无法重启代理。
       this.smbOriginalSrc = '';
     }
 

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -357,27 +357,25 @@ export class VideoPlayerController {
       this.backend = 'ijkplayer';
     }
 
-    // SMB 源（smb://）通过本地 HTTP 代理转发给 AVPlayer 播放，无需 native 路径。
+    // SMB 源（smb://）统一通过本地 HTTP 代理转发，avplayer 和 ijkplayer 均适用。
     // 在所有自动路由决策完成后（backend 已确定为 avplayer/ijkplayer），启动代理并将
     // videoSrc 替换为代理 URL，下游 AVPlayerAdapter / IjkPlayerAdapter 均透明使用。
     let smbOriginalUrl: string = '';
     if (videoData.videoSrc.startsWith('smb://')) {
       this.sourceProtocol = 'SMB';
       smbOriginalUrl = videoData.videoSrc;
-      if (this.backend === 'avplayer') {
-        const proxyUrl = VidAllPlayerAdapter.startSmbProxy(smbOriginalUrl);
-        if (proxyUrl.length > 0) {
-          videoData.videoSrc = proxyUrl;
-          this.smbProxyActive = true;
-          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-            `SMB 源已通过代理 URL 转交 AVPlayer（proxy started → rewritten to ${proxyUrl}）`);
-        } else {
-          // 代理启动失败，回退到 ijkplayer 兜底（不含代理，纯 smb:// 拉流路径）
-          this.backend = 'ijkplayer';
-          smbOriginalUrl = '';
-          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-            'SMB 代理启动失败，回退到 ijkplayer 后端');
-        }
+      // SMB 源统一通过本地 HTTP 代理转发，avplayer 和 ijkplayer 均适用
+      const proxyUrl = VidAllPlayerAdapter.startSmbProxy(smbOriginalUrl);
+      if (proxyUrl.length > 0) {
+        videoData.videoSrc = proxyUrl;
+        this.smbProxyActive = true;
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          `SMB 源已通过代理 URL 转交 ${this.backend}（proxy started → rewritten to ${proxyUrl}）`);
+      } else {
+        // 代理启动失败，保留原始 smb:// URL（ijkplayer 会尝试直连，大概率失败）
+        smbOriginalUrl = '';
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          `SMB 代理启动失败，backend=${this.backend} 将使用原始 smb:// URL`);
       }
     }
 

--- a/entry/src/main/ets/lib/ScrapeClient.ets
+++ b/entry/src/main/ets/lib/ScrapeClient.ets
@@ -11,6 +11,7 @@ export interface ScrapeCredit {
   role?: string;
   profilePath?: string;
   order?: number;
+  personId?: number;
 }
 
 /** 搜索参数 */
@@ -244,6 +245,7 @@ interface TmdbSearchItem {
 }
 
 interface TmdbCastItem {
+  id?: number;
   name?: string;
   character?: string;
   profile_path?: string;
@@ -251,6 +253,7 @@ interface TmdbCastItem {
 }
 
 interface TmdbCrewItem {
+  id?: number;
   name?: string;
   job?: string;
   profile_path?: string;
@@ -404,11 +407,11 @@ export class TmdbProvider implements IScrapeProvider {
     const rawJson = await this.httpGet(url);
     const item = JSON.parse(rawJson) as TmdbMovieDetail;
     const cast: ScrapeCredit[] = (item.credits?.cast ?? []).slice(0, 20).map(c => {
-      const cr: ScrapeCredit = { name: c.name ?? '', role: c.character, profilePath: c.profile_path ?? undefined, order: c.order };
+      const cr: ScrapeCredit = { name: c.name ?? '', role: c.character, profilePath: c.profile_path ?? undefined, order: c.order, personId: c.id };
       return cr;
     });
     const directors: ScrapeCredit[] = (item.credits?.crew ?? []).filter(c => c.job === 'Director').map(c => {
-      const cr: ScrapeCredit = { name: c.name ?? '', role: c.job, profilePath: c.profile_path ?? undefined };
+      const cr: ScrapeCredit = { name: c.name ?? '', role: c.job, profilePath: c.profile_path ?? undefined, personId: c.id };
       return cr;
     });
     const r: MovieScrapeResult = {
@@ -439,7 +442,7 @@ export class TmdbProvider implements IScrapeProvider {
     const rawJson = await this.httpGet(url);
     const item = JSON.parse(rawJson) as TmdbTvDetail;
     const cast: ScrapeCredit[] = (item.credits?.cast ?? []).slice(0, 20).map(c => {
-      const cr: ScrapeCredit = { name: c.name ?? '', role: c.character, profilePath: c.profile_path ?? undefined, order: c.order };
+      const cr: ScrapeCredit = { name: c.name ?? '', role: c.character, profilePath: c.profile_path ?? undefined, order: c.order, personId: c.id };
       return cr;
     });
     const r: TvSeriesScrapeResult = {

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -7,6 +7,7 @@ import { SettingsPage } from './settings/Index';
 import { SeriesDetailPage } from './detail/SeriesDetailPage';
 import { SeasonDetailPage } from './detail/SeasonDetailPage';
 import { MovieDetailPage } from './detail/MovieDetailPage';
+import { CastDetailPage } from './detail/CastDetailPage';
 @Entry
 @ComponentV2
 struct Index {
@@ -29,6 +30,8 @@ struct Index {
       MovieDetailPage();
     } else if (name === SeasonDetailPage.PAGE_NAME) {
       SeasonDetailPage();
+    } else if (name === CastDetailPage.PAGE_NAME) {
+      CastDetailPage();
     }
   }
 

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -202,7 +202,7 @@ export struct CastDetailPage {
               // Hero 区
               Row({ space: 24 }) {
                 // 左：照片
-                if (this.detail?.profile_path !== undefined && this.detail.profile_path.length > 0) {
+                if (this.detail?.profile_path != null && this.detail.profile_path.length > 0) {
                   Image(tmdbImg(this.detail.profile_path, 'w185'))
                     .width(120).height(180)
                     .borderRadius(8)
@@ -224,17 +224,17 @@ export struct CastDetailPage {
                     .fontSize(28).fontColor(Color.White).fontWeight(FontWeight.Bold)
                     .maxLines(2).textOverflow({ overflow: TextOverflow.Ellipsis })
 
-                  if (this.detail?.known_for_department !== undefined && this.detail.known_for_department.length > 0) {
+                  if (this.detail?.known_for_department != null && this.detail.known_for_department.length > 0) {
                     Text(this.detail.known_for_department)
                       .fontSize(14).fontColor('#1B78F2')
                   }
 
-                  if (this.detail?.birthday !== undefined && this.detail.birthday.length > 0) {
+                  if (this.detail?.birthday != null && this.detail.birthday.length > 0) {
                     Text('生日：' + this.detail.birthday)
                       .fontSize(13).fontColor('#AAAAAA')
                   }
 
-                  if (this.detail?.place_of_birth !== undefined && this.detail.place_of_birth.length > 0) {
+                  if (this.detail?.place_of_birth != null && this.detail.place_of_birth.length > 0) {
                     Text('出生地：' + this.detail.place_of_birth)
                       .fontSize(13).fontColor('#AAAAAA')
                       .maxLines(2).textOverflow({ overflow: TextOverflow.Ellipsis })
@@ -248,7 +248,7 @@ export struct CastDetailPage {
               .alignItems(VerticalAlign.Top)
 
               // Biography
-              if (this.detail?.biography !== undefined && this.detail.biography.length > 0) {
+              if (this.detail?.biography != null && this.detail.biography.length > 0) {
                 Column({ space: 8 }) {
                   Text('简介')
                     .fontSize(16).fontColor('#CCCCCC').fontWeight(FontWeight.Bold)
@@ -281,7 +281,7 @@ export struct CastDetailPage {
                     Row({ space: 12 }) {
                       ForEach(this.credits, (item: TmdbCreditItem) => {
                         Column({ space: 6 }) {
-                          if (item.poster_path !== undefined && item.poster_path.length > 0) {
+                          if (item.poster_path != null && item.poster_path.length > 0) {
                             Image(tmdbImg(item.poster_path, 'w185'))
                               .width(100).height(150)
                               .borderRadius(6).objectFit(ImageFit.Cover)
@@ -308,7 +308,7 @@ export struct CastDetailPage {
                           Text(this.getCreditsYear(item))
                             .fontSize(11).fontColor('#888888')
 
-                          if (item.character !== undefined && item.character.length > 0) {
+                          if (item.character != null && item.character.length > 0) {
                             Text(item.character)
                               .fontSize(11).fontColor('#666666')
                               .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -360,11 +360,12 @@ export struct CastDetailPage {
                             .fontSize(11).fontColor('#888888')
                             .width(100).textAlign(TextAlign.Center)
 
-                          Text(item.character ?? '')
+                          Text(item.character || ' ')
                             .fontSize(11).fontColor('#666666')
                             .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
                             .width(100).textAlign(TextAlign.Center)
                         }
+                        .alignItems(HorizontalAlign.Start)
                         .focusable(true)
                         .onClick(() => { this.navigateToCredit(item); })
                       }, (item: TmdbCreditItem) => {

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -190,9 +190,11 @@ export struct CastDetailPage {
   }
 
   private getInitial(): string {
-    const n = this.detail?.name ?? this.displayName;
+    const raw = this.detail?.name ?? this.displayName;
+    // 防御性转换：displayName 在运行时可能为 null，String() 确保不会调用 null.charAt
+    const n: string = (raw != null) ? String(raw) : '';
     if (n.length === 0) { return '?'; }
-    return n.charAt(0).toUpperCase();
+    return n[0].toUpperCase();
   }
 
   private getCreditsTitle(item: TmdbCreditItem): string {

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -360,9 +360,7 @@ export struct CastDetailPage {
                             .fontSize(11).fontColor('#888888')
                             .width(100).textAlign(TextAlign.Center)
 
-                          Text(item.character != null && item.character.length > 0
-                            ? item.character
-                            : (item.job != null && item.job.length > 0 ? item.job : ''))
+                          Text(item.character ?? '')
                             .fontSize(11).fontColor('#666666')
                             .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
                             .width(100).textAlign(TextAlign.Center)

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -1,0 +1,341 @@
+import http from '@ohos.net.http';
+import fs from '@ohos.file.fs';
+import { AppPreferences, PrefKey } from '../../utils/AppPreferences';
+import { MovieDetailPage } from './MovieDetailPage';
+import { SeriesDetailPage } from './SeriesDetailPage';
+import { MediaItem } from '../../db/models/MediaEntity';
+
+export interface CastDetailPageParam {
+  personId: number;
+  name: string;
+}
+
+interface TmdbPersonDetail {
+  id?: number;
+  name?: string;
+  biography?: string;
+  birthday?: string;
+  place_of_birth?: string;
+  profile_path?: string;
+  known_for_department?: string;
+}
+
+interface TmdbCreditItem {
+  id?: number;
+  title?: string;
+  name?: string;
+  media_type?: string;
+  character?: string;
+  job?: string;
+  poster_path?: string;
+  release_date?: string;
+  first_air_date?: string;
+  vote_average?: number;
+}
+
+interface CastCache {
+  detail: TmdbPersonDetail;
+  credits: TmdbCreditItem[];
+}
+
+interface TmdbCombinedCredits {
+  cast?: TmdbCreditItem[];
+  crew?: TmdbCreditItem[];
+}
+
+function tmdbImg(path: string | undefined, width: string): string {
+  if (!path || path.length === 0) { return ''; }
+  return 'https://image.tmdb.org/t/p/' + width + path;
+}
+
+function getYear(date: string | undefined): string {
+  if (!date || date.length < 4) { return ''; }
+  return date.substring(0, 4);
+}
+
+@ComponentV2
+export struct CastDetailPage {
+  static readonly PAGE_NAME: string = 'castDetail';
+
+  @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
+
+  @Local personId: number = 0;
+  @Local displayName: string = '';
+  @Local detail: TmdbPersonDetail | null = null;
+  @Local credits: TmdbCreditItem[] = [];
+  @Local loading: boolean = true;
+  @Local bioExpanded: boolean = false;
+
+  private getCacheDir(): string {
+    return getContext().cacheDir + '/cast';
+  }
+
+  private getCachePath(): string {
+    return this.getCacheDir() + '/' + this.personId.toString() + '.json';
+  }
+
+  private async loadData(): Promise<void> {
+    const cachePath = this.getCachePath();
+    try {
+      const text = fs.readTextSync(cachePath);
+      const cached = JSON.parse(text) as CastCache;
+      this.detail = cached.detail;
+      this.credits = (cached.credits ?? []).slice(0, 20);
+      this.loading = false;
+      return;
+    } catch (e) {
+      // 缓存不存在或解析失败，走 API
+    }
+
+    const apiKey = await AppPreferences.get(PrefKey.TMDB_API_KEY, '');
+    if (apiKey.length === 0) {
+      this.loading = false;
+      return;
+    }
+
+    const base = 'https://api.themoviedb.org/3';
+    const lang = 'zh-CN';
+    const pid = this.personId.toString();
+
+    try {
+      // 拉取 person detail
+      const req1 = http.createHttp();
+      const res1 = await req1.request(`${base}/person/${pid}?api_key=${apiKey}&language=${lang}`);
+      req1.destroy();
+      const d = JSON.parse(res1.result as string) as TmdbPersonDetail;
+      this.detail = d;
+
+      // 拉取 combined_credits
+      const req2 = http.createHttp();
+      const res2 = await req2.request(`${base}/person/${pid}/combined_credits?api_key=${apiKey}&language=${lang}`);
+      req2.destroy();
+      const cr = JSON.parse(res2.result as string) as TmdbCombinedCredits;
+      const allCredits: TmdbCreditItem[] = [...(cr.cast ?? []), ...(cr.crew ?? [])];
+      // 按 vote_average 降序，取前 20
+      allCredits.sort((a, b) => (b.vote_average ?? 0) - (a.vote_average ?? 0));
+      this.credits = allCredits.slice(0, 20);
+
+      // 写缓存
+      try {
+        fs.mkdirSync(this.getCacheDir());
+      } catch (e) {
+        // 目录已存在或创建失败，忽略
+      }
+      try {
+        const cache: CastCache = { detail: d, credits: this.credits };
+        const cacheText = JSON.stringify(cache);
+        const cacheFile = fs.openSync(this.getCachePath(), fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
+        fs.writeSync(cacheFile.fd, cacheText);
+        fs.closeSync(cacheFile);
+      } catch (e) {
+        // 缓存写入失败，忽略
+      }
+    } catch (e) {
+      // API 请求失败，忽略
+    }
+    this.loading = false;
+  }
+
+  private getInitial(): string {
+    const n = this.detail?.name ?? this.displayName;
+    if (n.length === 0) { return '?'; }
+    return n.charAt(0).toUpperCase();
+  }
+
+  private getCreditsTitle(item: TmdbCreditItem): string {
+    return item.title ?? item.name ?? '未知';
+  }
+
+  private getCreditsYear(item: TmdbCreditItem): string {
+    return getYear(item.release_date ?? item.first_air_date);
+  }
+
+  private navigateToCredit(item: TmdbCreditItem): void {
+    const mediaItem: MediaItem = {
+      id: 0,
+      sourceId: 0,
+      directoryPath: '',
+      filePath: '',
+      fileName: this.getCreditsTitle(item),
+      scannedAt: 0,
+      title: this.getCreditsTitle(item),
+      provider: 'tmdb',
+      providerId: item.id !== undefined ? item.id.toString() : '',
+      posterUrl: tmdbImg(item.poster_path, 'w342'),
+      mediaType: item.media_type === 'tv' ? 'series' : 'movie',
+    };
+    if (item.media_type === 'tv') {
+      this.pageStack.pushPathByName(SeriesDetailPage.PAGE_NAME, mediaItem);
+    } else {
+      this.pageStack.pushPathByName(MovieDetailPage.PAGE_NAME, mediaItem);
+    }
+  }
+
+  build() {
+    NavDestination() {
+      Stack({ alignContent: Alignment.TopStart }) {
+        // 背景
+        Column()
+          .width('100%').height('100%')
+          .backgroundColor('#111111')
+
+        // 返回按钮
+        Text('← 返回')
+          .fontSize(14).fontColor('#AAAAAA')
+          .padding({ left: 24, right: 12, top: 8, bottom: 8 })
+          .margin({ top: 16, left: 16 })
+          .backgroundColor('#222222').borderRadius(4)
+          .focusable(true)
+          .defaultFocus(true)
+          .onClick(() => { this.pageStack.pop(); })
+
+        if (this.loading) {
+          Column() {
+            Text('加载中…').fontSize(16).fontColor('#888888')
+          }
+          .width('100%').height('100%')
+          .justifyContent(FlexAlign.Center)
+          .alignItems(HorizontalAlign.Center)
+        } else {
+          Scroll() {
+            Column({ space: 0 }) {
+              // Hero 区
+              Row({ space: 24 }) {
+                // 左：照片
+                if (this.detail?.profile_path !== undefined && this.detail.profile_path.length > 0) {
+                  Image(tmdbImg(this.detail.profile_path, 'w185'))
+                    .width(120).height(180)
+                    .borderRadius(8)
+                    .objectFit(ImageFit.Cover)
+                } else {
+                  Column() {
+                    Text(this.getInitial())
+                      .fontSize(48).fontColor(Color.White).fontWeight(FontWeight.Bold)
+                  }
+                  .width(120).height(180)
+                  .backgroundColor('#333333').borderRadius(8)
+                  .justifyContent(FlexAlign.Center)
+                  .alignItems(HorizontalAlign.Center)
+                }
+
+                // 右：信息
+                Column({ space: 8 }) {
+                  Text(this.detail?.name ?? this.displayName)
+                    .fontSize(28).fontColor(Color.White).fontWeight(FontWeight.Bold)
+                    .maxLines(2).textOverflow({ overflow: TextOverflow.Ellipsis })
+
+                  if (this.detail?.known_for_department !== undefined && this.detail.known_for_department.length > 0) {
+                    Text(this.detail.known_for_department)
+                      .fontSize(14).fontColor('#1B78F2')
+                  }
+
+                  if (this.detail?.birthday !== undefined && this.detail.birthday.length > 0) {
+                    Text('生日：' + this.detail.birthday)
+                      .fontSize(13).fontColor('#AAAAAA')
+                  }
+
+                  if (this.detail?.place_of_birth !== undefined && this.detail.place_of_birth.length > 0) {
+                    Text('出生地：' + this.detail.place_of_birth)
+                      .fontSize(13).fontColor('#AAAAAA')
+                      .maxLines(2).textOverflow({ overflow: TextOverflow.Ellipsis })
+                  }
+                }
+                .layoutWeight(1)
+                .alignItems(HorizontalAlign.Start)
+              }
+              .width('100%')
+              .padding({ left: 40, right: 40, top: 80, bottom: 24 })
+              .alignItems(VerticalAlign.Top)
+
+              // Biography
+              if (this.detail?.biography !== undefined && this.detail.biography.length > 0) {
+                Column({ space: 8 }) {
+                  Text('简介')
+                    .fontSize(16).fontColor('#CCCCCC').fontWeight(FontWeight.Bold)
+
+                  Text(this.detail.biography)
+                    .fontSize(14).fontColor('#AAAAAA').lineHeight(22)
+                    .maxLines(this.bioExpanded ? 100 : 4)
+                    .textOverflow({ overflow: TextOverflow.Ellipsis })
+
+                  if (this.detail.biography.length > 200) {
+                    Text(this.bioExpanded ? '收起' : '展开')
+                      .fontSize(13).fontColor('#1B78F2')
+                      .focusable(true)
+                      .onClick(() => { this.bioExpanded = !this.bioExpanded; })
+                  }
+                }
+                .width('100%')
+                .padding({ left: 40, right: 40, bottom: 24 })
+                .alignItems(HorizontalAlign.Start)
+              }
+
+              // 作品列表
+              if (this.credits.length > 0) {
+                Column({ space: 12 }) {
+                  Text('参演作品')
+                    .fontSize(16).fontColor('#CCCCCC').fontWeight(FontWeight.Bold)
+                    .padding({ left: 40 })
+
+                  Scroll() {
+                    Row({ space: 12 }) {
+                      ForEach(this.credits, (item: TmdbCreditItem) => {
+                        Column({ space: 6 }) {
+                          if (item.poster_path !== undefined && item.poster_path.length > 0) {
+                            Image(tmdbImg(item.poster_path, 'w185'))
+                              .width(100).height(150)
+                              .borderRadius(6).objectFit(ImageFit.Cover)
+                          } else {
+                            Column() {
+                              Text('🎬').fontSize(24)
+                            }
+                            .width(100).height(150)
+                            .backgroundColor('#222222').borderRadius(6)
+                            .justifyContent(FlexAlign.Center)
+                            .alignItems(HorizontalAlign.Center)
+                          }
+
+                          Text(this.getCreditsTitle(item))
+                            .fontSize(12).fontColor('#CCCCCC')
+                            .maxLines(2).textOverflow({ overflow: TextOverflow.Ellipsis })
+                            .width(100).textAlign(TextAlign.Center)
+
+                          Text(this.getCreditsYear(item))
+                            .fontSize(11).fontColor('#888888')
+
+                          if (item.character !== undefined && item.character.length > 0) {
+                            Text(item.character)
+                              .fontSize(11).fontColor('#666666')
+                              .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
+                              .width(100).textAlign(TextAlign.Center)
+                          }
+                        }
+                        .focusable(true)
+                        .onClick(() => { this.navigateToCredit(item); })
+                      }, (item: TmdbCreditItem) => (item.id !== undefined ? item.id.toString() : '') + (item.media_type ?? ''))
+                    }
+                    .padding({ left: 40, right: 40 })
+                  }
+                  .scrollable(ScrollDirection.Horizontal)
+                  .scrollBar(BarState.Off)
+                }
+                .width('100%')
+                .alignItems(HorizontalAlign.Start)
+                .padding({ bottom: 40 })
+              }
+            }
+          }
+          .width('100%').height('100%')
+          .scrollBar(BarState.Off)
+        }
+      }
+      .width('100%').height('100%')
+    }
+    .onReady((context: NavDestinationContext) => {
+      const p = context.pathInfo.param as CastDetailPageParam;
+      this.personId = p.personId;
+      this.displayName = p.name;
+      this.loadData().catch(() => {});
+    })
+  }
+}

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -319,8 +319,8 @@ export struct CastDetailPage {
                           Text(this.getCreditsYear(item))
                             .fontSize(11).fontColor('#888888')
 
-                          if (item.character != null && item.character.length > 0) {
-                            Text(item.character)
+                          if ((item.character != null && item.character.length > 0) || (item.job != null && item.job.length > 0)) {
+                            Text(item.character != null && item.character.length > 0 ? item.character : (item.job ?? ''))
                               .fontSize(11).fontColor('#666666')
                               .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
                               .width(100).textAlign(TextAlign.Center)
@@ -328,7 +328,10 @@ export struct CastDetailPage {
                         }
                         .focusable(true)
                         .onClick(() => { this.navigateToCredit(item); })
-                      }, (item: TmdbCreditItem) => (item.id !== undefined ? item.id.toString() : '') + (item.media_type ?? ''))
+                      }, (item: TmdbCreditItem) => {
+                        const k: string = (item.media_type ?? 'x') + '-' + (item.id != null ? item.id.toString() : '0') + '-' + (item.title ?? item.name ?? '');
+                        return k;
+                      })
                     }
                     .padding({ left: 40, right: 40 })
                   }

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -230,16 +230,6 @@ export struct CastDetailPage {
           .width('100%').height('100%')
           .backgroundColor('#111111')
 
-        // 返回按钮
-        Text('← 返回')
-          .fontSize(14).fontColor('#AAAAAA')
-          .padding({ left: 24, right: 12, top: 8, bottom: 8 })
-          .margin({ top: 16, left: 16 })
-          .backgroundColor('#222222').borderRadius(4)
-          .focusable(true)
-          .defaultFocus(true)
-          .onClick(() => { this.pageStack.pop(); })
-
         if (this.loading) {
           Column() {
             Text('加载中…').fontSize(16).fontColor('#888888')

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -9,6 +9,15 @@ export interface CastDetailPageParam {
   name: string;
 }
 
+interface TmdbSearchPersonResult {
+  results?: TmdbPersonBrief[];
+}
+
+interface TmdbPersonBrief {
+  id?: number;
+  name?: string;
+}
+
 interface TmdbPersonDetail {
   id?: number;
   name?: string;
@@ -74,6 +83,37 @@ export struct CastDetailPage {
   }
 
   private async loadData(): Promise<void> {
+    // 若没有 personId，先通过名字搜索 TMDB
+    if (this.personId === 0 && this.displayName.length > 0) {
+      const apiKey = await AppPreferences.get(PrefKey.TMDB_API_KEY, '');
+      if (apiKey.length > 0) {
+        const searchReq = http.createHttp();
+        try {
+          const encodedName = encodeURIComponent(this.displayName);
+          const searchRes = await searchReq.request(
+            `https://api.themoviedb.org/3/search/person?api_key=${apiKey}&language=zh-CN&query=${encodedName}`,
+            { method: http.RequestMethod.GET, connectTimeout: 5000, readTimeout: 10000 }
+          );
+          if (searchRes.responseCode === 200) {
+            const searchData = JSON.parse(searchRes.result as string) as TmdbSearchPersonResult;
+            if (searchData.results != null && searchData.results.length > 0) {
+              const firstResult = searchData.results[0];
+              if (firstResult.id != null) {
+                this.personId = firstResult.id;
+              }
+            }
+          }
+        } finally {
+          searchReq.destroy();
+        }
+      }
+      // 若仍为 0 则无 TMDB 数据，直接退出
+      if (this.personId === 0) {
+        this.loading = false;
+        return;
+      }
+    }
+
     const cachePath = this.getCachePath();
     // Thread 4: 同步 readTextSync → 异步 readText
     try {

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -179,8 +179,11 @@ export struct CastDetailPage {
         try { await fs.mkdir(this.getCacheDir()); } catch (e) { /* 已存在 */ }
         const cache: CastCache = { detail: d, credits: this.credits };
         const cacheFile = await fs.open(this.getCachePath(), fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
-        await fs.write(cacheFile.fd, JSON.stringify(cache));
-        await fs.close(cacheFile.fd);
+        try {
+          await fs.write(cacheFile.fd, JSON.stringify(cache));
+        } finally {
+          await fs.close(cacheFile.fd);
+        }
       } catch (e) {
         // 缓存写入失败，忽略
       }
@@ -369,7 +372,7 @@ export struct CastDetailPage {
                         .focusable(true)
                         .onClick(() => { this.navigateToCredit(item); })
                       }, (item: TmdbCreditItem) => {
-                        const k: string = (item.media_type ?? 'x') + '-' + (item.id != null ? item.id.toString() : '0') + '-' + (item.title ?? item.name ?? '');
+                        const k: string = (item.media_type ?? 'x') + '-' + (item.id != null ? item.id.toString() : '0') + '-' + (item.title ?? item.name ?? '') + '-' + (item.character ?? item.job ?? '');
                         return k;
                       })
                     }

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -2,7 +2,6 @@ import http from '@ohos.net.http';
 import fs from '@ohos.file.fs';
 import { AppPreferences, PrefKey } from '../../utils/AppPreferences';
 import { MovieDetailPage } from './MovieDetailPage';
-import { SeriesDetailPage } from './SeriesDetailPage';
 import { MediaItem } from '../../db/models/MediaEntity';
 
 export interface CastDetailPageParam {
@@ -76,8 +75,9 @@ export struct CastDetailPage {
 
   private async loadData(): Promise<void> {
     const cachePath = this.getCachePath();
+    // Thread 4: 同步 readTextSync → 异步 readText
     try {
-      const text = fs.readTextSync(cachePath);
+      const text = await fs.readText(cachePath);
       const cached = JSON.parse(text) as CastCache;
       this.detail = cached.detail;
       this.credits = (cached.credits ?? []).slice(0, 20);
@@ -98,35 +98,48 @@ export struct CastDetailPage {
     const pid = this.personId.toString();
 
     try {
-      // 拉取 person detail
+      // Thread 3: req1 用 try/finally 保证 destroy()
       const req1 = http.createHttp();
-      const res1 = await req1.request(`${base}/person/${pid}?api_key=${apiKey}&language=${lang}`);
-      req1.destroy();
-      const d = JSON.parse(res1.result as string) as TmdbPersonDetail;
+      let d: TmdbPersonDetail = {};
+      try {
+        const res1 = await req1.request(
+          `${base}/person/${pid}?api_key=${apiKey}&language=${lang}`,
+          { method: http.RequestMethod.GET, connectTimeout: 5000, readTimeout: 10000 }
+        );
+        if (res1.responseCode === 200) {
+          d = JSON.parse(res1.result as string) as TmdbPersonDetail;
+        }
+      } finally {
+        req1.destroy();
+      }
       this.detail = d;
 
-      // 拉取 combined_credits
+      // Thread 3: req2 用 try/finally 保证 destroy()
       const req2 = http.createHttp();
-      const res2 = await req2.request(`${base}/person/${pid}/combined_credits?api_key=${apiKey}&language=${lang}`);
-      req2.destroy();
-      const cr = JSON.parse(res2.result as string) as TmdbCombinedCredits;
+      let cr: TmdbCombinedCredits = {};
+      try {
+        const res2 = await req2.request(
+          `${base}/person/${pid}/combined_credits?api_key=${apiKey}&language=${lang}`,
+          { method: http.RequestMethod.GET, connectTimeout: 5000, readTimeout: 10000 }
+        );
+        if (res2.responseCode === 200) {
+          cr = JSON.parse(res2.result as string) as TmdbCombinedCredits;
+        }
+      } finally {
+        req2.destroy();
+      }
       const allCredits: TmdbCreditItem[] = [...(cr.cast ?? []), ...(cr.crew ?? [])];
       // 按 vote_average 降序，取前 20
       allCredits.sort((a, b) => (b.vote_average ?? 0) - (a.vote_average ?? 0));
       this.credits = allCredits.slice(0, 20);
 
-      // 写缓存
+      // Thread 4: 同步 mkdirSync/openSync/writeSync/closeSync → 异步版本
       try {
-        fs.mkdirSync(this.getCacheDir());
-      } catch (e) {
-        // 目录已存在或创建失败，忽略
-      }
-      try {
+        try { await fs.mkdir(this.getCacheDir()); } catch (e) { /* 已存在 */ }
         const cache: CastCache = { detail: d, credits: this.credits };
-        const cacheText = JSON.stringify(cache);
-        const cacheFile = fs.openSync(this.getCachePath(), fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
-        fs.writeSync(cacheFile.fd, cacheText);
-        fs.closeSync(cacheFile);
+        const cacheFile = await fs.open(this.getCachePath(), fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
+        await fs.write(cacheFile.fd, JSON.stringify(cache));
+        await fs.close(cacheFile.fd);
       } catch (e) {
         // 缓存写入失败，忽略
       }
@@ -151,6 +164,8 @@ export struct CastDetailPage {
   }
 
   private navigateToCredit(item: TmdbCreditItem): void {
+    // TV 类型暂不支持跳转（SeriesDetailPage 需要 tvSeriesId，无法从 TMDB 直接构造）
+    if (item.media_type === 'tv') { return; }
     const mediaItem: MediaItem = {
       id: 0,
       sourceId: 0,
@@ -160,15 +175,11 @@ export struct CastDetailPage {
       scannedAt: 0,
       title: this.getCreditsTitle(item),
       provider: 'tmdb',
-      providerId: item.id !== undefined ? item.id.toString() : '',
+      providerId: item.id != null ? item.id.toString() : '',
       posterUrl: tmdbImg(item.poster_path, 'w342'),
-      mediaType: item.media_type === 'tv' ? 'series' : 'movie',
+      mediaType: 'movie',
     };
-    if (item.media_type === 'tv') {
-      this.pageStack.pushPathByName(SeriesDetailPage.PAGE_NAME, mediaItem);
-    } else {
-      this.pageStack.pushPathByName(MovieDetailPage.PAGE_NAME, mediaItem);
-    }
+    this.pageStack.pushPathByName(MovieDetailPage.PAGE_NAME, mediaItem);
   }
 
   build() {
@@ -315,7 +326,8 @@ export struct CastDetailPage {
                               .width(100).textAlign(TextAlign.Center)
                           }
                         }
-                        .focusable(false)
+                        .focusable(true)
+                        .onClick(() => { this.navigateToCredit(item); })
                       }, (item: TmdbCreditItem) => (item.id !== undefined ? item.id.toString() : '') + (item.media_type ?? ''))
                     }
                     .padding({ left: 40, right: 40 })

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -295,10 +295,15 @@ export struct CastDetailPage {
                             .alignItems(HorizontalAlign.Center)
                           }
 
-                          Text(this.getCreditsTitle(item))
-                            .fontSize(12).fontColor('#CCCCCC')
-                            .maxLines(2).textOverflow({ overflow: TextOverflow.Ellipsis })
-                            .width(100).textAlign(TextAlign.Center)
+                          Column() {
+                            Text(this.getCreditsTitle(item))
+                              .fontSize(12).fontColor('#CCCCCC')
+                              .maxLines(2).textOverflow({ overflow: TextOverflow.Ellipsis })
+                              .width(100).textAlign(TextAlign.Center)
+                          }
+                          .width(100)
+                          .height(36)
+                          .justifyContent(FlexAlign.Start)
 
                           Text(this.getCreditsYear(item))
                             .fontSize(11).fontColor('#888888')
@@ -310,8 +315,7 @@ export struct CastDetailPage {
                               .width(100).textAlign(TextAlign.Center)
                           }
                         }
-                        .focusable(true)
-                        .onClick(() => { this.navigateToCredit(item); })
+                        .focusable(false)
                       }, (item: TmdbCreditItem) => (item.id !== undefined ? item.id.toString() : '') + (item.media_type ?? ''))
                     }
                     .padding({ left: 40, right: 40 })

--- a/entry/src/main/ets/pages/detail/CastDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/CastDetailPage.ets
@@ -2,7 +2,8 @@ import http from '@ohos.net.http';
 import fs from '@ohos.file.fs';
 import { AppPreferences, PrefKey } from '../../utils/AppPreferences';
 import { MovieDetailPage } from './MovieDetailPage';
-import { MediaItem } from '../../db/models/MediaEntity';
+import { MediaItem, MovieEntity } from '../../db/models/MediaEntity';
+import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 
 export interface CastDetailPageParam {
   personId: number;
@@ -208,20 +209,27 @@ export struct CastDetailPage {
   private navigateToCredit(item: TmdbCreditItem): void {
     // TV 类型暂不支持跳转（SeriesDetailPage 需要 tvSeriesId，无法从 TMDB 直接构造）
     if (item.media_type === 'tv') { return; }
-    const mediaItem: MediaItem = {
-      id: 0,
-      sourceId: 0,
-      directoryPath: '',
-      filePath: '',
-      fileName: this.getCreditsTitle(item),
-      scannedAt: 0,
-      title: this.getCreditsTitle(item),
-      provider: 'tmdb',
-      providerId: item.id != null ? item.id.toString() : '',
-      posterUrl: tmdbImg(item.poster_path, 'w342'),
-      mediaType: 'movie',
-    };
-    this.pageStack.pushPathByName(MovieDetailPage.PAGE_NAME, mediaItem);
+    if (item.id == null) { return; }
+
+    const tmdbId = item.id.toString();
+    const db = FileSourceDatabase.getInstance();
+    db.getMovieByProviderId('tmdb', tmdbId).then((movie: MovieEntity | null) => {
+      if (movie == null) { return; }   // 本地库无此电影，不跳转
+      const mediaItem: MediaItem = {
+        id: 0,
+        sourceId: 0,
+        directoryPath: '',
+        filePath: '',
+        fileName: this.getCreditsTitle(item),
+        scannedAt: 0,
+        title: this.getCreditsTitle(item),
+        provider: 'tmdb',
+        providerId: tmdbId,
+        posterUrl: tmdbImg(item.poster_path, 'w342'),
+        mediaType: 'movie',
+      };
+      this.pageStack.pushPathByName(MovieDetailPage.PAGE_NAME, mediaItem);
+    }).catch(() => {});
   }
 
   build() {
@@ -341,22 +349,23 @@ export struct CastDetailPage {
                           Column() {
                             Text(this.getCreditsTitle(item))
                               .fontSize(12).fontColor('#CCCCCC')
-                              .maxLines(2).textOverflow({ overflow: TextOverflow.Ellipsis })
+                              .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
                               .width(100).textAlign(TextAlign.Center)
                           }
                           .width(100)
-                          .height(36)
+                          .height(24)
                           .justifyContent(FlexAlign.Start)
 
                           Text(this.getCreditsYear(item))
                             .fontSize(11).fontColor('#888888')
+                            .width(100).textAlign(TextAlign.Center)
 
-                          if ((item.character != null && item.character.length > 0) || (item.job != null && item.job.length > 0)) {
-                            Text(item.character != null && item.character.length > 0 ? item.character : (item.job ?? ''))
-                              .fontSize(11).fontColor('#666666')
-                              .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
-                              .width(100).textAlign(TextAlign.Center)
-                          }
+                          Text(item.character != null && item.character.length > 0
+                            ? item.character
+                            : (item.job != null && item.job.length > 0 ? item.job : ''))
+                            .fontSize(11).fontColor('#666666')
+                            .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
+                            .width(100).textAlign(TextAlign.Center)
                         }
                         .focusable(true)
                         .onClick(() => { this.navigateToCredit(item); })

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -712,12 +712,11 @@ export struct MovieDetailPage {
                 }
               }
               .width(110).alignItems(HorizontalAlign.Center)
-              .focusable(true)
+              .focusable((c.personId ?? 0) > 0)
               .onClick(() => {
+                if ((c.personId ?? 0) <= 0) { return; }
                 const castName = c.name ?? '';
-                const castProfile = c.profilePath ?? '';
-                if (castName.length === 0 && castProfile.length === 0) { return; }
-                const param: CastDetailPageParam = { personId: c.personId ?? 0, name: castName };
+                const param: CastDetailPageParam = { personId: c.personId!, name: castName };
                 this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
               })
             }, (c: CastCrewItem) => c.name ?? '')

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -9,6 +9,7 @@ import image from '@ohos.multimedia.image';
 import effectKit from '@ohos.effectKit';
 import { millisecondsToTime } from '../../utils/TimeUtil';
 import { BusinessError } from '@kit.BasicServicesKit';
+import { CastDetailPage, CastDetailPageParam } from './CastDetailPage';
 
 // ─────────────────────────────────────────────
 // TMDB 图片 URL 工具
@@ -66,6 +67,7 @@ interface CastPerson {
   name: string;
   character?: string;
   profilePath?: string;
+  personId?: number;
 }
 
 /** 演职人员统一展示项（导演 + 演员合并列表） */
@@ -73,6 +75,7 @@ interface CastCrewItem {
   name: string;
   role?: string;
   profilePath?: string;
+  personId?: number;
 }
 
 function parseCastArr(json: string | undefined): CastPerson[] {
@@ -250,7 +253,7 @@ export struct MovieDetailPage {
     }
     const castList = parseCastArr(this.movieEntity?.castJson);
     for (const c of castList) {
-      const ci: CastCrewItem = { name: c.name, role: c.character, profilePath: c.profilePath };
+      const ci: CastCrewItem = { name: c.name, role: c.character, profilePath: c.profilePath, personId: c.personId };
       result.push(ci);
     }
     return result;
@@ -707,6 +710,14 @@ export struct MovieDetailPage {
                 }
               }
               .width(110).alignItems(HorizontalAlign.Center)
+              .focusable(true)
+              .onClick(() => {
+                const pid = c.personId;
+                if (pid !== undefined && pid > 0) {
+                  const param: CastDetailPageParam = { personId: pid, name: c.name };
+                  this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
+                }
+              })
             }, (c: CastCrewItem) => c.name ?? '')
           }
           .padding({ left: 80, right: 80 })

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -714,7 +714,10 @@ export struct MovieDetailPage {
               .width(110).alignItems(HorizontalAlign.Center)
               .focusable(true)
               .onClick(() => {
-                const param: CastDetailPageParam = { personId: c.personId ?? 0, name: c.name ?? '' };
+                const castName = c.name ?? '';
+                const castProfile = c.profilePath ?? '';
+                if (castName.length === 0 && castProfile.length === 0) { return; }
+                const param: CastDetailPageParam = { personId: c.personId ?? 0, name: castName };
                 this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
               })
             }, (c: CastCrewItem) => c.name ?? '')

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -714,7 +714,7 @@ export struct MovieDetailPage {
               .onClick(() => {
                 const pid = c.personId;
                 if (pid !== undefined && pid > 0) {
-                  const param: CastDetailPageParam = { personId: pid, name: c.name };
+                  const param: CastDetailPageParam = { personId: pid, name: c.name ?? '' };
                   this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
                 }
               })

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -712,11 +712,8 @@ export struct MovieDetailPage {
               .width(110).alignItems(HorizontalAlign.Center)
               .focusable(true)
               .onClick(() => {
-                const pid = c.personId;
-                if (pid !== undefined && pid > 0) {
-                  const param: CastDetailPageParam = { personId: pid, name: c.name ?? '' };
-                  this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
-                }
+                const param: CastDetailPageParam = { personId: c.personId ?? 0, name: c.name ?? '' };
+                this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
               })
             }, (c: CastCrewItem) => c.name ?? '')
           }

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -852,26 +852,7 @@ export struct MovieDetailPage {
         // 简介全文弹窗
         this.OverviewDialog()
 
-        // 顶部浮动返回按钮
-        Row() {
-          Text('←')
-            .fontSize(30).fontColor(Color.White).fontWeight(FontWeight.Bold)
-            .textShadow({ radius: 6, color: '#88000000', offsetX: 1, offsetY: 1 })
-            .padding(20)
-            .onClick(() => {
-              if (this.showOverviewDialog) {
-                this.showOverviewDialog = false;
-              } else {
-                this.pageStack.pop();
-              }
-            })
-        }
-        .width('100%')
-        .padding({ left: 16, top: 8 })
-        .linearGradient({
-          angle: 180,
-          colors: [['#AA000000', 0.0], ['#00000000', 1.0]]
-        })
+
       }
       .width('100%').height('100%')
       .backgroundColor(this.dominantBgColor)

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -253,6 +253,8 @@ export struct MovieDetailPage {
     }
     const castList = parseCastArr(this.movieEntity?.castJson);
     for (const c of castList) {
+      // 过滤无名称的演员，避免导航到 CastDetailPage 时 displayName 为 null
+      if (c.name == null || c.name.length === 0) { continue; }
       const ci: CastCrewItem = { name: c.name, role: c.character, profilePath: c.profilePath, personId: c.personId };
       result.push(ci);
     }

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -1366,17 +1366,7 @@ export struct SeasonDetailPage {
         // 简介全文弹窗
         this.OverviewDialog()
 
-        // 顶部返回按钮
-        Row() {
-          Text('←')
-            .fontSize(30).fontColor(Color.White).fontWeight(FontWeight.Bold)
-            .textShadow({ radius: 6, color: '#88000000', offsetX: 1, offsetY: 1 })
-            .padding(20)
-            .onClick(() => { this.pageStack.pop(); })
-        }
-        .width('100%')
-        .padding({ left: 16, top: 8 })
-        .linearGradient({ angle: 180, colors: [['#AA000000', 0.0], ['#00000000', 1.0]] })
+
       }
       .width('100%').height('100%')
       .backgroundColor(this.dominantBgColor)

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -1,4 +1,5 @@
 import { SeriesGroup, TvSeriesEntity, TvSeasonEntity, TvEpisodeEntity, MediaItem, PlayProgressEntity } from '../../db/models/MediaEntity'
+import { CastDetailPage, CastDetailPageParam } from './CastDetailPage'
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase'
 import { ScrapeCredit } from '../../lib/ScrapeClient'
 import { PlayerPageParam, PlayerPage } from '../player/index'
@@ -69,6 +70,7 @@ interface SeasonRawJson {
 
 /** tv_series.raw_json 中 credits.cast 条目 */
 interface TmdbSeriesCastItem {
+  id?: number;
   name?: string;
   character?: string;
   profile_path?: string;
@@ -77,6 +79,7 @@ interface TmdbSeriesCastItem {
 
 /** tv_series.raw_json 中 credits.crew 条目 */
 interface TmdbSeriesCrewItem {
+  id?: number;
   name?: string;
   job?: string;
   profile_path?: string;
@@ -577,7 +580,8 @@ export struct SeasonDetailPage {
               name: c.name ?? '',
               role: c.character,
               profilePath: c.profile_path,
-              order: c.order
+              order: c.order,
+              personId: c.id
             };
             allCredits.push(cr);
           }
@@ -590,7 +594,8 @@ export struct SeasonDetailPage {
             const cr: ScrapeCredit = {
               name: cName,
               role: translateJob(c.job ?? ''),
-              profilePath: c.profile_path
+              profilePath: c.profile_path,
+              personId: c.id
             };
             allCredits.push(cr);
             castNames.push(cName);
@@ -1249,6 +1254,17 @@ export struct SeasonDetailPage {
                 }
               }
               .width(110).alignItems(HorizontalAlign.Center)
+              .focusable(true)
+              .onClick(() => {
+                const name = c.name ?? '';
+                const profilePath = c.profilePath ?? '';
+                if (name.length === 0 && profilePath.length === 0) { return; }
+                const param: CastDetailPageParam = {
+                  personId: c.personId ?? 0,
+                  name: name
+                };
+                this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
+              })
             }, (c: ScrapeCredit) => c.name ?? '')
           }
           .padding({ left: 80, right: 80 })

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -1287,7 +1287,7 @@ export struct SeriesDetailPage {
               .onClick(() => {
                 const pid = c.personId;
                 if (pid !== undefined && pid > 0) {
-                  const param: CastDetailPageParam = { personId: pid, name: c.name };
+                  const param: CastDetailPageParam = { personId: pid, name: c.name ?? '' };
                   this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
                 }
               })

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -1287,7 +1287,10 @@ export struct SeriesDetailPage {
               .width(110).alignItems(HorizontalAlign.Center)
               .focusable(true)
               .onClick(() => {
-                const param: CastDetailPageParam = { personId: c.personId ?? 0, name: c.name ?? '' };
+                const castName = c.name ?? '';
+                const castProfile = c.profilePath ?? '';
+                if (castName.length === 0 && castProfile.length === 0) { return; }
+                const param: CastDetailPageParam = { personId: c.personId ?? 0, name: castName };
                 this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
               })
             }, (c: ScrapeCredit) => c.name ?? '')

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -432,6 +432,8 @@ export struct SeriesDetailPage {
           const allCredits: ScrapeCredit[] = [];
           const castItems = detail2.credits?.cast ?? [];
           for (const c of castItems.slice(0, 20)) {
+            // 过滤无名称演员，避免下游 CastDetailPage 崩溃
+            if (c.name == null || (c.name as string).length === 0) { continue; }
             const cr: ScrapeCredit = {
               name: c.name ?? '',
               role: c.character,

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -1285,11 +1285,8 @@ export struct SeriesDetailPage {
               .width(110).alignItems(HorizontalAlign.Center)
               .focusable(true)
               .onClick(() => {
-                const pid = c.personId;
-                if (pid !== undefined && pid > 0) {
-                  const param: CastDetailPageParam = { personId: pid, name: c.name ?? '' };
-                  this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
-                }
+                const param: CastDetailPageParam = { personId: c.personId ?? 0, name: c.name ?? '' };
+                this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
               })
             }, (c: ScrapeCredit) => c.name ?? '')
           }

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -13,6 +13,7 @@ import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntit
 import { millisecondsToTime } from '../../utils/TimeUtil'
 import { FfprobeUtil, FfprobeTrack } from '../../utils/FfprobeUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
+import { CastDetailPage, CastDetailPageParam } from './CastDetailPage'
 
 // ─────────────────────────────────────────────
 // TMDB 图片 URL 工具
@@ -54,6 +55,7 @@ interface TmdbRawSeason {
 }
 
 interface TmdbRawCastItem {
+  id?: number;
   name?: string;
   character?: string;
   profile_path?: string;
@@ -61,6 +63,7 @@ interface TmdbRawCastItem {
 }
 
 interface TmdbRawCrewItem {
+  id?: number;
   name?: string;
   job?: string;
   profile_path?: string;
@@ -433,7 +436,8 @@ export struct SeriesDetailPage {
               name: c.name ?? '',
               role: c.character,
               profilePath: c.profile_path,
-              order: c.order
+              order: c.order,
+              personId: c.id
             };
             allCredits.push(cr);
           }
@@ -446,7 +450,8 @@ export struct SeriesDetailPage {
             const cr: ScrapeCredit = {
               name: cName,
               role: translateJob(c.job ?? ''),
-              profilePath: c.profile_path
+              profilePath: c.profile_path,
+              personId: c.id
             };
             allCredits.push(cr);
             castNames.push(cName);
@@ -1278,6 +1283,14 @@ export struct SeriesDetailPage {
                 }
               }
               .width(110).alignItems(HorizontalAlign.Center)
+              .focusable(true)
+              .onClick(() => {
+                const pid = c.personId;
+                if (pid !== undefined && pid > 0) {
+                  const param: CastDetailPageParam = { personId: pid, name: c.name };
+                  this.pageStack.pushPathByName(CastDetailPage.PAGE_NAME, param);
+                }
+              })
             }, (c: ScrapeCredit) => c.name ?? '')
           }
           .padding({ left: 80, right: 80 })

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -1498,20 +1498,7 @@ export struct SeriesDetailPage {
         // 简介全文弹窗
         this.OverviewDialog()
 
-        // 顶部透明导航栏（后退按钮）
-        Row() {
-          Text('←')
-            .fontSize(30).fontColor(Color.White).fontWeight(FontWeight.Bold)
-            .textShadow({ radius: 6, color: '#88000000', offsetX: 1, offsetY: 1 })
-            .padding(20)
-            .onClick(() => { this.pageStack.pop(); })
-        }
-        .width('100%')
-        .padding({ left: 16, top: 8 })
-        .linearGradient({
-          angle: 180,
-          colors: [['#AA000000', 0.0], ['#00000000', 1.0]]
-        })
+
       }
       .width('100%').height('100%')
       .backgroundColor(this.dominantBgColor)


### PR DESCRIPTION
## 功能说明

实现演职人员详情页 `CastDetailPage`，支持从电影/剧集详情页点击演员卡片后进入，展示 TMDB 人物数据并支持文件缓存。

## 主要变更

### 新增
- `entry/src/main/ets/pages/detail/CastDetailPage.ets`：演职人员详情页
  - TMDB `/person/{id}` + `/combined_credits` 双接口抓取
  - 文件缓存：`cacheDir/cast/{personId}.json`，首次 API 获取后写入，再次访问直接读文件
  - 展示：头像/首字母占位、姓名、职业类别、生日、出生地、简介（可展开）、参演作品横向滚动列表
  - 点击参演作品跳转到对应电影/剧集详情页

### 修改
- `ScrapeClient.ets`：`TmdbCastItem`/`TmdbCrewItem` 增加 `id` 字段，`ScrapeCredit` 增加 `personId`
- `MovieDetailPage.ets`：`CastPerson`/`CastCrewItem` 增加 `personId`，演员卡片增加 onClick 跳转（`personId > 0` 守卫）
- `SeriesDetailPage.ets`：内部 cast 数据增加 `id` 字段，演员卡片增加 onClick 跳转
- `pages/Index.ets`：注册 `castDetail` 路由

## 编译验证

- ✅ BUILD SUCCESSFUL（0 ERROR，若干弃用 API WARNING 不影响功能）
- ✅ 无未追踪文件

Closes #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cast Detail page: profile, expandable biography, key credits (max 20).
  * Cast cards now navigate to individual cast pages from movie, series and season detail lists when available.

* **UX**
  * Cast lists are focusable/clickable for keyboard/remote navigation.
  * Cast detail prefers local cache, falls back to online lookup and can resolve by name; TV credits don’t navigate.
  * Removed top overlay back button on several detail pages.

* **Bug Fixes**
  * Improved SMB playback proxy handling and more reliable fallback/restart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->