### PR TITLE
新增: #103 search_history 表与搜索历史 CRUD 接口

### DIFF
--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -401,6 +401,15 @@ export class FileSourceDatabase {
           )
         `);
         console.info(`FileSourceDatabase: CREATE TABLE media_progress`);
+        // v5 → v6：同步补建 search_history 表（旧版本升级时 onCreate 不再执行）
+        await rdbStore.executeSql(
+          'CREATE TABLE IF NOT EXISTS search_history (' +
+          'id INTEGER PRIMARY KEY AUTOINCREMENT, ' +
+          'keyword TEXT NOT NULL, ' +
+          'searched_at INTEGER NOT NULL DEFAULT 0, ' +
+          'UNIQUE(keyword))'
+        );
+        console.info(`FileSourceDatabase: CREATE TABLE IF NOT EXISTS search_history`);
       }
       console.info('FileSourceDatabase: Upgrade complete');
     } catch (error) {
@@ -2669,14 +2678,17 @@ export class FileSourceDatabase {
       const conditions: string[] = [];
       const params: relationalStore.ValueType[] = [];
 
+      // ── 统一 trim keyword，避免含前后空格时无法正确匹配 ──
+      const kw: string = keyword.trim();
+
       // ── keyword 非空时：title / original_title 四字段模糊匹配 ──
-      if (keyword.trim().length > 0) {
-        const kw: string = `%${keyword}%`;
+      if (kw.length > 0) {
+        const kwLike: string = `%${kw}%`;
         conditions.push('(m.title LIKE ? OR m.original_title LIKE ? OR ts.title LIKE ? OR ts.original_title LIKE ?)');
-        params.push(kw);
-        params.push(kw);
-        params.push(kw);
-        params.push(kw);
+        params.push(kwLike);
+        params.push(kwLike);
+        params.push(kwLike);
+        params.push(kwLike);
       }
 
       // ── mediaType 过滤（'all' 时不加条件） ──
@@ -2686,9 +2698,9 @@ export class FileSourceDatabase {
         params.push(mediaType);
       }
 
-      // ── genre 过滤：genres_json 模糊匹配 ──
+      // ── genre 过滤：genres_json 模糊匹配（加表别名避免多表 JOIN 时列名歧义） ──
       if (options?.genre !== undefined && options.genre.length > 0) {
-        conditions.push('genres_json LIKE ?');
+        conditions.push('m.genres_json LIKE ?');
         params.push(`%${options.genre}%`);
       }
 
@@ -2718,9 +2730,10 @@ export class FileSourceDatabase {
         orderClause = ' ORDER BY COALESCE(m.rating, ts.rating) DESC';
       }
 
-      // ── LIMIT（limit 是 number 类型，直接插值安全，不受注入风险） ──
-      const limit: number = options?.limit ?? 50;
-      const limitClause: string = ` LIMIT ${limit}`;
+      // ── LIMIT 范围校验，防止 NaN/负数/超大值 ──
+      const rawLimit: number = options?.limit ?? 50;
+      const safeLimit: number = (Number.isInteger(rawLimit) && rawLimit > 0) ? Math.min(rawLimit, 200) : 50;
+      const limitClause: string = ` LIMIT ${safeLimit}`;
 
       const sql: string = this.mediaItemSql + whereClause + orderClause + limitClause;
       rs = await this.rdbStore.querySql(sql, params);
@@ -2728,7 +2741,7 @@ export class FileSourceDatabase {
       while (rs.goToNextRow()) {
         items.push(this.parseMediaItem(rs));
       }
-      console.info(`[DB][searchMediaItems] keyword="${keyword}" type=${mediaType} count=${items.length}`);
+      console.info(`[DB][searchMediaItems] keyword=[${kw.length}chars] type=${mediaType} count=${items.length}`);
       return items;
     } catch (e) {
       const err = e as BusinessError;
@@ -2799,7 +2812,12 @@ export class FileSourceDatabase {
         ` ON CONFLICT(keyword) DO UPDATE SET searched_at = excluded.searched_at`,
         [keyword, now]
       );
-      console.info(`[DB][upsertSearchHistory] keyword="${keyword}"`);
+      // 裁剪：只保留最近 15 条，防止表无限增长
+      await this.rdbStore.executeSql(
+        'DELETE FROM search_history WHERE id NOT IN ' +
+        '(SELECT id FROM search_history ORDER BY searched_at DESC LIMIT 15)'
+      );
+      console.info(`[DB][upsertSearchHistory] keyword=[${keyword.length}chars]`);
     } catch (e) {
       const err = e as BusinessError;
       console.warn(`[DB][upsertSearchHistory] 失败 code=${err.code} msg=${err.message}`);
@@ -2814,11 +2832,13 @@ export class FileSourceDatabase {
     if (this.rdbStore === null) {
       return [];
     }
+    // 入口校验：防止 NaN / 负数 / 超出合理范围的值
+    const safeLimit: number = (Number.isInteger(limit) && limit > 0 && limit <= 50) ? limit : 20;
     let rs: relationalStore.ResultSet | null = null;
     try {
       rs = await this.rdbStore.querySql(
         `SELECT keyword, searched_at FROM ${FileSourceDatabase.TABLE_SEARCH_HISTORY}` +
-        ` ORDER BY searched_at DESC LIMIT ${limit}`
+        ` ORDER BY searched_at DESC LIMIT ${safeLimit}`
       );
       const result: SearchHistoryEntry[] = [];
       while (rs.goToNextRow()) {
@@ -2851,7 +2871,7 @@ export class FileSourceDatabase {
         `DELETE FROM ${FileSourceDatabase.TABLE_SEARCH_HISTORY} WHERE keyword = ?`,
         [keyword]
       );
-      console.info(`[DB][deleteSearchHistory] keyword="${keyword}" 已删除`);
+      console.info(`[DB][deleteSearchHistory] keyword=[${keyword.length}chars] 已删除`);
     } catch (e) {
       const err = e as BusinessError;
       console.warn(`[DB][deleteSearchHistory] 失败 code=${err.code} msg=${err.message}`);

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -3,7 +3,8 @@ import { Context } from '@ohos.abilityAccessCtrl';
 import { FileSource, FileSourceDirectory, FileSourceType } from '../models/FileSourceEntity';
 import {
   VideoEntity, ScrapeInfoEntity, MovieEntity, TvSeriesEntity, TvSeasonEntity, TvEpisodeEntity,
-  MediaItem, MediaStats, SeriesGroup, DecadeGroup, MediaListItem, PlayProgressEntity, MediaProgressEntry
+  MediaItem, MediaStats, SeriesGroup, DecadeGroup, MediaListItem, PlayProgressEntity, MediaProgressEntry,
+  SearchHistoryEntry
 } from '../models/MediaEntity';
 import { CryptoUtil } from '../../utils/CryptoUtil';
 import { BusinessError, emitter } from "@kit.BasicServicesKit";
@@ -42,6 +43,7 @@ export class FileSourceDatabase {
   private static readonly TABLE_TV_EPISODES = 'tv_episodes';
   private static readonly TABLE_PLAY_PROGRESS = 'play_progress';
   private static readonly TABLE_MEDIA_PROGRESS = 'media_progress';
+  private static readonly TABLE_SEARCH_HISTORY = 'search_history';
   private static readonly DATABASE_READY = 'FILE_SOURCES_DB_READY'
 
   // 单例实例
@@ -153,6 +155,15 @@ export class FileSourceDatabase {
         )
       `);
       await this.createMediaTablesV3(rdbStore);
