### PR TITLE
新增: 首页顶栏搜索入口，Epic #106 搜索闭环集成 (#105)

### DIFF
--- a/.github/agents/se-technical-writer.agent.md
+++ b/.github/agents/se-technical-writer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 'SE: 技术写作'
 description: '面向开发者文档、技术博客、教程与教学内容创作的技术写作专家'
-model: GPT-5
+model: GPT-5.4
 tools: ['codebase', 'edit/editFiles', 'search', 'web/fetch']
 ---
 

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -17,8 +17,10 @@ export interface SearchMediaOptions {
   genre?: string;
   /** 最低评分（含），对应 COALESCE(m.rating, ts.rating) */
   minRating?: number;
-  /** 年份（4位整数），对应 release_date/first_air_date 前4位 */
-  year?: number;
+  /** 年份起始（含），用于十年段筛选，例如 2020 表示 2020s 的起点 */
+  yearFrom?: number;
+  /** 年份截止（含），用于十年段筛选，例如 2029 表示 2020s 的终点 */
+  yearTo?: number;
   /** 排序方式：rating（默认）| year | title */
   sortBy?: 'rating' | 'year' | 'title';
   /** 最大返回条数，默认 50 */
@@ -2710,10 +2712,14 @@ export class FileSourceDatabase {
         params.push(options.minRating);
       }
 
-      // ── year 过滤：取日期字段前4位字符进行字符串比较 ──
-      if (options?.year !== undefined) {
-        conditions.push("substr(COALESCE(m.release_date, ts.first_air_date), 1, 4) = ?");
-        params.push(String(options.year));
+      // ── yearFrom / yearTo 过滤：十年段区间匹配 ──
+      if (options?.yearFrom !== undefined) {
+        conditions.push("CAST(substr(COALESCE(m.release_date, ts.first_air_date), 1, 4) AS INTEGER) >= ?");
+        params.push(options.yearFrom);
+      }
+      if (options?.yearTo !== undefined) {
+        conditions.push("CAST(substr(COALESCE(m.release_date, ts.first_air_date), 1, 4) AS INTEGER) <= ?");
+        params.push(options.yearTo);
       }
 
       const whereClause: string = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -2738,16 +2738,38 @@ export class FileSourceDatabase {
 
       // ── LIMIT 范围校验，防止 NaN/负数/超大值 ──
       const rawLimit: number = options?.limit ?? 50;
-      const safeLimit: number = (Number.isInteger(rawLimit) && rawLimit > 0) ? Math.min(rawLimit, 200) : 50;
-      const limitClause: string = ` LIMIT ${safeLimit}`;
+      const safeLimit: number = (Number.isInteger(rawLimit) && rawLimit > 0) ? Math.min(rawLimit, 500) : 50;
+      // SQL 层多拉一批，内存去重后再裁剪到 safeLimit
+      const fetchLimit: number = Math.min(safeLimit * 10, 2000);
+      const limitClause: string = ` LIMIT ${fetchLimit}`;
 
       const sql: string = this.mediaItemSql + whereClause + orderClause + limitClause;
       rs = await this.rdbStore.querySql(sql, params);
-      const items: MediaItem[] = [];
+      const rawItems: MediaItem[] = [];
       while (rs.goToNextRow()) {
-        items.push(this.parseMediaItem(rs));
+        rawItems.push(this.parseMediaItem(rs));
       }
-      console.info(`[DB][searchMediaItems] keyword=[${kw.length}chars] type=${mediaType} count=${items.length}`);
+
+      // 按 tvSeriesId / movieId 去重，避免同一部剧多集重复展示
+      const seen = new Set<string>();
+      const items: MediaItem[] = [];
+      for (const item of rawItems) {
+        let key: string;
+        if (item.tvSeriesId !== undefined) {
+          key = `tv-${item.tvSeriesId}`;
+        } else if (item.movieId !== undefined) {
+          key = `mv-${item.movieId}`;
+        } else {
+          key = `vid-${item.id}`;
+        }
+        if (!seen.has(key)) {
+          seen.add(key);
+          items.push(item);
+          if (items.length >= safeLimit) { break; }
+        }
+      }
+
+      console.info(`[DB][searchMediaItems] keyword=[${kw.length}chars] type=${mediaType} raw=${rawItems.length} deduped=${items.length}`);
       return items;
     } catch (e) {
       const err = e as BusinessError;

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -9,6 +9,8 @@ import { SeasonDetailPage } from './detail/SeasonDetailPage';
 import { MovieDetailPage } from './detail/MovieDetailPage';
 import { CastDetailPage } from './detail/CastDetailPage';
 import { PlayHistoryPage } from './history/PlayHistoryPage';
+import { SearchWorkspacePage } from './search';
+import { MediaResultPage } from './search';
 @Entry
 @ComponentV2
 struct Index {
@@ -35,6 +37,10 @@ struct Index {
       CastDetailPage();
     } else if (name === PlayHistoryPage.PAGE_NAME) {
       PlayHistoryPage();
+    } else if (name === SearchWorkspacePage.PAGE_NAME) {
+      SearchWorkspacePage();
+    } else if (name === MediaResultPage.PAGE_NAME) {
+      MediaResultPage();
     }
   }
 

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -17,6 +17,7 @@ import { WebDAVClient, WebDAVConfig } from "../../../lib/WebDAVClient"
 import { PlayHistoryPage } from "../../history/PlayHistoryPage"
 import { emitter } from "@kit.BasicServicesKit"
 import { PlayerEvents } from "../../../components/core/player/Constants"
+import { MediaResultPage, MediaResultPageParam } from "../../search/MediaResultPage"
 
 // ─────────────────────────────────────────────
 // 常量
@@ -334,6 +335,7 @@ struct SeriesCard {
 @ComponentV2
 struct RatingLabelCard {
   @Require @Param ratingLabel: RatingLabel
+  @Event onPress: () => void = () => {}
 
   private getLabelColor(): string {
     if (this.ratingLabel.minRating >= 9) { return '#FFD700'; }
@@ -357,6 +359,7 @@ struct RatingLabelCard {
       }
     }
     .width(RATING_CARD_W).height(RATING_CARD_H)
+    .onClick(() => { this.onPress(); })
   }
 }
 
@@ -366,6 +369,7 @@ struct RatingLabelCard {
 @ComponentV2
 struct DecadeCard {
   @Require @Param decade: DecadeGroup
+  @Event onPress: () => void = () => {}
 
   private isCurrentYear(): boolean { return this.decade.label === '今年'; }
 
@@ -388,6 +392,7 @@ struct DecadeCard {
       }
     }
     .width(DECADE_CARD_W).height(DECADE_CARD_H)
+    .onClick(() => { this.onPress(); })
   }
 }
 
@@ -398,6 +403,7 @@ struct DecadeCard {
 struct GenreCard {
   @Require @Param genre: string
   @Require @Param count: number
+  @Event onPress: () => void = () => {}
 
   build() {
     Stack({ alignContent: Alignment.Center }) {
@@ -413,6 +419,7 @@ struct GenreCard {
     }
     .width(WIDE_WIDTH)
     .aspectRatio(LANDSCAPE_ASPECT_RATIO)
+    .onClick(() => { this.onPress(); })
   }
 }
 
@@ -1058,7 +1065,10 @@ export struct MediaLibraryTab {
     if (this.getGenreKeys().length > 0) {
       SectionRow({ title: '类别' }) {
         ForEach(this.getGenreKeys(), (genre: string) => {
-          GenreCard({ genre, count: this.getGenreCount(genre) })
+          GenreCard({ genre, count: this.getGenreCount(genre), onPress: () => {
+            const param: MediaResultPageParam = { pageTitle: genre, genre };
+            this.pageStack.pushPathByName(MediaResultPage.PAGE_NAME, param);
+          }})
         })
       }
     }
@@ -1069,7 +1079,10 @@ export struct MediaLibraryTab {
     if (this.model.ratingLabels.length > 0) {
       SectionRow({ title: '高分推荐' }) {
         ForEach(this.model.ratingLabels, (rl: RatingLabel) => {
-          RatingLabelCard({ ratingLabel: rl })
+          RatingLabelCard({ ratingLabel: rl, onPress: () => {
+            const param: MediaResultPageParam = { pageTitle: rl.label, minRating: rl.minRating };
+            this.pageStack.pushPathByName(MediaResultPage.PAGE_NAME, param);
+          }})
         })
       }
     }
@@ -1080,7 +1093,13 @@ export struct MediaLibraryTab {
     if (this.model.decadeGroups.length > 0) {
       SectionRow({ title: '上映年代' }) {
         ForEach(this.model.decadeGroups, (decade: DecadeGroup) => {
-          DecadeCard({ decade })
+          DecadeCard({ decade, onPress: () => {
+            const decadeYear = decade.label === '今年'
+              ? new Date().getFullYear().toString()
+              : decade.label.replace('s', '');
+            const param: MediaResultPageParam = { pageTitle: decade.label, decadeYear };
+            this.pageStack.pushPathByName(MediaResultPage.PAGE_NAME, param);
+          }})
         })
       }
     }

--- a/entry/src/main/ets/pages/home/topbar/index.ets
+++ b/entry/src/main/ets/pages/home/topbar/index.ets
@@ -4,6 +4,7 @@ import { LucideCloudDownload } from "lucide"
 import { BasicClock } from "../../../components/common/BasicClock"
 import { SettingsPage, SettingsPageParam } from "../../settings/Index"
 import SettingType from "../../settings/SettingType"
+import { SearchWorkspacePage } from "../../search"
 
 @ComponentV2
 export struct HomeTopBar {
@@ -68,7 +69,10 @@ export struct HomeTopBar {
         IBestButton({
           buttonSize: "small",
           btnBorderColor: Color.Transparent,
-          iconBuilder: (): void => this.settingIBestIconBuilder('search')
+          iconBuilder: (): void => this.settingIBestIconBuilder('search'),
+          onBtnClick: () => {
+            this.pageStack.pushPathByName(SearchWorkspacePage.PAGE_NAME, null)
+          }
         }).bindTips('搜索')
 
         IBestButton({

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -12,6 +12,8 @@ export interface MediaResultPageParam {
   mediaType?: string;
   genre?: string;
   pageTitle?: string;
+  minRating?: number;
+  decadeYear?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -582,6 +584,12 @@ export struct MediaResultPage {
         this.keyword = param.keyword ?? '';
         this.filterMediaType = param.mediaType ?? '';
         this.filterGenre = param.genre ?? '';
+        if (param.minRating !== undefined && param.minRating > 0) {
+          this.filterRating = param.minRating;
+        }
+        if (param.decadeYear !== undefined && param.decadeYear.length > 0) {
+          this.filterYear = param.decadeYear;
+        }
       }
       this.doSearch().catch((): void => {});
     })

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -1,0 +1,846 @@
+import { FileSourceDatabase, SearchMediaOptions } from '../../db/files/FileSourceDatabase';
+import { MediaItem, SeriesGroup } from '../../db/models/MediaEntity';
+import { MovieDetailPage } from '../detail/MovieDetailPage';
+import { SeriesDetailPage } from '../detail/SeriesDetailPage';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 页面参数接口（供外部路由传参）
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MediaResultPageParam {
+  keyword?: string;
+  mediaType?: string;
+  genre?: string;
+  pageTitle?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 筛选选项类型（避免 Map<K, 内联接口> 的 ArkTS 告警）
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface StringOption {
+  label: string;
+  value: string;
+}
+
+interface NumberOption {
+  label: string;
+  value: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 筛选选项常量
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MEDIA_TYPE_OPTIONS: StringOption[] = [
+  { label: '全部', value: '' },
+  { label: '电影', value: 'movie' },
+  { label: '剧集', value: 'tv' },
+];
+
+const RATING_OPTIONS: NumberOption[] = [
+  { label: '全部', value: 0 },
+  { label: '8分+', value: 8 },
+  { label: '6分+', value: 6 },
+];
+
+const YEAR_OPTIONS: StringOption[] = [
+  { label: '全部', value: '' },
+  { label: '2020s', value: '2020' },
+  { label: '2010s', value: '2010' },
+  { label: '2000s', value: '2000' },
+  { label: '1990s', value: '1990' },
+];
+
+const SORT_OPTIONS: StringOption[] = [
+  { label: '默认', value: 'title' },
+  { label: '评分最高', value: 'rating' },
+  { label: '最新上映', value: 'year' },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 模块级辅助函数（避免在 build() 内定义变量或复杂逻辑）
+// ─────────────────────────────────────────────────────────────────────────────
+
+function itemTitle(item: MediaItem): string {
+  return item.title ?? item.fileName ?? '';
+}
+
+function itemHasPoster(item: MediaItem): boolean {
+  return (item.posterLocalPath !== undefined && item.posterLocalPath.length > 0) ||
+    (item.posterUrl !== undefined && item.posterUrl.length > 0);
+}
+
+function itemPosterSrc(item: MediaItem): string {
+  if (item.posterLocalPath && item.posterLocalPath.length > 0) {
+    return item.posterLocalPath;
+  }
+  return item.posterUrl ?? '';
+}
+
+function itemRatingText(r: number | undefined): string {
+  if (r === undefined || r <= 0) {
+    return '';
+  }
+  return r.toFixed(1);
+}
+
+function itemRatingColor(r: number | undefined): string {
+  if (r === undefined || r <= 0) {
+    return '#8F96A3';
+  }
+  if (r >= 8.0) {
+    return '#F7C06C';
+  }
+  if (r >= 6.0) {
+    return '#D0A26B';
+  }
+  return '#E6786C';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 海报卡片（局部组件，不导出）
+// ─────────────────────────────────────────────────────────────────────────────
+
+@ComponentV2
+struct ResultPosterCard {
+  @Require @Param item: MediaItem;
+  @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
+  @Local isFocused: boolean = false;
+
+  private navigateToDetail(): void {
+    if (this.item.mediaType === 'tv') {
+      const group: SeriesGroup = {
+        title: itemTitle(this.item),
+        tvSeriesId: this.item.tvSeriesId,
+        posterUrl: this.item.posterUrl,
+        posterLocalPath: this.item.posterLocalPath,
+        backdropUrl: this.item.backdropUrl,
+        rating: this.item.rating,
+        episodeCount: 0,
+        episodes: [this.item],
+        latestScannedAt: this.item.scannedAt,
+      };
+      this.pageStack.pushPathByName(SeriesDetailPage.PAGE_NAME, group);
+    } else {
+      this.pageStack.pushPathByName(MovieDetailPage.PAGE_NAME, this.item);
+    }
+  }
+
+  build() {
+    Column({ space: 8 }) {
+      Stack() {
+        if (itemHasPoster(this.item)) {
+          Image(itemPosterSrc(this.item))
+            .width(180)
+            .height(270)
+            .objectFit(ImageFit.Cover)
+        } else {
+          Column() {
+            Text(itemTitle(this.item))
+              .fontSize(13)
+              .fontColor('#CCCCCC')
+              .textAlign(TextAlign.Center)
+              .maxLines(3)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+              .padding(8)
+          }
+          .width(180)
+          .height(270)
+          .backgroundColor('#2A2A2A')
+          .justifyContent(FlexAlign.Center)
+        }
+      }
+      .width(180)
+      .height(270)
+      .clip(true)
+      .border({ width: this.isFocused ? 2 : 0, color: '#66A9D8FF' })
+      .shadow({
+        radius: this.isFocused ? 14 : 4,
+        color: this.isFocused ? '#553A86FF' : '#33000000',
+        offsetX: 0,
+        offsetY: this.isFocused ? 0 : 2,
+      })
+      .scale({ x: this.isFocused ? 1.03 : 1.0, y: this.isFocused ? 1.03 : 1.0 })
+      .animation({ duration: 150, curve: Curve.EaseOut })
+
+      Text(itemTitle(this.item))
+        .fontSize(22)
+        .fontColor('#E3E7ED')
+        .fontWeight(FontWeight.Normal)
+        .maxLines(2)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
+        .width(180)
+
+      if (itemRatingText(this.item.rating).length > 0) {
+        Text(itemRatingText(this.item.rating))
+          .fontSize(20)
+          .fontColor(itemRatingColor(this.item.rating))
+          .fontWeight(FontWeight.Medium)
+      }
+    }
+    .width(180)
+    .alignItems(HorizontalAlign.Start)
+    .focusable(true)
+    .onFocus(() => {
+      this.isFocused = true;
+    })
+    .onBlur(() => {
+      this.isFocused = false;
+    })
+    .onClick(() => {
+      this.navigateToDetail();
+    })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 主页面
+// ─────────────────────────────────────────────────────────────────────────────
+
+@ComponentV2
+export struct MediaResultPage {
+  static readonly PAGE_NAME: string = 'MediaResultPage';
+
+  @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
+
+  // ── 页面状态 ──────────────────────────────────────────────────────────────
+  @Local pageTitle: string = '搜索结果';
+  @Local keyword: string = '';
+
+  // ── 筛选状态 ──────────────────────────────────────────────────────────────
+  @Local filterMediaType: string = '';
+  @Local filterGenre: string = '';
+  @Local filterRating: number = 0;
+  @Local filterYear: string = '';
+  @Local filterSort: string = 'title';
+
+  // ── 数据状态 ──────────────────────────────────────────────────────────────
+  @Local results: MediaItem[] = [];
+  @Local genres: string[] = [];
+  @Local isLoading: boolean = false;
+  @Local totalCount: number = 0;
+
+  // ── Chip 焦点状态（-1=无，0-4=对应Chip）────────────────────────────────
+  @Local focusedChip: number = -1;
+
+  // ── Dropdown 开关（''=关，'mediaType'|'genre'|'rating'|'year'|'sort'=开）
+  @Local activeDropdown: string = '';
+
+  private db: FileSourceDatabase = FileSourceDatabase.getInstance();
+
+  // ── 数据加载 ──────────────────────────────────────────────────────────────
+
+  private async loadGenres(): Promise<void> {
+    try {
+      const rawList: string[] = await this.db.getDistinctGenres();
+      this.genres = this.parseGenres(rawList);
+    } catch {
+      this.genres = [];
+    }
+  }
+
+  /** 将 getDistinctGenres() 返回的 JSON 字符串数组拍平去重 */
+  private parseGenres(rawList: string[]): string[] {
+    const seen: string[] = [];
+    for (const raw of rawList) {
+      try {
+        const arr = JSON.parse(raw) as string[];
+        for (const g of arr) {
+          if (typeof g === 'string' && g.length > 0 && !seen.includes(g)) {
+            seen.push(g);
+          }
+        }
+      } catch {
+        // 跳过格式异常的记录
+      }
+    }
+    seen.sort();
+    return seen;
+  }
+
+  private async doSearch(): Promise<void> {
+    this.isLoading = true;
+    this.results = [];
+    try {
+      // 媒体类型映射
+      let mediaTypeParam: 'movie' | 'tv' | 'all' | undefined = undefined;
+      if (this.filterMediaType === 'movie') {
+        mediaTypeParam = 'movie';
+      } else if (this.filterMediaType === 'tv') {
+        mediaTypeParam = 'tv';
+      }
+
+      // 排序方式映射
+      let sortByParam: 'rating' | 'year' | 'title' = 'title';
+      if (this.filterSort === 'rating') {
+        sortByParam = 'rating';
+      } else if (this.filterSort === 'year') {
+        sortByParam = 'year';
+      }
+
+      // 年代字符串转数字
+      const yearNum: number | undefined = this.filterYear.length > 0
+        ? parseInt(this.filterYear, 10)
+        : undefined;
+
+      const options: SearchMediaOptions = {
+        mediaType: mediaTypeParam,
+        genre: this.filterGenre.length > 0 ? this.filterGenre : undefined,
+        minRating: this.filterRating > 0 ? this.filterRating : undefined,
+        year: yearNum,
+        sortBy: sortByParam,
+        limit: 200,
+      };
+
+      const items: MediaItem[] = await this.db.searchMediaItems(this.keyword, options);
+      this.results = items;
+      this.totalCount = items.length;
+    } catch {
+      this.results = [];
+      this.totalCount = 0;
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  private resetFilters(): void {
+    this.filterMediaType = '';
+    this.filterGenre = '';
+    this.filterRating = 0;
+    this.filterYear = '';
+    this.filterSort = 'title';
+    this.activeDropdown = '';
+    this.doSearch().catch((): void => {});
+  }
+
+  // ── 辅助：Chip 显示文案 ──────────────────────────────────────────────────
+
+  private getMediaTypeLabel(): string {
+    const opt = MEDIA_TYPE_OPTIONS.find((o: StringOption) => o.value === this.filterMediaType);
+    return (opt !== undefined && opt.value !== '') ? `${opt.label}▾` : '媒体类型▾';
+  }
+
+  private getGenreLabel(): string {
+    return this.filterGenre.length > 0 ? `${this.filterGenre}▾` : '类别▾';
+  }
+
+  private getRatingLabel(): string {
+    const opt = RATING_OPTIONS.find((o: NumberOption) => o.value === this.filterRating);
+    return (opt !== undefined && opt.value > 0) ? `${opt.label}▾` : '评分▾';
+  }
+
+  private getYearLabel(): string {
+    const opt = YEAR_OPTIONS.find((o: StringOption) => o.value === this.filterYear);
+    return (opt !== undefined && opt.value !== '') ? `${opt.label}▾` : '年代▾';
+  }
+
+  private getSortLabel(): string {
+    const opt = SORT_OPTIONS.find((o: StringOption) => o.value === this.filterSort);
+    return (opt !== undefined && opt.value !== 'title') ? `${opt.label}▾` : '排序▾';
+  }
+
+  // ── 辅助：Chip 样式计算 ──────────────────────────────────────────────────
+
+  private isChipSelected(key: string): boolean {
+    if (key === 'mediaType') {
+      return this.filterMediaType !== '';
+    }
+    if (key === 'genre') {
+      return this.filterGenre !== '';
+    }
+    if (key === 'rating') {
+      return this.filterRating > 0;
+    }
+    if (key === 'year') {
+      return this.filterYear !== '';
+    }
+    if (key === 'sort') {
+      return this.filterSort !== 'title';
+    }
+    return false;
+  }
+
+  private chipBg(key: string): string {
+    return this.isChipSelected(key) ? '#1D4ED860' : '#33415550';
+  }
+
+  private chipText(key: string): string {
+    return this.isChipSelected(key) ? '#BFDBFE' : '#CBD5E1';
+  }
+
+  private chipBorderColor(key: string, idx: number): string {
+    if (this.focusedChip === idx) {
+      return '#66A9D8FF';
+    }
+    return this.isChipSelected(key) ? '#93C5FD99' : '#CBD5E166';
+  }
+
+  private chipBorderWidth(idx: number): number {
+    return this.focusedChip === idx ? 2 : 1;
+  }
+
+  private chipShadowRadius(idx: number): number {
+    return this.focusedChip === idx ? 14 : 0;
+  }
+
+  // ── @Builder：下拉菜单内容 ────────────────────────────────────────────────
+
+  @Builder
+  buildMediaTypeMenu() {
+    Column() {
+      ForEach(MEDIA_TYPE_OPTIONS, (opt: StringOption) => {
+        Text(opt.label)
+          .fontSize(14)
+          .fontColor(this.filterMediaType === opt.value ? '#BFDBFE' : '#CBD5E1')
+          .backgroundColor(this.filterMediaType === opt.value ? '#1D4ED860' : Color.Transparent)
+          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
+          .width('100%')
+          .focusable(true)
+          .onClick(() => {
+            this.filterMediaType = opt.value;
+            this.activeDropdown = '';
+            this.doSearch().catch((): void => {});
+          })
+      }, (opt: StringOption) => opt.value)
+    }
+    .backgroundColor('#2A2E3A')
+    .borderRadius(8)
+    .width(160)
+  }
+
+  @Builder
+  buildGenreMenu() {
+    Scroll() {
+      Column() {
+        Text('全部')
+          .fontSize(14)
+          .fontColor(this.filterGenre === '' ? '#BFDBFE' : '#CBD5E1')
+          .backgroundColor(this.filterGenre === '' ? '#1D4ED860' : Color.Transparent)
+          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
+          .width('100%')
+          .focusable(true)
+          .onClick(() => {
+            this.filterGenre = '';
+            this.activeDropdown = '';
+            this.doSearch().catch((): void => {});
+          })
+        ForEach(this.genres, (g: string) => {
+          Text(g)
+            .fontSize(14)
+            .fontColor(this.filterGenre === g ? '#BFDBFE' : '#CBD5E1')
+            .backgroundColor(this.filterGenre === g ? '#1D4ED860' : Color.Transparent)
+            .padding({ top: 10, bottom: 10, left: 16, right: 16 })
+            .width('100%')
+            .focusable(true)
+            .onClick(() => {
+              this.filterGenre = g;
+              this.activeDropdown = '';
+              this.doSearch().catch((): void => {});
+            })
+        }, (g: string) => g)
+      }
+    }
+    .scrollBar(BarState.Off)
+    .constraintSize({ maxHeight: 300 })
+    .backgroundColor('#2A2E3A')
+    .borderRadius(8)
+    .width(160)
+  }
+
+  @Builder
+  buildRatingMenu() {
+    Column() {
+      ForEach(RATING_OPTIONS, (opt: NumberOption) => {
+        Text(opt.label)
+          .fontSize(14)
+          .fontColor(this.filterRating === opt.value ? '#BFDBFE' : '#CBD5E1')
+          .backgroundColor(this.filterRating === opt.value ? '#1D4ED860' : Color.Transparent)
+          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
+          .width('100%')
+          .focusable(true)
+          .onClick(() => {
+            this.filterRating = opt.value;
+            this.activeDropdown = '';
+            this.doSearch().catch((): void => {});
+          })
+      }, (opt: NumberOption) => String(opt.value))
+    }
+    .backgroundColor('#2A2E3A')
+    .borderRadius(8)
+    .width(160)
+  }
+
+  @Builder
+  buildYearMenu() {
+    Column() {
+      ForEach(YEAR_OPTIONS, (opt: StringOption) => {
+        Text(opt.label)
+          .fontSize(14)
+          .fontColor(this.filterYear === opt.value ? '#BFDBFE' : '#CBD5E1')
+          .backgroundColor(this.filterYear === opt.value ? '#1D4ED860' : Color.Transparent)
+          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
+          .width('100%')
+          .focusable(true)
+          .onClick(() => {
+            this.filterYear = opt.value;
+            this.activeDropdown = '';
+            this.doSearch().catch((): void => {});
+          })
+      }, (opt: StringOption) => opt.value)
+    }
+    .backgroundColor('#2A2E3A')
+    .borderRadius(8)
+    .width(160)
+  }
+
+  @Builder
+  buildSortMenu() {
+    Column() {
+      ForEach(SORT_OPTIONS, (opt: StringOption) => {
+        Text(opt.label)
+          .fontSize(14)
+          .fontColor(this.filterSort === opt.value ? '#BFDBFE' : '#CBD5E1')
+          .backgroundColor(this.filterSort === opt.value ? '#1D4ED860' : Color.Transparent)
+          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
+          .width('100%')
+          .focusable(true)
+          .onClick(() => {
+            this.filterSort = opt.value;
+            this.activeDropdown = '';
+            this.doSearch().catch((): void => {});
+          })
+      }, (opt: StringOption) => opt.value)
+    }
+    .backgroundColor('#2A2E3A')
+    .borderRadius(8)
+    .width(160)
+  }
+
+  // ── Build ─────────────────────────────────────────────────────────────────
+
+  build() {
+    NavDestination() {
+      Column() {
+
+        // ── Header Bar (72vp) ─────────────────────────────────────────────
+        Row() {
+          Button('← 返回')
+            .fontSize(14)
+            .fontColor('#FFFFFF')
+            .backgroundColor('#FFFFFF14')
+            .borderRadius(0)
+            .width(112)
+            .height(40)
+            .focusable(true)
+            .onClick(() => {
+              this.pageStack.pop();
+            })
+
+          Text(this.pageTitle)
+            .fontSize(22)
+            .fontColor('#FFFFFF')
+            .fontWeight(FontWeight.Bold)
+            .layoutWeight(1)
+            .textAlign(TextAlign.Center)
+
+          Text(`共 ${this.totalCount} 项`)
+            .fontSize(16)
+            .fontColor('#8F96A3')
+            .width(112)
+            .textAlign(TextAlign.End)
+        }
+        .width('100%')
+        .height(72)
+        .padding({ left: 64, right: 64 })
+        .alignItems(VerticalAlign.Center)
+
+        // ── Filter Bar (72vp) ─────────────────────────────────────────────
+        Column() {
+          Row({ space: 12 }) {
+
+            // Chip 0：媒体类型
+            Row({ space: 6 }) {
+              Text(this.getMediaTypeLabel())
+                .fontSize(14)
+                .fontColor(this.chipText('mediaType'))
+                .fontWeight(FontWeight.Medium)
+            }
+            .height(40)
+            .padding({ left: 14, right: 14 })
+            .borderRadius(0)
+            .backgroundColor(this.chipBg('mediaType'))
+            .border({ width: this.chipBorderWidth(0), color: this.chipBorderColor('mediaType', 0) })
+            .shadow({
+              radius: this.chipShadowRadius(0),
+              color: '#553A86FF',
+              offsetX: 0,
+              offsetY: 0,
+            })
+            .focusable(true)
+            .defaultFocus(true)
+            .onFocus(() => {
+              this.focusedChip = 0;
+            })
+            .onBlur(() => {
+              if (this.focusedChip === 0) {
+                this.focusedChip = -1;
+              }
+            })
+            .bindMenu(this.activeDropdown === 'mediaType', () => {
+              this.buildMediaTypeMenu();
+            })
+            .onClick(() => {
+              this.activeDropdown = this.activeDropdown === 'mediaType' ? '' : 'mediaType';
+            })
+
+            // Chip 1：类别
+            Row({ space: 6 }) {
+              Text(this.getGenreLabel())
+                .fontSize(14)
+                .fontColor(this.chipText('genre'))
+                .fontWeight(FontWeight.Medium)
+            }
+            .height(40)
+            .padding({ left: 14, right: 14 })
+            .borderRadius(0)
+            .backgroundColor(this.chipBg('genre'))
+            .border({ width: this.chipBorderWidth(1), color: this.chipBorderColor('genre', 1) })
+            .shadow({
+              radius: this.chipShadowRadius(1),
+              color: '#553A86FF',
+              offsetX: 0,
+              offsetY: 0,
+            })
+            .focusable(true)
+            .onFocus(() => {
+              this.focusedChip = 1;
+            })
+            .onBlur(() => {
+              if (this.focusedChip === 1) {
+                this.focusedChip = -1;
+              }
+            })
+            .bindMenu(this.activeDropdown === 'genre', () => {
+              this.buildGenreMenu();
+            })
+            .onClick(() => {
+              this.activeDropdown = this.activeDropdown === 'genre' ? '' : 'genre';
+            })
+
+            // Chip 2：评分
+            Row({ space: 6 }) {
+              Text(this.getRatingLabel())
+                .fontSize(14)
+                .fontColor(this.chipText('rating'))
+                .fontWeight(FontWeight.Medium)
+            }
+            .height(40)
+            .padding({ left: 14, right: 14 })
+            .borderRadius(0)
+            .backgroundColor(this.chipBg('rating'))
+            .border({ width: this.chipBorderWidth(2), color: this.chipBorderColor('rating', 2) })
+            .shadow({
+              radius: this.chipShadowRadius(2),
+              color: '#553A86FF',
+              offsetX: 0,
+              offsetY: 0,
+            })
+            .focusable(true)
+            .onFocus(() => {
+              this.focusedChip = 2;
+            })
+            .onBlur(() => {
+              if (this.focusedChip === 2) {
+                this.focusedChip = -1;
+              }
+            })
+            .bindMenu(this.activeDropdown === 'rating', () => {
+              this.buildRatingMenu();
+            })
+            .onClick(() => {
+              this.activeDropdown = this.activeDropdown === 'rating' ? '' : 'rating';
+            })
+
+            // Chip 3：年代
+            Row({ space: 6 }) {
+              Text(this.getYearLabel())
+                .fontSize(14)
+                .fontColor(this.chipText('year'))
+                .fontWeight(FontWeight.Medium)
+            }
+            .height(40)
+            .padding({ left: 14, right: 14 })
+            .borderRadius(0)
+            .backgroundColor(this.chipBg('year'))
+            .border({ width: this.chipBorderWidth(3), color: this.chipBorderColor('year', 3) })
+            .shadow({
+              radius: this.chipShadowRadius(3),
+              color: '#553A86FF',
+              offsetX: 0,
+              offsetY: 0,
+            })
+            .focusable(true)
+            .onFocus(() => {
+              this.focusedChip = 3;
+            })
+            .onBlur(() => {
+              if (this.focusedChip === 3) {
+                this.focusedChip = -1;
+              }
+            })
+            .bindMenu(this.activeDropdown === 'year', () => {
+              this.buildYearMenu();
+            })
+            .onClick(() => {
+              this.activeDropdown = this.activeDropdown === 'year' ? '' : 'year';
+            })
+
+            // Chip 4：排序
+            Row({ space: 6 }) {
+              Text(this.getSortLabel())
+                .fontSize(14)
+                .fontColor(this.chipText('sort'))
+                .fontWeight(FontWeight.Medium)
+            }
+            .height(40)
+            .padding({ left: 14, right: 14 })
+            .borderRadius(0)
+            .backgroundColor(this.chipBg('sort'))
+            .border({ width: this.chipBorderWidth(4), color: this.chipBorderColor('sort', 4) })
+            .shadow({
+              radius: this.chipShadowRadius(4),
+              color: '#553A86FF',
+              offsetX: 0,
+              offsetY: 0,
+            })
+            .focusable(true)
+            .onFocus(() => {
+              this.focusedChip = 4;
+            })
+            .onBlur(() => {
+              if (this.focusedChip === 4) {
+                this.focusedChip = -1;
+              }
+            })
+            .bindMenu(this.activeDropdown === 'sort', () => {
+              this.buildSortMenu();
+            })
+            .onClick(() => {
+              this.activeDropdown = this.activeDropdown === 'sort' ? '' : 'sort';
+            })
+
+          }
+          .width('100%')
+          .height(71)
+          .padding({ left: 64, right: 64 })
+          .alignItems(VerticalAlign.Center)
+
+          // 底部分割线 1px
+          Row()
+            .width('100%')
+            .height(1)
+            .backgroundColor('#ffffff20')
+        }
+        .width('100%')
+        .backgroundColor('#1E1E22')
+
+        // ── 内容区（剩余空间，竖向滚动网格）──────────────────────────────
+        if (this.isLoading) {
+          Column() {
+            LoadingProgress()
+              .width(48)
+              .height(48)
+              .color('#FFFFFF')
+          }
+          .width('100%')
+          .layoutWeight(1)
+          .justifyContent(FlexAlign.Center)
+          .alignItems(HorizontalAlign.Center)
+
+        } else if (this.results.length === 0) {
+          // 空结果态
+          Column({ space: 16 }) {
+            Text('📺')
+              .fontSize(56)
+              .opacity(0.35)
+              .fontColor('#FFFFFF')
+
+            Text('没有符合条件的内容')
+              .fontSize(18)
+              .fontColor('#666666')
+
+            Text('尝试调整筛选条件')
+              .fontSize(13)
+              .fontColor('#444444')
+
+            Button('重置筛选')
+              .width(200)
+              .height(44)
+              .backgroundColor('#FFFFFF14')
+              .fontColor('#FFFFFF')
+              .fontSize(14)
+              .borderRadius(0)
+              .focusable(true)
+              .onClick(() => {
+                this.resetFilters();
+              })
+          }
+          .width('100%')
+          .layoutWeight(1)
+          .justifyContent(FlexAlign.Center)
+          .alignItems(HorizontalAlign.Center)
+
+        } else {
+          // 9列海报网格
+          Grid() {
+            ForEach(this.results, (item: MediaItem) => {
+              GridItem() {
+                ResultPosterCard({ item: item })
+              }
+            }, (item: MediaItem) => String(item.id))
+          }
+          .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
+          .columnsGap(12)
+          .rowsGap(24)
+          .width('100%')
+          .layoutWeight(1)
+          .padding({ left: 64, right: 64, top: 24 })
+          .scrollBar(BarState.Auto)
+          .edgeEffect(EdgeEffect.Spring)
+          .focusable(true)
+        }
+
+      }
+      .width('100%')
+      .height('100%')
+      .backgroundColor('#1A1A1A')
+    }
+    .hideTitleBar(true)
+    .onReady((context: NavDestinationContext) => {
+      const param = context.pathInfo.param as MediaResultPageParam;
+      if (param !== undefined && param !== null) {
+        this.keyword = param.keyword ?? '';
+        if (param.mediaType !== undefined) {
+          this.filterMediaType = param.mediaType;
+        }
+        if (param.genre !== undefined) {
+          this.filterGenre = param.genre;
+        }
+        if (param.pageTitle !== undefined && param.pageTitle.length > 0) {
+          this.pageTitle = param.pageTitle;
+        } else if (param.keyword !== undefined && param.keyword.length > 0) {
+          this.pageTitle = `"${param.keyword}" 的搜索结果`;
+        } else if (param.genre !== undefined && param.genre.length > 0) {
+          this.pageTitle = param.genre;
+        } else if (param.mediaType === 'movie') {
+          this.pageTitle = '电影';
+        } else if (param.mediaType === 'tv') {
+          this.pageTitle = '剧集';
+        }
+      }
+      this.loadGenres().catch((): void => {});
+      this.doSearch().catch((): void => {});
+    })
+  }
+}

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -178,6 +178,15 @@ struct ResultPosterCard {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Helper type for decade-range mapping (avoids ArkTS inline-object-literal type)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface YearRange {
+  from: number;
+  to: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // MediaResultPage — generic search result page (TV vertical layout)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -204,12 +213,22 @@ export struct MediaResultPage {
   @Local totalCount: number = 0;
 
   private db: FileSourceDatabase = FileSourceDatabase.getInstance();
+  // 竞态保护：每次发起新请求时递增，回调中比对版本号，过期则丢弃
+  private searchGeneration: number = 0;
 
   // ── Data operations ───────────────────────────────────────────────────────
 
+  /** 将年代字符串（如 '2020'）转换为十年段区间 [2020, 2029] */
+  private decadeToYearRange(decade: string): YearRange | null {
+    if (decade.length === 0) { return null; }
+    const start: number = parseInt(decade, 10);
+    if (isNaN(start)) { return null; }
+    return { from: start, to: start + 9 };
+  }
+
   private async doSearch(): Promise<void> {
+    const generation = ++this.searchGeneration;
     this.isLoading = true;
-    this.results = [];
     try {
       let mt: 'movie' | 'tv' | 'all' | undefined = undefined;
       if (this.filterMediaType === 'movie') { mt = 'movie'; }
@@ -219,27 +238,30 @@ export struct MediaResultPage {
       if (this.filterSort === 'rating') { sb = 'rating'; }
       else if (this.filterSort === 'year') { sb = 'year'; }
 
-      const yearNum: number | undefined = this.filterYear.length > 0
-        ? parseInt(this.filterYear, 10)
-        : undefined;
+      const yearRange: YearRange | null = this.decadeToYearRange(this.filterYear);
 
       const options: SearchMediaOptions = {
         mediaType: mt,
         genre: this.filterGenre.length > 0 ? this.filterGenre : undefined,
         minRating: this.filterRating > 0 ? this.filterRating : undefined,
-        year: yearNum,
+        yearFrom: yearRange !== null ? yearRange.from : undefined,
+        yearTo: yearRange !== null ? yearRange.to : undefined,
         sortBy: sb,
         limit: 200,
       };
 
       const items: MediaItem[] = await this.db.searchMediaItems(this.keyword, options);
+      if (generation !== this.searchGeneration) { return; } // 丢弃过期结果
       this.results = items;
       this.totalCount = items.length;
     } catch {
+      if (generation !== this.searchGeneration) { return; }
       this.results = [];
       this.totalCount = 0;
     } finally {
-      this.isLoading = false;
+      if (generation === this.searchGeneration) {
+        this.isLoading = false;
+      }
     }
   }
 

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -154,10 +154,10 @@ struct ResultPosterCard {
       .width(180)
       .height(270)
       .clip(true)
-      .border({ width: this.isFocused ? 2 : 0, color: '#66A9D8FF' })
+      .border({ width: this.isFocused ? 2 : 0, color: '#FF66A9D8' })
       .shadow({
         radius: this.isFocused ? 14 : 4,
-        color: this.isFocused ? '#553A86FF' : '#33000000',
+        color: this.isFocused ? '#FF553A86' : '#33000000',
         offsetX: 0,
         offsetY: this.isFocused ? 0 : 2,
       })
@@ -362,7 +362,7 @@ export struct MediaResultPage {
   }
 
   private chipBg(key: string): string {
-    return this.isChipSelected(key) ? '#1D4ED860' : '#33415550';
+    return this.isChipSelected(key) ? '#601D4ED8' : '#50334155';
   }
 
   private chipText(key: string): string {
@@ -371,9 +371,9 @@ export struct MediaResultPage {
 
   private chipBorderColor(key: string, idx: number): string {
     if (this.focusedChip === idx) {
-      return '#66A9D8FF';
+      return '#FF66A9D8';
     }
-    return this.isChipSelected(key) ? '#93C5FD99' : '#CBD5E166';
+    return this.isChipSelected(key) ? '#9993C5FD' : '#66CBD5E1';
   }
 
   private chipBorderWidth(idx: number): number {
@@ -393,7 +393,7 @@ export struct MediaResultPage {
         Text(opt.label)
           .fontSize(14)
           .fontColor(this.filterMediaType === opt.value ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterMediaType === opt.value ? '#1D4ED860' : Color.Transparent)
+          .backgroundColor(this.filterMediaType === opt.value ? '#601D4ED8' : Color.Transparent)
           .padding({ top: 10, bottom: 10, left: 16, right: 16 })
           .width('100%')
           .focusable(true)
@@ -416,7 +416,7 @@ export struct MediaResultPage {
         Text('全部')
           .fontSize(14)
           .fontColor(this.filterGenre === '' ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterGenre === '' ? '#1D4ED860' : Color.Transparent)
+          .backgroundColor(this.filterGenre === '' ? '#601D4ED8' : Color.Transparent)
           .padding({ top: 10, bottom: 10, left: 16, right: 16 })
           .width('100%')
           .focusable(true)
@@ -429,7 +429,7 @@ export struct MediaResultPage {
           Text(g)
             .fontSize(14)
             .fontColor(this.filterGenre === g ? '#BFDBFE' : '#CBD5E1')
-            .backgroundColor(this.filterGenre === g ? '#1D4ED860' : Color.Transparent)
+            .backgroundColor(this.filterGenre === g ? '#601D4ED8' : Color.Transparent)
             .padding({ top: 10, bottom: 10, left: 16, right: 16 })
             .width('100%')
             .focusable(true)
@@ -455,7 +455,7 @@ export struct MediaResultPage {
         Text(opt.label)
           .fontSize(14)
           .fontColor(this.filterRating === opt.value ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterRating === opt.value ? '#1D4ED860' : Color.Transparent)
+          .backgroundColor(this.filterRating === opt.value ? '#601D4ED8' : Color.Transparent)
           .padding({ top: 10, bottom: 10, left: 16, right: 16 })
           .width('100%')
           .focusable(true)
@@ -478,7 +478,7 @@ export struct MediaResultPage {
         Text(opt.label)
           .fontSize(14)
           .fontColor(this.filterYear === opt.value ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterYear === opt.value ? '#1D4ED860' : Color.Transparent)
+          .backgroundColor(this.filterYear === opt.value ? '#601D4ED8' : Color.Transparent)
           .padding({ top: 10, bottom: 10, left: 16, right: 16 })
           .width('100%')
           .focusable(true)
@@ -501,7 +501,7 @@ export struct MediaResultPage {
         Text(opt.label)
           .fontSize(14)
           .fontColor(this.filterSort === opt.value ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterSort === opt.value ? '#1D4ED860' : Color.Transparent)
+          .backgroundColor(this.filterSort === opt.value ? '#601D4ED8' : Color.Transparent)
           .padding({ top: 10, bottom: 10, left: 16, right: 16 })
           .width('100%')
           .focusable(true)
@@ -528,7 +528,7 @@ export struct MediaResultPage {
           Button('← 返回')
             .fontSize(14)
             .fontColor('#FFFFFF')
-            .backgroundColor('#FFFFFF14')
+            .backgroundColor('#14FFFFFF')
             .borderRadius(0)
             .width(112)
             .height(40)
@@ -573,7 +573,7 @@ export struct MediaResultPage {
             .border({ width: this.chipBorderWidth(0), color: this.chipBorderColor('mediaType', 0) })
             .shadow({
               radius: this.chipShadowRadius(0),
-              color: '#553A86FF',
+              color: '#FF553A86',
               offsetX: 0,
               offsetY: 0,
             })
@@ -608,7 +608,7 @@ export struct MediaResultPage {
             .border({ width: this.chipBorderWidth(1), color: this.chipBorderColor('genre', 1) })
             .shadow({
               radius: this.chipShadowRadius(1),
-              color: '#553A86FF',
+              color: '#FF553A86',
               offsetX: 0,
               offsetY: 0,
             })
@@ -642,7 +642,7 @@ export struct MediaResultPage {
             .border({ width: this.chipBorderWidth(2), color: this.chipBorderColor('rating', 2) })
             .shadow({
               radius: this.chipShadowRadius(2),
-              color: '#553A86FF',
+              color: '#FF553A86',
               offsetX: 0,
               offsetY: 0,
             })
@@ -676,7 +676,7 @@ export struct MediaResultPage {
             .border({ width: this.chipBorderWidth(3), color: this.chipBorderColor('year', 3) })
             .shadow({
               radius: this.chipShadowRadius(3),
-              color: '#553A86FF',
+              color: '#FF553A86',
               offsetX: 0,
               offsetY: 0,
             })
@@ -710,7 +710,7 @@ export struct MediaResultPage {
             .border({ width: this.chipBorderWidth(4), color: this.chipBorderColor('sort', 4) })
             .shadow({
               radius: this.chipShadowRadius(4),
-              color: '#553A86FF',
+              color: '#FF553A86',
               offsetX: 0,
               offsetY: 0,
             })
@@ -740,7 +740,7 @@ export struct MediaResultPage {
           Row()
             .width('100%')
             .height(1)
-            .backgroundColor('#ffffff20')
+            .backgroundColor('#20FFFFFF')
         }
         .width('100%')
         .backgroundColor('#1E1E22')
@@ -777,7 +777,7 @@ export struct MediaResultPage {
             Button('重置筛选')
               .width(200)
               .height(44)
-              .backgroundColor('#FFFFFF14')
+              .backgroundColor('#14FFFFFF')
               .fontColor('#FFFFFF')
               .fontSize(14)
               .borderRadius(0)

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -4,7 +4,7 @@ import { MovieDetailPage } from '../detail/MovieDetailPage';
 import { SeriesDetailPage } from '../detail/SeriesDetailPage';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 页面参数接口（供外部路由传参）
+// Page param interface (for external route navigation)
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface MediaResultPageParam {
@@ -15,7 +15,7 @@ export interface MediaResultPageParam {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 筛选选项类型（避免 Map<K, 内联接口> 的 ArkTS 告警）
+// Filter option types — avoid ArkTS inline-object-literal type errors
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface StringOption {
@@ -29,41 +29,52 @@ interface NumberOption {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 筛选选项常量
+// Filter option constants
 // ─────────────────────────────────────────────────────────────────────────────
-
-const MEDIA_TYPE_OPTIONS: StringOption[] = [
-  { label: '全部', value: '' },
-  { label: '电影', value: 'movie' },
-  { label: '剧集', value: 'tv' },
-];
-
-const RATING_OPTIONS: NumberOption[] = [
-  { label: '全部', value: 0 },
-  { label: '8分+', value: 8 },
-  { label: '6分+', value: 6 },
-];
-
-const YEAR_OPTIONS: StringOption[] = [
-  { label: '全部', value: '' },
-  { label: '2020s', value: '2020' },
-  { label: '2010s', value: '2010' },
-  { label: '2000s', value: '2000' },
-  { label: '1990s', value: '1990' },
-];
 
 const SORT_OPTIONS: StringOption[] = [
-  { label: '默认', value: 'title' },
-  { label: '评分最高', value: 'rating' },
-  { label: '最新上映', value: 'year' },
+  { label: '\u7EFC\u5408\u6392\u5E8F', value: 'title' },
+  { label: '\u8BC4\u5206\u6700\u9AD8', value: 'rating' },
+  { label: '\u6700\u65B0\u4E0A\u6620', value: 'year' },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 模块级辅助函数（避免在 build() 内定义变量或复杂逻辑）
+// Design Token Constants — strictly follows Pencil vidall_pages.pen
 // ─────────────────────────────────────────────────────────────────────────────
+
+const C_PAGE_BG: string = '#232425';
+const C_COMPONENT_BG: string = '#2C3138';
+const C_SEL_BLUE: string = '#3B77D4';
+const C_BORDER: string = '#464E58';
+const C_TEXT_TITLE: string = '#EAF3FF';
+const C_TEXT_BODY: string = '#DDE4EE';
+const C_SECONDARY: string = '#8E96A3';
+const C_ICON: string = '#AAB4C3';
+const C_CHIP_DEFAULT_TEXT: string = '#E6EDF5';
+const C_CHIP_WEAK_TEXT: string = '#B8C1CD';
+const TRANSPARENT: string = '#00000000';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module-level helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function scoreColor(r: number | undefined): string {
+  if (r === undefined || r <= 0) { return '#8E96A3'; }
+  if (r >= 8.5) { return '#F7C06C'; }
+  if (r >= 8.0) { return '#F6B85F'; }
+  if (r >= 7.0) { return '#E6786C'; }
+  return '#D0A26B';
+}
 
 function itemTitle(item: MediaItem): string {
   return item.title ?? item.fileName ?? '';
+}
+
+function itemPosterSrc(item: MediaItem): string {
+  if (item.posterLocalPath !== undefined && item.posterLocalPath.length > 0) {
+    return 'file://' + item.posterLocalPath;
+  }
+  return item.posterUrl ?? '';
 }
 
 function itemHasPoster(item: MediaItem): boolean {
@@ -71,35 +82,13 @@ function itemHasPoster(item: MediaItem): boolean {
     (item.posterUrl !== undefined && item.posterUrl.length > 0);
 }
 
-function itemPosterSrc(item: MediaItem): string {
-  if (item.posterLocalPath && item.posterLocalPath.length > 0) {
-    return item.posterLocalPath;
-  }
-  return item.posterUrl ?? '';
-}
-
-function itemRatingText(r: number | undefined): string {
-  if (r === undefined || r <= 0) {
-    return '';
-  }
+function scoreText(r: number | undefined): string {
+  if (r === undefined || r <= 0) { return ''; }
   return r.toFixed(1);
 }
 
-function itemRatingColor(r: number | undefined): string {
-  if (r === undefined || r <= 0) {
-    return '#8F96A3';
-  }
-  if (r >= 8.0) {
-    return '#F7C06C';
-  }
-  if (r >= 6.0) {
-    return '#D0A26B';
-  }
-  return '#E6786C';
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
-// 海报卡片（局部组件，不导出）
+// ResultPosterCard — card for the 6-column result grid
 // ─────────────────────────────────────────────────────────────────────────────
 
 @ComponentV2
@@ -119,7 +108,7 @@ struct ResultPosterCard {
         rating: this.item.rating,
         episodeCount: 0,
         episodes: [this.item],
-        latestScannedAt: this.item.scannedAt,
+        latestScannedAt: this.item.scannedAt ?? 0,
       };
       this.pageStack.pushPathByName(SeriesDetailPage.PAGE_NAME, group);
     } else {
@@ -154,48 +143,42 @@ struct ResultPosterCard {
       .width(180)
       .height(270)
       .clip(true)
-      .border({ width: this.isFocused ? 2 : 0, color: '#FF66A9D8' })
+      .borderRadius(8)
+      .border({ width: this.isFocused ? 2 : 0, color: '#FF3B77D4' })
       .shadow({
-        radius: this.isFocused ? 14 : 4,
-        color: this.isFocused ? '#FF553A86' : '#33000000',
+        radius: this.isFocused ? 12 : 0,
+        color: this.isFocused ? '#803B77D4' : TRANSPARENT,
         offsetX: 0,
-        offsetY: this.isFocused ? 0 : 2,
+        offsetY: 0
       })
-      .scale({ x: this.isFocused ? 1.03 : 1.0, y: this.isFocused ? 1.03 : 1.0 })
-      .animation({ duration: 150, curve: Curve.EaseOut })
+      .scale({ x: this.isFocused ? 1.04 : 1.0, y: this.isFocused ? 1.04 : 1.0 })
+      .animation({ duration: 140, curve: Curve.EaseOut })
 
       Text(itemTitle(this.item))
         .fontSize(22)
         .fontColor('#E3E7ED')
-        .fontWeight(FontWeight.Normal)
-        .maxLines(2)
+        .maxLines(1)
         .textOverflow({ overflow: TextOverflow.Ellipsis })
         .width(180)
 
-      if (itemRatingText(this.item.rating).length > 0) {
-        Text(itemRatingText(this.item.rating))
+      if (scoreText(this.item.rating).length > 0) {
+        Text(scoreText(this.item.rating))
           .fontSize(20)
-          .fontColor(itemRatingColor(this.item.rating))
-          .fontWeight(FontWeight.Medium)
+          .fontWeight(600)
+          .fontColor(scoreColor(this.item.rating))
       }
     }
     .width(180)
     .alignItems(HorizontalAlign.Start)
     .focusable(true)
-    .onFocus(() => {
-      this.isFocused = true;
-    })
-    .onBlur(() => {
-      this.isFocused = false;
-    })
-    .onClick(() => {
-      this.navigateToDetail();
-    })
+    .onFocus(() => { this.isFocused = true; })
+    .onBlur(() => { this.isFocused = false; })
+    .onClick(() => { this.navigateToDetail(); })
   }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 主页面
+// MediaResultPage — generic search result page (TV vertical layout)
 // ─────────────────────────────────────────────────────────────────────────────
 
 @ComponentV2
@@ -204,92 +187,48 @@ export struct MediaResultPage {
 
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
 
-  // ── 页面状态 ──────────────────────────────────────────────────────────────
-  @Local pageTitle: string = '搜索结果';
+  // ── Page state ────────────────────────────────────────────────────────────
+  @Local pageTitle: string = '\u641C\u7D22\u7ED3\u679C';
   @Local keyword: string = '';
 
-  // ── 筛选状态 ──────────────────────────────────────────────────────────────
-  @Local filterMediaType: string = '';
+  // ── Filter state ──────────────────────────────────────────────────────────
+  @Local filterMediaType: string = '';   // '' | 'movie' | 'tv'
   @Local filterGenre: string = '';
-  @Local filterRating: number = 0;
-  @Local filterYear: string = '';
-  @Local filterSort: string = 'title';
+  @Local filterRating: number = 0;       // 0 = none, 7 = 7+, 8 = 8+
+  @Local filterYear: string = '';        // '' | '2020' | '2010' | '2000' | '1990'
+  @Local filterSort: string = 'title';   // 'title' | 'rating' | 'year'
 
-  // ── 数据状态 ──────────────────────────────────────────────────────────────
+  // ── Data state ────────────────────────────────────────────────────────────
   @Local results: MediaItem[] = [];
-  @Local genres: string[] = [];
   @Local isLoading: boolean = false;
   @Local totalCount: number = 0;
 
-  // ── Chip 焦点状态（-1=无，0-4=对应Chip）────────────────────────────────
-  @Local focusedChip: number = -1;
-
-  // ── Dropdown 开关（''=关，'mediaType'|'genre'|'rating'|'year'|'sort'=开）
-  @Local activeDropdown: string = '';
-
   private db: FileSourceDatabase = FileSourceDatabase.getInstance();
 
-  // ── 数据加载 ──────────────────────────────────────────────────────────────
-
-  private async loadGenres(): Promise<void> {
-    try {
-      const rawList: string[] = await this.db.getDistinctGenres();
-      this.genres = this.parseGenres(rawList);
-    } catch {
-      this.genres = [];
-    }
-  }
-
-  /** 将 getDistinctGenres() 返回的 JSON 字符串数组拍平去重 */
-  private parseGenres(rawList: string[]): string[] {
-    const seen: string[] = [];
-    for (const raw of rawList) {
-      try {
-        const arr = JSON.parse(raw) as string[];
-        for (const g of arr) {
-          if (typeof g === 'string' && g.length > 0 && !seen.includes(g)) {
-            seen.push(g);
-          }
-        }
-      } catch {
-        // 跳过格式异常的记录
-      }
-    }
-    seen.sort();
-    return seen;
-  }
+  // ── Data operations ───────────────────────────────────────────────────────
 
   private async doSearch(): Promise<void> {
     this.isLoading = true;
     this.results = [];
     try {
-      // 媒体类型映射
-      let mediaTypeParam: 'movie' | 'tv' | 'all' | undefined = undefined;
-      if (this.filterMediaType === 'movie') {
-        mediaTypeParam = 'movie';
-      } else if (this.filterMediaType === 'tv') {
-        mediaTypeParam = 'tv';
-      }
+      let mt: 'movie' | 'tv' | 'all' | undefined = undefined;
+      if (this.filterMediaType === 'movie') { mt = 'movie'; }
+      else if (this.filterMediaType === 'tv') { mt = 'tv'; }
 
-      // 排序方式映射
-      let sortByParam: 'rating' | 'year' | 'title' = 'title';
-      if (this.filterSort === 'rating') {
-        sortByParam = 'rating';
-      } else if (this.filterSort === 'year') {
-        sortByParam = 'year';
-      }
+      let sb: 'rating' | 'year' | 'title' = 'title';
+      if (this.filterSort === 'rating') { sb = 'rating'; }
+      else if (this.filterSort === 'year') { sb = 'year'; }
 
-      // 年代字符串转数字
       const yearNum: number | undefined = this.filterYear.length > 0
         ? parseInt(this.filterYear, 10)
         : undefined;
 
       const options: SearchMediaOptions = {
-        mediaType: mediaTypeParam,
+        mediaType: mt,
         genre: this.filterGenre.length > 0 ? this.filterGenre : undefined,
         minRating: this.filterRating > 0 ? this.filterRating : undefined,
         year: yearNum,
-        sortBy: sortByParam,
+        sortBy: sb,
         limit: 200,
       };
 
@@ -304,543 +243,329 @@ export struct MediaResultPage {
     }
   }
 
-  private resetFilters(): void {
-    this.filterMediaType = '';
-    this.filterGenre = '';
-    this.filterRating = 0;
-    this.filterYear = '';
-    this.filterSort = 'title';
-    this.activeDropdown = '';
+  // ── Filter cycle helpers (TV-friendly: no dropdown needed, click to cycle) ─
+
+  private cycleMediaType(): void {
+    if (this.filterMediaType === '') { this.filterMediaType = 'movie'; }
+    else if (this.filterMediaType === 'movie') { this.filterMediaType = 'tv'; }
+    else { this.filterMediaType = ''; }
     this.doSearch().catch((): void => {});
   }
 
-  // ── 辅助：Chip 显示文案 ──────────────────────────────────────────────────
-
-  private getMediaTypeLabel(): string {
-    const opt = MEDIA_TYPE_OPTIONS.find((o: StringOption) => o.value === this.filterMediaType);
-    return (opt !== undefined && opt.value !== '') ? `${opt.label}▾` : '媒体类型▾';
+  private cycleRating(): void {
+    if (this.filterRating === 0) { this.filterRating = 8; }
+    else if (this.filterRating === 8) { this.filterRating = 7; }
+    else { this.filterRating = 0; }
+    this.doSearch().catch((): void => {});
   }
 
-  private getGenreLabel(): string {
-    return this.filterGenre.length > 0 ? `${this.filterGenre}▾` : '类别▾';
+  private cycleYear(): void {
+    const opts: string[] = ['', '2020', '2010', '2000', '1990'];
+    const idx: number = opts.indexOf(this.filterYear);
+    this.filterYear = opts[(idx + 1) % opts.length];
+    this.doSearch().catch((): void => {});
   }
 
-  private getRatingLabel(): string {
-    const opt = RATING_OPTIONS.find((o: NumberOption) => o.value === this.filterRating);
-    return (opt !== undefined && opt.value > 0) ? `${opt.label}▾` : '评分▾';
+  private cycleSort(): void {
+    if (this.filterSort === 'title') { this.filterSort = 'rating'; }
+    else if (this.filterSort === 'rating') { this.filterSort = 'year'; }
+    else { this.filterSort = 'title'; }
+    this.doSearch().catch((): void => {});
   }
 
-  private getYearLabel(): string {
-    const opt = YEAR_OPTIONS.find((o: StringOption) => o.value === this.filterYear);
-    return (opt !== undefined && opt.value !== '') ? `${opt.label}▾` : '年代▾';
+  private resetAll(): void {
+    this.filterMediaType = '';
+    this.filterRating = 0;
+    this.filterYear = '';
+    this.filterSort = 'title';
+    this.doSearch().catch((): void => {});
   }
 
-  private getSortLabel(): string {
-    const opt = SORT_OPTIONS.find((o: StringOption) => o.value === this.filterSort);
-    return (opt !== undefined && opt.value !== 'title') ? `${opt.label}▾` : '排序▾';
+  // ── Label helpers ─────────────────────────────────────────────────────────
+
+  private mediaTypeLabel(): string {
+    if (this.filterMediaType === 'movie') { return '\u7535\u5F71'; }
+    if (this.filterMediaType === 'tv') { return '\u5267\u96C6'; }
+    return '\u7C7B\u578B';
   }
 
-  // ── 辅助：Chip 样式计算 ──────────────────────────────────────────────────
+  private ratingLabel(): string {
+    if (this.filterRating === 8) { return '8\u5206+'; }
+    if (this.filterRating === 7) { return '7\u5206+'; }
+    return '\u8BC4\u5206';
+  }
 
-  private isChipSelected(key: string): boolean {
-    if (key === 'mediaType') {
-      return this.filterMediaType !== '';
-    }
-    if (key === 'genre') {
-      return this.filterGenre !== '';
-    }
-    if (key === 'rating') {
-      return this.filterRating > 0;
-    }
-    if (key === 'year') {
-      return this.filterYear !== '';
-    }
-    if (key === 'sort') {
-      return this.filterSort !== 'title';
-    }
-    return false;
+  private yearLabel(): string {
+    if (this.filterYear === '2020') { return '2020s'; }
+    if (this.filterYear === '2010') { return '2010s'; }
+    if (this.filterYear === '2000') { return '2000s'; }
+    if (this.filterYear === '1990') { return '1990s'; }
+    return '\u5E74\u4EE3';
+  }
+
+  private sortLabel(): string {
+    const opt: StringOption | undefined = SORT_OPTIONS.find((o: StringOption) => o.value === this.filterSort);
+    return opt !== undefined ? opt.label : '\u7EFC\u5408\u6392\u5E8F';
+  }
+
+  private summaryText(): string {
+    const parts: string[] = ['\u5168\u90E8'];
+    if (this.filterMediaType === 'movie') { parts.push('\u7535\u5F71'); }
+    else if (this.filterMediaType === 'tv') { parts.push('\u5267\u96C6'); }
+    if (this.filterRating > 0) { parts.push(this.filterRating.toString() + '\u5206+'); }
+    if (this.filterYear.length > 0) { parts.push(this.filterYear + 's'); }
+    return parts.join(' \u00B7 ');
+  }
+
+  // ── Chip style helpers ────────────────────────────────────────────────────
+
+  private isAllDefault(): boolean {
+    return this.filterMediaType === '' && this.filterRating === 0 && this.filterYear === '';
   }
 
   private chipBg(key: string): string {
-    return this.isChipSelected(key) ? '#601D4ED8' : '#50334155';
+    if (key === 'all') { return this.isAllDefault() ? C_SEL_BLUE : C_COMPONENT_BG; }
+    if (key === 'mediaType') { return this.filterMediaType !== '' ? C_SEL_BLUE : C_COMPONENT_BG; }
+    if (key === 'rating') { return this.filterRating > 0 ? C_SEL_BLUE : C_COMPONENT_BG; }
+    if (key === 'year') { return this.filterYear !== '' ? C_SEL_BLUE : C_COMPONENT_BG; }
+    return C_COMPONENT_BG;
   }
 
-  private chipText(key: string): string {
-    return this.isChipSelected(key) ? '#BFDBFE' : '#CBD5E1';
+  private chipTextColor(key: string): string {
+    if (key === 'more') { return C_CHIP_WEAK_TEXT; }
+    if (key === 'all') { return this.isAllDefault() ? C_TEXT_TITLE : C_CHIP_DEFAULT_TEXT; }
+    if (key === 'mediaType') { return this.filterMediaType !== '' ? C_TEXT_TITLE : C_CHIP_DEFAULT_TEXT; }
+    if (key === 'rating') { return this.filterRating > 0 ? C_TEXT_TITLE : C_CHIP_DEFAULT_TEXT; }
+    if (key === 'year') { return this.filterYear !== '' ? C_TEXT_TITLE : C_CHIP_DEFAULT_TEXT; }
+    return C_CHIP_DEFAULT_TEXT;
   }
 
-  private chipBorderColor(key: string, idx: number): string {
-    if (this.focusedChip === idx) {
-      return '#FF66A9D8';
-    }
-    return this.isChipSelected(key) ? '#9993C5FD' : '#66CBD5E1';
+  private chipFw(key: string): number {
+    if (key === 'more') { return 500; }
+    if (key === 'all') { return this.isAllDefault() ? 700 : 600; }
+    if (key === 'mediaType') { return this.filterMediaType !== '' ? 700 : 600; }
+    if (key === 'rating') { return this.filterRating > 0 ? 700 : 600; }
+    if (key === 'year') { return this.filterYear !== '' ? 700 : 600; }
+    return 600;
   }
 
-  private chipBorderWidth(idx: number): number {
-    return this.focusedChip === idx ? 2 : 1;
+  private chipBorderColor(key: string): string {
+    if (key === 'all' && this.isAllDefault()) { return TRANSPARENT; }
+    if (key === 'mediaType' && this.filterMediaType !== '') { return TRANSPARENT; }
+    if (key === 'rating' && this.filterRating > 0) { return TRANSPARENT; }
+    if (key === 'year' && this.filterYear !== '') { return TRANSPARENT; }
+    return C_BORDER;
   }
 
-  private chipShadowRadius(idx: number): number {
-    return this.focusedChip === idx ? 14 : 0;
-  }
-
-  // ── @Builder：下拉菜单内容 ────────────────────────────────────────────────
+  // ── @Builder sections ─────────────────────────────────────────────────────
 
   @Builder
-  buildMediaTypeMenu() {
-    Column() {
-      ForEach(MEDIA_TYPE_OPTIONS, (opt: StringOption) => {
-        Text(opt.label)
-          .fontSize(14)
-          .fontColor(this.filterMediaType === opt.value ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterMediaType === opt.value ? '#601D4ED8' : Color.Transparent)
-          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
-          .width('100%')
-          .focusable(true)
-          .onClick(() => {
-            this.filterMediaType = opt.value;
-            this.activeDropdown = '';
-            this.doSearch().catch((): void => {});
-          })
-      }, (opt: StringOption) => opt.value)
-    }
-    .backgroundColor('#2A2E3A')
-    .borderRadius(8)
-    .width(160)
-  }
-
-  @Builder
-  buildGenreMenu() {
-    Scroll() {
-      Column() {
-        Text('全部')
-          .fontSize(14)
-          .fontColor(this.filterGenre === '' ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterGenre === '' ? '#601D4ED8' : Color.Transparent)
-          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
-          .width('100%')
-          .focusable(true)
-          .onClick(() => {
-            this.filterGenre = '';
-            this.activeDropdown = '';
-            this.doSearch().catch((): void => {});
-          })
-        ForEach(this.genres, (g: string) => {
-          Text(g)
-            .fontSize(14)
-            .fontColor(this.filterGenre === g ? '#BFDBFE' : '#CBD5E1')
-            .backgroundColor(this.filterGenre === g ? '#601D4ED8' : Color.Transparent)
-            .padding({ top: 10, bottom: 10, left: 16, right: 16 })
-            .width('100%')
-            .focusable(true)
-            .onClick(() => {
-              this.filterGenre = g;
-              this.activeDropdown = '';
-              this.doSearch().catch((): void => {});
-            })
-        }, (g: string) => g)
+  buildBackRow() {
+    Row() {
+      Row() {
+        Text('\u2039')
+          .fontSize(22)
+          .fontColor(C_TEXT_BODY)
       }
+      .width(48)
+      .height(48)
+      .borderRadius(24)
+      .backgroundColor(C_COMPONENT_BG)
+      .border({ width: 1, color: C_BORDER })
+      .justifyContent(FlexAlign.Center)
+      .alignItems(VerticalAlign.Center)
+      .focusable(true)
+      .onClick(() => { this.pageStack.pop(); })
     }
-    .scrollBar(BarState.Off)
-    .constraintSize({ maxHeight: 300 })
-    .backgroundColor('#2A2E3A')
-    .borderRadius(8)
-    .width(160)
+    .width('100%')
+    .height(48)
+    .alignItems(VerticalAlign.Center)
   }
 
   @Builder
-  buildRatingMenu() {
-    Column() {
-      ForEach(RATING_OPTIONS, (opt: NumberOption) => {
-        Text(opt.label)
-          .fontSize(14)
-          .fontColor(this.filterRating === opt.value ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterRating === opt.value ? '#601D4ED8' : Color.Transparent)
-          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
-          .width('100%')
-          .focusable(true)
-          .onClick(() => {
-            this.filterRating = opt.value;
-            this.activeDropdown = '';
-            this.doSearch().catch((): void => {});
-          })
-      }, (opt: NumberOption) => String(opt.value))
+  buildHeader() {
+    Row() {
+      Column({ space: 8 }) {
+        Text(this.pageTitle)
+          .fontSize(34)
+          .fontWeight(700)
+          .fontColor(C_TEXT_TITLE)
+        Text('\u5171 ' + this.totalCount.toString() + ' \u90E8\u5185\u5BB9')
+          .fontSize(18)
+          .fontWeight(500)
+          .fontColor(C_SECONDARY)
+      }
+      .alignItems(HorizontalAlign.Start)
+
+      // Sort box
+      Row({ space: 8 }) {
+        Text(this.sortLabel())
+          .fontSize(18)
+          .fontWeight(600)
+          .fontColor(C_TEXT_BODY)
+        Text('\u2304')
+          .fontSize(18)
+          .fontColor(C_ICON)
+      }
+      .padding({ left: 16, right: 16, top: 10, bottom: 10 })
+      .backgroundColor(C_COMPONENT_BG)
+      .borderRadius(12)
+      .border({ width: 1, color: C_BORDER })
+      .alignItems(VerticalAlign.Center)
+      .focusable(true)
+      .onClick(() => { this.cycleSort(); })
     }
-    .backgroundColor('#2A2E3A')
-    .borderRadius(8)
-    .width(160)
+    .width('100%')
+    .justifyContent(FlexAlign.SpaceBetween)
+    .alignItems(VerticalAlign.Bottom)
   }
 
   @Builder
-  buildYearMenu() {
-    Column() {
-      ForEach(YEAR_OPTIONS, (opt: StringOption) => {
-        Text(opt.label)
-          .fontSize(14)
-          .fontColor(this.filterYear === opt.value ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterYear === opt.value ? '#601D4ED8' : Color.Transparent)
-          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
-          .width('100%')
-          .focusable(true)
-          .onClick(() => {
-            this.filterYear = opt.value;
-            this.activeDropdown = '';
-            this.doSearch().catch((): void => {});
-          })
-      }, (opt: StringOption) => opt.value)
+  buildFilterChips() {
+    Row({ space: 10 }) {
+      // Chip 1: All — resets all filters
+      Text('\u5168\u90E8')
+        .fontSize(16)
+        .fontWeight(this.chipFw('all'))
+        .fontColor(this.chipTextColor('all'))
+        .height(36)
+        .padding({ left: 14, right: 14 })
+        .backgroundColor(this.chipBg('all'))
+        .borderRadius(999)
+        .border({ width: 1, color: this.chipBorderColor('all') })
+        .focusable(true)
+        .onClick(() => { this.resetAll(); })
+
+      // Chip 2: Media type (cycle: all→movie→tv)
+      Text(this.mediaTypeLabel())
+        .fontSize(16)
+        .fontWeight(this.chipFw('mediaType'))
+        .fontColor(this.chipTextColor('mediaType'))
+        .height(36)
+        .padding({ left: 14, right: 14 })
+        .backgroundColor(this.chipBg('mediaType'))
+        .borderRadius(999)
+        .border({ width: 1, color: this.chipBorderColor('mediaType') })
+        .focusable(true)
+        .onClick(() => { this.cycleMediaType(); })
+
+      // Chip 3: Rating (cycle: none→8+→7+)
+      Text(this.ratingLabel())
+        .fontSize(16)
+        .fontWeight(this.chipFw('rating'))
+        .fontColor(this.chipTextColor('rating'))
+        .height(36)
+        .padding({ left: 14, right: 14 })
+        .backgroundColor(this.chipBg('rating'))
+        .borderRadius(999)
+        .border({ width: 1, color: this.chipBorderColor('rating') })
+        .focusable(true)
+        .onClick(() => { this.cycleRating(); })
+
+      // Chip 4: Year (cycle: none→2020→2010→2000→1990)
+      Text(this.yearLabel())
+        .fontSize(16)
+        .fontWeight(this.chipFw('year'))
+        .fontColor(this.chipTextColor('year'))
+        .height(36)
+        .padding({ left: 14, right: 14 })
+        .backgroundColor(this.chipBg('year'))
+        .borderRadius(999)
+        .border({ width: 1, color: this.chipBorderColor('year') })
+        .focusable(true)
+        .onClick(() => { this.cycleYear(); })
+
+      // Chip 5: More filters (weakened, decorative for now)
+      Text('\u66F4\u591A\u7B5B\u9009')
+        .fontSize(16)
+        .fontWeight(this.chipFw('more'))
+        .fontColor(this.chipTextColor('more'))
+        .height(36)
+        .padding({ left: 14, right: 14 })
+        .backgroundColor(C_COMPONENT_BG)
+        .borderRadius(999)
+        .border({ width: 1, color: C_BORDER })
+        .focusable(true)
     }
-    .backgroundColor('#2A2E3A')
-    .borderRadius(8)
-    .width(160)
+    .width('100%')
+    .alignItems(VerticalAlign.Center)
   }
 
   @Builder
-  buildSortMenu() {
-    Column() {
-      ForEach(SORT_OPTIONS, (opt: StringOption) => {
-        Text(opt.label)
-          .fontSize(14)
-          .fontColor(this.filterSort === opt.value ? '#BFDBFE' : '#CBD5E1')
-          .backgroundColor(this.filterSort === opt.value ? '#601D4ED8' : Color.Transparent)
-          .padding({ top: 10, bottom: 10, left: 16, right: 16 })
-          .width('100%')
-          .focusable(true)
-          .onClick(() => {
-            this.filterSort = opt.value;
-            this.activeDropdown = '';
-            this.doSearch().catch((): void => {});
-          })
-      }, (opt: StringOption) => opt.value)
-    }
-    .backgroundColor('#2A2E3A')
-    .borderRadius(8)
-    .width(160)
+  buildSummary() {
+    Text(this.summaryText())
+      .fontSize(16)
+      .fontWeight(500)
+      .fontColor(C_SECONDARY)
+      .width('100%')
   }
 
-  // ── Build ─────────────────────────────────────────────────────────────────
+  @Builder
+  buildResultGrid() {
+    if (this.isLoading) {
+      Column() {
+        Text('\u52A0\u8F7D\u4E2D\u2026')
+          .fontSize(18)
+          .fontColor(C_SECONDARY)
+      }
+      .layoutWeight(1)
+      .width('100%')
+      .justifyContent(FlexAlign.Center)
+      .alignItems(HorizontalAlign.Center)
+    } else if (this.results.length === 0) {
+      Column() {
+        Text('\u6682\u65E0\u7ED3\u679C')
+          .fontSize(18)
+          .fontColor(C_SECONDARY)
+      }
+      .layoutWeight(1)
+      .width('100%')
+      .justifyContent(FlexAlign.Center)
+      .alignItems(HorizontalAlign.Center)
+    } else {
+      Grid() {
+        ForEach(this.results, (item: MediaItem) => {
+          GridItem() {
+            ResultPosterCard({ item: item })
+          }
+        }, (item: MediaItem) => String(item.id))
+      }
+      .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr')
+      .columnsGap(30)
+      .rowsGap(30)
+      .width('100%')
+      .layoutWeight(1)
+    }
+  }
 
   build() {
     NavDestination() {
-      Column() {
-
-        // ── Header Bar (72vp) ─────────────────────────────────────────────
-        Row() {
-          Button('← 返回')
-            .fontSize(14)
-            .fontColor('#FFFFFF')
-            .backgroundColor('#14FFFFFF')
-            .borderRadius(0)
-            .width(112)
-            .height(40)
-            .focusable(true)
-            .onClick(() => {
-              this.pageStack.pop();
-            })
-
-          Text(this.pageTitle)
-            .fontSize(22)
-            .fontColor('#FFFFFF')
-            .fontWeight(FontWeight.Bold)
-            .layoutWeight(1)
-            .textAlign(TextAlign.Center)
-
-          Text(`共 ${this.totalCount} 项`)
-            .fontSize(16)
-            .fontColor('#8F96A3')
-            .width(112)
-            .textAlign(TextAlign.End)
-        }
-        .width('100%')
-        .height(72)
-        .padding({ left: 64, right: 64 })
-        .alignItems(VerticalAlign.Center)
-
-        // ── Filter Bar (72vp) ─────────────────────────────────────────────
-        Column() {
-          Row({ space: 12 }) {
-
-            // Chip 0：媒体类型
-            Row({ space: 6 }) {
-              Text(this.getMediaTypeLabel())
-                .fontSize(14)
-                .fontColor(this.chipText('mediaType'))
-                .fontWeight(FontWeight.Medium)
-            }
-            .height(40)
-            .padding({ left: 14, right: 14 })
-            .borderRadius(0)
-            .backgroundColor(this.chipBg('mediaType'))
-            .border({ width: this.chipBorderWidth(0), color: this.chipBorderColor('mediaType', 0) })
-            .shadow({
-              radius: this.chipShadowRadius(0),
-              color: '#FF553A86',
-              offsetX: 0,
-              offsetY: 0,
-            })
-            .focusable(true)
-            .defaultFocus(true)
-            .onFocus(() => {
-              this.focusedChip = 0;
-            })
-            .onBlur(() => {
-              if (this.focusedChip === 0) {
-                this.focusedChip = -1;
-              }
-            })
-            .bindMenu(this.activeDropdown === 'mediaType', () => {
-              this.buildMediaTypeMenu();
-            })
-            .onClick(() => {
-              this.activeDropdown = this.activeDropdown === 'mediaType' ? '' : 'mediaType';
-            })
-
-            // Chip 1：类别
-            Row({ space: 6 }) {
-              Text(this.getGenreLabel())
-                .fontSize(14)
-                .fontColor(this.chipText('genre'))
-                .fontWeight(FontWeight.Medium)
-            }
-            .height(40)
-            .padding({ left: 14, right: 14 })
-            .borderRadius(0)
-            .backgroundColor(this.chipBg('genre'))
-            .border({ width: this.chipBorderWidth(1), color: this.chipBorderColor('genre', 1) })
-            .shadow({
-              radius: this.chipShadowRadius(1),
-              color: '#FF553A86',
-              offsetX: 0,
-              offsetY: 0,
-            })
-            .focusable(true)
-            .onFocus(() => {
-              this.focusedChip = 1;
-            })
-            .onBlur(() => {
-              if (this.focusedChip === 1) {
-                this.focusedChip = -1;
-              }
-            })
-            .bindMenu(this.activeDropdown === 'genre', () => {
-              this.buildGenreMenu();
-            })
-            .onClick(() => {
-              this.activeDropdown = this.activeDropdown === 'genre' ? '' : 'genre';
-            })
-
-            // Chip 2：评分
-            Row({ space: 6 }) {
-              Text(this.getRatingLabel())
-                .fontSize(14)
-                .fontColor(this.chipText('rating'))
-                .fontWeight(FontWeight.Medium)
-            }
-            .height(40)
-            .padding({ left: 14, right: 14 })
-            .borderRadius(0)
-            .backgroundColor(this.chipBg('rating'))
-            .border({ width: this.chipBorderWidth(2), color: this.chipBorderColor('rating', 2) })
-            .shadow({
-              radius: this.chipShadowRadius(2),
-              color: '#FF553A86',
-              offsetX: 0,
-              offsetY: 0,
-            })
-            .focusable(true)
-            .onFocus(() => {
-              this.focusedChip = 2;
-            })
-            .onBlur(() => {
-              if (this.focusedChip === 2) {
-                this.focusedChip = -1;
-              }
-            })
-            .bindMenu(this.activeDropdown === 'rating', () => {
-              this.buildRatingMenu();
-            })
-            .onClick(() => {
-              this.activeDropdown = this.activeDropdown === 'rating' ? '' : 'rating';
-            })
-
-            // Chip 3：年代
-            Row({ space: 6 }) {
-              Text(this.getYearLabel())
-                .fontSize(14)
-                .fontColor(this.chipText('year'))
-                .fontWeight(FontWeight.Medium)
-            }
-            .height(40)
-            .padding({ left: 14, right: 14 })
-            .borderRadius(0)
-            .backgroundColor(this.chipBg('year'))
-            .border({ width: this.chipBorderWidth(3), color: this.chipBorderColor('year', 3) })
-            .shadow({
-              radius: this.chipShadowRadius(3),
-              color: '#FF553A86',
-              offsetX: 0,
-              offsetY: 0,
-            })
-            .focusable(true)
-            .onFocus(() => {
-              this.focusedChip = 3;
-            })
-            .onBlur(() => {
-              if (this.focusedChip === 3) {
-                this.focusedChip = -1;
-              }
-            })
-            .bindMenu(this.activeDropdown === 'year', () => {
-              this.buildYearMenu();
-            })
-            .onClick(() => {
-              this.activeDropdown = this.activeDropdown === 'year' ? '' : 'year';
-            })
-
-            // Chip 4：排序
-            Row({ space: 6 }) {
-              Text(this.getSortLabel())
-                .fontSize(14)
-                .fontColor(this.chipText('sort'))
-                .fontWeight(FontWeight.Medium)
-            }
-            .height(40)
-            .padding({ left: 14, right: 14 })
-            .borderRadius(0)
-            .backgroundColor(this.chipBg('sort'))
-            .border({ width: this.chipBorderWidth(4), color: this.chipBorderColor('sort', 4) })
-            .shadow({
-              radius: this.chipShadowRadius(4),
-              color: '#FF553A86',
-              offsetX: 0,
-              offsetY: 0,
-            })
-            .focusable(true)
-            .onFocus(() => {
-              this.focusedChip = 4;
-            })
-            .onBlur(() => {
-              if (this.focusedChip === 4) {
-                this.focusedChip = -1;
-              }
-            })
-            .bindMenu(this.activeDropdown === 'sort', () => {
-              this.buildSortMenu();
-            })
-            .onClick(() => {
-              this.activeDropdown = this.activeDropdown === 'sort' ? '' : 'sort';
-            })
-
-          }
-          .width('100%')
-          .height(71)
-          .padding({ left: 64, right: 64 })
-          .alignItems(VerticalAlign.Center)
-
-          // 底部分割线 1px
-          Row()
-            .width('100%')
-            .height(1)
-            .backgroundColor('#20FFFFFF')
-        }
-        .width('100%')
-        .backgroundColor('#1E1E22')
-
-        // ── 内容区（剩余空间，竖向滚动网格）──────────────────────────────
-        if (this.isLoading) {
-          Column() {
-            LoadingProgress()
-              .width(48)
-              .height(48)
-              .color('#FFFFFF')
-          }
-          .width('100%')
-          .layoutWeight(1)
-          .justifyContent(FlexAlign.Center)
-          .alignItems(HorizontalAlign.Center)
-
-        } else if (this.results.length === 0) {
-          // 空结果态
-          Column({ space: 16 }) {
-            Text('📺')
-              .fontSize(56)
-              .opacity(0.35)
-              .fontColor('#FFFFFF')
-
-            Text('没有符合条件的内容')
-              .fontSize(18)
-              .fontColor('#666666')
-
-            Text('尝试调整筛选条件')
-              .fontSize(13)
-              .fontColor('#444444')
-
-            Button('重置筛选')
-              .width(200)
-              .height(44)
-              .backgroundColor('#14FFFFFF')
-              .fontColor('#FFFFFF')
-              .fontSize(14)
-              .borderRadius(0)
-              .focusable(true)
-              .onClick(() => {
-                this.resetFilters();
-              })
-          }
-          .width('100%')
-          .layoutWeight(1)
-          .justifyContent(FlexAlign.Center)
-          .alignItems(HorizontalAlign.Center)
-
-        } else {
-          // 9列海报网格
-          Grid() {
-            ForEach(this.results, (item: MediaItem) => {
-              GridItem() {
-                ResultPosterCard({ item: item })
-              }
-            }, (item: MediaItem) => String(item.id))
-          }
-          .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
-          .columnsGap(12)
-          .rowsGap(24)
-          .width('100%')
-          .layoutWeight(1)
-          .padding({ left: 64, right: 64, top: 24 })
-          .scrollBar(BarState.Auto)
-          .edgeEffect(EdgeEffect.Spring)
-          .focusable(true)
-        }
-
+      Column({ space: 26 }) {
+        this.buildBackRow()
+        this.buildHeader()
+        this.buildFilterChips()
+        this.buildSummary()
+        this.buildResultGrid()
       }
       .width('100%')
       .height('100%')
-      .backgroundColor('#1A1A1A')
+      .padding(20)
+      .backgroundColor(C_PAGE_BG)
     }
     .hideTitleBar(true)
     .onReady((context: NavDestinationContext) => {
       const param = context.pathInfo.param as MediaResultPageParam;
       if (param !== undefined && param !== null) {
+        this.pageTitle = param.pageTitle ?? '\u641C\u7D22\u7ED3\u679C';
         this.keyword = param.keyword ?? '';
-        if (param.mediaType !== undefined) {
-          this.filterMediaType = param.mediaType;
-        }
-        if (param.genre !== undefined) {
-          this.filterGenre = param.genre;
-        }
-        if (param.pageTitle !== undefined && param.pageTitle.length > 0) {
-          this.pageTitle = param.pageTitle;
-        } else if (param.keyword !== undefined && param.keyword.length > 0) {
-          this.pageTitle = `"${param.keyword}" 的搜索结果`;
-        } else if (param.genre !== undefined && param.genre.length > 0) {
-          this.pageTitle = param.genre;
-        } else if (param.mediaType === 'movie') {
-          this.pageTitle = '电影';
-        } else if (param.mediaType === 'tv') {
-          this.pageTitle = '剧集';
-        }
+        this.filterMediaType = param.mediaType ?? '';
+        this.filterGenre = param.genre ?? '';
       }
-      this.loadGenres().catch((): void => {});
       this.doSearch().catch((): void => {});
+    })
+    .onBackPressed(() => {
+      this.pageStack.pop();
+      return true;
     })
   }
 }

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -67,7 +67,6 @@ function posterSrc(item: MediaItem): string {
 @ComponentV2
 struct KeyButton {
   @Param label: string = '';
-  @Param kw: number = 112;
   @Param kh: number = 60;
   @Param kbg: string = C_LETTER_KEY_BG;
   @Event onPress: () => void = () => {};
@@ -79,7 +78,6 @@ struct KeyButton {
       .fontWeight(600)
       .fontColor(C_KEY_TEXT)
       .textAlign(TextAlign.Center)
-      .width(this.kw)
       .height(this.kh)
       .borderRadius(10)
       .backgroundColor(this.isFocused ? C_SEL_BLUE : this.kbg)
@@ -360,7 +358,7 @@ struct SearchWorkspacePage {
           .maxLines(1)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
       } else {
-        Text('\u8f93\u5165\u5173\u952e\u8bcd\u641c\u7d22\u2026')
+        Text('\u652f\u6301\u9996\u5b57\u6bcd\u3001\u5168\u62fc\u3001\u4e2d\u6587\u7247\u540d\u641c\u7d22')
           .fontSize(22)
           .fontWeight(500)
           .fontColor(C_PLACEHOLDER)
@@ -380,103 +378,93 @@ struct SearchWorkspacePage {
   // row1: Q-P + 1-4
   @Builder
   buildKbdRow1() {
-    Row() {
-      Row({ space: 8 }) {
-        ForEach(KBD_R1_L, (key: string) => {
-          KeyButton({ label: key, kw: 112, kh: 60, onPress: () => { this.appendChar(key); } })
-        }, (key: string) => key)
-      }
-      Row({ space: 8 }) {
-        ForEach(KBD_R1_R, (key: string) => {
-          KeyButton({ label: key, kw: 128, kh: 60, onPress: () => { this.appendChar(key); } })
-        }, (key: string) => key)
-      }
+    Row({ space: 8 }) {
+      ForEach(KBD_R1_L, (key: string) => {
+        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
+          .layoutWeight(1)
+      }, (key: string) => key)
+      ForEach(KBD_R1_R, (key: string) => {
+        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
+          .layoutWeight(1.14)
+      }, (key: string) => key)
     }
     .width('100%')
-    .justifyContent(FlexAlign.SpaceBetween)
   }
 
   // row2: A-L + clear + 5-8
   @Builder
   buildKbdRow2() {
-    Row() {
-      Row({ space: 8 }) {
-        ForEach(KBD_R2_L, (key: string) => {
-          KeyButton({ label: key, kw: 112, kh: 60, onPress: () => { this.appendChar(key); } })
-        }, (key: string) => key)
-        // Clear key — red-toned, trash icon
-        Text('\uD83D\uDDD1')
-          .fontSize(24)
-          .fontColor(C_CLEAR_ICON)
-          .textAlign(TextAlign.Center)
-          .width(112)
-          .height(60)
-          .borderRadius(10)
-          .backgroundColor(C_CLEAR_BG)
-          .border({ width: 1, color: C_CLEAR_BORDER })
-          .focusable(true)
-          .onClick(() => { this.clearSearch(); })
-      }
-      Row({ space: 8 }) {
-        ForEach(KBD_R2_R, (key: string) => {
-          KeyButton({ label: key, kw: 128, kh: 60, onPress: () => { this.appendChar(key); } })
-        }, (key: string) => key)
-      }
+    Row({ space: 8 }) {
+      ForEach(KBD_R2_L, (key: string) => {
+        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
+          .layoutWeight(1)
+      }, (key: string) => key)
+      // Clear key — red-toned, trash icon
+      Text('\uD83D\uDDD1')
+        .fontSize(24)
+        .fontColor(C_CLEAR_ICON)
+        .textAlign(TextAlign.Center)
+        .height(60)
+        .borderRadius(10)
+        .backgroundColor(C_CLEAR_BG)
+        .border({ width: 1, color: C_CLEAR_BORDER })
+        .focusable(true)
+        .onClick(() => { this.clearSearch(); })
+        .layoutWeight(1)
+      ForEach(KBD_R2_R, (key: string) => {
+        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
+          .layoutWeight(1.14)
+      }, (key: string) => key)
     }
     .width('100%')
-    .justifyContent(FlexAlign.SpaceBetween)
   }
 
-  // row3: Z-M + backspace(352) + 9(128) + 0(400)
+  // row3: Z-M + backspace + 9 + 0
   @Builder
   buildKbdRow3() {
-    Row() {
-      Row({ space: 8 }) {
-        ForEach(KBD_R3_L, (key: string) => {
-          KeyButton({ label: key, kw: 112, kh: 60, onPress: () => { this.appendChar(key); } })
-        }, (key: string) => key)
-        // Backspace key
-        Text('\u232B')
-          .fontSize(20)
-          .fontWeight(700)
-          .fontColor('#FFFFFF')
-          .textAlign(TextAlign.Center)
-          .width(352)
-          .height(60)
-          .borderRadius(10)
-          .backgroundColor(C_BKSP_BG)
-          .focusable(true)
-          .onClick(() => { this.deleteLastChar(); })
-      }
-      Row({ space: 8 }) {
-        // 9 key
-        Text('9')
-          .fontSize(20)
-          .fontWeight(600)
-          .fontColor(C_KEY_TEXT)
-          .textAlign(TextAlign.Center)
-          .width(128)
-          .height(60)
-          .borderRadius(10)
-          .backgroundColor(C_LETTER_KEY_BG)
-          .focusable(true)
-          .onClick(() => { this.appendChar('9'); })
-        // 0 key (wide)
-        Text('0')
-          .fontSize(20)
-          .fontWeight(600)
-          .fontColor(C_KEY_TEXT)
-          .textAlign(TextAlign.Center)
-          .width(400)
-          .height(60)
-          .borderRadius(10)
-          .backgroundColor(C_LETTER_KEY_BG)
-          .focusable(true)
-          .onClick(() => { this.appendChar('0'); })
-      }
+    Row({ space: 8 }) {
+      ForEach(KBD_R3_L, (key: string) => {
+        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
+          .layoutWeight(1)
+      }, (key: string) => key)
+      // Backspace key
+      Text('\u232B')
+        .fontSize(20)
+        .fontWeight(700)
+        .fontColor('#FFFFFF')
+        .textAlign(TextAlign.Center)
+        .height(60)
+        .borderRadius(10)
+        .backgroundColor(C_BKSP_BG)
+        .focusable(true)
+        .onClick(() => { this.deleteLastChar(); })
+        .layoutWeight(3.14)
+      // 9 key
+      Text('9')
+        .fontSize(20)
+        .fontWeight(600)
+        .fontColor(C_KEY_TEXT)
+        .textAlign(TextAlign.Center)
+        .height(60)
+        .borderRadius(10)
+        .backgroundColor(C_LETTER_KEY_BG)
+        .focusable(true)
+        .onClick(() => { this.appendChar('9'); })
+        .layoutWeight(1.14)
+      // 0 key (wide)
+      Text('0')
+        .fontSize(20)
+        .fontWeight(600)
+        .fontColor(C_KEY_TEXT)
+        .textAlign(TextAlign.Center)
+        .height(60)
+        .borderRadius(10)
+        .backgroundColor(C_LETTER_KEY_BG)
+        .focusable(true)
+        .onClick(() => { this.appendChar('0'); })
+        .layoutWeight(3.57)
     }
     .width('100%')
-    .justifyContent(FlexAlign.SpaceBetween)
   }
 
   @Builder
@@ -601,21 +589,25 @@ struct SearchWorkspacePage {
 
   build() {
     NavDestination() {
-      Column({ space: 20 }) {
-        this.buildBackRow()
-        this.buildTitleArea()
-        this.buildSearchBar()
-        this.buildKeyboard()
-        // M7：始终显示历史和热搜；本地预览结果只在有内容时附加展示
-        this.buildHistory()
-        this.buildHotSearch()
-        if (this.searchResults.length > 0) {
-          this.buildResultsPreview()
+      Scroll() {
+        Column({ space: 20 }) {
+          this.buildBackRow()
+          this.buildSearchBar()
+          this.buildKeyboard()
+          // M7：始终显示历史和热搜；本地预览结果只在有内容时附加展示
+          this.buildHistory()
+          this.buildHotSearch()
+          if (this.searchResults.length > 0) {
+            this.buildResultsPreview()
+          }
         }
+        .width('100%')
+        .padding(20)
+        .backgroundColor(C_PAGE_BG)
       }
+      .scrollable(ScrollDirection.Vertical)
       .width('100%')
       .height('100%')
-      .padding(20)
       .backgroundColor(C_PAGE_BG)
     }
     .hideTitleBar(true)

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -571,6 +571,8 @@ struct SearchWorkspacePage {
           this.buildResultsPreview()
         }
         .width('100%')
+        .alignItems(HorizontalAlign.Start)
+        .justifyContent(FlexAlign.Start)
         .padding(20)
         .backgroundColor(C_PAGE_BG)
       }

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -1,5 +1,6 @@
 import { MediaItem, SearchHistoryEntry, SeriesGroup } from '../../db/models/MediaEntity';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
+import { MediaResultPage, MediaResultPageParam } from './MediaResultPage';
 import { SeriesDetailPage } from '../detail/SeriesDetailPage';
 import { MovieDetailPage } from '../detail/MovieDetailPage';
 
@@ -177,6 +178,8 @@ struct SearchWorkspacePage {
 
   private db: FileSourceDatabase = FileSourceDatabase.getInstance();
   private searchTimerId: number = 0;
+  // 竞态保护：快速连续输入时，丢弃旧请求的返回结果
+  private searchGeneration: number = 0;
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -210,28 +213,45 @@ struct SearchWorkspacePage {
   private scheduleSearch(): void {
     clearTimeout(this.searchTimerId);
     this.searchTimerId = setTimeout((): void => {
-      this.executeSearch();
+      this.executeSearch().catch((): void => {});
     }, 300);
   }
 
-  private executeSearch(): void {
+  /** 本地预览搜索（仅实时展示结果，不保存历史、不跳转） */
+  private async executeSearch(): Promise<void> {
     const kw: string = this.searchText.trim();
     if (kw.length === 0) {
       this.searchResults = [];
       return;
     }
+    const generation = ++this.searchGeneration;
     this.isSearching = true;
-    this.db.searchMediaItems(kw, { limit: 50 })
-      .then((results: MediaItem[]) => {
-        this.searchResults = results;
+    try {
+      const items: MediaItem[] = await this.db.searchMediaItems(kw, { limit: 50 });
+      if (generation !== this.searchGeneration) { return; } // 丢弃过期结果
+      this.searchResults = items;
+    } catch {
+      if (generation !== this.searchGeneration) { return; }
+      this.searchResults = []; // 失败时清空，不保留旧数据
+    } finally {
+      if (generation === this.searchGeneration) {
         this.isSearching = false;
-      })
-      .catch(() => {
-        this.isSearching = false;
-      });
+      }
+    }
+  }
+
+  /** 确认搜索：保存历史 + 导航到 MediaResultPage（M1 核心路由） */
+  private triggerSearchAndNavigate(): void {
+    const kw: string = this.searchText.trim();
+    if (kw.length === 0) { return; }
     this.db.upsertSearchHistory(kw)
       .then(() => { this.loadHistory(); })
       .catch(() => {});
+    const param: MediaResultPageParam = {
+      keyword: kw,
+      pageTitle: kw,
+    };
+    this.pageStack.pushPathByName(MediaResultPage.PAGE_NAME, param);
   }
 
   private appendChar(c: string): void {
@@ -465,6 +485,19 @@ struct SearchWorkspacePage {
       this.buildKbdRow1()
       this.buildKbdRow2()
       this.buildKbdRow3()
+      // M1：确认搜索按钮 — 跳转到 MediaResultPage
+      Text('\u641C\u7D22')
+        .fontSize(22)
+        .fontWeight(700)
+        .fontColor('#FFFFFF')
+        .textAlign(TextAlign.Center)
+        .width('100%')
+        .height(60)
+        .borderRadius(10)
+        .backgroundColor(this.searchText.trim().length > 0 ? C_SEL_BLUE : C_BKSP_BG)
+        .animation({ duration: 140, curve: Curve.EaseInOut })
+        .focusable(true)
+        .onClick(() => { this.triggerSearchAndNavigate(); })
     }
     .width('100%')
     .backgroundColor(C_KBD_BG)
@@ -477,27 +510,31 @@ struct SearchWorkspacePage {
     if (this.historyList.length > 0) {
       Flex({ wrap: FlexWrap.Wrap }) {
         ForEach(this.historyList, (entry: SearchHistoryEntry) => {
-          Row({ space: 4 }) {
+          // M2：拆成两个独立可聚焦节点，遥控器 D-pad 可分别聚焦到关键词和删除按钮
+          Row({ space: 0 }) {
+            // 左侧：关键词文字 — 聚焦后 OK 键触发搜索并跳转
             Text(entry.keyword)
               .fontSize(16)
               .fontWeight(500)
               .fontColor(C_HIST_TEXT)
+              .padding({ left: 14, right: 6, top: 8, bottom: 8 })
+              .focusable(true)
+              .onClick(() => {
+                this.searchText = entry.keyword;
+                this.triggerSearchAndNavigate();
+              })
+            // 右侧：× 删除按钮 — 聚焦后 OK 键触发删除
             Text('\u00D7')
               .fontSize(14)
               .fontColor(C_SECONDARY)
-              .hitTestBehavior(HitTestMode.Block)
+              .padding({ left: 6, right: 14, top: 8, bottom: 8 })
+              .focusable(true)
               .onClick(() => { this.deleteHistory(entry.keyword); })
           }
-          .padding({ left: 14, right: 14, top: 8, bottom: 8 })
           .backgroundColor(C_HIST_CHIP_BG)
           .borderRadius(999)
           .border({ width: 1, color: C_HIST_BORDER })
           .margin({ right: 10, bottom: 10 })
-          .focusable(true)
-          .onClick(() => {
-            this.searchText = entry.keyword;
-            this.executeSearch();
-          })
         }, (entry: SearchHistoryEntry) => entry.keyword)
 
         // Clear-all button styled same as chip
@@ -569,11 +606,11 @@ struct SearchWorkspacePage {
         this.buildTitleArea()
         this.buildSearchBar()
         this.buildKeyboard()
-        if (this.searchText.length > 0) {
+        // M7：始终显示历史和热搜；本地预览结果只在有内容时附加展示
+        this.buildHistory()
+        this.buildHotSearch()
+        if (this.searchResults.length > 0) {
           this.buildResultsPreview()
-        } else {
-          this.buildHistory()
-          this.buildHotSearch()
         }
       }
       .width('100%')

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -67,7 +67,6 @@ function posterSrc(item: MediaItem): string {
 @ComponentV2
 struct KeyButton {
   @Param label: string = '';
-  @Param kh: number = 60;
   @Param kbg: string = C_LETTER_KEY_BG;
   @Event onPress: () => void = () => {};
   @Local isFocused: boolean = false;
@@ -78,7 +77,8 @@ struct KeyButton {
       .fontWeight(600)
       .fontColor(C_KEY_TEXT)
       .textAlign(TextAlign.Center)
-      .height(this.kh)
+      .width('100%')
+      .aspectRatio(112 / 60)   // 高度由列宽自动推导，无需硬编码 height
       .borderRadius(10)
       .backgroundColor(this.isFocused ? C_SEL_BLUE : this.kbg)
       .border({ width: this.isFocused ? 2 : 0, color: '#5B9BD5' })
@@ -175,7 +175,7 @@ struct SearchWorkspacePage {
   @Local hotItems: MediaItem[] = [];
 
   private db: FileSourceDatabase = FileSourceDatabase.getInstance();
-  private searchTimerId: number = 0;
+  @Local private searchDebounceTimer: number = -1;
   // 竞态保护：快速连续输入时，丢弃旧请求的返回结果
   private searchGeneration: number = 0;
 
@@ -187,7 +187,9 @@ struct SearchWorkspacePage {
   }
 
   aboutToDisappear(): void {
-    clearTimeout(this.searchTimerId);
+    if (this.searchDebounceTimer !== -1) {
+      clearTimeout(this.searchDebounceTimer);
+    }
   }
 
   // ── Data helpers ──────────────────────────────────────────────────────────
@@ -209,10 +211,18 @@ struct SearchWorkspacePage {
   }
 
   private scheduleSearch(): void {
-    clearTimeout(this.searchTimerId);
-    this.searchTimerId = setTimeout((): void => {
-      this.executeSearch().catch((): void => {});
-    }, 300);
+    if (this.searchDebounceTimer !== -1) {
+      clearTimeout(this.searchDebounceTimer);
+      this.searchDebounceTimer = -1;
+    }
+    if (this.searchText.trim().length === 0) {
+      this.searchResults = [];
+      return;
+    }
+    this.searchDebounceTimer = setTimeout(() => {
+      this.searchDebounceTimer = -1;
+      this.triggerSearchAndNavigate();
+    }, 800);
   }
 
   /** 本地预览搜索（仅实时展示结果，不保存历史、不跳转） */
@@ -267,6 +277,7 @@ struct SearchWorkspacePage {
   private clearSearch(): void {
     this.searchText = '';
     this.searchResults = [];
+    this.scheduleSearch();
   }
 
   private deleteHistory(keyword: string): void {
@@ -378,93 +389,111 @@ struct SearchWorkspacePage {
   // row1: Q-P + 1-4
   @Builder
   buildKbdRow1() {
-    Row({ space: 8 }) {
+    Grid() {
       ForEach(KBD_R1_L, (key: string) => {
-        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
-          .layoutWeight(1)
+        GridItem() {
+          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        }
       }, (key: string) => key)
       ForEach(KBD_R1_R, (key: string) => {
-        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
-          .layoutWeight(1.14)
+        GridItem() {
+          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        }
       }, (key: string) => key)
     }
+    .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
+    .columnsGap(8)
     .width('100%')
   }
 
   // row2: A-L + clear + 5-8
   @Builder
   buildKbdRow2() {
-    Row({ space: 8 }) {
+    Grid() {
       ForEach(KBD_R2_L, (key: string) => {
-        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
-          .layoutWeight(1)
+        GridItem() {
+          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        }
       }, (key: string) => key)
-      // Clear key — red-toned, trash icon
-      Text('\uD83D\uDDD1')
-        .fontSize(24)
-        .fontColor(C_CLEAR_ICON)
-        .textAlign(TextAlign.Center)
-        .height(60)
-        .borderRadius(10)
-        .backgroundColor(C_CLEAR_BG)
-        .border({ width: 1, color: C_CLEAR_BORDER })
-        .focusable(true)
-        .onClick(() => { this.clearSearch(); })
-        .layoutWeight(1)
+      // Clear key（占 1 列）
+      GridItem() {
+        Text('\uD83D\uDDD1')
+          .fontSize(22)
+          .fontColor(C_CLEAR_ICON)
+          .textAlign(TextAlign.Center)
+          .width('100%')
+          .aspectRatio(112 / 60)
+          .borderRadius(10)
+          .backgroundColor(C_CLEAR_BG)
+          .border({ width: 1, color: C_CLEAR_BORDER })
+          .focusable(true)
+          .onClick(() => { this.clearSearch(); })
+      }
       ForEach(KBD_R2_R, (key: string) => {
-        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
-          .layoutWeight(1.14)
+        GridItem() {
+          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        }
       }, (key: string) => key)
     }
+    .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
+    .columnsGap(8)
     .width('100%')
   }
 
-  // row3: Z-M + backspace + 9 + 0
+  // row3: Z-M + backspace(3cols) + 9 + 0(3cols)
   @Builder
   buildKbdRow3() {
-    Row({ space: 8 }) {
-      ForEach(KBD_R3_L, (key: string) => {
-        KeyButton({ label: key, kh: 60, onPress: () => { this.appendChar(key); } })
-          .layoutWeight(1)
+    Grid() {
+      ForEach(KBD_R3_L, (key: string, index: number) => {
+        GridItem() {
+          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        }
+        .columnStart(index)
+        .columnEnd(index)
       }, (key: string) => key)
-      // Backspace key
-      Text('\u232B')
-        .fontSize(20)
-        .fontWeight(700)
-        .fontColor('#FFFFFF')
-        .textAlign(TextAlign.Center)
-        .height(60)
-        .borderRadius(10)
-        .backgroundColor(C_BKSP_BG)
-        .focusable(true)
-        .onClick(() => { this.deleteLastChar(); })
-        .layoutWeight(3.14)
-      // 9 key
-      Text('9')
-        .fontSize(20)
-        .fontWeight(600)
-        .fontColor(C_KEY_TEXT)
-        .textAlign(TextAlign.Center)
-        .height(60)
-        .borderRadius(10)
-        .backgroundColor(C_LETTER_KEY_BG)
-        .focusable(true)
-        .onClick(() => { this.appendChar('9'); })
-        .layoutWeight(1.14)
-      // 0 key (wide)
-      Text('0')
-        .fontSize(20)
-        .fontWeight(600)
-        .fontColor(C_KEY_TEXT)
-        .textAlign(TextAlign.Center)
-        .height(60)
-        .borderRadius(10)
-        .backgroundColor(C_LETTER_KEY_BG)
-        .focusable(true)
-        .onClick(() => { this.appendChar('0'); })
-        .layoutWeight(3.57)
+      // Backspace（跨 3 列：colStart 7-9）
+      GridItem() {
+        Text('\u232B')
+          .fontSize(20)
+          .fontWeight(700)
+          .fontColor('#FFFFFF')
+          .textAlign(TextAlign.Center)
+          .width('100%')
+          .height('100%')
+          .borderRadius(10)
+          .backgroundColor(C_BKSP_BG)
+          .focusable(true)
+          .onClick(() => { this.deleteLastChar(); })
+      }
+      .columnStart(7)
+      .columnEnd(9)
+      // 9 key（colStart 10）
+      GridItem() {
+        KeyButton({ label: '9', onPress: () => { this.appendChar('9'); } })
+      }
+      .columnStart(10)
+      .columnEnd(10)
+      // 0 key（跨 3 列：colStart 11-13）
+      GridItem() {
+        Text('0')
+          .fontSize(20)
+          .fontWeight(600)
+          .fontColor(C_KEY_TEXT)
+          .textAlign(TextAlign.Center)
+          .width('100%')
+          .height('100%')
+          .borderRadius(10)
+          .backgroundColor(C_LETTER_KEY_BG)
+          .focusable(true)
+          .onClick(() => { this.appendChar('0'); })
+      }
+      .columnStart(11)
+      .columnEnd(13)
     }
+    .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
+    .columnsGap(8)
     .width('100%')
+    .height(64)   // 跨列 GridItem 的 height('100%') 需 Grid 有已知高度；64vp ≈ aspectRatio 推算结果
   }
 
   @Builder
@@ -473,19 +502,7 @@ struct SearchWorkspacePage {
       this.buildKbdRow1()
       this.buildKbdRow2()
       this.buildKbdRow3()
-      // M1：确认搜索按钮 — 跳转到 MediaResultPage
-      Text('\u641C\u7D22')
-        .fontSize(22)
-        .fontWeight(700)
-        .fontColor('#FFFFFF')
-        .textAlign(TextAlign.Center)
-        .width('100%')
-        .height(60)
-        .borderRadius(10)
-        .backgroundColor(this.searchText.trim().length > 0 ? C_SEL_BLUE : C_BKSP_BG)
-        .animation({ duration: 140, curve: Curve.EaseInOut })
-        .focusable(true)
-        .onClick(() => { this.triggerSearchAndNavigate(); })
+      // 搜索按钮已移除，改由防抖 800ms 自动触发 triggerSearchAndNavigate
     }
     .width('100%')
     .backgroundColor(C_KBD_BG)

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -1,6 +1,6 @@
 import { MediaItem, SearchHistoryEntry, SeriesGroup } from '../../db/models/MediaEntity';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
-import { MediaResultPage, MediaResultPageParam } from './MediaResultPage';
+
 import { SeriesDetailPage } from '../detail/SeriesDetailPage';
 import { MovieDetailPage } from '../detail/MovieDetailPage';
 import { LengthMetrics } from '@kit.ArkUI';
@@ -173,7 +173,6 @@ struct SearchWorkspacePage {
   @Local searchResults: MediaItem[] = [];
   @Local historyList: SearchHistoryEntry[] = [];
   @Local isSearching: boolean = false;
-  @Local hotItems: MediaItem[] = [];
 
   private db: FileSourceDatabase | null = null;
   @Local private searchDebounceTimer: number = -1;
@@ -186,7 +185,6 @@ struct SearchWorkspacePage {
     try {
       this.db = FileSourceDatabase.getInstance();
       this.loadHistory();
-      this.loadHotItems();
     } catch (e) {
       // Preview 沙箱：native DB 不可用，静默降级
     }
@@ -209,14 +207,6 @@ struct SearchWorkspacePage {
       .catch(() => {});
   }
 
-  private loadHotItems(): void {
-    if (this.db === null) { return; }
-    this.db.searchMediaItems('', { sortBy: 'rating', limit: 8 })
-      .then((items: MediaItem[]) => {
-        this.hotItems = items;
-      })
-      .catch(() => {});
-  }
 
   private scheduleSearch(): void {
     if (this.searchDebounceTimer !== -1) {
@@ -229,7 +219,7 @@ struct SearchWorkspacePage {
     }
     this.searchDebounceTimer = setTimeout(() => {
       this.searchDebounceTimer = -1;
-      this.triggerSearchAndNavigate();
+      this.executeSearch();
     }, 800);
   }
 
@@ -256,8 +246,8 @@ struct SearchWorkspacePage {
     }
   }
 
-  /** 确认搜索：保存历史 + 导航到 MediaResultPage（M1 核心路由） */
-  private triggerSearchAndNavigate(): void {
+  /** 执行搜索并保存历史 */
+  private executeSearchWithHistory(): void {
     const kw: string = this.searchText.trim();
     if (kw.length === 0) { return; }
     if (this.db !== null) {
@@ -265,11 +255,7 @@ struct SearchWorkspacePage {
         .then(() => { this.loadHistory(); })
         .catch(() => {});
     }
-    const param: MediaResultPageParam = {
-      keyword: kw,
-      pageTitle: kw,
-    };
-    this.pageStack.pushPathByName(MediaResultPage.PAGE_NAME, param);
+    this.executeSearch();
   }
 
   private appendChar(c: string): void {
@@ -498,7 +484,7 @@ struct SearchWorkspacePage {
     } }) {
       this.buildAlphabetKbd()
       this.buildNumericKbd()
-      // 搜索按钮已移除，改由防抖 800ms 自动触发 triggerSearchAndNavigate
+      // 防抖 800ms 自动触发搜索
     }
     .alignSelf(ItemAlign.Center)
     .width('90%')
@@ -523,7 +509,7 @@ struct SearchWorkspacePage {
               .focusable(true)
               .onClick(() => {
                 this.searchText = entry.keyword;
-                this.triggerSearchAndNavigate();
+                this.executeSearchWithHistory();
               })
             // 右侧：× 删除按钮 — 聚焦后 OK 键触发删除
             Text('\u00D7')
@@ -557,33 +543,6 @@ struct SearchWorkspacePage {
   }
 
   @Builder
-  buildHotSearch() {
-    if (this.hotItems.length > 0) {
-      Column({ space: 16 }) {
-        Text('\u5927\u5bb6\u90fd\u5728\u641c')
-          .fontSize(24)
-          .fontWeight(700)
-          .fontColor('#DDE2EA')
-          .width('100%')
-        Scroll() {
-          Row({ space: 30 }) {
-            ForEach(this.hotItems, (item: MediaItem) => {
-              WorkspacePosterCard({
-                item: item,
-                onPress: () => { this.navigateToDetail(item); }
-              })
-            }, (item: MediaItem) => String(item.id))
-          }
-        }
-        .scrollable(ScrollDirection.Horizontal)
-        .width('100%')
-      }
-      .width('100%')
-      .alignItems(HorizontalAlign.Start)
-    }
-  }
-
-  @Builder
   buildResultsPreview() {
     if (this.searchResults.length > 0) {
       Scroll() {
@@ -608,12 +567,8 @@ struct SearchWorkspacePage {
           this.buildBackRow()
           this.buildSearchBar()
           this.buildKeyboard()
-          // M7：始终显示历史和热搜；本地预览结果只在有内容时附加展示
           this.buildHistory()
-          this.buildHotSearch()
-          if (this.searchResults.length > 0) {
-            this.buildResultsPreview()
-          }
+          this.buildResultsPreview()
         }
         .width('100%')
         .padding(20)

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -559,58 +559,13 @@ struct SearchWorkspacePage {
   @Builder
   buildResultsPreview() {
     if (this.searchResults.length > 0) {
-      Column({ space: 0 }) {
+      Flex({ wrap: FlexWrap.Wrap, justifyContent: FlexAlign.Start }) {
         ForEach(this.searchResults, (item: MediaItem) => {
-          Row({ space: 16 }) {
-            // 左：缩略图
-            if (posterSrc(item).length > 0) {
-              Image(posterSrc(item))
-                .width(80)
-                .height(120)
-                .objectFit(ImageFit.Cover)
-                .borderRadius(6)
-            } else {
-              Column() {
-                Text('\u{1F3AC}')
-                  .fontSize(28)
-                  .opacity(0.4)
-              }
-              .width(80)
-              .height(120)
-              .backgroundColor(C_COMPONENT_BG)
-              .borderRadius(6)
-              .justifyContent(FlexAlign.Center)
-              .alignItems(HorizontalAlign.Center)
-            }
-            // 右：信息
-            Column({ space: 6 }) {
-              Text(item.title ?? '')
-                .fontSize(22)
-                .fontColor('#E3E7ED')
-                .fontWeight(500)
-                .maxLines(2)
-                .textOverflow({ overflow: TextOverflow.Ellipsis })
-              if (item.rating !== undefined && item.rating > 0) {
-                Text(item.rating.toFixed(1))
-                  .fontSize(18)
-                  .fontWeight(600)
-                  .fontColor(scoreColor(item.rating))
-              }
-              if (item.releaseDate !== undefined && item.releaseDate.length >= 4) {
-                Text(item.releaseDate.slice(0, 4))
-                  .fontSize(16)
-                  .fontColor('#8A9BB0')
-              }
-            }
-            .layoutWeight(1)
-            .alignItems(HorizontalAlign.Start)
-            .justifyContent(FlexAlign.Center)
-          }
-          .width('100%')
-          .padding({ top: 10, bottom: 10, left: 4, right: 4 })
-          .borderRadius(10)
-          .focusable(true)
-          .onClick(() => { this.navigateToDetail(item); })
+          WorkspacePosterCard({
+            item: item,
+            onPress: () => { this.navigateToDetail(item); }
+          })
+          .margin({ right: 20, bottom: 20 })
         }, (item: MediaItem) => String(item.id))
       }
       .width('100%')

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -305,7 +305,7 @@ struct SearchWorkspacePage {
   }
 
   private navigateToDetail(item: MediaItem): void {
-    if (item.mediaType === 'tv') {
+    if (item.tvSeriesId !== undefined) {
       const group: SeriesGroup = {
         title: item.title ?? '',
         tvSeriesId: item.tvSeriesId,

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -79,7 +79,7 @@ struct KeyButton {
       .fontColor(C_KEY_TEXT)
       .textAlign(TextAlign.Center)
       .width('100%')
-      .aspectRatio(112 / 60)   // 高度由列宽自动推导，无需硬编码 height
+      .aspectRatio(112/60)
       .borderRadius(10)
       .backgroundColor(this.isFocused ? C_SEL_BLUE : this.kbg)
       .border({ width: this.isFocused ? 2 : 0, color: '#5B9BD5' })
@@ -398,86 +398,49 @@ struct SearchWorkspacePage {
     .defaultFocus(true)
   }
 
-  // row1: Q-P + 1-4
   @Builder
-  buildKbdRow1() {
-    Flex({
-      space: {
-        main: LengthMetrics.vp(8)
-      }
-    }) {
-      ForEach(KBD_R1_L, (key: string) => {
-        KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
-        // GridItem() {
-        //   KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
-        // }
-      }, (key: string) => key)
-      ForEach(KBD_R1_R, (key: string) => {
-        KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
-        // GridItem() {
-        //   KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
-        // }
-      }, (key: string) => key)
-    }
-    // .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
-    // .columnsGap(8)
-    .width('100%')
-  }
-
-  // row2: A-L + clear + 5-8
-  @Builder
-  buildKbdRow2() {
+  buildAlphabetKbd() {
     Grid() {
+      ForEach(KBD_R1_L, (key: string) => {
+        GridItem() {
+          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        }
+      }, (key: string) => key)
+
       ForEach(KBD_R2_L, (key: string) => {
         GridItem() {
           KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
         }
       }, (key: string) => key)
-      // Clear key（占 1 列）
+
       GridItem() {
         Text('\uD83D\uDDD1')
           .fontSize(22)
           .fontColor(C_CLEAR_ICON)
           .textAlign(TextAlign.Center)
           .width('100%')
-          .aspectRatio(112 / 60)
+          .aspectRatio(112/60)
           .borderRadius(10)
           .backgroundColor(C_CLEAR_BG)
           .border({ width: 1, color: C_CLEAR_BORDER })
           .focusable(true)
           .onClick(() => { this.clearSearch(); })
       }
-      ForEach(KBD_R2_R, (key: string) => {
-        GridItem() {
-          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
-        }
-      }, (key: string) => key)
-    }
-    .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
-    .columnsGap(8)
-    .width('100%')
-  }
 
-  // row3: Z-M + backspace(3cols) + 9 + 0(3cols)
-  @Builder
-  buildKbdRow3() {
-    Grid() {
-      ForEach(KBD_R3_L, (key: string, index: number) => {
+      ForEach(KBD_R3_L, (key: string) => {
         GridItem() {
           KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
         }
-        .columnStart(index)
-        .columnEnd(index)
       }, (key: string) => key)
-      // Backspace（跨 3 列：colStart 7-9）
+
       GridItem() {
         Text('\u232B')
           .fontSize(20)
           .fontWeight("100%")
           .fontColor('#FFFFFF')
+          .width("100%")
+          .aspectRatio(352/60)
           .textAlign(TextAlign.Center)
-          .width('100%')
-          .height('100%')
           .borderRadius(10)
           .backgroundColor(C_BKSP_BG)
           .focusable(true)
@@ -485,13 +448,25 @@ struct SearchWorkspacePage {
       }
       .columnStart(7)
       .columnEnd(9)
-      // 9 key（colStart 10）
+    }
+    .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
+    .columnsGap(8)
+    .rowsGap(8)
+  }
+
+  @Builder
+  buildNumericKbd() {
+    Grid() {
+      ForEach([...KBD_R1_R, ...KBD_R2_R], (key: string) => {
+        GridItem() {
+          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        }
+      })
+
       GridItem() {
         KeyButton({ label: '9', onPress: () => { this.appendChar('9'); } })
       }
-      .columnStart(10)
-      .columnEnd(10)
-      // 0 key（跨 3 列：colStart 11-13）
+
       GridItem() {
         Text('0')
           .fontSize(20)
@@ -499,26 +474,30 @@ struct SearchWorkspacePage {
           .fontColor(C_KEY_TEXT)
           .textAlign(TextAlign.Center)
           .width('100%')
-          .height('100%')
+          .aspectRatio(352/60)
           .borderRadius(10)
           .backgroundColor(C_LETTER_KEY_BG)
           .focusable(true)
-          .onClick(() => { this.appendChar('0'); })
+          .onClick(() => {
+            this.appendChar('0');
+          })
       }
-      .columnStart(11)
-      .columnEnd(13)
+      .columnStart(1)
+      .columnEnd(3)
     }
-    .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
+    .columnsTemplate('1fr 1fr 1fr 1fr')
     .columnsGap(8)
-    .width('100%')
+    .rowsGap(8)
+    .width("40%")
   }
 
   @Builder
   buildKeyboard() {
-    Column({ space: 10 }) {
-      this.buildKbdRow1()
-      this.buildKbdRow2()
-      this.buildKbdRow3()
+    Flex({ space: {
+      main: LengthMetrics.vp(50)
+    } }) {
+      this.buildAlphabetKbd()
+      this.buildNumericKbd()
       // 搜索按钮已移除，改由防抖 800ms 自动触发 triggerSearchAndNavigate
     }
     .width('100%')

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -2,59 +2,56 @@ import { MediaItem, SearchHistoryEntry, SeriesGroup } from '../../db/models/Medi
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { SeriesDetailPage } from '../detail/SeriesDetailPage';
 import { MovieDetailPage } from '../detail/MovieDetailPage';
-import { BusinessError } from '@kit.BasicServicesKit';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Color tokens
+// Design Token Constants — strictly follows Pencil vidall_pages.pen
 // ─────────────────────────────────────────────────────────────────────────────
-const PAGE_BG: string = '#1A1A1A';
-const KEY_BG: string = '#2D2F33';
-const KEY_BG_FOCUS: string = '#3B77D4';
-const KEY_BG_PRESS: string = '#4488FF';
-const FOCUS_BORDER_CLR: string = '#FF66A9D8';
-const FOCUS_SHADOW_CLR: string = '#FF553A86';
-const KEY_TEXT_CLR: string = '#E3E7ED';
-const PLACEHOLDER_CLR: string = '#97A9CD';
-const INPUT_TEXT_CLR: string = '#E8EEFF';
-const INPUT_BG: string = '#12FFFFFF';
-const INPUT_BORDER: string = '#25FFFFFF';
-const SPACE_KEY_BG: string = '#3B3D40';
-const CLEAR_KEY_BG: string = '#14FF6B6B';
-const CLEAR_KEY_BORDER: string = '#4DFF6B6B';
-const SEARCH_KEY_BG: string = '#2F77F5';
-const HISTORY_TITLE_CLR: string = '#DDE2EA';
-const HISTORY_TAG_CLR: string = '#CBD5E1';
-const HISTORY_TAG_BG: string = '#50334155';
-const HISTORY_TAG_BORDER: string = '#66CBD5E1';
-const CLEAR_ALL_CLR: string = '#FF6B6B';
-const CLEAR_ALL_BG: string = '#14FF6B6B';
-const CLEAR_ALL_BORDER: string = '#4DFF6B6B';
-const RESULT_CNT_CLR: string = '#97A9CD';
-const CARD_TITLE_CLR: string = '#E3E7ED';
+
+const C_PAGE_BG: string = '#232425';
+const C_KBD_BG: string = '#1C1E22';
+const C_HIST_CHIP_BG: string = '#23272E';
+const C_COMPONENT_BG: string = '#2C3138';
+const C_LETTER_KEY_BG: string = '#3A3F46';
+const C_BKSP_BG: string = '#565D67';
+const C_CLEAR_BG: string = '#6B3339';
+const C_SEL_BLUE: string = '#3B77D4';
+const C_BORDER: string = '#464E58';
+const C_HIST_BORDER: string = '#454C55';
+const C_CLEAR_BORDER: string = '#B85A64';
+const C_TEXT_TITLE: string = '#EAF3FF';
+const C_TEXT_BODY: string = '#DDE4EE';
+const C_KEY_TEXT: string = '#F3F6FA';
+const C_PLACEHOLDER: string = '#C7CED8';
+const C_SECONDARY: string = '#8E96A3';
+const C_ICON: string = '#AAB4C3';
+const C_HIST_TEXT: string = '#E6EDF5';
+const C_CLEAR_ICON: string = '#FFD7DB';
 const TRANSPARENT: string = '#00000000';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Keyboard layout constants
+// Keyboard layout arrays — row1/row2/row3, left letters + right numbers
 // ─────────────────────────────────────────────────────────────────────────────
-const QWERTY_ROW: string[] = ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'];
-const ASDFG_ROW: string[] = ['A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L'];
-const ZXCVB_ROW: string[] = ['Z', 'X', 'C', 'V', 'B', 'N', 'M'];
-const NUM_ROW1: string[] = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'];
-const NUM_ROW2: string[] = ['-', '/', ':', ';', '(', ')', '$', '&', '@', '"'];
-const NUM_ROW3: string[] = ['.', ',', '?', '!', "'"];
+
+const KBD_R1_L: string[] = ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'];
+const KBD_R1_R: string[] = ['1', '2', '3', '4'];
+const KBD_R2_L: string[] = ['A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L'];
+const KBD_R2_R: string[] = ['5', '6', '7', '8'];
+const KBD_R3_L: string[] = ['Z', 'X', 'C', 'V', 'B', 'N', 'M'];
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Helpers
+// Module-level helpers (avoid logic in build())
 // ─────────────────────────────────────────────────────────────────────────────
-function getRatingColor(rating: number): string {
-  if (rating >= 8.0) { return '#F7C06C'; }
-  if (rating >= 6.0) { return '#D0A26B'; }
-  return '#E6786C';
+
+function scoreColor(s: number): string {
+  if (s >= 8.5) { return '#F7C06C'; }
+  if (s >= 8.0) { return '#F6B85F'; }
+  if (s >= 7.0) { return '#E6786C'; }
+  return '#D0A26B';
 }
 
-function getPosterSrc(item: MediaItem): string {
+function posterSrc(item: MediaItem): string {
   if (item.posterLocalPath !== undefined && item.posterLocalPath.length > 0) {
-    return `file://${item.posterLocalPath}`;
+    return 'file://' + item.posterLocalPath;
   }
   if (item.posterUrl !== undefined && item.posterUrl.length > 0) {
     return item.posterUrl;
@@ -63,31 +60,29 @@ function getPosterSrc(item: MediaItem): string {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// KeyButton — single keyboard key
+// KeyButton — single keyboard key component
 // ─────────────────────────────────────────────────────────────────────────────
+
 @ComponentV2
 struct KeyButton {
   @Param label: string = '';
-  @Param kw: number = 60;
-  @Param kh: number = 56;
-  @Param kbg: string = KEY_BG;
+  @Param kw: number = 112;
+  @Param kh: number = 60;
+  @Param kbg: string = C_LETTER_KEY_BG;
   @Event onPress: () => void = () => {};
   @Local isFocused: boolean = false;
 
   build() {
     Text(this.label)
-      .fontSize(22)
+      .fontSize(20)
       .fontWeight(600)
-      .fontColor(KEY_TEXT_CLR)
+      .fontColor(C_KEY_TEXT)
       .textAlign(TextAlign.Center)
       .width(this.kw)
       .height(this.kh)
-      .borderRadius(8)
-      .backgroundColor(this.isFocused ? KEY_BG_FOCUS : this.kbg)
-      .border({ width: this.isFocused ? 2 : 0, color: FOCUS_BORDER_CLR })
-      .shadow(this.isFocused
-        ? { radius: 14, color: FOCUS_SHADOW_CLR, offsetX: 0, offsetY: 0 }
-        : { radius: 0, color: TRANSPARENT, offsetX: 0, offsetY: 0 })
+      .borderRadius(10)
+      .backgroundColor(this.isFocused ? C_SEL_BLUE : this.kbg)
+      .border({ width: this.isFocused ? 2 : 0, color: '#5B9BD5' })
       .animation({ duration: 140, curve: Curve.EaseInOut })
       .focusable(true)
       .onFocus(() => { this.isFocused = true; })
@@ -97,92 +92,66 @@ struct KeyButton {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// HistoryTag — single search history entry
+// WorkspacePosterCard — card used in workspace hot-search / results preview
 // ─────────────────────────────────────────────────────────────────────────────
-@ComponentV2
-struct HistoryTag {
-  @Param keyword: string = '';
-  @Event onSearch: () => void = () => {};
-  @Event onDelete: () => void = () => {};
-  @Local isFocused: boolean = false;
 
-  build() {
-    Row({ space: 4 }) {
-      Text(this.keyword)
-        .fontSize(16)
-        .fontColor(this.isFocused ? '#BFDBFE' : HISTORY_TAG_CLR)
-        .padding({ left: 16, right: 4 })
-      Text('×')
-        .fontSize(13)
-        .fontColor(this.isFocused ? '#80BFDBFE' : '#60CBD5E1')
-        .padding({ right: 12 })
-        .hitTestBehavior(HitTestMode.Block)
-        .onClick(() => { this.onDelete(); })
-    }
-    .height(38)
-    .backgroundColor(this.isFocused ? '#601D4ED8' : HISTORY_TAG_BG)
-    .borderRadius(19)
-    .border({ width: this.isFocused ? 2 : 1, color: this.isFocused ? FOCUS_BORDER_CLR : HISTORY_TAG_BORDER })
-    .animation({ duration: 140, curve: Curve.EaseInOut })
-    .focusable(true)
-    .onFocus(() => { this.isFocused = true; })
-    .onBlur(() => { this.isFocused = false; })
-    .onClick(() => { this.onSearch(); })
-  }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// PosterCard — search result card
-// ─────────────────────────────────────────────────────────────────────────────
 @ComponentV2
-struct PosterCard {
+struct WorkspacePosterCard {
   @Require @Param item: MediaItem;
   @Event onPress: () => void = () => {};
   @Local isFocused: boolean = false;
 
   build() {
-    Column({ space: 6 }) {
-      if (getPosterSrc(this.item).length > 0) {
-        Image(getPosterSrc(this.item))
+    Column({ space: 8 }) {
+      Stack() {
+        if (posterSrc(this.item).length > 0) {
+          Image(posterSrc(this.item))
+            .width(180)
+            .height(270)
+            .objectFit(ImageFit.Cover)
+        } else {
+          Column() {
+            Text('\u{1F3AC}')
+              .fontSize(36)
+              .opacity(0.4)
+          }
           .width(180)
           .height(270)
-          .borderRadius(8)
-          .objectFit(ImageFit.Cover)
-      } else {
-        Column() {
-          Text('🎬')
-            .fontSize(36)
-            .opacity(0.4)
+          .backgroundColor(C_COMPONENT_BG)
+          .justifyContent(FlexAlign.Center)
+          .alignItems(HorizontalAlign.Center)
         }
-        .width(180)
-        .height(270)
-        .backgroundColor(KEY_BG)
-        .borderRadius(8)
-        .justifyContent(FlexAlign.Center)
-        .alignItems(HorizontalAlign.Center)
       }
+      .width(180)
+      .height(270)
+      .clip(true)
+      .borderRadius(8)
+      .border({ width: this.isFocused ? 2 : 0, color: '#FF3B77D4' })
+      .shadow({
+        radius: this.isFocused ? 12 : 0,
+        color: this.isFocused ? '#803B77D4' : TRANSPARENT,
+        offsetX: 0,
+        offsetY: 0
+      })
+      .scale({ x: this.isFocused ? 1.04 : 1.0, y: this.isFocused ? 1.04 : 1.0 })
+      .animation({ duration: 140, curve: Curve.EaseInOut })
+
       Text(this.item.title ?? '')
         .fontSize(22)
-        .fontColor(CARD_TITLE_CLR)
-        .maxLines(2)
+        .fontColor('#E3E7ED')
+        .maxLines(1)
         .textOverflow({ overflow: TextOverflow.Ellipsis })
         .width(180)
+
       if (this.item.rating !== undefined && this.item.rating > 0) {
         Text(this.item.rating.toFixed(1))
           .fontSize(20)
           .fontWeight(600)
-          .fontColor(getRatingColor(this.item.rating))
+          .fontColor(scoreColor(this.item.rating))
       }
     }
+    .width(180)
     .alignItems(HorizontalAlign.Start)
-    .padding(4)
-    .border({ width: this.isFocused ? 2 : 0, color: FOCUS_BORDER_CLR })
-    .borderRadius(10)
-    .shadow(this.isFocused
-      ? { radius: 14, color: FOCUS_SHADOW_CLR, offsetX: 0, offsetY: 0 }
-      : { radius: 0, color: TRANSPARENT, offsetX: 0, offsetY: 0 })
-    .scale(this.isFocused ? { x: 1.03, y: 1.03 } : { x: 1.0, y: 1.0 })
-    .animation({ duration: 140, curve: Curve.EaseInOut })
     .focusable(true)
     .onFocus(() => { this.isFocused = true; })
     .onBlur(() => { this.isFocused = false; })
@@ -191,8 +160,9 @@ struct PosterCard {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// SearchWorkspacePage — main page
+// SearchWorkspacePage — main search entry page (TV vertical layout)
 // ─────────────────────────────────────────────────────────────────────────────
+
 @ComponentV2
 struct SearchWorkspacePage {
   static readonly PAGE_NAME: string = 'SearchWorkspacePage';
@@ -200,30 +170,56 @@ struct SearchWorkspacePage {
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
 
   @Local searchText: string = '';
-  @Local isNumericMode: boolean = false;
   @Local searchResults: MediaItem[] = [];
   @Local historyList: SearchHistoryEntry[] = [];
   @Local isSearching: boolean = false;
+  @Local hotItems: MediaItem[] = [];
 
   private db: FileSourceDatabase = FileSourceDatabase.getInstance();
+  private searchTimerId: number = 0;
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
 
   aboutToAppear(): void {
     this.loadHistory();
+    this.loadHotItems();
   }
 
-  // ─── Data operations ────────────────────────────────────────────────────────
+  aboutToDisappear(): void {
+    clearTimeout(this.searchTimerId);
+  }
+
+  // ── Data helpers ──────────────────────────────────────────────────────────
 
   private loadHistory(): void {
-    this.db.getSearchHistory(15)
+    this.db.getSearchHistory(20)
       .then((list: SearchHistoryEntry[]) => {
         this.historyList = list;
       })
       .catch(() => {});
   }
 
+  private loadHotItems(): void {
+    this.db.searchMediaItems('', { sortBy: 'rating', limit: 8 })
+      .then((items: MediaItem[]) => {
+        this.hotItems = items;
+      })
+      .catch(() => {});
+  }
+
+  private scheduleSearch(): void {
+    clearTimeout(this.searchTimerId);
+    this.searchTimerId = setTimeout((): void => {
+      this.executeSearch();
+    }, 300);
+  }
+
   private executeSearch(): void {
-    const kw = this.searchText.trim();
-    if (kw.length === 0) { return; }
+    const kw: string = this.searchText.trim();
+    if (kw.length === 0) {
+      this.searchResults = [];
+      return;
+    }
     this.isSearching = true;
     this.db.searchMediaItems(kw, { limit: 50 })
       .then((results: MediaItem[]) => {
@@ -238,13 +234,15 @@ struct SearchWorkspacePage {
       .catch(() => {});
   }
 
-  private appendChar(char: string): void {
-    this.searchText += char;
+  private appendChar(c: string): void {
+    this.searchText += c;
+    this.scheduleSearch();
   }
 
   private deleteLastChar(): void {
     if (this.searchText.length > 0) {
       this.searchText = this.searchText.slice(0, -1);
+      this.scheduleSearch();
     }
   }
 
@@ -261,9 +259,7 @@ struct SearchWorkspacePage {
 
   private clearAllHistory(): void {
     this.db.clearSearchHistory()
-      .then(() => {
-        this.historyList = [];
-      })
+      .then(() => { this.historyList = []; })
       .catch(() => {});
   }
 
@@ -274,10 +270,11 @@ struct SearchWorkspacePage {
         tvSeriesId: item.tvSeriesId,
         posterUrl: item.posterUrl,
         posterLocalPath: item.posterLocalPath,
+        backdropUrl: item.backdropUrl,
         rating: item.rating,
         episodeCount: 0,
-        episodes: [],
-        latestScannedAt: 0,
+        episodes: [item],
+        latestScannedAt: item.scannedAt ?? 0,
       };
       this.pageStack.pushPathByName(SeriesDetailPage.PAGE_NAME, group);
     } else {
@@ -285,360 +282,304 @@ struct SearchWorkspacePage {
     }
   }
 
-  // ─── Builders ────────────────────────────────────────────────────────────────
+  // ── @Builder sections ─────────────────────────────────────────────────────
 
   @Builder
-  headerBar() {
+  buildBackRow() {
     Row() {
-      // Back button
-      Row({ space: 8 }) {
-        Text('←')
-          .fontSize(20)
-          .fontColor('#FFFFFF')
-        Text('返回')
-          .fontSize(16)
-          .fontColor('#FFFFFF')
+      Row() {
+        Text('\u{2039}')
+          .fontSize(22)
+          .fontColor(C_TEXT_BODY)
       }
-      .width(112)
-      .height(40)
-      .backgroundColor('#14FFFFFF')
-      .borderRadius(8)
+      .width(48)
+      .height(48)
+      .borderRadius(24)
+      .backgroundColor(C_COMPONENT_BG)
+      .border({ width: 1, color: C_BORDER })
       .justifyContent(FlexAlign.Center)
+      .alignItems(VerticalAlign.Center)
       .focusable(true)
       .onClick(() => { this.pageStack.pop(); })
-
-      // Title
-      Text('搜索')
-        .fontSize(22)
-        .fontWeight(700)
-        .fontColor('#FFFFFF')
-        .layoutWeight(1)
-        .textAlign(TextAlign.Center)
-
-      // Placeholder
-      Row()
-        .width(112)
-        .height(40)
     }
     .width('100%')
-    .height(72)
-    .padding({ left: 48, right: 64 })
+    .height(48)
     .alignItems(VerticalAlign.Center)
-    .backgroundColor(PAGE_BG)
   }
 
   @Builder
-  searchInputBar() {
-    Row({ space: 0 }) {
-      // Search icon
-      Text('🔍')
-        .fontSize(20)
-        .fontColor(PLACEHOLDER_CLR)
-        .padding({ left: 16, right: 8 })
+  buildTitleArea() {
+    Column({ space: 8 }) {
+      Text('\u641c\u7d22')
+        .fontSize(34)
+        .fontWeight(700)
+        .fontColor(C_TEXT_TITLE)
+      Text('\u652f\u6301\u9996\u5b57\u6bcd\u3001\u5168\u62fc\u3001\u4e2d\u6587\u7247\u540d\u641c\u7d22')
+        .fontSize(18)
+        .fontWeight(500)
+        .fontColor(C_SECONDARY)
+    }
+    .alignItems(HorizontalAlign.Start)
+    .width('100%')
+  }
 
-      // Search text or placeholder
+  @Builder
+  buildSearchBar() {
+    Row({ space: 12 }) {
+      Text('\uD83D\uDD0D')
+        .fontSize(22)
+        .fontColor(C_ICON)
+        .width(22)
+        .height(22)
       if (this.searchText.length > 0) {
         Text(this.searchText)
-          .fontSize(18)
-          .fontColor(INPUT_TEXT_CLR)
+          .fontSize(22)
+          .fontWeight(500)
+          .fontColor(C_TEXT_TITLE)
           .layoutWeight(1)
           .maxLines(1)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
       } else {
-        Text('搜索电影、剧集、演员…')
-          .fontSize(18)
-          .fontColor(PLACEHOLDER_CLR)
+        Text('\u8f93\u5165\u5173\u952e\u8bcd\u641c\u7d22\u2026')
+          .fontSize(22)
+          .fontWeight(500)
+          .fontColor(C_PLACEHOLDER)
           .layoutWeight(1)
-      }
-
-      // Clear button
-      if (this.searchText.length > 0) {
-        Text('✕')
-          .fontSize(16)
-          .fontColor('#FFFFFF')
-          .textAlign(TextAlign.Center)
-          .width(28)
-          .height(28)
-          .borderRadius(14)
-          .backgroundColor('#25FFFFFF')
-          .margin({ right: 12 })
-          .focusable(true)
-          .onClick(() => { this.clearSearch(); })
       }
     }
     .width('100%')
-    .height(66)
-    .borderRadius(8)
-    .backgroundColor(INPUT_BG)
-    .border({ width: 1, color: INPUT_BORDER })
+    .height(56)
+    .padding({ left: 16, right: 16 })
+    .backgroundColor(C_COMPONENT_BG)
+    .borderRadius(14)
+    .border({ width: 1, color: C_BORDER })
     .alignItems(VerticalAlign.Center)
     .defaultFocus(true)
   }
 
+  // row1: Q-P + 1-4
   @Builder
-  keyboardRow(keys: string[]) {
-    Row({ space: 8 }) {
-      ForEach(keys, (key: string) => {
-        KeyButton({
-          label: key,
-          kw: 60,
-          kh: 56,
-          kbg: KEY_BG,
-          onPress: () => { this.appendChar(key); }
-        })
-      }, (key: string) => key)
+  buildKbdRow1() {
+    Row() {
+      Row({ space: 8 }) {
+        ForEach(KBD_R1_L, (key: string) => {
+          KeyButton({ label: key, kw: 112, kh: 60, onPress: () => { this.appendChar(key); } })
+        }, (key: string) => key)
+      }
+      Row({ space: 8 }) {
+        ForEach(KBD_R1_R, (key: string) => {
+          KeyButton({ label: key, kw: 128, kh: 60, onPress: () => { this.appendChar(key); } })
+        }, (key: string) => key)
+      }
     }
-    .justifyContent(FlexAlign.Center)
     .width('100%')
+    .justifyContent(FlexAlign.SpaceBetween)
+  }
+
+  // row2: A-L + clear + 5-8
+  @Builder
+  buildKbdRow2() {
+    Row() {
+      Row({ space: 8 }) {
+        ForEach(KBD_R2_L, (key: string) => {
+          KeyButton({ label: key, kw: 112, kh: 60, onPress: () => { this.appendChar(key); } })
+        }, (key: string) => key)
+        // Clear key — red-toned, trash icon
+        Text('\uD83D\uDDD1')
+          .fontSize(24)
+          .fontColor(C_CLEAR_ICON)
+          .textAlign(TextAlign.Center)
+          .width(112)
+          .height(60)
+          .borderRadius(10)
+          .backgroundColor(C_CLEAR_BG)
+          .border({ width: 1, color: C_CLEAR_BORDER })
+          .focusable(true)
+          .onClick(() => { this.clearSearch(); })
+      }
+      Row({ space: 8 }) {
+        ForEach(KBD_R2_R, (key: string) => {
+          KeyButton({ label: key, kw: 128, kh: 60, onPress: () => { this.appendChar(key); } })
+        }, (key: string) => key)
+      }
+    }
+    .width('100%')
+    .justifyContent(FlexAlign.SpaceBetween)
+  }
+
+  // row3: Z-M + backspace(352) + 9(128) + 0(400)
+  @Builder
+  buildKbdRow3() {
+    Row() {
+      Row({ space: 8 }) {
+        ForEach(KBD_R3_L, (key: string) => {
+          KeyButton({ label: key, kw: 112, kh: 60, onPress: () => { this.appendChar(key); } })
+        }, (key: string) => key)
+        // Backspace key
+        Text('\u232B')
+          .fontSize(20)
+          .fontWeight(700)
+          .fontColor('#FFFFFF')
+          .textAlign(TextAlign.Center)
+          .width(352)
+          .height(60)
+          .borderRadius(10)
+          .backgroundColor(C_BKSP_BG)
+          .focusable(true)
+          .onClick(() => { this.deleteLastChar(); })
+      }
+      Row({ space: 8 }) {
+        // 9 key
+        Text('9')
+          .fontSize(20)
+          .fontWeight(600)
+          .fontColor(C_KEY_TEXT)
+          .textAlign(TextAlign.Center)
+          .width(128)
+          .height(60)
+          .borderRadius(10)
+          .backgroundColor(C_LETTER_KEY_BG)
+          .focusable(true)
+          .onClick(() => { this.appendChar('9'); })
+        // 0 key (wide)
+        Text('0')
+          .fontSize(20)
+          .fontWeight(600)
+          .fontColor(C_KEY_TEXT)
+          .textAlign(TextAlign.Center)
+          .width(400)
+          .height(60)
+          .borderRadius(10)
+          .backgroundColor(C_LETTER_KEY_BG)
+          .focusable(true)
+          .onClick(() => { this.appendChar('0'); })
+      }
+    }
+    .width('100%')
+    .justifyContent(FlexAlign.SpaceBetween)
   }
 
   @Builder
-  keyboardZxcvbRow() {
-    Row({ space: 8 }) {
-      ForEach(ZXCVB_ROW, (key: string) => {
-        KeyButton({
-          label: key,
-          kw: 60,
-          kh: 56,
-          kbg: KEY_BG,
-          onPress: () => { this.appendChar(key); }
-        })
-      }, (key: string) => key)
-      // Backspace key
-      KeyButton({
-        label: '⌫',
-        kw: 100,
-        kh: 56,
-        kbg: KEY_BG,
-        onPress: () => { this.deleteLastChar(); }
-      })
+  buildKeyboard() {
+    Column({ space: 10 }) {
+      this.buildKbdRow1()
+      this.buildKbdRow2()
+      this.buildKbdRow3()
     }
-    .justifyContent(FlexAlign.Center)
     .width('100%')
+    .backgroundColor(C_KBD_BG)
+    .borderRadius(14)
+    .padding(14)
   }
 
   @Builder
-  keyboardFuncRow() {
-    Row({ space: 8 }) {
-      // Mode toggle
-      KeyButton({
-        label: this.isNumericMode ? 'ABC' : '123',
-        kw: 96,
-        kh: 56,
-        kbg: KEY_BG,
-        onPress: () => { this.isNumericMode = !this.isNumericMode; }
-      })
-      // Space
-      KeyButton({
-        label: '空格',
-        kw: 220,
-        kh: 56,
-        kbg: SPACE_KEY_BG,
-        onPress: () => { this.appendChar(' '); }
-      })
-      // Clear
-      KeyButton({
-        label: '× 清空',
-        kw: 96,
-        kh: 56,
-        kbg: CLEAR_KEY_BG,
-        onPress: () => { this.clearSearch(); }
-      })
-      // Search
-      KeyButton({
-        label: '🔍搜索',
-        kw: 128,
-        kh: 56,
-        kbg: SEARCH_KEY_BG,
-        onPress: () => { this.executeSearch(); }
-      })
-    }
-    .justifyContent(FlexAlign.Center)
-    .width('100%')
-  }
-
-  @Builder
-  softKeyboard() {
-    Column({ space: 8 }) {
-      if (this.isNumericMode) {
-        // Numeric mode rows
-        this.keyboardRow(NUM_ROW1)
-        this.keyboardRow(NUM_ROW2)
-        Row({ space: 8 }) {
-          ForEach(NUM_ROW3, (key: string) => {
-            KeyButton({
-              label: key,
-              kw: 60,
-              kh: 56,
-              kbg: KEY_BG,
-              onPress: () => { this.appendChar(key); }
-            })
-          }, (key: string) => key)
-          KeyButton({
-            label: '⌫',
-            kw: 100,
-            kh: 56,
-            kbg: KEY_BG,
-            onPress: () => { this.deleteLastChar(); }
+  buildHistory() {
+    if (this.historyList.length > 0) {
+      Flex({ wrap: FlexWrap.Wrap }) {
+        ForEach(this.historyList, (entry: SearchHistoryEntry) => {
+          Row({ space: 4 }) {
+            Text(entry.keyword)
+              .fontSize(16)
+              .fontWeight(500)
+              .fontColor(C_HIST_TEXT)
+            Text('\u00D7')
+              .fontSize(14)
+              .fontColor(C_SECONDARY)
+              .hitTestBehavior(HitTestMode.Block)
+              .onClick(() => { this.deleteHistory(entry.keyword); })
+          }
+          .padding({ left: 14, right: 14, top: 8, bottom: 8 })
+          .backgroundColor(C_HIST_CHIP_BG)
+          .borderRadius(999)
+          .border({ width: 1, color: C_HIST_BORDER })
+          .margin({ right: 10, bottom: 10 })
+          .focusable(true)
+          .onClick(() => {
+            this.searchText = entry.keyword;
+            this.executeSearch();
           })
-        }
-        .justifyContent(FlexAlign.Center)
-        .width('100%')
-      } else {
-        // QWERTY mode rows
-        this.keyboardRow(QWERTY_ROW)
-        this.keyboardRow(ASDFG_ROW)
-        this.keyboardZxcvbRow()
+        }, (entry: SearchHistoryEntry) => entry.keyword)
+
+        // Clear-all button styled same as chip
+        Text('\u5220\u9664\u5386\u53f2')
+          .fontSize(16)
+          .fontWeight(600)
+          .fontColor('#D7DEE7')
+          .padding({ left: 14, right: 14, top: 8, bottom: 8 })
+          .backgroundColor(C_HIST_CHIP_BG)
+          .borderRadius(999)
+          .border({ width: 1, color: C_HIST_BORDER })
+          .margin({ right: 10, bottom: 10 })
+          .focusable(true)
+          .onClick(() => { this.clearAllHistory(); })
       }
-      // Function row (shared)
-      this.keyboardFuncRow()
+      .width('100%')
     }
-    .width(680)
-    .height(560)
-    .margin({ top: 16 })
   }
 
   @Builder
-  leftPanel() {
-    Column() {
-      this.searchInputBar()
-      this.softKeyboard()
-    }
-    .width(760)
-    .height(1008)
-    .padding({ left: 48, right: 32, top: 32 })
-    .alignItems(HorizontalAlign.Start)
-    .backgroundColor(PAGE_BG)
-  }
-
-  @Builder
-  historyArea() {
-    Column({ space: 16 }) {
-      if (this.historyList.length > 0) {
-        // Title row
-        Row() {
-          Text('搜索历史')
-            .fontSize(16)
-            .fontWeight(600)
-            .fontColor(HISTORY_TITLE_CLR)
-          Blank()
-          Text('全部清除')
-            .fontSize(13)
-            .fontColor(CLEAR_ALL_CLR)
-            .width(80)
-            .height(32)
-            .textAlign(TextAlign.Center)
-            .backgroundColor(CLEAR_ALL_BG)
-            .borderRadius(6)
-            .border({ width: 1, color: CLEAR_ALL_BORDER })
-            .focusable(true)
-            .onClick(() => { this.clearAllHistory(); })
+  buildHotSearch() {
+    if (this.hotItems.length > 0) {
+      Column({ space: 16 }) {
+        Text('\u5927\u5bb6\u90fd\u5728\u641c')
+          .fontSize(24)
+          .fontWeight(700)
+          .fontColor('#DDE2EA')
+          .width('100%')
+        Scroll() {
+          Row({ space: 30 }) {
+            ForEach(this.hotItems, (item: MediaItem) => {
+              WorkspacePosterCard({
+                item: item,
+                onPress: () => { this.navigateToDetail(item); }
+              })
+            }, (item: MediaItem) => String(item.id))
+          }
         }
+        .scrollable(ScrollDirection.Horizontal)
         .width('100%')
-        .alignItems(VerticalAlign.Center)
-
-        // History tags
-        Flex({ wrap: FlexWrap.Wrap }) {
-          ForEach(this.historyList, (entry: SearchHistoryEntry) => {
-            HistoryTag({
-              keyword: entry.keyword,
-              onSearch: () => {
-                this.searchText = entry.keyword;
-                this.executeSearch();
-              },
-              onDelete: () => { this.deleteHistory(entry.keyword); }
-            })
-            .margin({ right: 10, bottom: 10 })
-          }, (entry: SearchHistoryEntry) => entry.keyword)
-        }
-        .width('100%')
-      } else {
-        // Empty state
-        Column({ space: 16 }) {
-          Text('🔍')
-            .fontSize(48)
-            .opacity(0.25)
-          Text('暂无搜索记录')
-            .fontSize(18)
-            .fontColor('#666666')
-          Text('输入关键词开始搜索')
-            .fontSize(13)
-            .fontColor('#444444')
-        }
-        .width('100%')
-        .layoutWeight(1)
-        .justifyContent(FlexAlign.Center)
-        .alignItems(HorizontalAlign.Center)
       }
+      .width('100%')
+      .alignItems(HorizontalAlign.Start)
     }
-    .width('100%')
-    .alignItems(HorizontalAlign.Start)
   }
 
   @Builder
-  resultsArea() {
-    Column({ space: 16 }) {
-      // Result count
-      Text(`找到 ${this.searchResults.length} 个结果`)
-        .fontSize(16)
-        .fontColor(RESULT_CNT_CLR)
-
-      // Results grid
-      Grid() {
-        ForEach(this.searchResults, (item: MediaItem) => {
-          GridItem() {
-            PosterCard({
+  buildResultsPreview() {
+    if (this.searchResults.length > 0) {
+      Scroll() {
+        Row({ space: 30 }) {
+          ForEach(this.searchResults, (item: MediaItem) => {
+            WorkspacePosterCard({
               item: item,
               onPress: () => { this.navigateToDetail(item); }
             })
-          }
-        }, (item: MediaItem) => `${item.id}`)
+          }, (item: MediaItem) => String(item.id))
+        }
       }
-      .columnsTemplate('1fr 1fr 1fr 1fr 1fr')
-      .columnsGap(16)
-      .rowsGap(20)
+      .scrollable(ScrollDirection.Horizontal)
       .width('100%')
-      .layoutWeight(1)
     }
-    .width('100%')
-    .layoutWeight(1)
-    .alignItems(HorizontalAlign.Start)
-  }
-
-  @Builder
-  rightPanel() {
-    Column() {
-      if (this.searchText.trim().length === 0) {
-        this.historyArea()
-      } else {
-        this.resultsArea()
-      }
-    }
-    .width(1160)
-    .height(1008)
-    .padding({ left: 48, right: 64, top: 32 })
-    .alignItems(HorizontalAlign.Start)
-    .backgroundColor(PAGE_BG)
   }
 
   build() {
     NavDestination() {
-      Column() {
-        // Header
-        this.headerBar()
-
-        // Body: left panel + right panel
-        Row() {
-          this.leftPanel()
-          this.rightPanel()
+      Column({ space: 20 }) {
+        this.buildBackRow()
+        this.buildTitleArea()
+        this.buildSearchBar()
+        this.buildKeyboard()
+        if (this.searchText.length > 0) {
+          this.buildResultsPreview()
+        } else {
+          this.buildHistory()
+          this.buildHotSearch()
         }
-        .width('100%')
-        .height(1008)
-        .alignItems(VerticalAlign.Top)
       }
       .width('100%')
       .height('100%')
-      .backgroundColor(PAGE_BG)
+      .padding(20)
+      .backgroundColor(C_PAGE_BG)
     }
     .hideTitleBar(true)
     .onBackPressed(() => {

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -1,0 +1,651 @@
+import { MediaItem, SearchHistoryEntry, SeriesGroup } from '../../db/models/MediaEntity';
+import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
+import { SeriesDetailPage } from '../detail/SeriesDetailPage';
+import { MovieDetailPage } from '../detail/MovieDetailPage';
+import { BusinessError } from '@kit.BasicServicesKit';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Color tokens
+// ─────────────────────────────────────────────────────────────────────────────
+const PAGE_BG: string = '#1A1A1A';
+const KEY_BG: string = '#2D2F33';
+const KEY_BG_FOCUS: string = '#3B77D4';
+const KEY_BG_PRESS: string = '#4488FF';
+const FOCUS_BORDER_CLR: string = '#66A9D8FF';
+const FOCUS_SHADOW_CLR: string = '#553A86FF';
+const KEY_TEXT_CLR: string = '#E3E7ED';
+const PLACEHOLDER_CLR: string = '#97A9CD';
+const INPUT_TEXT_CLR: string = '#E8EEFF';
+const INPUT_BG: string = '#ffffff12';
+const INPUT_BORDER: string = '#ffffff25';
+const SPACE_KEY_BG: string = '#3B3D40';
+const CLEAR_KEY_BG: string = '#FF6B6B14';
+const CLEAR_KEY_BORDER: string = '#FF6B6B4D';
+const SEARCH_KEY_BG: string = '#2F77F5';
+const HISTORY_TITLE_CLR: string = '#DDE2EA';
+const HISTORY_TAG_CLR: string = '#CBD5E1';
+const HISTORY_TAG_BG: string = '#33415550';
+const HISTORY_TAG_BORDER: string = '#CBD5E166';
+const CLEAR_ALL_CLR: string = '#FF6B6B';
+const CLEAR_ALL_BG: string = '#FF6B6B14';
+const CLEAR_ALL_BORDER: string = '#FF6B6B4D';
+const RESULT_CNT_CLR: string = '#97A9CD';
+const CARD_TITLE_CLR: string = '#E3E7ED';
+const TRANSPARENT: string = '#00000000';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Keyboard layout constants
+// ─────────────────────────────────────────────────────────────────────────────
+const QWERTY_ROW: string[] = ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'];
+const ASDFG_ROW: string[] = ['A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L'];
+const ZXCVB_ROW: string[] = ['Z', 'X', 'C', 'V', 'B', 'N', 'M'];
+const NUM_ROW1: string[] = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'];
+const NUM_ROW2: string[] = ['-', '/', ':', ';', '(', ')', '$', '&', '@', '"'];
+const NUM_ROW3: string[] = ['.', ',', '?', '!', "'"];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+function getRatingColor(rating: number): string {
+  if (rating >= 8.0) { return '#F7C06C'; }
+  if (rating >= 6.0) { return '#D0A26B'; }
+  return '#E6786C';
+}
+
+function getPosterSrc(item: MediaItem): string {
+  if (item.posterLocalPath !== undefined && item.posterLocalPath.length > 0) {
+    return `file://${item.posterLocalPath}`;
+  }
+  if (item.posterUrl !== undefined && item.posterUrl.length > 0) {
+    return item.posterUrl;
+  }
+  return '';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// KeyButton — single keyboard key
+// ─────────────────────────────────────────────────────────────────────────────
+@ComponentV2
+struct KeyButton {
+  @Param label: string = '';
+  @Param kw: number = 60;
+  @Param kh: number = 56;
+  @Param kbg: string = KEY_BG;
+  @Event onPress: () => void = () => {};
+  @Local isFocused: boolean = false;
+
+  build() {
+    Text(this.label)
+      .fontSize(22)
+      .fontWeight(600)
+      .fontColor(KEY_TEXT_CLR)
+      .textAlign(TextAlign.Center)
+      .width(this.kw)
+      .height(this.kh)
+      .borderRadius(8)
+      .backgroundColor(this.isFocused ? KEY_BG_FOCUS : this.kbg)
+      .border({ width: this.isFocused ? 2 : 0, color: FOCUS_BORDER_CLR })
+      .shadow(this.isFocused
+        ? { radius: 14, color: FOCUS_SHADOW_CLR, offsetX: 0, offsetY: 0 }
+        : { radius: 0, color: TRANSPARENT, offsetX: 0, offsetY: 0 })
+      .animation({ duration: 140, curve: Curve.EaseInOut })
+      .focusable(true)
+      .onFocus(() => { this.isFocused = true; })
+      .onBlur(() => { this.isFocused = false; })
+      .onClick(() => { this.onPress(); })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HistoryTag — single search history entry
+// ─────────────────────────────────────────────────────────────────────────────
+@ComponentV2
+struct HistoryTag {
+  @Param keyword: string = '';
+  @Event onSearch: () => void = () => {};
+  @Event onDelete: () => void = () => {};
+  @Local isFocused: boolean = false;
+
+  build() {
+    Row({ space: 4 }) {
+      Text(this.keyword)
+        .fontSize(16)
+        .fontColor(this.isFocused ? '#BFDBFE' : HISTORY_TAG_CLR)
+        .padding({ left: 16, right: 4 })
+      Text('×')
+        .fontSize(13)
+        .fontColor(this.isFocused ? '#BFDBFE80' : '#CBD5E160')
+        .padding({ right: 12 })
+        .hitTestBehavior(HitTestMode.Block)
+        .onClick(() => { this.onDelete(); })
+    }
+    .height(38)
+    .backgroundColor(this.isFocused ? '#1D4ED860' : HISTORY_TAG_BG)
+    .borderRadius(19)
+    .border({ width: this.isFocused ? 2 : 1, color: this.isFocused ? FOCUS_BORDER_CLR : HISTORY_TAG_BORDER })
+    .animation({ duration: 140, curve: Curve.EaseInOut })
+    .focusable(true)
+    .onFocus(() => { this.isFocused = true; })
+    .onBlur(() => { this.isFocused = false; })
+    .onClick(() => { this.onSearch(); })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PosterCard — search result card
+// ─────────────────────────────────────────────────────────────────────────────
+@ComponentV2
+struct PosterCard {
+  @Require @Param item: MediaItem;
+  @Event onPress: () => void = () => {};
+  @Local isFocused: boolean = false;
+
+  build() {
+    Column({ space: 6 }) {
+      if (getPosterSrc(this.item).length > 0) {
+        Image(getPosterSrc(this.item))
+          .width(180)
+          .height(270)
+          .borderRadius(8)
+          .objectFit(ImageFit.Cover)
+      } else {
+        Column() {
+          Text('🎬')
+            .fontSize(36)
+            .opacity(0.4)
+        }
+        .width(180)
+        .height(270)
+        .backgroundColor(KEY_BG)
+        .borderRadius(8)
+        .justifyContent(FlexAlign.Center)
+        .alignItems(HorizontalAlign.Center)
+      }
+      Text(this.item.title ?? '')
+        .fontSize(22)
+        .fontColor(CARD_TITLE_CLR)
+        .maxLines(2)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
+        .width(180)
+      if (this.item.rating !== undefined && this.item.rating > 0) {
+        Text(this.item.rating.toFixed(1))
+          .fontSize(20)
+          .fontWeight(600)
+          .fontColor(getRatingColor(this.item.rating))
+      }
+    }
+    .alignItems(HorizontalAlign.Start)
+    .padding(4)
+    .border({ width: this.isFocused ? 2 : 0, color: FOCUS_BORDER_CLR })
+    .borderRadius(10)
+    .shadow(this.isFocused
+      ? { radius: 14, color: FOCUS_SHADOW_CLR, offsetX: 0, offsetY: 0 }
+      : { radius: 0, color: TRANSPARENT, offsetX: 0, offsetY: 0 })
+    .scale(this.isFocused ? { x: 1.03, y: 1.03 } : { x: 1.0, y: 1.0 })
+    .animation({ duration: 140, curve: Curve.EaseInOut })
+    .focusable(true)
+    .onFocus(() => { this.isFocused = true; })
+    .onBlur(() => { this.isFocused = false; })
+    .onClick(() => { this.onPress(); })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SearchWorkspacePage — main page
+// ─────────────────────────────────────────────────────────────────────────────
+@ComponentV2
+struct SearchWorkspacePage {
+  static readonly PAGE_NAME: string = 'SearchWorkspacePage';
+
+  @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
+
+  @Local searchText: string = '';
+  @Local isNumericMode: boolean = false;
+  @Local searchResults: MediaItem[] = [];
+  @Local historyList: SearchHistoryEntry[] = [];
+  @Local isSearching: boolean = false;
+
+  private db: FileSourceDatabase = FileSourceDatabase.getInstance();
+
+  aboutToAppear(): void {
+    this.loadHistory();
+  }
+
+  // ─── Data operations ────────────────────────────────────────────────────────
+
+  private loadHistory(): void {
+    this.db.getSearchHistory(15)
+      .then((list: SearchHistoryEntry[]) => {
+        this.historyList = list;
+      })
+      .catch(() => {});
+  }
+
+  private executeSearch(): void {
+    const kw = this.searchText.trim();
+    if (kw.length === 0) { return; }
+    this.isSearching = true;
+    this.db.searchMediaItems(kw, { limit: 50 })
+      .then((results: MediaItem[]) => {
+        this.searchResults = results;
+        this.isSearching = false;
+      })
+      .catch(() => {
+        this.isSearching = false;
+      });
+    this.db.upsertSearchHistory(kw)
+      .then(() => { this.loadHistory(); })
+      .catch(() => {});
+  }
+
+  private appendChar(char: string): void {
+    this.searchText += char;
+  }
+
+  private deleteLastChar(): void {
+    if (this.searchText.length > 0) {
+      this.searchText = this.searchText.slice(0, -1);
+    }
+  }
+
+  private clearSearch(): void {
+    this.searchText = '';
+    this.searchResults = [];
+  }
+
+  private deleteHistory(keyword: string): void {
+    this.db.deleteSearchHistory(keyword)
+      .then(() => { this.loadHistory(); })
+      .catch(() => {});
+  }
+
+  private clearAllHistory(): void {
+    this.db.clearSearchHistory()
+      .then(() => {
+        this.historyList = [];
+      })
+      .catch(() => {});
+  }
+
+  private navigateToDetail(item: MediaItem): void {
+    if (item.mediaType === 'tv') {
+      const group: SeriesGroup = {
+        title: item.title ?? '',
+        tvSeriesId: item.tvSeriesId,
+        posterUrl: item.posterUrl,
+        posterLocalPath: item.posterLocalPath,
+        rating: item.rating,
+        episodeCount: 0,
+        episodes: [],
+        latestScannedAt: 0,
+      };
+      this.pageStack.pushPathByName(SeriesDetailPage.PAGE_NAME, group);
+    } else {
+      this.pageStack.pushPathByName(MovieDetailPage.PAGE_NAME, item);
+    }
+  }
+
+  // ─── Builders ────────────────────────────────────────────────────────────────
+
+  @Builder
+  headerBar() {
+    Row() {
+      // Back button
+      Row({ space: 8 }) {
+        Text('←')
+          .fontSize(20)
+          .fontColor('#FFFFFF')
+        Text('返回')
+          .fontSize(16)
+          .fontColor('#FFFFFF')
+      }
+      .width(112)
+      .height(40)
+      .backgroundColor('#FFFFFF14')
+      .borderRadius(8)
+      .justifyContent(FlexAlign.Center)
+      .focusable(true)
+      .onClick(() => { this.pageStack.pop(); })
+
+      // Title
+      Text('搜索')
+        .fontSize(22)
+        .fontWeight(700)
+        .fontColor('#FFFFFF')
+        .layoutWeight(1)
+        .textAlign(TextAlign.Center)
+
+      // Placeholder
+      Row()
+        .width(112)
+        .height(40)
+    }
+    .width('100%')
+    .height(72)
+    .padding({ left: 48, right: 64 })
+    .alignItems(VerticalAlign.Center)
+    .backgroundColor(PAGE_BG)
+  }
+
+  @Builder
+  searchInputBar() {
+    Row({ space: 0 }) {
+      // Search icon
+      Text('🔍')
+        .fontSize(20)
+        .fontColor(PLACEHOLDER_CLR)
+        .padding({ left: 16, right: 8 })
+
+      // Search text or placeholder
+      if (this.searchText.length > 0) {
+        Text(this.searchText)
+          .fontSize(18)
+          .fontColor(INPUT_TEXT_CLR)
+          .layoutWeight(1)
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+      } else {
+        Text('搜索电影、剧集、演员…')
+          .fontSize(18)
+          .fontColor(PLACEHOLDER_CLR)
+          .layoutWeight(1)
+      }
+
+      // Clear button
+      if (this.searchText.length > 0) {
+        Text('✕')
+          .fontSize(16)
+          .fontColor('#FFFFFF')
+          .textAlign(TextAlign.Center)
+          .width(28)
+          .height(28)
+          .borderRadius(14)
+          .backgroundColor('#FFFFFF25')
+          .margin({ right: 12 })
+          .focusable(true)
+          .onClick(() => { this.clearSearch(); })
+      }
+    }
+    .width('100%')
+    .height(66)
+    .borderRadius(8)
+    .backgroundColor(INPUT_BG)
+    .border({ width: 1, color: INPUT_BORDER })
+    .alignItems(VerticalAlign.Center)
+    .defaultFocus(true)
+  }
+
+  @Builder
+  keyboardRow(keys: string[]) {
+    Row({ space: 8 }) {
+      ForEach(keys, (key: string) => {
+        KeyButton({
+          label: key,
+          kw: 60,
+          kh: 56,
+          kbg: KEY_BG,
+          onPress: () => { this.appendChar(key); }
+        })
+      }, (key: string) => key)
+    }
+    .justifyContent(FlexAlign.Center)
+    .width('100%')
+  }
+
+  @Builder
+  keyboardZxcvbRow() {
+    Row({ space: 8 }) {
+      ForEach(ZXCVB_ROW, (key: string) => {
+        KeyButton({
+          label: key,
+          kw: 60,
+          kh: 56,
+          kbg: KEY_BG,
+          onPress: () => { this.appendChar(key); }
+        })
+      }, (key: string) => key)
+      // Backspace key
+      KeyButton({
+        label: '⌫',
+        kw: 100,
+        kh: 56,
+        kbg: KEY_BG,
+        onPress: () => { this.deleteLastChar(); }
+      })
+    }
+    .justifyContent(FlexAlign.Center)
+    .width('100%')
+  }
+
+  @Builder
+  keyboardFuncRow() {
+    Row({ space: 8 }) {
+      // Mode toggle
+      KeyButton({
+        label: this.isNumericMode ? 'ABC' : '123',
+        kw: 96,
+        kh: 56,
+        kbg: KEY_BG,
+        onPress: () => { this.isNumericMode = !this.isNumericMode; }
+      })
+      // Space
+      KeyButton({
+        label: '空格',
+        kw: 220,
+        kh: 56,
+        kbg: SPACE_KEY_BG,
+        onPress: () => { this.appendChar(' '); }
+      })
+      // Clear
+      KeyButton({
+        label: '× 清空',
+        kw: 96,
+        kh: 56,
+        kbg: CLEAR_KEY_BG,
+        onPress: () => { this.clearSearch(); }
+      })
+      // Search
+      KeyButton({
+        label: '🔍搜索',
+        kw: 128,
+        kh: 56,
+        kbg: SEARCH_KEY_BG,
+        onPress: () => { this.executeSearch(); }
+      })
+    }
+    .justifyContent(FlexAlign.Center)
+    .width('100%')
+  }
+
+  @Builder
+  softKeyboard() {
+    Column({ space: 8 }) {
+      if (this.isNumericMode) {
+        // Numeric mode rows
+        this.keyboardRow(NUM_ROW1)
+        this.keyboardRow(NUM_ROW2)
+        Row({ space: 8 }) {
+          ForEach(NUM_ROW3, (key: string) => {
+            KeyButton({
+              label: key,
+              kw: 60,
+              kh: 56,
+              kbg: KEY_BG,
+              onPress: () => { this.appendChar(key); }
+            })
+          }, (key: string) => key)
+          KeyButton({
+            label: '⌫',
+            kw: 100,
+            kh: 56,
+            kbg: KEY_BG,
+            onPress: () => { this.deleteLastChar(); }
+          })
+        }
+        .justifyContent(FlexAlign.Center)
+        .width('100%')
+      } else {
+        // QWERTY mode rows
+        this.keyboardRow(QWERTY_ROW)
+        this.keyboardRow(ASDFG_ROW)
+        this.keyboardZxcvbRow()
+      }
+      // Function row (shared)
+      this.keyboardFuncRow()
+    }
+    .width(680)
+    .height(560)
+    .margin({ top: 16 })
+  }
+
+  @Builder
+  leftPanel() {
+    Column() {
+      this.searchInputBar()
+      this.softKeyboard()
+    }
+    .width(760)
+    .height(1008)
+    .padding({ left: 48, right: 32, top: 32 })
+    .alignItems(HorizontalAlign.Start)
+    .backgroundColor(PAGE_BG)
+  }
+
+  @Builder
+  historyArea() {
+    Column({ space: 16 }) {
+      if (this.historyList.length > 0) {
+        // Title row
+        Row() {
+          Text('搜索历史')
+            .fontSize(16)
+            .fontWeight(600)
+            .fontColor(HISTORY_TITLE_CLR)
+          Blank()
+          Text('全部清除')
+            .fontSize(13)
+            .fontColor(CLEAR_ALL_CLR)
+            .width(80)
+            .height(32)
+            .textAlign(TextAlign.Center)
+            .backgroundColor(CLEAR_ALL_BG)
+            .borderRadius(6)
+            .border({ width: 1, color: CLEAR_ALL_BORDER })
+            .focusable(true)
+            .onClick(() => { this.clearAllHistory(); })
+        }
+        .width('100%')
+        .alignItems(VerticalAlign.Center)
+
+        // History tags
+        Flex({ wrap: FlexWrap.Wrap }) {
+          ForEach(this.historyList, (entry: SearchHistoryEntry) => {
+            HistoryTag({
+              keyword: entry.keyword,
+              onSearch: () => {
+                this.searchText = entry.keyword;
+                this.executeSearch();
+              },
+              onDelete: () => { this.deleteHistory(entry.keyword); }
+            })
+            .margin({ right: 10, bottom: 10 })
+          }, (entry: SearchHistoryEntry) => entry.keyword)
+        }
+        .width('100%')
+      } else {
+        // Empty state
+        Column({ space: 16 }) {
+          Text('🔍')
+            .fontSize(48)
+            .opacity(0.25)
+          Text('暂无搜索记录')
+            .fontSize(18)
+            .fontColor('#666666')
+          Text('输入关键词开始搜索')
+            .fontSize(13)
+            .fontColor('#444444')
+        }
+        .width('100%')
+        .layoutWeight(1)
+        .justifyContent(FlexAlign.Center)
+        .alignItems(HorizontalAlign.Center)
+      }
+    }
+    .width('100%')
+    .alignItems(HorizontalAlign.Start)
+  }
+
+  @Builder
+  resultsArea() {
+    Column({ space: 16 }) {
+      // Result count
+      Text(`找到 ${this.searchResults.length} 个结果`)
+        .fontSize(16)
+        .fontColor(RESULT_CNT_CLR)
+
+      // Results grid
+      Grid() {
+        ForEach(this.searchResults, (item: MediaItem) => {
+          GridItem() {
+            PosterCard({
+              item: item,
+              onPress: () => { this.navigateToDetail(item); }
+            })
+          }
+        }, (item: MediaItem) => `${item.id}`)
+      }
+      .columnsTemplate('1fr 1fr 1fr 1fr 1fr')
+      .columnsGap(16)
+      .rowsGap(20)
+      .width('100%')
+      .layoutWeight(1)
+    }
+    .width('100%')
+    .layoutWeight(1)
+    .alignItems(HorizontalAlign.Start)
+  }
+
+  @Builder
+  rightPanel() {
+    Column() {
+      if (this.searchText.trim().length === 0) {
+        this.historyArea()
+      } else {
+        this.resultsArea()
+      }
+    }
+    .width(1160)
+    .height(1008)
+    .padding({ left: 48, right: 64, top: 32 })
+    .alignItems(HorizontalAlign.Start)
+    .backgroundColor(PAGE_BG)
+  }
+
+  build() {
+    NavDestination() {
+      Column() {
+        // Header
+        this.headerBar()
+
+        // Body: left panel + right panel
+        Row() {
+          this.leftPanel()
+          this.rightPanel()
+        }
+        .width('100%')
+        .height(1008)
+        .alignItems(VerticalAlign.Top)
+      }
+      .width('100%')
+      .height('100%')
+      .backgroundColor(PAGE_BG)
+    }
+    .hideTitleBar(true)
+    .onBackPressed(() => {
+      this.pageStack.pop();
+      return true;
+    })
+  }
+}
+
+export { SearchWorkspacePage };

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -11,24 +11,24 @@ const PAGE_BG: string = '#1A1A1A';
 const KEY_BG: string = '#2D2F33';
 const KEY_BG_FOCUS: string = '#3B77D4';
 const KEY_BG_PRESS: string = '#4488FF';
-const FOCUS_BORDER_CLR: string = '#66A9D8FF';
-const FOCUS_SHADOW_CLR: string = '#553A86FF';
+const FOCUS_BORDER_CLR: string = '#FF66A9D8';
+const FOCUS_SHADOW_CLR: string = '#FF553A86';
 const KEY_TEXT_CLR: string = '#E3E7ED';
 const PLACEHOLDER_CLR: string = '#97A9CD';
 const INPUT_TEXT_CLR: string = '#E8EEFF';
-const INPUT_BG: string = '#ffffff12';
-const INPUT_BORDER: string = '#ffffff25';
+const INPUT_BG: string = '#12FFFFFF';
+const INPUT_BORDER: string = '#25FFFFFF';
 const SPACE_KEY_BG: string = '#3B3D40';
-const CLEAR_KEY_BG: string = '#FF6B6B14';
-const CLEAR_KEY_BORDER: string = '#FF6B6B4D';
+const CLEAR_KEY_BG: string = '#14FF6B6B';
+const CLEAR_KEY_BORDER: string = '#4DFF6B6B';
 const SEARCH_KEY_BG: string = '#2F77F5';
 const HISTORY_TITLE_CLR: string = '#DDE2EA';
 const HISTORY_TAG_CLR: string = '#CBD5E1';
-const HISTORY_TAG_BG: string = '#33415550';
-const HISTORY_TAG_BORDER: string = '#CBD5E166';
+const HISTORY_TAG_BG: string = '#50334155';
+const HISTORY_TAG_BORDER: string = '#66CBD5E1';
 const CLEAR_ALL_CLR: string = '#FF6B6B';
-const CLEAR_ALL_BG: string = '#FF6B6B14';
-const CLEAR_ALL_BORDER: string = '#FF6B6B4D';
+const CLEAR_ALL_BG: string = '#14FF6B6B';
+const CLEAR_ALL_BORDER: string = '#4DFF6B6B';
 const RESULT_CNT_CLR: string = '#97A9CD';
 const CARD_TITLE_CLR: string = '#E3E7ED';
 const TRANSPARENT: string = '#00000000';
@@ -114,13 +114,13 @@ struct HistoryTag {
         .padding({ left: 16, right: 4 })
       Text('×')
         .fontSize(13)
-        .fontColor(this.isFocused ? '#BFDBFE80' : '#CBD5E160')
+        .fontColor(this.isFocused ? '#80BFDBFE' : '#60CBD5E1')
         .padding({ right: 12 })
         .hitTestBehavior(HitTestMode.Block)
         .onClick(() => { this.onDelete(); })
     }
     .height(38)
-    .backgroundColor(this.isFocused ? '#1D4ED860' : HISTORY_TAG_BG)
+    .backgroundColor(this.isFocused ? '#601D4ED8' : HISTORY_TAG_BG)
     .borderRadius(19)
     .border({ width: this.isFocused ? 2 : 1, color: this.isFocused ? FOCUS_BORDER_CLR : HISTORY_TAG_BORDER })
     .animation({ duration: 140, curve: Curve.EaseInOut })
@@ -301,7 +301,7 @@ struct SearchWorkspacePage {
       }
       .width(112)
       .height(40)
-      .backgroundColor('#FFFFFF14')
+      .backgroundColor('#14FFFFFF')
       .borderRadius(8)
       .justifyContent(FlexAlign.Center)
       .focusable(true)
@@ -360,7 +360,7 @@ struct SearchWorkspacePage {
           .width(28)
           .height(28)
           .borderRadius(14)
-          .backgroundColor('#FFFFFF25')
+          .backgroundColor('#25FFFFFF')
           .margin({ right: 12 })
           .focusable(true)
           .onClick(() => { this.clearSearch(); })

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -233,12 +233,26 @@ struct SearchWorkspacePage {
     const generation = ++this.searchGeneration;
     this.isSearching = true;
     try {
-      const items: MediaItem[] = await this.db!.searchMediaItems(kw, { limit: 50 });
-      if (generation !== this.searchGeneration) { return; } // 丢弃过期结果
-      this.searchResults = items;
+      const items: MediaItem[] = await this.db!.searchMediaItems(kw, { limit: 200 });
+      if (generation !== this.searchGeneration) { return; }
+      // 按 (tvSeriesId, movieId) 去重：同一部剧/电影只保留第一条
+      const seen: Set<string> = new Set<string>();
+      const deduped: MediaItem[] = [];
+      for (const item of items) {
+        const key: string = item.tvSeriesId !== undefined
+          ? `tv-${item.tvSeriesId}`
+          : item.movieId !== undefined
+            ? `mv-${item.movieId}`
+            : `v-${item.id}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          deduped.push(item);
+        }
+      }
+      this.searchResults = deduped;
     } catch {
       if (generation !== this.searchGeneration) { return; }
-      this.searchResults = []; // 失败时清空，不保留旧数据
+      this.searchResults = [];
     } finally {
       if (generation === this.searchGeneration) {
         this.isSearching = false;
@@ -545,17 +559,60 @@ struct SearchWorkspacePage {
   @Builder
   buildResultsPreview() {
     if (this.searchResults.length > 0) {
-      Scroll() {
-        Row({ space: 30 }) {
-          ForEach(this.searchResults, (item: MediaItem) => {
-            WorkspacePosterCard({
-              item: item,
-              onPress: () => { this.navigateToDetail(item); }
-            })
-          }, (item: MediaItem) => String(item.id))
-        }
+      Column({ space: 0 }) {
+        ForEach(this.searchResults, (item: MediaItem) => {
+          Row({ space: 16 }) {
+            // 左：缩略图
+            if (posterSrc(item).length > 0) {
+              Image(posterSrc(item))
+                .width(80)
+                .height(120)
+                .objectFit(ImageFit.Cover)
+                .borderRadius(6)
+            } else {
+              Column() {
+                Text('\u{1F3AC}')
+                  .fontSize(28)
+                  .opacity(0.4)
+              }
+              .width(80)
+              .height(120)
+              .backgroundColor(C_COMPONENT_BG)
+              .borderRadius(6)
+              .justifyContent(FlexAlign.Center)
+              .alignItems(HorizontalAlign.Center)
+            }
+            // 右：信息
+            Column({ space: 6 }) {
+              Text(item.title ?? '')
+                .fontSize(22)
+                .fontColor('#E3E7ED')
+                .fontWeight(500)
+                .maxLines(2)
+                .textOverflow({ overflow: TextOverflow.Ellipsis })
+              if (item.rating !== undefined && item.rating > 0) {
+                Text(item.rating.toFixed(1))
+                  .fontSize(18)
+                  .fontWeight(600)
+                  .fontColor(scoreColor(item.rating))
+              }
+              if (item.releaseDate !== undefined && item.releaseDate.length >= 4) {
+                Text(item.releaseDate.slice(0, 4))
+                  .fontSize(16)
+                  .fontColor('#8A9BB0')
+              }
+            }
+            .layoutWeight(1)
+            .alignItems(HorizontalAlign.Start)
+            .justifyContent(FlexAlign.Center)
+          }
+          .width('100%')
+          .padding({ top: 10, bottom: 10, left: 4, right: 4 })
+          .borderRadius(10)
+          .focusable(true)
+          .onClick(() => { this.navigateToDetail(item); })
+        }, (item: MediaItem) => String(item.id))
       }
-      .scrollable(ScrollDirection.Horizontal)
       .width('100%')
     }
   }
@@ -579,6 +636,7 @@ struct SearchWorkspacePage {
       .scrollable(ScrollDirection.Vertical)
       .width('100%')
       .height('100%')
+      .align(Alignment.TopStart)
       .backgroundColor(C_PAGE_BG)
     }
     .hideTitleBar(true)

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -3,6 +3,7 @@ import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { MediaResultPage, MediaResultPageParam } from './MediaResultPage';
 import { SeriesDetailPage } from '../detail/SeriesDetailPage';
 import { MovieDetailPage } from '../detail/MovieDetailPage';
+import { LengthMetrics } from '@kit.ArkUI';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Design Token Constants — strictly follows Pencil vidall_pages.pen
@@ -174,7 +175,7 @@ struct SearchWorkspacePage {
   @Local isSearching: boolean = false;
   @Local hotItems: MediaItem[] = [];
 
-  private db: FileSourceDatabase = FileSourceDatabase.getInstance();
+  private db: FileSourceDatabase | null = null;
   @Local private searchDebounceTimer: number = -1;
   // 竞态保护：快速连续输入时，丢弃旧请求的返回结果
   private searchGeneration: number = 0;
@@ -182,8 +183,13 @@ struct SearchWorkspacePage {
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
   aboutToAppear(): void {
-    this.loadHistory();
-    this.loadHotItems();
+    try {
+      this.db = FileSourceDatabase.getInstance();
+      this.loadHistory();
+      this.loadHotItems();
+    } catch (e) {
+      // Preview 沙箱：native DB 不可用，静默降级
+    }
   }
 
   aboutToDisappear(): void {
@@ -195,6 +201,7 @@ struct SearchWorkspacePage {
   // ── Data helpers ──────────────────────────────────────────────────────────
 
   private loadHistory(): void {
+    if (this.db === null) { return; }
     this.db.getSearchHistory(20)
       .then((list: SearchHistoryEntry[]) => {
         this.historyList = list;
@@ -203,6 +210,7 @@ struct SearchWorkspacePage {
   }
 
   private loadHotItems(): void {
+    if (this.db === null) { return; }
     this.db.searchMediaItems('', { sortBy: 'rating', limit: 8 })
       .then((items: MediaItem[]) => {
         this.hotItems = items;
@@ -235,7 +243,7 @@ struct SearchWorkspacePage {
     const generation = ++this.searchGeneration;
     this.isSearching = true;
     try {
-      const items: MediaItem[] = await this.db.searchMediaItems(kw, { limit: 50 });
+      const items: MediaItem[] = await this.db!.searchMediaItems(kw, { limit: 50 });
       if (generation !== this.searchGeneration) { return; } // 丢弃过期结果
       this.searchResults = items;
     } catch {
@@ -252,9 +260,11 @@ struct SearchWorkspacePage {
   private triggerSearchAndNavigate(): void {
     const kw: string = this.searchText.trim();
     if (kw.length === 0) { return; }
-    this.db.upsertSearchHistory(kw)
-      .then(() => { this.loadHistory(); })
-      .catch(() => {});
+    if (this.db !== null) {
+      this.db.upsertSearchHistory(kw)
+        .then(() => { this.loadHistory(); })
+        .catch(() => {});
+    }
     const param: MediaResultPageParam = {
       keyword: kw,
       pageTitle: kw,
@@ -281,12 +291,14 @@ struct SearchWorkspacePage {
   }
 
   private deleteHistory(keyword: string): void {
+    if (this.db === null) { return; }
     this.db.deleteSearchHistory(keyword)
       .then(() => { this.loadHistory(); })
       .catch(() => {});
   }
 
   private clearAllHistory(): void {
+    if (this.db === null) { return; }
     this.db.clearSearchHistory()
       .then(() => { this.historyList = []; })
       .catch(() => {});
@@ -389,20 +401,26 @@ struct SearchWorkspacePage {
   // row1: Q-P + 1-4
   @Builder
   buildKbdRow1() {
-    Grid() {
+    Flex({
+      space: {
+        main: LengthMetrics.vp(8)
+      }
+    }) {
       ForEach(KBD_R1_L, (key: string) => {
-        GridItem() {
-          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
-        }
+        KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        // GridItem() {
+        //   KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        // }
       }, (key: string) => key)
       ForEach(KBD_R1_R, (key: string) => {
-        GridItem() {
-          KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
-        }
+        KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        // GridItem() {
+        //   KeyButton({ label: key, onPress: () => { this.appendChar(key); } })
+        // }
       }, (key: string) => key)
     }
-    .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
-    .columnsGap(8)
+    // .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
+    // .columnsGap(8)
     .width('100%')
   }
 
@@ -455,7 +473,7 @@ struct SearchWorkspacePage {
       GridItem() {
         Text('\u232B')
           .fontSize(20)
-          .fontWeight(700)
+          .fontWeight("100%")
           .fontColor('#FFFFFF')
           .textAlign(TextAlign.Center)
           .width('100%')
@@ -493,7 +511,6 @@ struct SearchWorkspacePage {
     .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr')
     .columnsGap(8)
     .width('100%')
-    .height(64)   // 跨列 GridItem 的 height('100%') 需 Grid 有已知高度；64vp ≈ aspectRatio 推算结果
   }
 
   @Builder
@@ -636,3 +653,4 @@ struct SearchWorkspacePage {
 }
 
 export { SearchWorkspacePage };
+

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -500,7 +500,8 @@ struct SearchWorkspacePage {
       this.buildNumericKbd()
       // 搜索按钮已移除，改由防抖 800ms 自动触发 triggerSearchAndNavigate
     }
-    .width('100%')
+    .alignSelf(ItemAlign.Center)
+    .width('90%')
     .backgroundColor(C_KBD_BG)
     .borderRadius(14)
     .padding(14)

--- a/entry/src/main/ets/pages/search/index.ets
+++ b/entry/src/main/ets/pages/search/index.ets
@@ -1,0 +1,3 @@
+export { SearchWorkspacePage } from './SearchWorkspacePage';
+export { MediaResultPage } from './MediaResultPage';
+export type { MediaResultPageParam } from './MediaResultPage';


### PR DESCRIPTION
## 关联 Issue

closes #105

## 变更说明

完成 Epic #106 搜索功能最小闭环：首页顶栏搜索按钮 → SearchWorkspacePage → MediaResultPage。

## 主要改动

### 搜索入口
- `pages/home/topbar/index.ets`：顶栏已有搜索按钮补充 `onBtnClick` 导航逻辑
- 导航：`pageStack.pushPathByName(SearchWorkspacePage.PAGE_NAME, null)`
- 零新组件引入，完全复用现有 IBestButton 风格

### 集成页面（cherry-pick 自 #104/#102）
- `pages/search/SearchWorkspacePage.ets`（TV 软键盘 + 历史 + 结果预览）
- `pages/search/MediaResultPage.ets`（筛选 + 9列网格结果页）
- `pages/search/index.ets`（合并导出两个页面）
- `pages/Index.ets`（同时注册两个页面路由）

## 依赖

- #101 DB 搜索接口（已合并）
- #102 MediaResultPage（PR #129，本 PR 已集成）
- #103 搜索历史 DB（已合并）
- #104 SearchWorkspacePage（PR #128，本 PR 已集成）

## QA 编译验证

BUILD SUCCESSFUL（零 ERROR）

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-screen search workspace with on-screen keyboard, history, hot items, live preview, and confirm-to-results flow.
  * Media results page with filter chips, sortable counts, and grid cards that navigate to detail pages.
  * Topbar search button now opens the search workspace and routes into results pages.

* **Changes**
  * Year filter expanded to support inclusive from/to range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->