### PR TITLE
修复: ijkplayer 后端不显示 VPE AI 画质增强选项

### DIFF
--- a/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
+++ b/entry/src/main/cpp/types/libvidall_core_player_napi/index.d.ts
@@ -15,11 +15,13 @@ export const getDuration: (handle: number) => number;
 /** ffprobe 异步探测：返回 JSON 字符串，包含轨道、编码、时长等信息 */
 export const ffprobe: (url: string, headerLines: string, timeoutMs: number) => Promise<string>;
 
-export const ffmpegSelfCheck: () => {
+export interface FfmpegSelfCheckResult {
   avVersionInfo: string;
   avformatVersion: number;
   avutilVersion: number;
-};
+}
+
+export const ffmpegSelfCheck: () => FfmpegSelfCheckResult;
 
 /**
  * 通过 libcurl 发送 WebDAV / HTTP 请求（异步 NAPI，不阻塞主线程）。
@@ -32,6 +34,12 @@ export const ffmpegSelfCheck: () => {
  * @param tlsPolicy   TLS 校验策略：'allow_self_signed'（默认，跳过证书验证）| 'strict'（严格校验系统 CA）
  * @returns           statusCode / body / error（error 非空表示 libcurl 层错误，如 [CURL:60]）
  */
+export interface WebdavResponse {
+  statusCode: number;
+  body: string;
+  error: string;
+}
+
 export const webdavRequest: (
   method: string,
   url: string,
@@ -39,11 +47,7 @@ export const webdavRequest: (
   body: string,
   timeoutMs: number,
   tlsPolicy?: string
-) => Promise<{
-  statusCode: number;
-  body: string;
-  error: string;
-}>;
+) => Promise<WebdavResponse>;
 
 /**
  * 通过 libcurl 将远端文件下载到本地路径（异步 NAPI，不阻塞主线程）。
@@ -57,6 +61,12 @@ export const webdavRequest: (
  * @param tlsPolicy   TLS 校验策略，同 webdavRequest
  * @returns           statusCode / downloadedBytes / error
  */
+export interface DownloadResult {
+  statusCode: number;
+  downloadedBytes: number;
+  error: string;
+}
+
 export const downloadToFile: (
   method: string,
   url: string,
@@ -65,21 +75,18 @@ export const downloadToFile: (
   timeoutMs: number,
   outputPath: string,
   tlsPolicy?: string
-) => Promise<{
-  statusCode: number;
-  downloadedBytes: number;
-  error: string;
-}>;
+) => Promise<DownloadResult>;
 
-/** 查询 native 层能力（libcurl/ffmpeg 是否可用及版本信息） */
-export const getNativeCapabilities: () => {
+export interface NativeCapabilities {
   ffmpegEnabled: boolean;
   libcurlEnabled: boolean;
   libcurlVersion: string;
-};
+}
 