+      // search_history：持久化搜索关键词，keyword 唯一
+      await rdbStore.executeSql(`
+        CREATE TABLE IF NOT EXISTS ${FileSourceDatabase.TABLE_SEARCH_HISTORY} (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          keyword TEXT NOT NULL,
+          searched_at INTEGER NOT NULL,
+          UNIQUE(keyword)
+        )
+      `);
       console.info('FileSourceDatabase: Tables created (v3)');
     } catch (error) {
       console.error('FileSourceDatabase: Failed to create tables', JSON.stringify(error));
@@ -2765,6 +2776,103 @@ export class FileSourceDatabase {
       return [];
     } finally {
       rs?.close();
+    }
+  }
+
+  // ─────────────────────────────────────────────
+  // 搜索历史 CRUD
+  // ─────────────────────────────────────────────
+
+  /**
+   * 新增或更新搜索历史（upsert by keyword）。
+   * 相同关键词重复搜索时，更新 searched_at 为当前时间。
+   */
+  async upsertSearchHistory(keyword: string): Promise<void> {
+    if (this.rdbStore === null) {
+      return;
+    }
+    const now = Date.now();
+    try {
+      // 标准 SQLite upsert：ON CONFLICT(keyword) DO UPDATE
+      await this.rdbStore.executeSql(
+        `INSERT INTO ${FileSourceDatabase.TABLE_SEARCH_HISTORY} (keyword, searched_at) VALUES (?, ?)` +
+        ` ON CONFLICT(keyword) DO UPDATE SET searched_at = excluded.searched_at`,
+        [keyword, now]
+      );
+      console.info(`[DB][upsertSearchHistory] keyword="${keyword}"`);
+    } catch (e) {
+      const err = e as BusinessError;
+      console.warn(`[DB][upsertSearchHistory] 失败 code=${err.code} msg=${err.message}`);
+    }
+  }
+
+  /**
+   * 获取搜索历史列表，按 searched_at 倒序排列。
+   * @param limit 最大返回条数，默认 20
+   */
+  async getSearchHistory(limit: number = 20): Promise<SearchHistoryEntry[]> {
+    if (this.rdbStore === null) {
+      return [];
+    }
+    let rs: relationalStore.ResultSet | null = null;
+    try {
+      rs = await this.rdbStore.querySql(
+        `SELECT keyword, searched_at FROM ${FileSourceDatabase.TABLE_SEARCH_HISTORY}` +
+        ` ORDER BY searched_at DESC LIMIT ${limit}`
+      );
+      const result: SearchHistoryEntry[] = [];
+      while (rs.goToNextRow()) {
+        const entry = new SearchHistoryEntry();
+        entry.keyword = rs.getString(rs.getColumnIndex('keyword'));
+        entry.searchedAt = rs.getLong(rs.getColumnIndex('searched_at'));
+        result.push(entry);
+      }
+      console.info(`[DB][getSearchHistory] 共 ${result.length} 条记录`);
+      return result;
+    } catch (e) {
+      const err = e as BusinessError;
+      console.warn(`[DB][getSearchHistory] 查询失败 code=${err.code} msg=${err.message}`);
+      return [];
+    } finally {
+      rs?.close();
+    }
+  }
+
+  /**
+   * 删除单条搜索历史。
+   * @param keyword 要删除的关键词
+   */
+  async deleteSearchHistory(keyword: string): Promise<void> {
+    if (this.rdbStore === null) {
+      return;
+    }
+    try {
+      await this.rdbStore.executeSql(
+        `DELETE FROM ${FileSourceDatabase.TABLE_SEARCH_HISTORY} WHERE keyword = ?`,
+        [keyword]
+      );
+      console.info(`[DB][deleteSearchHistory] keyword="${keyword}" 已删除`);
+    } catch (e) {
+      const err = e as BusinessError;
+      console.warn(`[DB][deleteSearchHistory] 失败 code=${err.code} msg=${err.message}`);
+    }
+  }
+
+  /**
+   * 清空全部搜索历史。
+   */
+  async clearSearchHistory(): Promise<void> {
+    if (this.rdbStore === null) {
+      return;
+    }
+    try {
+      await this.rdbStore.executeSql(
+        `DELETE FROM ${FileSourceDatabase.TABLE_SEARCH_HISTORY}`
+      );
+      console.info('[DB][clearSearchHistory] 全部搜索历史已清空');
+    } catch (e) {
+      const err = e as BusinessError;
+      console.warn(`[DB][clearSearchHistory] 失败 code=${err.code} msg=${err.message}`);
     }
   }
 }

