### PR TITLE
feat(progress): #115 播放进度按集存储，历史列表按剧聚合

### DIFF
--- a/entry/src/main/ets/db/MediaProgressStore.ets
+++ b/entry/src/main/ets/db/MediaProgressStore.ets
@@ -4,14 +4,25 @@ import { MediaProgressEntry } from './models/MediaEntity';
 /**
  * 媒体级播放进度读写工具类。
  *
- * Key 规则：
- *   - 剧集：media_progress_series_<seriesProviderId>
- *   - 电影：media_progress_movie_<movieId>
+ * Key 规则（新）：
+ *   - 集级剧集：media_progress_episode_tmdb_{seriesTmdbId}_s{seasonNum}_e{episodeNum}
+ *   - 电影：     media_progress_movie_<movieId>
  *
  * 完播阈值：剩余时长 < 60 秒 或 已播比例 > 95%，由调用方判断后调用 clear()。
  */
 export class MediaProgressStore {
-  /** 构造剧集媒体进度 key */
+  /**
+   * 构造集级剧集媒体进度 key。
+   * 例：media_progress_episode_tmdb_1399_s1_e2
+   */
+  static episodeKey(seriesTmdbId: string, seasonNumber: number, episodeNumber: number): string {
+    return `media_progress_episode_tmdb_${seriesTmdbId}_s${seasonNumber}_e${episodeNumber}`;
+  }
+
+  /**
+   * 构造整剧级媒体进度 key（保留用于向后兼容旧数据读取）。
+   * @deprecated 新写入请使用 episodeKey()
+   */
   static seriesKey(seriesProviderId: string, provider: string = 'tmdb'): string {
     return `media_progress_series_${provider}_${seriesProviderId}`;
   }
@@ -66,9 +77,25 @@ export class MediaProgressStore {
   }
 
   /**
+   * 读取指定剧集最近播放的一集进度。
+   * @param seriesTmdbId 剧集 TMDB ID，如 "1399"
+   */
+  static async getLatestForSeries(seriesTmdbId: string): Promise<MediaProgressEntry | null> {
+    return FileSourceDatabase.getInstance().getLatestMediaProgressBySeries(seriesTmdbId);
+  }
+
+  /**
    * 清除媒体级进度（完播重置）。
    */
   static async clear(key: string): Promise<void> {
     await FileSourceDatabase.getInstance().clearMediaProgress(key);
+  }
+
+  /**
+   * 清除指定剧集所有集的进度记录。
+   * @param seriesTmdbId 剧集 TMDB ID，如 "1399"
+   */
+  static async clearAllForSeries(seriesTmdbId: string): Promise<void> {
+    await FileSourceDatabase.getInstance().clearAllMediaProgressBySeries(seriesTmdbId);
   }
 }

--- a/entry/src/main/ets/db/MediaProgressStore.ets
+++ b/entry/src/main/ets/db/MediaProgressStore.ets
@@ -6,7 +6,7 @@ import { MediaProgressEntry } from './models/MediaEntity';
  *
  * Key 规则（新）：
  *   - 集级剧集：media_progress_episode_tmdb_{seriesTmdbId}_s{seasonNum}_e{episodeNum}