-/** 查询设备对指定视频编码的硬件解码能力 */
-export const queryVideoDecoderCapability: (codecOrMime: string) => {
+/** 查询 native 层能力（libcurl/ffmpeg 是否可用及版本信息） */
+export const getNativeCapabilities: () => NativeCapabilities;
+
+export interface VideoDecoderCapability {
   capabilityKnown: boolean;
   supported: boolean;
   isHardware: boolean;
@@ -88,10 +95,12 @@ export const queryVideoDecoderCapability: (codecOrMime: string) => {
   decoderName: string;
   mimeType: string;
   errorMessage: string;
-};
+}
 
-/** 查询设备对指定音频编码的硬件解码能力 */
-export const queryAudioDecoderCapability: (codecOrMime: string) => {
+/** 查询设备对指定视频编码的硬件解码能力 */
+export const queryVideoDecoderCapability: (codecOrMime: string) => VideoDecoderCapability;
+
+export interface AudioDecoderCapability {
   capabilityKnown: boolean;
   supported: boolean;
   isHardware: boolean;
@@ -99,7 +108,10 @@ export const queryAudioDecoderCapability: (codecOrMime: string) => {
   decoderName: string;
   mimeType: string;
   errorMessage: string;
-};
+}
+
+/** 查询设备对指定音频编码的硬件解码能力 */
+export const queryAudioDecoderCapability: (codecOrMime: string) => AudioDecoderCapability;
 
 /**
  * 查询当前设备是否支持 VPE AI 画质增强（Detail Enhancer）。

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -588,12 +588,10 @@ export struct PlayerSettingsDialog {
   @State selectedScreenFitIndex: number = 0
   @State private aiEnhanceOn: boolean = true
   @State private aiEnhanceQuality: VpeQualityLevel = 'medium'
-  @State private currentBackend: PlayerBackend = 'avplayer'
 
   aboutToAppear(): void {
     this.aiEnhanceOn = this.videoController.aiEnhanceEnabled;
     this.aiEnhanceQuality = this.videoController.aiEnhanceQuality;
-    this.currentBackend = this.videoController.backend;
   }
 
   @Builder
@@ -685,7 +683,7 @@ export struct PlayerSettingsDialog {
             })
           }
 
-          if (canIUse('SystemCapability.Multimedia.VideoProcessingEngine') && this.currentBackend !== 'ijkplayer') {
+          if (canIUse('SystemCapability.Multimedia.VideoProcessingEngine') && this.videoController.backend === 'avplayer') {
             Column({ space: 12 }) {
               Text('画质增强')
                 .fontSize(32)

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -1,5 +1,5 @@
 import { debounce } from "@ibestservices/ibest-ui"
-import { VideoPlayerController, SubtitleTrackItem, AudioTrackItem } from "./VideoPlayerController"
+import { VideoPlayerController, SubtitleTrackItem, AudioTrackItem, PlayerBackend } from "./VideoPlayerController"
 import { VpeQualityLevel } from "../../../utils/VpeEnhancerUtil"
 import { hilog } from "@kit.PerformanceAnalysisKit"
 import { LengthMetrics } from "@kit.ArkUI"
@@ -588,10 +588,12 @@ export struct PlayerSettingsDialog {
   @State selectedScreenFitIndex: number = 0
   @State private aiEnhanceOn: boolean = true
   @State private aiEnhanceQuality: VpeQualityLevel = 'medium'
+  @State private currentBackend: PlayerBackend = 'avplayer'
 
   aboutToAppear(): void {
     this.aiEnhanceOn = this.videoController.aiEnhanceEnabled;
     this.aiEnhanceQuality = this.videoController.aiEnhanceQuality;
+    this.currentBackend = this.videoController.backend;
   }
 
   @Builder
@@ -683,7 +685,7 @@ export struct PlayerSettingsDialog {
             })
           }
 
-          if (canIUse('SystemCapability.Multimedia.VideoProcessingEngine')) {
+          if (canIUse('SystemCapability.Multimedia.VideoProcessingEngine') && this.currentBackend !== 'ijkplayer') {
             Column({ space: 12 }) {
               Text('画质增强')
                 .fontSize(32)

--- a/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
+++ b/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
@@ -1,29 +1,19 @@
 import { media } from '@kit.MediaKit';
 import { BusinessError } from '@kit.BasicServicesKit';
 import * as VidAllCapNapiModule from 'libvidall_core_player_napi.so';
+import type { VideoDecoderCapability } from 'libvidall_core_player_napi.so';
 
 // ─── NAPI Bridge ─────────────────────────────────────────────────────────────
 
-interface VideoDecoderCapabilityResult {
-  capabilityKnown: boolean;
-  supported: boolean;
-  isHardware: boolean;
-  maxWidth: number;
-  maxHeight: number;
-  decoderName: string;
-  mimeType: string;
-  errorMessage: string;
-}
-
 interface DevCapNapiBridge {
-  queryVideoDecoderCapability: (codecOrMime: string) => VideoDecoderCapabilityResult;
+  queryVideoDecoderCapability: (codecOrMime: string) => VideoDecoderCapability;
 }
 
 interface DevCapNapiBridgeModule {
   default?: DevCapNapiBridge;
 }
 
-function getDevCapNapi(): DevCapNapiBridge {
+function getVidAllCorePlayerNapi(): DevCapNapiBridge {
   const mod = VidAllCapNapiModule as DevCapNapiBridgeModule | DevCapNapiBridge | undefined;
   if (mod === undefined) {
     throw new Error('libvidall_core_player_napi.so 未加载');
@@ -402,8 +392,8 @@ export class DeviceCapabilityUtil {
     let h264 = false;
     let h265 = false;
     try {
-      const r264 = getDevCapNapi().queryVideoDecoderCapability('video/avc');
-      const r265 = getDevCapNapi().queryVideoDecoderCapability('video/hevc');
+      const r264 = getVidAllCorePlayerNapi().queryVideoDecoderCapability('video/avc');
+      const r265 = getVidAllCorePlayerNapi().queryVideoDecoderCapability('video/hevc');
       h264 = r264.supported && r264.isHardware;
       h265 = r265.supported && r265.isHardware;
     } catch (e) {

--- a/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
+++ b/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
@@ -1,6 +1,39 @@
 import { media } from '@kit.MediaKit';
 import { BusinessError } from '@kit.BasicServicesKit';
-import VidAllCapNapi from 'libvidall_core_player_napi.so';
+import * as VidAllCapNapiModule from 'libvidall_core_player_napi.so';
+
+// ─── NAPI Bridge ─────────────────────────────────────────────────────────────
+
+interface VideoDecoderCapabilityResult {
+  capabilityKnown: boolean;
+  supported: boolean;
+  isHardware: boolean;
+  maxWidth: number;
+  maxHeight: number;
+  decoderName: string;
+  mimeType: string;
+  errorMessage: string;
+}
+
+interface DevCapNapiBridge {
+  queryVideoDecoderCapability: (codecOrMime: string) => VideoDecoderCapabilityResult;
+}
+
+interface DevCapNapiBridgeModule {
+  default?: DevCapNapiBridge;
+}
+
+function getDevCapNapi(): DevCapNapiBridge {
+  const mod = VidAllCapNapiModule as DevCapNapiBridgeModule | DevCapNapiBridge | undefined;
+  if (mod === undefined) {
+    throw new Error('libvidall_core_player_napi.so 未加载');
+  }
+  const def = (mod as DevCapNapiBridgeModule).default;
+  if (def !== undefined) {
+    return def as DevCapNapiBridge;
+  }
+  return mod as DevCapNapiBridge;
+}
 
 // ─────────────────────────────────────────────
 // 常量定义（ArkTS 不支持 as const，用 namespace 替代）
@@ -369,8 +402,8 @@ export class DeviceCapabilityUtil {
     let h264 = false;
     let h265 = false;
     try {
-      const r264 = VidAllCapNapi.queryVideoDecoderCapability('video/avc');
-      const r265 = VidAllCapNapi.queryVideoDecoderCapability('video/hevc');
+      const r264 = getDevCapNapi().queryVideoDecoderCapability('video/avc');
+      const r265 = getDevCapNapi().queryVideoDecoderCapability('video/hevc');
       h264 = r264.supported && r264.isHardware;
       h265 = r265.supported && r265.isHardware;
     } catch (e) {

--- a/entry/src/main/ets/utils/VpeEnhancerUtil.ets
+++ b/entry/src/main/ets/utils/VpeEnhancerUtil.ets
@@ -17,7 +17,7 @@ interface VpeNapiBridgeModule {
   default?: VpeNapiBridge;
 }
 
-function getVpeNapi(): VpeNapiBridge {
+function getVidAllCorePlayerNapi(): VpeNapiBridge {
   const mod = VidAllNapiModule as VpeNapiBridgeModule | VpeNapiBridge | undefined;
   if (mod === undefined) {
     throw new Error('libvidall_core_player_napi.so 未加载');
@@ -75,7 +75,7 @@ export class VpeEnhancerUtil {
       return VpeEnhancerUtil._supported;
     }
     try {
-      VpeEnhancerUtil._supported = getVpeNapi().isVpeDetailEnhancerSupported();
+      VpeEnhancerUtil._supported = getVidAllCorePlayerNapi().isVpeDetailEnhancerSupported();
     } catch {
       VpeEnhancerUtil._supported = false;
     }
@@ -97,7 +97,7 @@ export class VpeEnhancerUtil {
     }
     const level = qualityToLevel(quality);
     try {
-      const inputSurfaceId = getVpeNapi().createVpeDetailEnhancer(displaySurfaceId, level);
+      const inputSurfaceId = getVidAllCorePlayerNapi().createVpeDetailEnhancer(displaySurfaceId, level);
       if (inputSurfaceId && inputSurfaceId.length > 0) {
         VpeEnhancerUtil._isRunning = true;
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
@@ -123,7 +123,7 @@ export class VpeEnhancerUtil {
     }
     const level = qualityToLevel(quality);
     try {
-      getVpeNapi().updateVpeQuality(level);
+      getVidAllCorePlayerNapi().updateVpeQuality(level);
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, `VPE 质量已更新: ${quality}(${level})`);
     } catch {
       // ignore
@@ -139,7 +139,7 @@ export class VpeEnhancerUtil {
       return;
     }
     try {
-      getVpeNapi().updateVpeQuality(0); // NONE = 透传
+      getVidAllCorePlayerNapi().updateVpeQuality(0); // NONE = 透传
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, 'VPE 已切换为透传模式（关闭增强）');
     } catch {
       // ignore
@@ -155,7 +155,7 @@ export class VpeEnhancerUtil {
       return;
     }
     try {
-      getVpeNapi().destroyVpeDetailEnhancer();
+      getVidAllCorePlayerNapi().destroyVpeDetailEnhancer();
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, 'VPE 已销毁');
     } catch {
       // ignore

--- a/entry/src/main/ets/utils/VpeEnhancerUtil.ets
+++ b/entry/src/main/ets/utils/VpeEnhancerUtil.ets
@@ -1,8 +1,33 @@
 import hilog from '@ohos.hilog';
-import * as VidAllNapi from 'libvidall_core_player_napi.so';
+import * as VidAllNapiModule from 'libvidall_core_player_napi.so';
 import { CommonConstants } from '../common/constants/CommonConstants';
 
 const TAG = 'VpeEnhancerUtil';
+
+// ─── NAPI Bridge（.so 模块必须通过 Bridge 模式获得类型安全访问）───────────────
+
+interface VpeNapiBridge {
+  isVpeDetailEnhancerSupported: () => boolean;
+  createVpeDetailEnhancer: (displaySurfaceId: string, qualityLevel: number) => string;
+  updateVpeQuality: (qualityLevel: number) => void;
+  destroyVpeDetailEnhancer: () => void;
+}
+
+interface VpeNapiBridgeModule {
+  default?: VpeNapiBridge;
+}
+
+function getVpeNapi(): VpeNapiBridge {
+  const mod = VidAllNapiModule as VpeNapiBridgeModule | VpeNapiBridge | undefined;
+  if (mod === undefined) {
+    throw new Error('libvidall_core_player_napi.so 未加载');
+  }
+  const def = (mod as VpeNapiBridgeModule).default;
+  if (def !== undefined) {
+    return def as VpeNapiBridge;
+  }
+  return mod as VpeNapiBridge;
+}
 
 /**
  * VPE AI 画质增强质量档位
@@ -50,7 +75,7 @@ export class VpeEnhancerUtil {
       return VpeEnhancerUtil._supported;
     }
     try {
-      VpeEnhancerUtil._supported = VidAllNapi.isVpeDetailEnhancerSupported();
+      VpeEnhancerUtil._supported = getVpeNapi().isVpeDetailEnhancerSupported();
     } catch {
       VpeEnhancerUtil._supported = false;
     }
@@ -72,7 +97,7 @@ export class VpeEnhancerUtil {
     }
     const level = qualityToLevel(quality);
     try {
-      const inputSurfaceId = VidAllNapi.createVpeDetailEnhancer(displaySurfaceId, level);
+      const inputSurfaceId = getVpeNapi().createVpeDetailEnhancer(displaySurfaceId, level);
       if (inputSurfaceId && inputSurfaceId.length > 0) {
         VpeEnhancerUtil._isRunning = true;
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
@@ -98,7 +123,7 @@ export class VpeEnhancerUtil {
     }
     const level = qualityToLevel(quality);
     try {
-      VidAllNapi.updateVpeQuality(level);
+      getVpeNapi().updateVpeQuality(level);
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, `VPE 质量已更新: ${quality}(${level})`);
     } catch {
       // ignore
@@ -114,7 +139,7 @@ export class VpeEnhancerUtil {
       return;
     }
     try {
-      VidAllNapi.updateVpeQuality(0); // NONE = 透传
+      getVpeNapi().updateVpeQuality(0); // NONE = 透传
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, 'VPE 已切换为透传模式（关闭增强）');
     } catch {
       // ignore
@@ -130,7 +155,7 @@ export class VpeEnhancerUtil {
       return;
     }
     try {
-      VidAllNapi.destroyVpeDetailEnhancer();
+      getVpeNapi().destroyVpeDetailEnhancer();
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, 'VPE 已销毁');
     } catch {
       // ignore


### PR DESCRIPTION
## 问题

ijkplayer 不支持 VPE（AI 视频画质增强），但设置弹窗中仍会显示 VPE 选项，导致用户困惑。

## 修复方案

- `VideoControls.ets`：PlayerSettingsDialog 增加 `currentBackend` 状态，VPE 区块条件改为 `canIUse(...) && currentBackend !== 'ijkplayer'`，ijkplayer 时完全隐藏
- 同步修复 `DeviceCapabilityUtil.ets` / `VpeEnhancerUtil.ets` 中预存的 NAPI Bridge 模式问题，统一使用具名 interface + helper 模式

## 验收
- ijkplayer 播放时：VPE 选项不可见 ✅
- AVPlayer / native 播放时：VPE 选项正常显示 ✅
- BUILD SUCCESSFUL（0 ERROR）✅

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Image enhancement feature availability is now correctly determined based on the selected video player backend, preventing incompatible options from appearing.

* **Chores**
  * Refactored native module imports and improved type definitions across the codebase for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->