--- a/entry/src/main/ets/db/models/MediaEntity.ets
+++ b/entry/src/main/ets/db/models/MediaEntity.ets
@@ -334,3 +334,13 @@ export interface DecadeGroup {
   count: number;
 }
 
+// ─────────────────────────────────────────────
+// 搜索历史
+// ─────────────────────────────────────────────
+
+/** 搜索历史条目（对应 search_history 表） */
+export class SearchHistoryEntry {
+  keyword: string = '';
+  searchedAt: number = 0;
+}
+


### PR DESCRIPTION
## 变更说明

### 新增功能
- `SearchHistoryEntry` 类（MediaEntity.ets）：keyword + searchedAt 字段
- `search_history` 建表（onCreate，含 UNIQUE(keyword)，不改 DB_VERSION）
- `upsertSearchHistory(keyword)`：INSERT … ON CONFLICT DO UPDATE，精准更新 searched_at
- `getSearchHistory(limit=20)`：倒序查询，最近搜索优先
- `deleteSearchHistory(keyword)`：参数化单条删除
- `clearSearchHistory()`：清空全表

### 技术规范
- 所有 SQL 全参数化
- catch 不加类型注解（ArkTS 规范）
- 编译 BUILD SUCCESSFUL 验证通过

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added search history functionality to track and manage your recent searches with timestamps
- Ability to view previous searches and delete individual entries or clear entire search history as needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->