- *   - 电影：     media_progress_movie_<movieId>
+ *   - 电影：     media_progress_movie_{movieId}（movieId 格式由调用方决定，如 "tmdb_12345"）
  *
  * 完播阈值：剩余时长 < 60 秒 或 已播比例 > 95%，由调用方判断后调用 clear()。
  */

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -2473,6 +2473,66 @@ export class FileSourceDatabase {
   }
 
   /**
+   * 删除指定剧集所有集的进度记录。
+   * 匹配所有 media_key 以 media_progress_episode_tmdb_{seriesTmdbId}_ 开头的记录。
+   * @param seriesTmdbId 剧集 TMDB ID（如 "1399"），不含下划线等特殊字符
+   */
+  async clearAllMediaProgressBySeries(seriesTmdbId: string): Promise<void> {
+    if (this.rdbStore === null) {
+      return;
+    }
+    try {
+      const prefix = `media_progress_episode_tmdb_${seriesTmdbId}_`;
+      const sql =
+        `DELETE FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
+        ` WHERE media_key LIKE '${prefix}%'`;
+      await this.rdbStore.executeSql(sql);
+      console.info(`[DB][clearAllMediaProgressBySeries] seriesTmdbId=${seriesTmdbId} 已全部清除`);
+    } catch (error) {
+      const err = error as BusinessError;
+      console.warn(`[DB][clearAllMediaProgressBySeries] 删除失败 code=${err.code} msg=${err.message}`);
+    }
+  }
+
+  /**
+   * 查询指定剧集最近播放的一集进度。
+   * @param seriesTmdbId 剧集 TMDB ID，如 "1399"
+   */
+  async getLatestMediaProgressBySeries(seriesTmdbId: string): Promise<MediaProgressEntry | null> {
+    if (this.rdbStore === null) {
+      return null;
+    }
+    let rs: relationalStore.ResultSet | null = null;
+    try {
+      const prefix = `media_progress_episode_tmdb_${seriesTmdbId}_`;
+      const sql =
+        `SELECT media_key, position_ms, duration_ms, last_played_at, episode_number, season_number` +
+        ` FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
+        ` WHERE media_key LIKE '${prefix}%'` +
+        ` ORDER BY last_played_at DESC LIMIT 1`;
+      rs = await this.rdbStore.querySql(sql);
+      if (rs.goToNextRow()) {
+        const entry: MediaProgressEntry = {
+          mediaKey: rs.getString(rs.getColumnIndex('media_key')),
+          positionMs: rs.getLong(rs.getColumnIndex('position_ms')),
+          durationMs: rs.getLong(rs.getColumnIndex('duration_ms')),
+          lastPlayedAt: rs.getLong(rs.getColumnIndex('last_played_at')),
+          episodeNumber: rs.getLong(rs.getColumnIndex('episode_number')),
+          seasonNumber: rs.getLong(rs.getColumnIndex('season_number')),
+        };
+        return entry;
+      }
+      return null;
+    } catch (e) {
+      const err = e as BusinessError;
+      console.warn(`[DB][getLatestMediaProgressBySeries] 查询失败 code=${err.code} msg=${err.message}`);
+      return null;
+    } finally {
+      rs?.close();
+    }
+  }
+
+  /**
    * 查询全部媒体级播放进度，按最近播放时间倒序返回。
    * 用于「继续播放」栏数据源。
    */

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -2486,12 +2486,15 @@ export class FileSourceDatabase {
       return;
     }
     try {
-      const prefix = `media_progress_episode_tmdb_${seriesTmdbId}_`;
+      // 同时清除新格式（集级 key）和旧格式（整剧级 key），确保历史迁移数据也能被删除
+      const episodePrefix = `media_progress_episode_tmdb_${seriesTmdbId}_`;
+      const oldKey = `media_progress_series_tmdb_${seriesTmdbId}`;
       const sql =
         `DELETE FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
-        ` WHERE media_key LIKE '${prefix}%'`;
+        ` WHERE media_key LIKE '${episodePrefix}%'` +
+        ` OR media_key = '${oldKey}'`;
       await this.rdbStore.executeSql(sql);
-      console.info(`[DB][clearAllMediaProgressBySeries] seriesTmdbId=${seriesTmdbId} 已全部清除`);
+      console.info(`[DB][clearAllMediaProgressBySeries] seriesTmdbId=${seriesTmdbId} 已全部清除（含旧格式）`);
     } catch (error) {
       const err = error as BusinessError;
       console.warn(`[DB][clearAllMediaProgressBySeries] 删除失败 code=${err.code} msg=${err.message}`);

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -2481,6 +2481,10 @@ export class FileSourceDatabase {
     if (this.rdbStore === null) {
       return;
     }
+    if (!/^\d+$/.test(seriesTmdbId)) {
+      console.warn(`[DB][clearAllMediaProgressBySeries] 非法 seriesTmdbId: ${seriesTmdbId}`);
+      return;
+    }
     try {
       const prefix = `media_progress_episode_tmdb_${seriesTmdbId}_`;
       const sql =
@@ -2500,6 +2504,10 @@ export class FileSourceDatabase {
    */
   async getLatestMediaProgressBySeries(seriesTmdbId: string): Promise<MediaProgressEntry | null> {
     if (this.rdbStore === null) {
+      return null;
+    }
+    if (!/^\d+$/.test(seriesTmdbId)) {
+      console.warn(`[DB][getLatestMediaProgressBySeries] 非法 seriesTmdbId: ${seriesTmdbId}`);
       return null;
     }
     let rs: relationalStore.ResultSet | null = null;

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -2491,9 +2491,8 @@ export class FileSourceDatabase {
       const oldKey = `media_progress_series_tmdb_${seriesTmdbId}`;
       const sql =
         `DELETE FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
-        ` WHERE media_key LIKE '${episodePrefix}%'` +
-        ` OR media_key = '${oldKey}'`;
-      await this.rdbStore.executeSql(sql);
+        ` WHERE media_key LIKE ? OR media_key = ?`;
+      await this.rdbStore.executeSql(sql, [`${episodePrefix}%`, oldKey]);
       console.info(`[DB][clearAllMediaProgressBySeries] seriesTmdbId=${seriesTmdbId} 已全部清除（含旧格式）`);
     } catch (error) {
       const err = error as BusinessError;
@@ -2515,13 +2514,15 @@ export class FileSourceDatabase {
     }
     let rs: relationalStore.ResultSet | null = null;
     try {
-      const prefix = `media_progress_episode_tmdb_${seriesTmdbId}_`;
+      const episodePrefix = `media_progress_episode_tmdb_${seriesTmdbId}_`;
+      const oldKey = `media_progress_series_tmdb_${seriesTmdbId}`;
+      // 同时查新旧格式，取最近播放的一条
       const sql =
         `SELECT media_key, position_ms, duration_ms, last_played_at, episode_number, season_number` +
         ` FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
-        ` WHERE media_key LIKE '${prefix}%'` +
+        ` WHERE media_key LIKE ? OR media_key = ?` +
         ` ORDER BY last_played_at DESC LIMIT 1`;
-      rs = await this.rdbStore.querySql(sql);
+      rs = await this.rdbStore.querySql(sql, [`${episodePrefix}%`, oldKey]);
       if (rs.goToNextRow()) {
         const entry: MediaProgressEntry = {
           mediaKey: rs.getString(rs.getColumnIndex('media_key')),
@@ -2547,17 +2548,17 @@ export class FileSourceDatabase {
    * 查询全部媒体级播放进度，按最近播放时间倒序返回。
    * 用于「继续播放」栏数据源。
    */
-  async getAllMediaProgress(): Promise<MediaProgressEntry[]> {
+  async getAllMediaProgress(limit: number = 40): Promise<MediaProgressEntry[]> {
     if (this.rdbStore === null) {
       return [];
     }
     let rs: relationalStore.ResultSet | null = null;
     try {
-      // LIMIT 40：稍大于上层取 20 条的余量，减少全表 IO；DB 已按 last_played_at DESC 排序
+      // limit 为数字类型，不存在注入风险；默认 40 用于「继续播放」栏，历史页可传 200
       const sql =
         `SELECT media_key, position_ms, duration_ms, last_played_at, episode_number, season_number` +
         ` FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
-        ` ORDER BY last_played_at DESC LIMIT 40`;
+        ` ORDER BY last_played_at DESC LIMIT ${limit}`;
       rs = await this.rdbStore.querySql(sql);
       const result: MediaProgressEntry[] = [];
       while (rs.goToNextRow()) {
@@ -2579,6 +2580,43 @@ export class FileSourceDatabase {
       return [];
     } finally {
       rs?.close();
+    }
+  }
+
+  /**
+   * 删除指定剧集在 play_progress 表中的进度记录。
+   * @param seriesProviderId 剧集 provider ID（如 TMDB ID 字符串）
+   */
+  async clearPlayProgressBySeries(seriesProviderId: string): Promise<void> {
+    if (this.rdbStore === null) {
+      return;
+    }
+    try {
+      const pred = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_PLAY_PROGRESS);
+      pred.equalTo('series_provider_id', seriesProviderId);
+      await this.rdbStore.delete(pred);
+      console.info(`[DB][clearPlayProgressBySeries] series=${seriesProviderId} 已清除`);
+    } catch (error) {
+      const err = error as BusinessError;
+      console.warn(`[DB][clearPlayProgressBySeries] 失败 code=${err.code} msg=${err.message}`);
+    }
+  }
+
+  /**
+   * 清空 play_progress 表全部记录（用于"清除全部历史"场景）。
+   */
+  async clearAllPlayProgress(): Promise<void> {
+    if (this.rdbStore === null) {
+      return;
+    }
+    try {
+      await this.rdbStore.executeSql(
+        `DELETE FROM ${FileSourceDatabase.TABLE_PLAY_PROGRESS}`
+      );
+      console.info('[DB][clearAllPlayProgress] 全部已清除');
+    } catch (error) {
+      const err = error as BusinessError;
+      console.warn(`[DB][clearAllPlayProgress] 失败 code=${err.code} msg=${err.message}`);
     }
   }
 }

--- a/entry/src/main/ets/db/models/MediaEntity.ets
+++ b/entry/src/main/ets/db/models/MediaEntity.ets
@@ -185,7 +185,11 @@ export interface PlayProgressEntity {
 
 /** 媒体级播放进度实体（对应 media_progress 表） */
 export interface MediaProgressEntry {
-  /** 存储 key，格式 media_progress_series_<id> 或 media_progress_movie_<id> */
+  /** 存储 key，格式：
+   *   集级剧集：media_progress_episode_tmdb_{seriesTmdbId}_s{sn}_e{en}
+   *   电影：    media_progress_movie_{movieId}
+   *   旧剧级（向后兼容）：media_progress_series_tmdb_{seriesTmdbId}
+   */
   mediaKey: string;
   /** 上次播放位置（毫秒） */
   positionMs: number;

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -644,7 +644,7 @@ export struct MovieDetailPage {
                 Span(this.getOverviewShort())
                   .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
                 Span('更多')
-                  .fontSize(14).fontColor('#1B78F2')
+                  .fontSize(16).fontColor('#1B78F2')
                   .fontWeight(FontWeight.Medium)
                   .onClick(() => { this.showOverviewDialog = true; })
               }

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -1005,7 +1005,7 @@ export struct SeasonDetailPage {
       const episodeSeason = episode.seasonNumber ?? 0;
       const episodeNum = episode.episodeNumber ?? 0;
       // 集级 key：每集独立存储进度，避免跨集覆盖
-      const mKey = (seriesProviderId.length > 0 && episodeSeason > 0 && episodeNum > 0)
+      const mKey = (seriesProviderId.length > 0 && episodeNum > 0)
         ? MediaProgressStore.episodeKey(seriesProviderId, episodeSeason, episodeNum)
         : undefined;
       const param: PlayerPageParam = {

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -1117,15 +1117,14 @@ export struct SeasonDetailPage {
         // 简介
         if (this.getOverview().length > 0) {
           if (this.isOverviewLong()) {
-            Row({ space: 4 }) {
-              Text(this.getOverviewShort())
+            Text() {
+              Span(this.getOverviewShort())
                 .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
-              Text('更多')
-                .fontSize(14).fontColor('#1B78F2').fontWeight(FontWeight.Medium)
+              Span('更多')
+                .fontSize(16).fontColor('#1B78F2').fontWeight(FontWeight.Medium)
                 .focusable(true)
                 .onClick(() => { this.showOverviewDialog = true; })
             }
-            .alignItems(VerticalAlign.Bottom)
             .constraintSize({ maxWidth: 700 })
           } else {
             Text(this.getOverview())

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -11,6 +11,8 @@ import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient'
 import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntity'
 import { FfprobeUtil, FfprobeTrack } from '../../utils/FfprobeUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
+import { emitter } from "@kit.BasicServicesKit"
+import { PlayerEvents } from '../../components/core/player/Constants'
 
 // ─────────────────────────────────────────────
 // 工具函数
@@ -713,6 +715,15 @@ export struct SeasonDetailPage {
     this.refreshProgressState().catch(() => {
       console.warn('[SeasonDetailPage] aboutToAppear refresh failed');
     });
+    emitter.on(PlayerEvents.MEDIA_PROGRESS_SAVED, () => {
+      this.refreshProgressState().catch(() => {
+        console.warn('[SeasonDetailPage] progress refresh on event failed');
+      });
+    });
+  }
+
+  aboutToDisappear(): void {
+    emitter.off(PlayerEvents.MEDIA_PROGRESS_SAVED.eventId);
   }
 
   // ── 数据加载 ──────────────────────────────────

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -170,6 +170,8 @@ export struct SeasonDetailPage {
 
   static PAGE_NAME = 'seasonDetail'
 
+  private progressRefreshCallback: () => void = () => {};
+
   // ── 属性计算方法 ──────────────────────────────────
 
   private getSeasonNumber(): number { return this.group?.seasonNumber ?? 0; }
@@ -715,15 +717,16 @@ export struct SeasonDetailPage {
     this.refreshProgressState().catch(() => {
       console.warn('[SeasonDetailPage] aboutToAppear refresh failed');
     });
-    emitter.on(PlayerEvents.MEDIA_PROGRESS_SAVED, () => {
+    this.progressRefreshCallback = () => {
       this.refreshProgressState().catch(() => {
         console.warn('[SeasonDetailPage] progress refresh on event failed');
       });
-    });
+    };
+    emitter.on(PlayerEvents.MEDIA_PROGRESS_SAVED, this.progressRefreshCallback);
   }
 
   aboutToDisappear(): void {
-    emitter.off(PlayerEvents.MEDIA_PROGRESS_SAVED.eventId);
+    emitter.off(PlayerEvents.MEDIA_PROGRESS_SAVED.eventId, this.progressRefreshCallback);
   }
 
   // ── 数据加载 ──────────────────────────────────

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -678,9 +678,8 @@ export struct SeasonDetailPage {
       this.resumeEpisode = this.seasonEpisodes.length > 0 ? this.seasonEpisodes[0].mediaItem : undefined;
     }
 
-    // ── 跨季次级入口：读整剧最近观看指针 ────────────────────────────────
-    const seriesKey = MediaProgressStore.seriesKey(seriesProviderId);
-    const latestEntry = await MediaProgressStore.get(seriesKey);
+    // ── 跨季次级入口：读整剧最近观看指针（集级进度）────────────────────────────────
+    const latestEntry = await MediaProgressStore.getLatestForSeries(seriesProviderId);
     const currentSeason = this.getSeasonNumber();
     if (latestEntry !== null
         && latestEntry.seasonNumber !== currentSeason
@@ -1003,7 +1002,12 @@ export struct SeasonDetailPage {
 
       const episodeName = await this.resolveEpisodeName(db, episode);
       const seriesProviderId = this.seriesEntity?.providerId ?? '';
-      const mKey = seriesProviderId.length > 0 ? MediaProgressStore.seriesKey(seriesProviderId) : undefined;
+      const episodeSeason = episode.seasonNumber ?? 0;
+      const episodeNum = episode.episodeNumber ?? 0;
+      // 集级 key：每集独立存储进度，避免跨集覆盖
+      const mKey = (seriesProviderId.length > 0 && episodeSeason > 0 && episodeNum > 0)
+        ? MediaProgressStore.episodeKey(seriesProviderId, episodeSeason, episodeNum)
+        : undefined;
       const param: PlayerPageParam = {
         // getFullUrl() 已编码，传给播放页时保持原值，避免二次编码。
         url: fullUrl,
@@ -1012,8 +1016,8 @@ export struct SeasonDetailPage {
         durationHintMs: durationHintMs > 0 ? durationHintMs : undefined,
         videoId: episode.id,
         seriesProviderId,
-        seasonNumber: episode.seasonNumber ?? 0,
-        episodeNumber: episode.episodeNumber ?? 0,
+        seasonNumber: episodeSeason,
+        episodeNumber: episodeNum,
         presetAudioTracks: presetAudioTracks.length > 0 ? presetAudioTracks : undefined,
         presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined,
         mediaKey: mKey,

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -1132,16 +1132,15 @@ export struct SeriesDetailPage {
           // 简介：超100字截断显示 + 「更多」按钮（独立 Text，支持 TV 焦点）
           if (this.getOverview().length > 0) {
             if (this.isOverviewLong()) {
-              Row({ space: 4 }) {
-                Text(this.getOverviewShort())
+              Text() {
+                Span(this.getOverviewShort())
                   .fontSize(16).fontColor('#BBBBBB').lineHeight(26)
-                Text('更多')
-                  .fontSize(14).fontColor('#1B78F2')
+                Span('更多')
+                  .fontSize(16).fontColor('#1B78F2')
                   .fontWeight(FontWeight.Medium)
                   .focusable(true)
                   .onClick(() => { this.showOverviewDialog = true; })
               }
-              .alignItems(VerticalAlign.Bottom)
               .constraintSize({ maxWidth: 700 })
             } else {
               Text(this.getOverview())

--- a/entry/src/main/ets/pages/history/PlayHistoryPage.ets
+++ b/entry/src/main/ets/pages/history/PlayHistoryPage.ets
@@ -57,16 +57,32 @@ interface ActionMenuSuccessResult {
 /**
  * 解析 mediaKey 格式：
  *   media_progress_movie_<providerId>
- *   media_progress_series_tmdb_<seriesProviderId>
+ *   media_progress_episode_tmdb_<seriesTmdbId>_s<sn>_e<en>  （新集级格式）
+ *   media_progress_series_tmdb_<seriesTmdbId>              （旧剧级格式，向后兼容）
+ *
+ * 返回 providerId：
+ *   - 电影：movieProviderId（如 "tmdb_12345"）
+ *   - 剧集：seriesTmdbId（如 "1399"）
  */
 function parseMediaKey(mediaKey: string): ParsedMediaKey {
   const MOVIE_PREFIX = 'media_progress_movie_';
+  const EPISODE_TMDB_PREFIX = 'media_progress_episode_tmdb_';
   const SERIES_TMDB_PREFIX = 'media_progress_series_tmdb_';
   const SERIES_PREFIX = 'media_progress_series_';
 
   if (mediaKey.startsWith(MOVIE_PREFIX)) {
     return { kind: 'movie', providerId: mediaKey.substring(MOVIE_PREFIX.length) };
   }
+  if (mediaKey.startsWith(EPISODE_TMDB_PREFIX)) {
+    // 格式：media_progress_episode_tmdb_{seriesTmdbId}_s{sn}_e{en}
+    const rest = mediaKey.slice(EPISODE_TMDB_PREFIX.length);
+    // 从尾部找 _e{digits} 再找 _s{digits}，以提取 seriesTmdbId
+    const eIdx = rest.lastIndexOf('_e');
+    const sIdx = eIdx >= 0 ? rest.lastIndexOf('_s', eIdx) : -1;
+    const seriesProviderId = sIdx >= 0 ? rest.substring(0, sIdx) : rest;
+    return { kind: 'series', providerId: seriesProviderId };
+  }
+  // 向后兼容：旧剧级 key
   if (mediaKey.startsWith(SERIES_TMDB_PREFIX)) {
     return { kind: 'series', providerId: mediaKey.substring(SERIES_TMDB_PREFIX.length) };
   }
@@ -162,11 +178,21 @@ export struct PlayHistoryPage {
       }
 
       const items: HistoryDisplayItem[] = [];
+      // 剧集按 seriesProviderId 聚合，entries 已按 lastPlayedAt DESC 排序，第一次出现即最近播放集
+      const seriesSeenSet = new Set<string>();
       for (let i = 0; i < entries.length; i++) {
         const entry = entries[i];
         const parsed = parseMediaKey(entry.mediaKey);
         if (parsed.kind === 'unknown') {
           continue;
+        }
+
+        // 剧集去重：每个 seriesProviderId 只取最近一条
+        if (parsed.kind === 'series') {
+          if (seriesSeenSet.has(parsed.providerId)) {
+            continue;
+          }
+          seriesSeenSet.add(parsed.providerId);
         }
 
         let title: string = '';
@@ -376,7 +402,12 @@ export struct PlayHistoryPage {
 
   private async doDeleteItemAsync(item: HistoryDisplayItem): Promise<void> {
     try {
-      await FileSourceDatabase.getInstance().clearMediaProgress(item.mediaKey);
+      if (item.kind === 'series' && item.seriesProviderId.length > 0) {
+        // 按剧删除：清除该剧所有集的进度记录
+        await FileSourceDatabase.getInstance().clearAllMediaProgressBySeries(item.seriesProviderId);
+      } else {
+        await FileSourceDatabase.getInstance().clearMediaProgress(item.mediaKey);
+      }
       // DB 成功后才更新 UI，确保原子性
       this.historyList = this.historyList.filter(
         (i: HistoryDisplayItem): boolean => i.mediaKey !== item.mediaKey
@@ -421,11 +452,19 @@ export struct PlayHistoryPage {
 
   private async doClearAllAsync(): Promise<void> {
     const db = FileSourceDatabase.getInstance();
-    const keys = this.historyList.map((i: HistoryDisplayItem): string => i.mediaKey);
     let failCount = 0;
-    for (let i = 0; i < keys.length; i++) {
+    const deletedSeriesIds = new Set<string>();
+    for (let i = 0; i < this.historyList.length; i++) {
+      const item = this.historyList[i];
       try {
-        await db.clearMediaProgress(keys[i]);
+        if (item.kind === 'series' && item.seriesProviderId.length > 0) {
+          if (!deletedSeriesIds.has(item.seriesProviderId)) {
+            await db.clearAllMediaProgressBySeries(item.seriesProviderId);
+            deletedSeriesIds.add(item.seriesProviderId);
+          }
+        } else {
+          await db.clearMediaProgress(item.mediaKey);
+        }
       } catch (e) {
         failCount++;
       }
@@ -562,10 +601,10 @@ export struct PlayHistoryPage {
         }
         .width('100%')
 
-        // 副标题：剧集显示「第S季 第E集」，电影显示年份
+        // 副标题：剧集显示「第S季第E集 · X分钟」，电影显示年份
         Text(
           item.kind === 'series' && item.episodeNumber > 0
-            ? `第${item.seasonNumber}季 第${item.episodeNumber}集`
+            ? `第${item.seasonNumber}季第${item.episodeNumber}集 · ${Math.floor(item.positionMs / 60000).toString()}分钟`
             : item.releaseYear
         )
           .fontSize(12)

--- a/entry/src/main/ets/pages/history/PlayHistoryPage.ets
+++ b/entry/src/main/ets/pages/history/PlayHistoryPage.ets
@@ -378,9 +378,12 @@ export struct PlayHistoryPage {
    * 弹出 AlertDialog 确认后删除单条记录。
    */
   private confirmDeleteItem(item: HistoryDisplayItem): void {
+    const message = item.kind === 'series'
+      ? `确定删除《${item.title}》的播放记录吗？\n这将清除该剧全部集数的播放进度，此操作无法撤销。`
+      : `确定删除《${item.title}》的播放记录吗？此操作无法撤销。`;
     AlertDialog.show({
       title: '删除播放记录',
-      message: `确定删除《${item.title}》的播放记录吗？此操作无法撤销。`,
+      message,
       primaryButton: {
         value: '取消',
         action: () => {},

--- a/entry/src/main/ets/pages/history/PlayHistoryPage.ets
+++ b/entry/src/main/ets/pages/history/PlayHistoryPage.ets
@@ -488,8 +488,8 @@ export struct PlayHistoryPage {
       }
     }
     this.historyList = [];
-    emitter.emit(PlayerEvents.MEDIA_PROGRESS_SAVED);
     await FileSourceDatabase.getInstance().clearAllPlayProgress();
+    emitter.emit(PlayerEvents.MEDIA_PROGRESS_SAVED);
     if (failCount > 0) {
       promptAction.showToast({ message: `清除完成，${failCount} 条删除失败` });
     } else {

--- a/entry/src/main/ets/pages/history/PlayHistoryPage.ets
+++ b/entry/src/main/ets/pages/history/PlayHistoryPage.ets
@@ -412,9 +412,16 @@ export struct PlayHistoryPage {
         await FileSourceDatabase.getInstance().clearMediaProgress(item.mediaKey);
       }
       // DB 成功后才更新 UI，确保原子性
-      this.historyList = this.historyList.filter(
-        (i: HistoryDisplayItem): boolean => i.mediaKey !== item.mediaKey
-      );
+      if (item.kind === 'series') {
+        // 按剧删除：过滤掉该剧的全部聚合条目
+        this.historyList = this.historyList.filter(
+          (i: HistoryDisplayItem): boolean => i.seriesProviderId !== item.seriesProviderId
+        );
+      } else {
+        this.historyList = this.historyList.filter(
+          (i: HistoryDisplayItem): boolean => i.mediaKey !== item.mediaKey
+        );
+      }
       emitter.emit(PlayerEvents.MEDIA_PROGRESS_SAVED);
       promptAction.showToast({ message: '已删除播放记录' });
     } catch (e) {

--- a/entry/src/main/ets/pages/history/PlayHistoryPage.ets
+++ b/entry/src/main/ets/pages/history/PlayHistoryPage.ets
@@ -127,7 +127,7 @@ export struct PlayHistoryPage {
     this.isLoading = true;
     const db = FileSourceDatabase.getInstance();
     try {
-      const entries = await db.getAllMediaProgress();
+      const entries = await db.getAllMediaProgress(200);
       if (entries.length === 0) {
         this.historyList = [];
         return;
@@ -192,7 +192,7 @@ export struct PlayHistoryPage {
           if (seriesSeenSet.has(parsed.providerId)) {
             continue;
           }
-          seriesSeenSet.add(parsed.providerId);
+          // 不在此处 add，需等确认找到 metadata 后才标记，避免 metadata 缺失时跳过后续更完整的条目
         }
 
         let title: string = '';
@@ -245,6 +245,10 @@ export struct PlayHistoryPage {
                 filePath = matched.filePath;
               }
             }
+            // 确认找到 series metadata 后才标记已处理，未找到则跳过让后续条目尝试
+            seriesSeenSet.add(parsed.providerId);
+          } else {
+            continue;
           }
         }
 
@@ -413,6 +417,10 @@ export struct PlayHistoryPage {
       }
       // DB 成功后才更新 UI，确保原子性
       if (item.kind === 'series') {
+        // 同时清理 play_progress 表（按 series_provider_id）
+        if (item.seriesProviderId.length > 0) {
+          await FileSourceDatabase.getInstance().clearPlayProgressBySeries(item.seriesProviderId);
+        }
         // 按剧删除：过滤掉该剧的全部聚合条目
         this.historyList = this.historyList.filter(
           (i: HistoryDisplayItem): boolean => i.seriesProviderId !== item.seriesProviderId
@@ -481,6 +489,7 @@ export struct PlayHistoryPage {
     }
     this.historyList = [];
     emitter.emit(PlayerEvents.MEDIA_PROGRESS_SAVED);
+    await FileSourceDatabase.getInstance().clearAllPlayProgress();
     if (failCount > 0) {
       promptAction.showToast({ message: `清除完成，${failCount} 条删除失败` });
     } else {

--- a/entry/src/main/ets/stores/media/MediaLibraryModel.ets
+++ b/entry/src/main/ets/stores/media/MediaLibraryModel.ets
@@ -194,6 +194,8 @@ export class MediaLibraryModel {
       const seriesIdCache = new Map<string, number>();
 
       const result: ContinueWatchingItem[] = [];
+      // 剧集按 seriesProviderId 去重：entries 已按 lastPlayedAt DESC 排序，第一次出现即最近播放集
+      const seriesSeenSet = new Set<string>();
 
       for (const entry of top20) {
         const key = entry.mediaKey;
@@ -229,12 +231,77 @@ export class MediaLibraryModel {
             };
             result.push(cwi);
           }
+        } else if (key.startsWith('media_progress_episode_tmdb_')) {
+          // ── 集级剧集（新格式）──
+          // 格式：media_progress_episode_tmdb_{seriesTmdbId}_s{sn}_e{en}
+          const rest = key.slice('media_progress_episode_tmdb_'.length);
+          const eIdx = rest.lastIndexOf('_e');
+          const sIdx = eIdx >= 0 ? rest.lastIndexOf('_s', eIdx) : -1;
+          const seriesProviderId = sIdx >= 0 ? rest.substring(0, sIdx) : rest;
+          if (seriesProviderId.length === 0) {
+            continue;
+          }
+          // 每剧只展示最近一集（已按时间倒序，首次出现即最新）
+          if (seriesSeenSet.has(seriesProviderId)) {
+            continue;
+          }
+          seriesSeenSet.add(seriesProviderId);
+
+          // 解析 tvSeriesDbId（优先读缓存）
+          if (!seriesIdCache.has(seriesProviderId)) {
+            const seriesEntity: TvSeriesEntity | null =
+              await db.getTvSeriesByProviderId('tmdb', seriesProviderId);
+            if (seriesEntity !== null && seriesEntity.id !== undefined) {
+              seriesIdCache.set(seriesProviderId, seriesEntity.id);
+            } else {
+              seriesIdCache.set(seriesProviderId, -1);
+            }
+          }
+          const tvSeriesDbId: number = seriesIdCache.get(seriesProviderId) ?? -1;
+          if (tvSeriesDbId <= 0) {
+            continue;
+          }
+
+          const epKey =
+            `${tvSeriesDbId}_S${entry.seasonNumber}E${entry.episodeNumber}`;
+          const mi: MediaItem | undefined = episodeMap.get(epKey);
+          if (mi !== undefined) {
+            const ratio: number = entry.positionMs / entry.durationMs;
+            const cwi: ContinueWatchingItem = {
+              mediaKey: key,
+              title: mi.title ?? mi.fileName,
+              posterLocalPath: mi.posterLocalPath ?? '',
+              posterUrl: mi.posterUrl ?? '',
+              backdropLocalPath: mi.backdropLocalPath ?? '',
+              backdropUrl: mi.backdropUrl ?? '',
+              kind: 'series',
+              progressRatio: ratio,
+              positionFormatted: millisecondsToTime(entry.positionMs),
+              durationFormatted: millisecondsToTime(entry.durationMs),
+              lastPlayedAt: entry.lastPlayedAt,
+              seasonNumber: entry.seasonNumber,
+              episodeNumber: entry.episodeNumber,
+              episodeTitle: '',
+              videoId: mi.id,
+              tvSeriesId: tvSeriesDbId,
+              startPositionMs: entry.positionMs,
+              sourceId: mi.sourceId,
+              filePath: mi.filePath,
+              durationMs: entry.durationMs,
+              seriesProviderId: seriesProviderId
+            };
+            result.push(cwi);
+          }
         } else if (key.startsWith('media_progress_series_tmdb_')) {
-          // ── 剧集 ──
+          // ── 旧剧级格式（向后兼容）──
           const seriesProviderId = key.slice('media_progress_series_tmdb_'.length);
           if (seriesProviderId.length === 0) {
             continue;
           }
+          if (seriesSeenSet.has(seriesProviderId)) {
+            continue;
+          }
+          seriesSeenSet.add(seriesProviderId);
 
           // 解析 tvSeriesDbId（优先读缓存）
           if (!seriesIdCache.has(seriesProviderId)) {


### PR DESCRIPTION
## 关联 Issue
Closes #115

## 变更说明

### 核心架构变更
将剧集播放进度从「整剧一个 key」改为「每集独立 key」，历史页按剧聚合展示，删除时清除该剧所有集进度。

### 新 mediaKey 格式
- **电影**：`media_progress_movie_tmdb_{id}`（不变）
- **剧集（新）**：`media_progress_episode_tmdb_{seriesTmdbId}_s{seasonNum}_e{episodeNum}`
- **剧集（旧，@deprecated）**：`media_progress_series_tmdb_{id}`（保留向后兼容）

### 修改文件
| 文件 | 说明 |
|------|------|
| `db/MediaProgressStore.ets` | 新增 `episodeKey()`，旧 `seriesKey()` 标注 `@deprecated` |
| `db/files/FileSourceDatabase.ets` | 新增 `clearAllMediaProgressBySeries()` / `getLatestMediaProgressBySeries()`，含入口格式校验 |
| `db/models/MediaEntity.ets` | 注释更新说明新旧 key 格式 |
| `pages/detail/SeasonDetailPage.ets` | 改用 `episodeKey()` 写入集级进度 |
| `pages/history/PlayHistoryPage.ets` | 历史页按剧聚合 + 删除清全剧进度 + 弹窗文案补充说明 + 按剧 ID 过滤 UI |
| `stores/media/MediaLibraryModel.ets` | 续播区块支持集级 key 聚合 |

### 验收结论
- ✅ UX 验收通过（Must Fix：删除弹窗补充全剧清除说明 已修复）
- ✅ QA 编译验证：BUILD SUCCESSFUL，0 编译错误
- ✅ Medium 风险修复：DB 入口加 `seriesTmdbId` 格式校验（`/^\d+$/`）
- ✅ UI 过滤改为按剧 ID 聚合删除

### Nice to Have（后续迭代）
- `Y分钟` 加前缀消歧义（「看到第Y分钟」）
- 删除事件改用语义更准确的事件名
- 旧格式副标题兜底文案


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Episode-level progress keys for series; fetch most-recent episode progress for a series; clear all episode progress for a series.

* **Improvements**
  * Deduplicates series in Continue Watching and Play History (only most recent episode shown).
  * Deletion clears all episode progress and related play progress for a series; “clear all” optimized to avoid redundant clears.
  * Play History shows watch duration (minutes) for series items.
  * History load is bounded; pages auto-refresh progress when playback updates.

* **Documentation**
  * Updated storage key format docs to cover episode-level, movie, and legacy series keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->