### PR TITLE
新增: #135 扫描模式三分 + origin_country_json 地区过滤

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /docs
 /scripts
 .worktrees/
+/certs

--- a/AppScope/resources/base/element/string.json
+++ b/AppScope/resources/base/element/string.json
@@ -15,10 +15,6 @@
     {
       "name": "reason_get_network_info",
       "value": "用户在播放视频时获取网络相关信息"
-    },
-    {
-      "name": "reason_file_access_persist",
-      "value": "用于持久化用户对文件的授权"
     }
   ]
 }

--- a/build-profile.json5
+++ b/build-profile.json5
@@ -7,11 +7,24 @@
         "material": {
           "certpath": "/Users/yaoshining/.ohos/config/default_VidAll_TV_CVN80dExYXumUogQhhatKo1F9BfL3s3VCemMeMdSQic=.cer",
           "keyAlias": "debugKey",
-          "keyPassword": "0000001AD549548D5DE7525D5FEF25F3912CA5B5C359CE6E796D09583430D48B649B2B3E4D5BCBAC1A58",
+          "keyPassword": "0000001A9130DBD4E6127F87CCEA6CE34B13E55D2D5EC046961CD973DDF1A06520C8A71C20D78169B3AF",
           "profile": "/Users/yaoshining/.ohos/config/default_VidAll_TV_CVN80dExYXumUogQhhatKo1F9BfL3s3VCemMeMdSQic=.p7b",
           "signAlg": "SHA256withECDSA",
           "storeFile": "/Users/yaoshining/.ohos/config/default_VidAll_TV_CVN80dExYXumUogQhhatKo1F9BfL3s3VCemMeMdSQic=.p12",
-          "storePassword": "0000001A7993CACE1F915685FCE403B7E59F7154D2A9DD44B105ED1B8AEE44284300244ACB6C8B1A5611"
+          "storePassword": "0000001A20C04C1B03EEB86A54CEE3F86A31F698E0D075C92A60F3394DA297BEDD6BA6DE08B290975C6A"
+        }
+      },
+      {
+        "name": "release",
+        "type": "HarmonyOS",
+        "material": {
+          "certpath": "/Users/yaoshining/DevEcoStudioProjects/VidAll_TV/certs/release/发布证书.cer",
+          "keyAlias": "vidall_tv",
+          "keyPassword": "00000018D5755E024FA4584DC72E2E0BF3D1DCBE6E2F30AA76815E6A296ABE770F8810A10E6B2140",
+          "profile": "/Users/yaoshining/DevEcoStudioProjects/VidAll_TV/certs/release/测试ProfileRelease.p7b",
+          "signAlg": "SHA256withECDSA",
+          "storeFile": "/Users/yaoshining/DevEcoStudioProjects/VidAll_TV/certs/release/key.p12",
+          "storePassword": "00000018FF1417790D7CF0C8D765ADF90A989A67078AA20E53679839AC8AD059210053D6562C7750"
         }
       }
     ],

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -2872,6 +2872,10 @@ export class FileSourceDatabase {
         if (item.mediaType === 'episode' || item.mediaType === 'tv') {
           return item.tvSeriesId !== undefined && item.title !== undefined;
         }
+        // 剔除完全未刮削的视频（无标题、无海报），此类内容在媒体库中无可识别信息
+        if (item.title === undefined && item.posterUrl === undefined && item.posterLocalPath === undefined) {
+          return false;
+        }
         return true;
       });
 
@@ -3060,6 +3064,56 @@ export class FileSourceDatabase {
     } catch (e) {
       const err = e as BusinessError;
       console.warn(`[DB][deleteSearchHistory] 失败 code=${err.code} msg=${err.message}`);
+    }
+  }
+
+  /**
+   * 检查指定 movie 是否已有 origin_country_json。
+   */
+  async hasMovieOriginCountry(movieId: number): Promise<boolean> {
+    if (!this.rdbStore) {
+      return false;
+    }
+    let rs: relationalStore.ResultSet | undefined;
+    try {
+      rs = await this.rdbStore.querySql('SELECT origin_country_json FROM movies WHERE id = ?', [movieId]);
+      if (rs.goToNextRow()) {
+        const idx = rs.getColumnIndex('origin_country_json');
+        const isNull = rs.isColumnNull(idx);
+        return !isNull;
+      }
+      return false;
+    } catch (e) {
+      const err = e as BusinessError;
+      console.warn(`[DB][hasMovieOriginCountry] 失败 code=${err.code} msg=${err.message}`);
+      return false;
+    } finally {
+      rs?.close();
+    }
+  }
+
+  /**
+   * 检查指定 tv_series 是否已有 origin_country_json。
+   */
+  async hasTvSeriesOriginCountry(seriesId: number): Promise<boolean> {
+    if (!this.rdbStore) {
+      return false;
+    }
+    let rs: relationalStore.ResultSet | undefined;
+    try {
+      rs = await this.rdbStore.querySql('SELECT origin_country_json FROM tv_series WHERE id = ?', [seriesId]);
+      if (rs.goToNextRow()) {
+        const idx = rs.getColumnIndex('origin_country_json');
+        const isNull = rs.isColumnNull(idx);
+        return !isNull;
+      }
+      return false;
+    } catch (e) {
+      const err = e as BusinessError;
+      console.warn(`[DB][hasTvSeriesOriginCountry] 失败 code=${err.code} msg=${err.message}`);
+      return false;
+    } finally {
+      rs?.close();
     }
   }
 

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -42,7 +42,7 @@ export interface SearchMediaOptions {
  *         movies, tv_series, tv_seasons, tv_episodes, play_progress, media_progress
  */
 export class FileSourceDatabase {
-  private static readonly DB_VERSION = 7;
+  private static readonly DB_VERSION = 8;
   private static readonly DB_NAME = 'FILE_SOURCES_DB';
   private static readonly TABLE_FILE_SOURCES = 'file_sources';
   private static readonly TABLE_DIRECTORIES = 'file_source_directories';
@@ -394,6 +394,16 @@ export class FileSourceDatabase {
         await rdbStore.executeSql('ALTER TABLE tv_series ADD COLUMN origin_country_json TEXT');
         currentVersion = 7;
         console.info('[DB] 已迁移到 v7：movies/tv_series 新增 origin_country_json');
+      }
+      if (currentVersion < 8) {
+        // 移除 scrape_info.(provider,provider_id) 唯一索引：多个文件源可以对应同一 TMDB 条目
+        await rdbStore.executeSql(`DROP INDEX IF EXISTS idx_scrape_info_provider_pid_uq`);
+        // 清理孤立 scrape_info（video_id 不在 videos 表中，由历史 INSERT OR REPLACE 产生）
+        await rdbStore.executeSql(
+          `DELETE FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} WHERE video_id NOT IN (SELECT id FROM ${FileSourceDatabase.TABLE_VIDEOS})`
+        );
+        currentVersion = 8;
+        console.info('[DB] 已迁移到 v8：移除 scrape_info 唯一索引，清理孤立刮削数据');
       }
       console.info('FileSourceDatabase: Upgrade complete');
     } catch (error) {
@@ -756,9 +766,35 @@ export class FileSourceDatabase {
       throw new Error('Database not initialized');
     }
     try {
-      // INSERT OR REPLACE 保证 file_path UNIQUE 并发安全
+      // 先查是否已存在，有则 UPDATE（保留原始 id，避免外键级联删除 scrape_info）
+      const existing = await this.getVideoByPath(entity.filePath);
+      if (existing && existing.id !== undefined) {
+        const bucket: relationalStore.ValuesBucket = {
+          source_id: entity.sourceId,
+          directory_path: entity.directoryPath,
+          file_name: entity.fileName,
+          file_size: entity.fileSize !== undefined ? entity.fileSize : null,
+          last_modified: entity.lastModified ?? null,
+          content_type: entity.contentType ?? null,
+          duration_ms: entity.durationMs !== undefined ? entity.durationMs : null,
+          width: entity.width !== undefined ? entity.width : null,
+          height: entity.height !== undefined ? entity.height : null,
+          frame_rate: entity.frameRate !== undefined ? entity.frameRate : null,
+          video_codec: entity.videoCodec ?? null,
+          audio_tracks_json: entity.audioTracksJson ?? null,
+          subtitle_tracks_json: entity.subtitleTracksJson ?? null,
+          updated_in_last_scan: 1,
+          scanned_at: entity.scannedAt
+        };
+        const pred = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_VIDEOS);
+        pred.equalTo('id', existing.id);
+        await this.rdbStore.update(bucket, pred);
+        console.info(`[FileSourceDatabase] upsertVideo UPDATE id=${existing.id} path=${entity.filePath}`);
+        return existing.id;
+      }
+      // 新文件 INSERT
       const sql = `
-        INSERT OR REPLACE INTO ${FileSourceDatabase.TABLE_VIDEOS}
+        INSERT OR IGNORE INTO ${FileSourceDatabase.TABLE_VIDEOS}
           (source_id, directory_path, file_path, file_name, file_size, last_modified,
            content_type, duration_ms, width, height, frame_rate, video_codec,
            audio_tracks_json, subtitle_tracks_json, updated_in_last_scan, scanned_at)
@@ -779,10 +815,9 @@ export class FileSourceDatabase {
         entity.scannedAt
       ];
       await this.rdbStore.executeSql(sql, args);
-      // 查回 id
       const inserted = await this.getVideoByPath(entity.filePath);
       const rowId = inserted?.id ?? -1;
-      console.info(`[FileSourceDatabase] upsertVideo id=${rowId} path=${entity.filePath}`);
+      console.info(`[FileSourceDatabase] upsertVideo INSERT id=${rowId} path=${entity.filePath}`);
       return rowId;
     } catch (error) {
       console.error(`[FileSourceDatabase] upsertVideo 失败: ${JSON.stringify(error)}`);
@@ -1402,6 +1437,19 @@ export class FileSourceDatabase {
     } catch { return null; } finally { rs?.close(); }
   }
 
+  /** 清理孤立 scrape_info（video_id 不在 videos 表中），由历史 INSERT OR REPLACE 产生 */
+  async cleanupOrphanedScrapeInfo(): Promise<void> {
+    if (this.rdbStore === null) { return; }
+    try {
+      await this.rdbStore.executeSql(
+        `DELETE FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} WHERE video_id NOT IN (SELECT id FROM ${FileSourceDatabase.TABLE_VIDEOS})`
+      );
+      console.info('[DB] cleanupOrphanedScrapeInfo 完成');
+    } catch (e) {
+      console.warn(`[DB] cleanupOrphanedScrapeInfo 失败: ${JSON.stringify(e)}`);
+    }
+  }
+
   /** 查询 scrape_info 中某剧已刮削的所有季号（用于季列表过滤） */
   async getScrapedSeasonNumbers(tvSeriesId: number): Promise<number[]> {
     if (this.rdbStore === null) { return []; }
@@ -1421,11 +1469,31 @@ export class FileSourceDatabase {
 
   async upsertScrapeInfo(e: ScrapeInfoEntity): Promise<void> {
     if (this.rdbStore === null) { throw new Error('Database not initialized'); }
-    // 诊断日志
     console.info(`[DB][upsertScrapeInfo] videoId=${e.videoId} type=${e.mediaType} movieId=${e.movieId ?? 'null'} tvSeriesId=${e.tvSeriesId ?? 'null'} episodeId=${e.episodeId ?? 'null'} title="${e.title}"`);
-    // 使用 INSERT OR REPLACE，配合 UNIQUE(video_id) 与 UNIQUE(provider,provider_id) 做幂等写入
+    // 先查 video_id 是否已有 scrape_info，有则 UPDATE（不依赖 provider+provider_id 唯一索引）
+    const existing = await this.getScrapeInfoByVideoId(e.videoId);
+    if (existing && existing.id !== undefined) {
+      const bucket: relationalStore.ValuesBucket = {
+        provider: e.provider,
+        provider_id: e.providerId,
+        media_type: e.mediaType,
+        title: e.title,
+        original_title: e.originalTitle ?? null,
+        movie_id: e.movieId !== undefined ? e.movieId : null,
+        tv_series_id: e.tvSeriesId !== undefined ? e.tvSeriesId : null,
+        episode_id: e.episodeId !== undefined ? e.episodeId : null,
+        season_number: e.seasonNumber !== undefined ? e.seasonNumber : null,
+        episode_number: e.episodeNumber !== undefined ? e.episodeNumber : null,
+        scraped_at: e.scrapedAt
+      };
+      const pred = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_SCRAPE_INFO);
+      pred.equalTo('id', existing.id);
+      await this.rdbStore.update(bucket, pred);
+      console.info(`[DB][upsertScrapeInfo] ✅ 写入成功 videoId=${e.videoId}`);
+      return;
+    }
     const sql = `
-      INSERT OR REPLACE INTO ${FileSourceDatabase.TABLE_SCRAPE_INFO}
+      INSERT OR IGNORE INTO ${FileSourceDatabase.TABLE_SCRAPE_INFO}
         (video_id, provider, provider_id, media_type, title, original_title,
          movie_id, tv_series_id, episode_id, season_number, episode_number, scraped_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -32,6 +32,8 @@ export interface SearchMediaOptions {
    * 'done'    - 已看完：position_ms >= duration_ms * 0.9
    */
   watchProgress?: 'unseen' | 'partial' | 'done';
+  /** 制作国过滤：ISO 3166-1 代码，如 "CN"、"JP"、"US"，LIKE 匹配 origin_country_json */
+  originCountry?: string;
 }
 
 /**
@@ -2800,6 +2802,12 @@ export class FileSourceDatabase {
             `AND CAST(mp2.position_ms AS REAL) >= CAST(mp2.duration_ms AS REAL) * 0.9` +
           `)))`
         );
+      }
+
+      // ── originCountry 过滤：LIKE 匹配 origin_country_json ──
+      if (options?.originCountry !== undefined && options.originCountry.length > 0) {
+        conditions.push('COALESCE(m.origin_country_json, ts.origin_country_json) LIKE ?');
+        params.push(`%"${options.originCountry}"%`);
       }
 
       const whereClause: string = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -1450,6 +1450,28 @@ export class FileSourceDatabase {
     }
   }
 
+  /**
+   * 全量覆盖模式专用：清空指定文件源下所有视频的 scrape_info，
+   * 确保重刮前无历史垃圾数据干扰。
+   */
+  async clearScrapeInfoForSources(sourceIds: number[]): Promise<void> {
+    if (this.rdbStore === null || sourceIds.length === 0) { return; }
+    try {
+      const placeholders = sourceIds.map(() => '?').join(',');
+      const args: relationalStore.ValueType[] = sourceIds.map(id => id as relationalStore.ValueType);
+      await this.rdbStore.executeSql(
+        `DELETE FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO}
+         WHERE video_id IN (
+           SELECT id FROM ${FileSourceDatabase.TABLE_VIDEOS} WHERE source_id IN (${placeholders})
+         )`,
+        args
+      );
+      console.info(`[DB] clearScrapeInfoForSources 完成 sourceIds=[${sourceIds.join(',')}]`);
+    } catch (e) {
+      console.warn(`[DB] clearScrapeInfoForSources 失败: ${JSON.stringify(e)}`);
+    }
+  }
+
   /** 查询 scrape_info 中某剧已刮削的所有季号（用于季列表过滤） */
   async getScrapedSeasonNumbers(tvSeriesId: number): Promise<number[]> {
     if (this.rdbStore === null) { return []; }

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -977,6 +977,22 @@ export class FileSourceDatabase {
     } catch { return null; }
   }
 
+  async getMovieById(id: number): Promise<MovieEntity | null> {
+    if (this.rdbStore === null) { return null; }
+    let rs: relationalStore.ResultSet | null = null;
+    try {
+      const pred = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_MOVIES);
+      pred.equalTo('id', id);
+      rs = await this.rdbStore.query(pred);
+      if (rs.goToFirstRow()) { return this.parseMovieEntity(rs); }
+      return null;
+    } catch {
+      return null;
+    } finally {
+      rs?.close();
+    }
+  }
+
   /** 批量获取所有电影，供播放历史等场景一次性加载 */
   async getAllMovies(): Promise<MovieEntity[]> {
     if (this.rdbStore === null) { return []; }

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -1458,7 +1458,10 @@ export class FileSourceDatabase {
     if (this.rdbStore === null || sourceIds.length === 0) { return; }
     try {
       const placeholders = sourceIds.map(() => '?').join(',');
-      const args: relationalStore.ValueType[] = sourceIds.map(id => id as relationalStore.ValueType);
+      const args: relationalStore.ValueType[] = [];
+      for (const id of sourceIds) {
+        args.push(id);
+      }
       await this.rdbStore.executeSql(
         `DELETE FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO}
          WHERE video_id IN (

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -131,6 +131,9 @@ export class FileSourceDatabase {
       // 防御性 schema 兼容：补齐 videos 扫描更新标记列
       await this.ensureVideosSchema(this.rdbStore);
 
+      // 防御性 schema 兼容：补齐 movies/tv_series origin_country_json 列（v7 新增，幂等）
+      await this.ensureOriginCountrySchema(this.rdbStore);
+
       // 防御性修复：确保 provider+provider_id 唯一索引已被移除（v8 起允许多文件源对应同一 TMDB 内容）
       await this.dropScrapeInfoProviderPidIndex(this.rdbStore);
 
@@ -389,9 +392,8 @@ export class FileSourceDatabase {
         currentVersion = 6;
         console.info(`[DB] 迁移: v${fromVersion} → v${currentVersion} 完成`);
       }
-      if (currentVersion < 7) {
-        await rdbStore.executeSql('ALTER TABLE movies ADD COLUMN origin_country_json TEXT');
-        await rdbStore.executeSql('ALTER TABLE tv_series ADD COLUMN origin_country_json TEXT');
+      if (currentVersion < 7 && currentVersion < newVersion) {
+        await this.ensureOriginCountrySchema(rdbStore);
         currentVersion = 7;
         console.info('[DB] 已迁移到 v7：movies/tv_series 新增 origin_country_json');
       }
@@ -1358,6 +1360,23 @@ export class FileSourceDatabase {
   // ─────────────────────────────────────────────
 
   /** 确保 videos 表存在扫描更新标记列 */
+  private async ensureOriginCountrySchema(rdbStore: relationalStore.RdbStore): Promise<void> {
+    try {
+      await rdbStore.executeSql(
+        `ALTER TABLE ${FileSourceDatabase.TABLE_MOVIES} ADD COLUMN origin_country_json TEXT`
+      );
+    } catch {
+      // 列已存在时忽略
+    }
+    try {
+      await rdbStore.executeSql(
+        `ALTER TABLE ${FileSourceDatabase.TABLE_TV_SERIES} ADD COLUMN origin_country_json TEXT`
+      );
+    } catch {
+      // 列已存在时忽略
+    }
+  }
+
   private async ensureVideosSchema(rdbStore: relationalStore.RdbStore): Promise<void> {
     try {
       await rdbStore.executeSql(

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -40,7 +40,7 @@ export interface SearchMediaOptions {
  *         movies, tv_series, tv_seasons, tv_episodes, play_progress, media_progress
  */
 export class FileSourceDatabase {
-  private static readonly DB_VERSION = 6;
+  private static readonly DB_VERSION = 7;
   private static readonly DB_NAME = 'FILE_SOURCES_DB';
   private static readonly TABLE_FILE_SOURCES = 'file_sources';
   private static readonly TABLE_DIRECTORIES = 'file_source_directories';
@@ -228,6 +228,7 @@ export class FileSourceDatabase {
         directors_json TEXT,
         runtime INTEGER,
         original_language TEXT,
+        origin_country_json TEXT,
         raw_json TEXT,
         scraped_at INTEGER NOT NULL,
         UNIQUE(provider, provider_id)
@@ -255,6 +256,7 @@ export class FileSourceDatabase {
         cast_json TEXT,
         number_of_seasons INTEGER,
         original_language TEXT,
+        origin_country_json TEXT,
         raw_json TEXT,
         scraped_at INTEGER NOT NULL,
         UNIQUE(provider, provider_id)
@@ -384,6 +386,12 @@ export class FileSourceDatabase {
         await this.migrateV5ToV6(rdbStore);
         currentVersion = 6;
         console.info(`[DB] 迁移: v${fromVersion} → v${currentVersion} 完成`);
+      }
+      if (currentVersion < 7) {
+        await rdbStore.executeSql('ALTER TABLE movies ADD COLUMN origin_country_json TEXT');
+        await rdbStore.executeSql('ALTER TABLE tv_series ADD COLUMN origin_country_json TEXT');
+        currentVersion = 7;
+        console.info('[DB] 已迁移到 v7：movies/tv_series 新增 origin_country_json');
       }
       console.info('FileSourceDatabase: Upgrade complete');
     } catch (error) {
@@ -966,6 +974,7 @@ export class FileSourceDatabase {
         backdrop_local_path: e.backdropLocalPath ?? null, genres_json: e.genresJson ?? null,
         cast_json: e.castJson ?? null, directors_json: e.directorsJson ?? null,
         runtime: e.runtime ?? null, original_language: e.originalLanguage ?? null,
+        origin_country_json: e.originCountryJson ?? null,
         raw_json: e.rawJson ?? null, scraped_at: e.scrapedAt
       };
       const pred = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_MOVIES);
@@ -979,8 +988,8 @@ export class FileSourceDatabase {
         (provider, provider_id, title, original_title, overview, release_date, rating,
          vote_count, poster_path, backdrop_path, poster_url, backdrop_url,
          poster_local_path, backdrop_local_path, genres_json, cast_json, directors_json,
-         runtime, original_language, raw_json, scraped_at)
-      VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         runtime, original_language, origin_country_json, raw_json, scraped_at)
+      VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
     `;
     const args: relationalStore.ValueType[] = [
       e.provider, e.providerId, e.title, e.originalTitle ?? null, e.overview ?? null,
@@ -988,7 +997,7 @@ export class FileSourceDatabase {
       e.posterPath ?? null, e.backdropPath ?? null, e.posterUrl ?? null,
       e.backdropUrl ?? null, e.posterLocalPath ?? null, e.backdropLocalPath ?? null,
       e.genresJson ?? null, e.castJson ?? null, e.directorsJson ?? null,
-      e.runtime ?? null, e.originalLanguage ?? null, e.rawJson ?? null, e.scrapedAt
+      e.runtime ?? null, e.originalLanguage ?? null, e.originCountryJson ?? null, e.rawJson ?? null, e.scrapedAt
     ];
     await this.rdbStore.executeSql(sql, args);
     // 查回刚插入的 id
@@ -1014,6 +1023,7 @@ export class FileSourceDatabase {
       posterLocalPath: str('poster_local_path'), backdropLocalPath: str('backdrop_local_path'),
       genresJson: str('genres_json'), castJson: str('cast_json'), directorsJson: str('directors_json'),
       runtime: num('runtime'), originalLanguage: str('original_language'),
+      originCountryJson: str('origin_country_json'),
       rawJson: str('raw_json'), scrapedAt: rs.getLong(rs.getColumnIndex('scraped_at'))
     };
   }
@@ -1064,7 +1074,8 @@ export class FileSourceDatabase {
         backdrop_url: e.backdropUrl ?? null, poster_local_path: e.posterLocalPath ?? null,
         backdrop_local_path: e.backdropLocalPath ?? null, genres_json: e.genresJson ?? null,
         cast_json: e.castJson ?? null, number_of_seasons: e.numberOfSeasons ?? null,
-        original_language: e.originalLanguage ?? null, raw_json: e.rawJson ?? null,
+        original_language: e.originalLanguage ?? null, origin_country_json: e.originCountryJson ?? null,
+        raw_json: e.rawJson ?? null,
         scraped_at: e.scrapedAt
       };
       const pred = new relationalStore.RdbPredicates(FileSourceDatabase.TABLE_TV_SERIES);
@@ -1077,8 +1088,8 @@ export class FileSourceDatabase {
         (provider, provider_id, title, original_title, overview, first_air_date, rating,
          vote_count, poster_path, backdrop_path, poster_url, backdrop_url,
          poster_local_path, backdrop_local_path, genres_json, cast_json,
-         number_of_seasons, original_language, raw_json, scraped_at)
-      VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         number_of_seasons, original_language, origin_country_json, raw_json, scraped_at)
+      VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
     `;
     const args: relationalStore.ValueType[] = [
       e.provider, e.providerId, e.title, e.originalTitle ?? null, e.overview ?? null,
@@ -1087,7 +1098,7 @@ export class FileSourceDatabase {
       e.backdropUrl ?? null, e.posterLocalPath ?? null, e.backdropLocalPath ?? null,
       e.genresJson ?? null, e.castJson ?? null,
       e.numberOfSeasons !== undefined ? e.numberOfSeasons : null,
-      e.originalLanguage ?? null, e.rawJson ?? null, e.scrapedAt
+      e.originalLanguage ?? null, e.originCountryJson ?? null, e.rawJson ?? null, e.scrapedAt
     ];
     await this.rdbStore.executeSql(sql, args);
     const inserted = await this.getTvSeriesByProviderId(e.provider, e.providerId);
@@ -1110,6 +1121,7 @@ export class FileSourceDatabase {
       posterLocalPath: str('poster_local_path'), backdropLocalPath: str('backdrop_local_path'),
       genresJson: str('genres_json'), castJson: str('cast_json'),
       numberOfSeasons: num('number_of_seasons'), originalLanguage: str('original_language'),
+      originCountryJson: str('origin_country_json'),
       rawJson: str('raw_json'), scrapedAt: rs.getLong(rs.getColumnIndex('scraped_at'))
     };
   }

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -131,8 +131,8 @@ export class FileSourceDatabase {
       // 防御性 schema 兼容：补齐 videos 扫描更新标记列
       await this.ensureVideosSchema(this.rdbStore);
 
-      // 防御性修复：清理历史重复 scrape_info，并确保 provider + provider_id 唯一
-      await this.ensureScrapeInfoUniqueness(this.rdbStore);
+      // 防御性修复：确保 provider+provider_id 唯一索引已被移除（v8 起允许多文件源对应同一 TMDB 内容）
+      await this.dropScrapeInfoProviderPidIndex(this.rdbStore);
 
       emitter.emit(FileSourceDatabase.DATABASE_READY);
       console.info('FileSourceDatabase: Database initialized successfully');
@@ -1380,48 +1380,73 @@ export class FileSourceDatabase {
   }
 
   /**
-   * 清理 scrape_info 历史重复数据，并确保 provider + provider_id 联合唯一索引存在。
-   * 同一 provider/provider_id 仅保留最新一条（以 id 最大作为最新）。
+   * 确保 scrape_info 的 provider+provider_id 联合唯一索引已被移除。
+   * v8 起允许多个文件源（WebDAV/SMB）指向同一 TMDB 内容，不能再用该索引限制写入。
    */
-  private async ensureScrapeInfoUniqueness(rdbStore: relationalStore.RdbStore): Promise<void> {
+  private async dropScrapeInfoProviderPidIndex(rdbStore: relationalStore.RdbStore): Promise<void> {
     try {
-      const beforeRs = await rdbStore.querySql(
-        `SELECT COUNT(*) AS cnt FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO}`
-      );
-      let before = 0;
-      if (beforeRs.goToFirstRow()) {
-        before = beforeRs.getLong(beforeRs.getColumnIndex('cnt'));
-      }
-      beforeRs.close();
-
-      await rdbStore.executeSql(`
-        DELETE FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO}
-        WHERE id NOT IN (
-          SELECT keep_id FROM (
-            SELECT MAX(id) AS keep_id
-            FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO}
-            GROUP BY provider, provider_id
-          )
-        )
-      `);
-
-      await rdbStore.executeSql(`
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_scrape_info_provider_pid_uq
-        ON ${FileSourceDatabase.TABLE_SCRAPE_INFO}(provider, provider_id)
-      `);
-
-      const afterRs = await rdbStore.querySql(
-        `SELECT COUNT(*) AS cnt FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO}`
-      );
-      let after = 0;
-      if (afterRs.goToFirstRow()) {
-        after = afterRs.getLong(afterRs.getColumnIndex('cnt'));
-      }
-      afterRs.close();
-
-      console.info(`[DB][scrape_info] 去重完成 before=${before} after=${after} removed=${before - after}`);
+      await rdbStore.executeSql(`DROP INDEX IF EXISTS idx_scrape_info_provider_pid_uq`);
+      console.info('[DB] scrape_info provider+provider_id 唯一索引已移除（多文件源兼容）');
     } catch (e) {
-      console.warn(`[DB][scrape_info] 去重/唯一索引修复失败: ${JSON.stringify(e)}`);
+      console.warn('[DB] 移除 scrape_info 唯一索引失败: ' + JSON.stringify(e));
+    }
+  }
+
+  /**
+   * 全量覆盖扫描完成后，删除指定文件源中不再存在的鬼记录（旧扫描遗留、现已不在 NAS 上的视频）。
+   * foundPaths：本轮扫描写入 DB 的 file_path 集合。
+   * 注意：SQLite 外键未启用，需显式删除 scrape_info（overwrite 模式下已由 clearScrapeInfoForSources 预清空）。
+   */
+  async deleteGhostVideosForSources(sourceIds: number[], foundPaths: string[]): Promise<number> {
+    if (!this.rdbStore || sourceIds.length === 0) { return 0; }
+    try {
+      const foundPathsSet = new Set<string>(foundPaths);
+      const sidHolders = sourceIds.map(() => '?').join(', ');
+      const sidArgs: relationalStore.ValueType[] = sourceIds.map(id => id as relationalStore.ValueType);
+
+      // 1. 查询这些文件源的所有视频记录
+      const rs = await this.rdbStore.querySql(
+        `SELECT id, file_path FROM ${FileSourceDatabase.TABLE_VIDEOS} WHERE source_id IN (${sidHolders})`,
+        sidArgs
+      );
+      const ghostIds: number[] = [];
+      while (rs.goToNextRow()) {
+        const filePath = rs.getString(rs.getColumnIndex('file_path'));
+        const id = rs.getLong(rs.getColumnIndex('id'));
+        if (!foundPathsSet.has(filePath)) {
+          ghostIds.push(id);
+        }
+      }
+      rs.close();
+
+      if (ghostIds.length === 0) {
+        console.info(`[DB][deleteGhostVideos] 无鬼记录，无需清理`);
+        return 0;
+      }
+
+      // 2. 分批删除（SQLite IN 参数上限 999）
+      const BATCH = 100;
+      for (let i = 0; i < ghostIds.length; i += BATCH) {
+        const batch = ghostIds.slice(i, i + BATCH);
+        const idHolders = batch.map(() => '?').join(', ');
+        const idArgs: relationalStore.ValueType[] = batch.map(gid => gid as relationalStore.ValueType);
+        // 先删 scrape_info（无外键 CASCADE）
+        await this.rdbStore!.executeSql(
+          `DELETE FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} WHERE video_id IN (${idHolders})`,
+          idArgs
+        );
+        // 再删 videos
+        await this.rdbStore!.executeSql(
+          `DELETE FROM ${FileSourceDatabase.TABLE_VIDEOS} WHERE id IN (${idHolders})`,
+          idArgs
+        );
+      }
+
+      console.info(`[DB][deleteGhostVideos] 已清理 ${ghostIds.length} 条鬼记录，source_id IN (${sourceIds})`);
+      return ghostIds.length;
+    } catch (e) {
+      console.warn('[DB][deleteGhostVideos] 清理鬼记录失败: ' + JSON.stringify(e));
+      return 0;
     }
   }
 

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -1639,7 +1639,32 @@ export class FileSourceDatabase {
       const movies = await q(`SELECT COUNT(DISTINCT movie_id) AS cnt FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} WHERE movie_id IS NOT NULL`);
       const tv = await q(`SELECT COUNT(DISTINCT tv_series_id) AS cnt FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} WHERE tv_series_id IS NOT NULL`);
       const scraped = await q(`SELECT COUNT(DISTINCT video_id) AS cnt FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO}`);
-      return { total, movies, tv, other: total - scraped };
+      const other = total - scraped;
+
+      // 诊断：打印无刮削记录的文件列表（source_id + file_name）
+      if (other > 0 && this.rdbStore) {
+        let diagRs: relationalStore.ResultSet | undefined;
+        try {
+          diagRs = await this.rdbStore.querySql(
+            `SELECT v.source_id, v.file_name, v.file_path FROM ${FileSourceDatabase.TABLE_VIDEOS} v
+             WHERE NOT EXISTS (SELECT 1 FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} s WHERE s.video_id = v.id)
+             ORDER BY v.source_id, v.file_name`
+          );
+          const unscrapedFiles: string[] = [];
+          while (diagRs.goToNextRow()) {
+            const sid = diagRs.getLong(diagRs.getColumnIndex('source_id'));
+            const name = diagRs.getString(diagRs.getColumnIndex('file_name'));
+            unscrapedFiles.push(`[src=${sid}] ${name}`);
+          }
+          console.info(`[DB][getMediaStats] 未刮削文件(${other}个):\n${unscrapedFiles.join('\n')}`);
+        } catch {
+          // 诊断失败不影响主流程
+        } finally {
+          diagRs?.close();
+        }
+      }
+
+      return { total, movies, tv, other };
     } catch { return { total: 0, movies: 0, tv: 0, other: 0 }; }
   }
 

--- a/entry/src/main/ets/db/models/MediaEntity.ets
+++ b/entry/src/main/ets/db/models/MediaEntity.ets
@@ -86,6 +86,7 @@ export interface MovieEntity {
   directorsJson?: string;
   runtime?: number;
   originalLanguage?: string;
+  originCountryJson?: string;
   rawJson?: string;
   scrapedAt: number;
 }
@@ -114,6 +115,7 @@ export interface TvSeriesEntity {
   castJson?: string;
   numberOfSeasons?: number;
   originalLanguage?: string;
+  originCountryJson?: string;
   rawJson?: string;
   scrapedAt: number;
 }

--- a/entry/src/main/ets/lib/ScrapeClient.ets
+++ b/entry/src/main/ets/lib/ScrapeClient.ets
@@ -45,6 +45,7 @@ export interface MovieScrapeResult {
   directorsJson?: string;
   runtime?: number;
   originalLanguage?: string;
+  originCountryJson?: string;
   rawJson?: string;
 }
 
@@ -66,6 +67,7 @@ export interface TvSeriesScrapeResult {
   castJson?: string;
   numberOfSeasons?: number;
   originalLanguage?: string;
+  originCountryJson?: string;
   rawJson?: string;
 }
 
@@ -269,6 +271,11 @@ interface TmdbCredits {
   crew?: TmdbCrewItem[];
 }
 
+interface TmdbProductionCountry {
+  iso_3166_1: string;
+  name: string;
+}
+
 interface TmdbMovieDetail {
   id: number;
   title?: string;
@@ -283,6 +290,7 @@ interface TmdbMovieDetail {
   original_language?: string;
   runtime?: number;
   credits?: TmdbCredits;
+  production_countries?: TmdbProductionCountry[];
 }
 
 interface TmdbTvDetail {
@@ -300,6 +308,7 @@ interface TmdbTvDetail {
   number_of_seasons?: number;
   episode_run_time?: number[];
   credits?: TmdbCredits;
+  origin_country?: string[];
 }
 
 interface TmdbSeasonDetail {
@@ -432,6 +441,12 @@ export class TmdbProvider implements IScrapeProvider {
       directorsJson: directors.length > 0 ? JSON.stringify(directors) : undefined,
       runtime: item.runtime ?? undefined,
       originalLanguage: item.original_language ?? undefined,
+      originCountryJson: (() => {
+        const countries = item.production_countries;
+        if (!countries || countries.length === 0) { return undefined; }
+        const codes: string[] = countries.map((c: TmdbProductionCountry): string => c.iso_3166_1);
+        return JSON.stringify(codes);
+      })(),
       rawJson
     };
     return r;
@@ -462,6 +477,11 @@ export class TmdbProvider implements IScrapeProvider {
       castJson: cast.length > 0 ? JSON.stringify(cast) : undefined,
       numberOfSeasons: item.number_of_seasons ?? undefined,
       originalLanguage: item.original_language ?? undefined,
+      originCountryJson: (() => {
+        const countries = item.origin_country;
+        if (!countries || countries.length === 0) { return undefined; }
+        return JSON.stringify(countries);
+      })(),
       rawJson
     };
     return r;

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -1,6 +1,6 @@
 import { TabBarModel, TabItem } from "../../../stores/tabbar/TabBarModel"
 import { TabBarStore } from "../../../stores/tabbar/TabBarStore"
-import { VideoScannerUtil } from "../../../utils/VideoScannerUtil"
+import { VideoScannerUtil, ScanMode } from "../../../utils/VideoScannerUtil"
 import { ScrapeClient, parseFileName, TvSeriesScrapeResult } from "../../../lib/ScrapeClient"
 import { AppPreferences, PrefKey } from "../../../utils/AppPreferences"
 import { MediaItem, MediaStats, SeriesGroup, MediaListItem, ScrapeInfoEntity, MovieEntity, TvSeriesEntity, TvSeasonEntity, TvEpisodeEntity, ContinueWatchingItem } from "../../../db/models/MediaEntity"
@@ -505,15 +505,34 @@ export struct MediaLibraryTab {
     emitter.off(PlayerEvents.MEDIA_PROGRESS_SAVED.eventId);
   }
 
-  private async startScan(): Promise<void> {
-    await this.runScan(false);
-  }
-
   private async startIncrementalScan(): Promise<void> {
-    await this.runScan(true);
+    await this.runScan('incremental');
   }
 
-  private async runScan(incremental: boolean): Promise<void> {
+  private async startFixMissingScan(): Promise<void> {
+    await this.runScan('fix-missing');
+  }
+
+  private startOverwriteScan(): void {
+    if (this.isScanning) { return; }
+    AlertDialog.show({
+      title: '覆盖所有元数据',
+      message: '「覆盖所有元数据」将重新刮削所有视频的信息，覆盖现有海报、评分、分类等数据。确定继续吗？',
+      autoCancel: true,
+      secondaryButton: {
+        value: '取消',
+        action: () => {}
+      },
+      primaryButton: {
+        value: '确定覆盖',
+        action: () => {
+          this.runScan('overwrite');
+        }
+      }
+    });
+  }
+
+  private async runScan(mode: ScanMode): Promise<void> {
     if (this.isScanning) { return; }
     this.isScanning = true;
     try {
@@ -527,20 +546,20 @@ export struct MediaLibraryTab {
         });
       }
 
-      const result = await VideoScannerUtil.scan(context, scrapeClient, { incremental });
+      const result = await VideoScannerUtil.scan(context, scrapeClient, { mode });
       console.info(
-        `[MediaLibraryTab] ${incremental ? '增量扫描' : '扫描'}完成，共 ${result.totalVideos} 个视频，` +
+        `[MediaLibraryTab] 扫描(${mode})完成，共 ${result.totalVideos} 个视频，` +
         `处理 ${result.processedVideos} 个，跳过 ${result.skippedVideos} 个，耗时 ${result.elapsedMs}ms`
       );
       await this.model.reload();
       promptAction.showToast({
-        message: `${incremental ? '增量扫描' : '扫描'}完成：处理 ${result.processedVideos}，跳过 ${result.skippedVideos}`
+        message: `扫描完成：处理 ${result.processedVideos}，跳过 ${result.skippedVideos}`
       });
     } catch (e) {
       const err = e as Error;
-      console.error(`[MediaLibraryTab] ${incremental ? '增量扫描' : '扫描'}异常: ${err.message}`);
+      console.error(`[MediaLibraryTab] 扫描(${mode})异常: ${err.message}`);
       promptAction.showToast({
-        message: `${incremental ? '增量扫描' : '扫描'}失败: ` + err.message
+        message: `扫描失败: ` + err.message
       });
     } finally {
       this.isScanning = false;
@@ -986,20 +1005,27 @@ export struct MediaLibraryTab {
       Text(this.getLastScanText())
         .fontSize(11).fontColor('#555555').textAlign(TextAlign.Center).width('100%').margin({ bottom: 16 })
 
-      Row({ space: 16 }) {
-        Button(this.isScanning ? '扫描中...' : '重新扫描')
-          .width(150).height(40).fontSize(14)
+      Row({ space: 12 }) {
+        Button(this.isScanning ? '扫描中...' : '扫描新增')
+          .height(40).fontSize(13).layoutWeight(1)
           .enabled(!this.isScanning)
           .buttonStyle(ButtonStyleMode.EMPHASIZED)
-          .onClick(() => { this.startScan(); })
+          .onClick(() => { this.startIncrementalScan(); })
 
-        Button(this.isScanning ? '扫描中...' : '非全量更新')
-          .width(150).height(40).fontSize(14)
+        Button(this.isScanning ? '扫描中...' : '补全元数据')
+          .height(40).fontSize(13).layoutWeight(1)
           .enabled(!this.isScanning)
           .buttonStyle(ButtonStyleMode.TEXTUAL)
-          .onClick(() => { this.startIncrementalScan(); })
+          .onClick(() => { this.startFixMissingScan(); })
+
+        Button(this.isScanning ? '扫描中...' : '全量覆盖')
+          .height(40).fontSize(13).layoutWeight(1)
+          .enabled(!this.isScanning)
+          .buttonStyle(ButtonStyleMode.TEXTUAL)
+          .onClick(() => { this.startOverwriteScan(); })
       }
       .justifyContent(FlexAlign.Center)
+      .width('100%')
 
       Row({ space: 16 }) {
         Button(this.isScanning ? '刷新中...' : '刷新元数据')
@@ -1033,7 +1059,7 @@ export struct MediaLibraryTab {
   EmptyView() {
     Column() {
       Text('暂无媒体').fontSize(16).fontColor('#666666')
-      Text('请先配置文件源并点击"重新扫描"')
+      Text('请先配置文件源并点击"扫描新增"')
         .fontSize(12).fontColor('#444444').margin({ top: 8 })
     }
     .width('100%').height(300).justifyContent(FlexAlign.Center).alignItems(HorizontalAlign.Center)

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -1006,19 +1006,19 @@ export struct MediaLibraryTab {
         .fontSize(11).fontColor('#555555').textAlign(TextAlign.Center).width('100%').margin({ bottom: 16 })
 
       Row({ space: 12 }) {
-        Button(this.isScanning ? '扫描中...' : '扫描新增')
+        Button(this.isScanning ? '扫描中...' : '扫描新的和有修改的文件')
           .height(40).fontSize(13).layoutWeight(1)
           .enabled(!this.isScanning)
           .buttonStyle(ButtonStyleMode.EMPHASIZED)
           .onClick(() => { this.startIncrementalScan(); })
 
-        Button(this.isScanning ? '扫描中...' : '补全元数据')
+        Button(this.isScanning ? '扫描中...' : '搜索缺少的元数据')
           .height(40).fontSize(13).layoutWeight(1)
           .enabled(!this.isScanning)
           .buttonStyle(ButtonStyleMode.TEXTUAL)
           .onClick(() => { this.startFixMissingScan(); })
 
-        Button(this.isScanning ? '扫描中...' : '全量覆盖')
+        Button(this.isScanning ? '扫描中...' : '覆盖所有元数据')
           .height(40).fontSize(13).layoutWeight(1)
           .enabled(!this.isScanning)
           .buttonStyle(ButtonStyleMode.TEXTUAL)
@@ -1026,22 +1026,7 @@ export struct MediaLibraryTab {
       }
       .justifyContent(FlexAlign.Center)
       .width('100%')
-
-      Row({ space: 16 }) {
-        Button(this.isScanning ? '刷新中...' : '刷新元数据')
-          .width(150).height(40).fontSize(14)
-          .enabled(!this.isScanning)
-          .buttonStyle(ButtonStyleMode.TEXTUAL)
-          .onClick(() => { this.refreshMetadata(); })
-
-        Button(this.isScanning ? '刷新中...' : '刷新字幕轨信息')
-          .width(150).height(40).fontSize(14)
-          .enabled(!this.isScanning)
-          .buttonStyle(ButtonStyleMode.TEXTUAL)
-          .onClick(() => { this.showRefreshSubtitleTrackDialog(); })
-      }
-      .justifyContent(FlexAlign.Center)
-      .margin({ top: 12, bottom: 40 })
+      .margin({ bottom: 40 })
     }
     .width('100%').alignItems(HorizontalAlign.Center).padding({ left: 16, right: 16 })
   }
@@ -1059,7 +1044,7 @@ export struct MediaLibraryTab {
   EmptyView() {
     Column() {
       Text('暂无媒体').fontSize(16).fontColor('#666666')
-      Text('请先配置文件源并点击"扫描新增"')
+      Text('请先配置文件源并点击"扫描新的和有修改的文件"')
         .fontSize(12).fontColor('#444444').margin({ top: 8 })
     }
     .width('100%').height(300).justifyContent(FlexAlign.Center).alignItems(HorizontalAlign.Center)

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -1009,25 +1009,41 @@ export struct MediaLibraryTab {
         .fontSize(11).fontColor('#555555').textAlign(TextAlign.Center).width('100%').margin({ bottom: 16 })
 
       Row({ space: 12 }) {
-        Button(this.isScanning ? '扫描中...' : '扫描新的和有修改的文件')
-          .height(40).fontSize(13).layoutWeight(1)
-          .enabled(!this.isScanning)
-          .buttonStyle(ButtonStyleMode.EMPHASIZED)
-          .onClick(() => { this.startIncrementalScan(); })
+        Column({ space: 6 }) {
+          Button(this.isScanning ? '扫描中...' : '扫描新的和有修改的文件')
+            .height(40).fontSize(13).width('100%')
+            .enabled(!this.isScanning)
+            .buttonStyle(ButtonStyleMode.EMPHASIZED)
+            .onClick(() => { this.startIncrementalScan(); })
+          Text('仅处理新增或已改动的文件，已有元数据不受影响')
+            .fontSize(11).fontColor('#888888').textAlign(TextAlign.Center)
+        }
+        .layoutWeight(1)
 
-        Button(this.isScanning ? '扫描中...' : '搜索缺少的元数据')
-          .height(40).fontSize(13).layoutWeight(1)
-          .enabled(!this.isScanning)
-          .buttonStyle(ButtonStyleMode.TEXTUAL)
-          .onClick(() => { this.startFixMissingScan(); })
+        Column({ space: 6 }) {
+          Button(this.isScanning ? '扫描中...' : '搜索缺少的元数据')
+            .height(40).fontSize(13).width('100%')
+            .enabled(!this.isScanning)
+            .buttonStyle(ButtonStyleMode.TEXTUAL)
+            .onClick(() => { this.startFixMissingScan(); })
+          Text('为缺少海报或信息的视频重新补全，已完整的跳过')
+            .fontSize(11).fontColor('#888888').textAlign(TextAlign.Center)
+        }
+        .layoutWeight(1)
 
-        Button(this.isScanning ? '扫描中...' : '覆盖所有元数据')
-          .height(40).fontSize(13).layoutWeight(1)
-          .enabled(!this.isScanning)
-          .buttonStyle(ButtonStyleMode.TEXTUAL)
-          .onClick(() => { this.startOverwriteScan(); })
+        Column({ space: 6 }) {
+          Button(this.isScanning ? '扫描中...' : '覆盖所有元数据')
+            .height(40).fontSize(13).width('100%')
+            .enabled(!this.isScanning)
+            .buttonStyle(ButtonStyleMode.TEXTUAL)
+            .onClick(() => { this.startOverwriteScan(); })
+          Text('重新刮削全部视频，覆盖现有海报、评分和分类')
+            .fontSize(11).fontColor('#888888').textAlign(TextAlign.Center)
+        }
+        .layoutWeight(1)
       }
       .justifyContent(FlexAlign.Center)
+      .alignItems(VerticalAlign.Top)
       .width('100%')
       .margin({ bottom: 40 })
     }

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -1008,44 +1008,53 @@ export struct MediaLibraryTab {
       Text(this.getLastScanText())
         .fontSize(11).fontColor('#555555').textAlign(TextAlign.Center).width('100%').margin({ bottom: 16 })
 
-      Row({ space: 12 }) {
-        Column({ space: 6 }) {
-          Button(this.isScanning ? '扫描中...' : '扫描新的和有修改的文件')
-            .height(40).fontSize(13).width('100%')
-            .enabled(!this.isScanning)
-            .buttonStyle(ButtonStyleMode.EMPHASIZED)
-            .onClick(() => { this.startIncrementalScan(); })
-          Text('仅处理新增或已改动的文件，已有元数据不受影响')
-            .fontSize(11).fontColor('#888888').textAlign(TextAlign.Center)
+      Column({ space: 10 }) {
+        Button({ type: ButtonType.Normal, stateEffect: true }) {
+          Column({ space: 5 }) {
+            Text(this.isScanning ? '扫描中...' : '扫描新增和已修改的文件')
+              .fontSize(15).fontColor(this.isScanning ? '#555555' : '#4A9FFF')
+              .fontWeight(FontWeight.Medium).width('100%').textAlign(TextAlign.Start)
+            Text('仅处理新增或已改动的文件，已有元数据不受影响')
+              .fontSize(12).fontColor('#AAAAAA').width('100%').textAlign(TextAlign.Start)
+          }
+          .width('100%').padding({ left: 16, right: 16, top: 14, bottom: 14 })
+          .alignItems(HorizontalAlign.Start)
         }
-        .layoutWeight(1)
+        .width('100%').backgroundColor('#1C1C1C').borderRadius(10)
+        .enabled(!this.isScanning)
+        .onClick(() => { this.startIncrementalScan(); })
 
-        Column({ space: 6 }) {
-          Button(this.isScanning ? '扫描中...' : '搜索缺少的元数据')
-            .height(40).fontSize(13).width('100%')
-            .enabled(!this.isScanning)
-            .buttonStyle(ButtonStyleMode.TEXTUAL)
-            .onClick(() => { this.startFixMissingScan(); })
-          Text('为缺少海报或信息的视频重新补全，已完整的跳过')
-            .fontSize(11).fontColor('#888888').textAlign(TextAlign.Center)
+        Button({ type: ButtonType.Normal, stateEffect: true }) {
+          Column({ space: 5 }) {
+            Text(this.isScanning ? '扫描中...' : '补全缺少的元数据')
+              .fontSize(15).fontColor(this.isScanning ? '#555555' : '#52C41A')
+              .fontWeight(FontWeight.Medium).width('100%').textAlign(TextAlign.Start)
+            Text('为缺少海报或信息的视频重新补全，已完整的跳过')
+              .fontSize(12).fontColor('#AAAAAA').width('100%').textAlign(TextAlign.Start)
+          }
+          .width('100%').padding({ left: 16, right: 16, top: 14, bottom: 14 })
+          .alignItems(HorizontalAlign.Start)
         }
-        .layoutWeight(1)
+        .width('100%').backgroundColor('#1C1C1C').borderRadius(10)
+        .enabled(!this.isScanning)
+        .onClick(() => { this.startFixMissingScan(); })
 
-        Column({ space: 6 }) {
-          Button(this.isScanning ? '扫描中...' : '覆盖所有元数据')
-            .height(40).fontSize(13).width('100%')
-            .enabled(!this.isScanning)
-            .buttonStyle(ButtonStyleMode.TEXTUAL)
-            .onClick(() => { this.startOverwriteScan(); })
-          Text('重新刮削全部视频，覆盖现有海报、评分和分类')
-            .fontSize(11).fontColor('#888888').textAlign(TextAlign.Center)
+        Button({ type: ButtonType.Normal, stateEffect: true }) {
+          Column({ space: 5 }) {
+            Text(this.isScanning ? '扫描中...' : '覆盖所有元数据')
+              .fontSize(15).fontColor(this.isScanning ? '#555555' : '#FF8C4A')
+              .fontWeight(FontWeight.Medium).width('100%').textAlign(TextAlign.Start)
+            Text('重新刮削全部视频，覆盖现有海报、评分和分类')
+              .fontSize(12).fontColor('#AAAAAA').width('100%').textAlign(TextAlign.Start)
+          }
+          .width('100%').padding({ left: 16, right: 16, top: 14, bottom: 14 })
+          .alignItems(HorizontalAlign.Start)
         }
-        .layoutWeight(1)
+        .width('100%').backgroundColor('#1C1C1C').borderRadius(10)
+        .enabled(!this.isScanning)
+        .onClick(() => { this.startOverwriteScan(); })
       }
-      .justifyContent(FlexAlign.Center)
-      .alignItems(VerticalAlign.Top)
-      .width('100%')
-      .margin({ bottom: 40 })
+      .width('100%').margin({ bottom: 40 })
     }
     .width('100%').alignItems(HorizontalAlign.Center).padding({ left: 16, right: 16 })
   }

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -547,13 +547,16 @@ export struct MediaLibraryTab {
       }
 
       const result = await VideoScannerUtil.scan(context, scrapeClient, { mode });
+      const scrapeStats = result.scrapeSkippedVideos > 0
+        ? `，已跳过 ${result.scrapeSkippedVideos} 个元数据完整的视频`
+        : '';
       console.info(
         `[MediaLibraryTab] 扫描(${mode})完成，共 ${result.totalVideos} 个视频，` +
-        `处理 ${result.processedVideos} 个，跳过 ${result.skippedVideos} 个，耗时 ${result.elapsedMs}ms`
+        `处理 ${result.processedVideos} 个，跳过 ${result.skippedVideos} 个，刮削跳过 ${result.scrapeSkippedVideos} 个，耗时 ${result.elapsedMs}ms`
       );
       await this.model.reload();
       promptAction.showToast({
-        message: `扫描完成：处理 ${result.processedVideos}，跳过 ${result.skippedVideos}`
+        message: `扫描完成：共 ${result.totalVideos} 个视频${scrapeStats}`
       });
     } catch (e) {
       const err = e as Error;

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -82,6 +82,19 @@ const TV_PROGRESS_OPTIONS: StringOption[] = [
   { label: '已看完', value: 'done' },
 ];
 
+const REGION_OPTIONS: StringOption[] = [
+  { label: '全部地区', value: '' },
+  { label: '中国大陆', value: 'CN' },
+  { label: '中国香港', value: 'HK' },
+  { label: '中国台湾', value: 'TW' },
+  { label: '日本', value: 'JP' },
+  { label: '韩国', value: 'KR' },
+  { label: '美国', value: 'US' },
+  { label: '英国', value: 'GB' },
+  { label: '法国', value: 'FR' },
+  { label: '德国', value: 'DE' },
+];
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Design Token Constants — strictly follows Pencil vidall_pages.pen
 // ─────────────────────────────────────────────────────────────────────────────
@@ -276,6 +289,7 @@ export struct MediaResultPage {
   @Local filterYearLabel: string = '';     // '' | '2020s' | '2010s' | '2000s' | '1990s' | '更早'
   @Local filterRating: number = 0;         // 0 = 全部，6/7/8 = 对应最低分
   @Local filterProgress: string = '';      // '' | 'unseen' | 'partial' | 'done'
+  @Local filterRegion: string = '';        // '' 或 ISO 3166-1 代码，如 "CN"、"JP"
   @Local genreOptions: string[] = [];      // 从库中动态加载
 
   // ── Data state ────────────────────────────────────────────────────────────
@@ -342,6 +356,7 @@ export struct MediaResultPage {
         limit: 200,
         minRating: this.filterRating > 0 ? this.filterRating : undefined,
         watchProgress: this.getWatchProgressFilter(),
+        originCountry: this.filterRegion.length > 0 ? this.filterRegion : undefined,
       };
 
       const items: MediaItem[] = await this.db.searchMediaItems(this.keyword, options);
@@ -389,6 +404,7 @@ export struct MediaResultPage {
     this.filterYearLabel = '';
     this.filterRating = 0;
     this.filterProgress = '';
+    this.filterRegion = '';
     this.filterSort = 'composite';
     this.pageTitle = this.initialPageTitle;
     this.doSearch().catch((): void => {});
@@ -662,6 +678,37 @@ export struct MediaResultPage {
         .height(48)
         .alignItems(VerticalAlign.Center)
       }
+
+      // 行7：地区
+      Divider().color('#3A3A3A').height(1)
+
+      Row() {
+        Scroll() {
+          Row({ space: 8 }) {
+            ForEach(REGION_OPTIONS, (opt: StringOption) => {
+              FilterChip({
+                label: opt.label,
+                selected: this.filterRegion === opt.value,
+                onPress: () => {
+                  this.filterRegion = opt.value;
+                  this.doSearch().catch((): void => {});
+                }
+              })
+            }, (opt: StringOption) => 'region_' + opt.value + '_' + this.filterRegion)
+          }
+          .padding({ left: 12, right: 12 })
+          .justifyContent(FlexAlign.Start)
+          .alignItems(VerticalAlign.Center)
+        }
+        .scrollable(ScrollDirection.Horizontal)
+        .scrollBar(BarState.Off)
+        .layoutWeight(1)
+        .height(48)
+        .align(Alignment.Start)
+      }
+      .width('100%')
+      .height(48)
+      .alignItems(VerticalAlign.Center)
     }
     .width('100%')
     .backgroundColor(C_FILTER_BG)

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -971,6 +971,17 @@ export class VideoScannerUtil {
     const fileSources = await db.getAllFileSources();
     console.info(`[VideoScanner] 共找到 ${fileSources.length} 个文件源`);
 
+    // 全量覆盖模式：先清空所有源的 scrape_info，确保重刮前无历史垃圾数据
+    if (scanOptions.mode === 'overwrite') {
+      const sourceIds = fileSources
+        .map((s: FileSource) => s.id)
+        .filter((id: number | undefined): id is number => id !== undefined && id > 0);
+      if (sourceIds.length > 0) {
+        await db.clearScrapeInfoForSources(sourceIds);
+        console.info(`[VideoScanner] 全量覆盖预清空完成，已清除 ${sourceIds.length} 个文件源的 scrape_info`);
+      }
+    }
+
     const seenPaths = new Set<string>();
     const allVideos: VideoFileInfo[] = [];
     const perSourceStats: SourceScanStat[] = [];

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -286,16 +286,32 @@ export class WebDAVAdapter implements ISourceAdapter {
                   return;
                 }
               } else if (capturedMode === 'fix-missing') {
-                // fix-missing: 仅在 scrape_info 完整时跳过（已有 movieId 或 tvSeriesId）
+                // fix-missing: 仅在 scrape_info 完整且 origin_country_json 已填充时跳过
                 if (existing) {
                   const isComplete = existing.mediaType === 'movie'
                     ? existing.movieId !== undefined
                     : existing.tvSeriesId !== undefined;
                   if (isComplete) {
-                    console.info(`[VideoScanner][SCRAPE] fix-missing 元数据完整，跳过 fileName=${fileName}`);
-                    return;
+                    // 额外检查 origin_country_json 是否已填充（DB v7 新增字段，老数据为 NULL）
+                    let hasCountry = false;
+                    try {
+                      const db = FileSourceDatabase.getInstance();
+                      if (existing.mediaType === 'movie' && existing.movieId !== undefined) {
+                        hasCountry = await db.hasMovieOriginCountry(existing.movieId);
+                      } else if (existing.tvSeriesId !== undefined) {
+                        hasCountry = await db.hasTvSeriesOriginCountry(existing.tvSeriesId);
+                      }
+                    } catch {
+                      hasCountry = false;
+                    }
+                    if (hasCountry) {
+                      console.info(`[VideoScanner][SCRAPE] fix-missing 元数据完整，跳过 fileName=${fileName}`);
+                      return;
+                    }
+                    console.info(`[VideoScanner][SCRAPE] fix-missing origin_country_json 缺失，重新刮削 fileName=${fileName}`);
+                  } else {
+                    console.info(`[VideoScanner][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${fileName}`);
                   }
-                  console.info(`[VideoScanner][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${fileName}`);
                 }
               }
               // overwrite: 不跳过，强制重新刮削（upsertScrapeInfo 已是 upsert）
@@ -693,10 +709,26 @@ export class SMBAdapter implements ISourceAdapter {
                   ? existing.movieId !== undefined
                   : existing.tvSeriesId !== undefined;
                 if (isComplete) {
-                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据完整，跳过 fileName=${capturedInfo.fileName}`);
-                  return;
+                  // 额外检查 origin_country_json 是否已填充（DB v7 新增字段，老数据为 NULL）
+                  let hasCountry = false;
+                  try {
+                    const dbInst = FileSourceDatabase.getInstance();
+                    if (existing.mediaType === 'movie' && existing.movieId !== undefined) {
+                      hasCountry = await dbInst.hasMovieOriginCountry(existing.movieId);
+                    } else if (existing.tvSeriesId !== undefined) {
+                      hasCountry = await dbInst.hasTvSeriesOriginCountry(existing.tvSeriesId);
+                    }
+                  } catch {
+                    hasCountry = false;
+                  }
+                  if (hasCountry) {
+                    console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据完整，跳过 fileName=${capturedInfo.fileName}`);
+                    return;
+                  }
+                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing origin_country_json 缺失，重新刮削 fileName=${capturedInfo.fileName}`);
+                } else {
+                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${capturedInfo.fileName}`);
                 }
-                console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${capturedInfo.fileName}`);
               }
             }
             // overwrite: 不跳过，强制重新刮削（upsertScrapeInfo 已是 upsert）

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -23,6 +23,7 @@ export interface VideoFileInfo {
   lastModified?: string;
   contentType?: string;
   wasProcessed?: boolean;
+  scrapeSkipped?: boolean;
 }
 
 export interface SourceScanStat {
@@ -38,6 +39,7 @@ export interface ScanResult {
   totalVideos: number;
   processedVideos: number;
   skippedVideos: number;
+  scrapeSkippedVideos: number;
   perSourceStats: SourceScanStat[];
   elapsedMs: number;
   videos: VideoFileInfo[];
@@ -286,32 +288,17 @@ export class WebDAVAdapter implements ISourceAdapter {
                   return;
                 }
               } else if (capturedMode === 'fix-missing') {
-                // fix-missing: 仅在 scrape_info 完整且 origin_country_json 已填充时跳过
+                // fix-missing: scrape_info 存在且 ID 已关联就跳过，不检查额外字段
                 if (existing) {
                   const isComplete = existing.mediaType === 'movie'
                     ? existing.movieId !== undefined
                     : existing.tvSeriesId !== undefined;
                   if (isComplete) {
-                    // 额外检查 origin_country_json 是否已填充（DB v7 新增字段，老数据为 NULL）
-                    let hasCountry = false;
-                    try {
-                      const db = FileSourceDatabase.getInstance();
-                      if (existing.mediaType === 'movie' && existing.movieId !== undefined) {
-                        hasCountry = await db.hasMovieOriginCountry(existing.movieId);
-                      } else if (existing.tvSeriesId !== undefined) {
-                        hasCountry = await db.hasTvSeriesOriginCountry(existing.tvSeriesId);
-                      }
-                    } catch {
-                      hasCountry = false;
-                    }
-                    if (hasCountry) {
-                      console.info(`[VideoScanner][SCRAPE] fix-missing 元数据完整，跳过 fileName=${fileName}`);
-                      return;
-                    }
-                    console.info(`[VideoScanner][SCRAPE] fix-missing origin_country_json 缺失，重新刮削 fileName=${fileName}`);
-                  } else {
-                    console.info(`[VideoScanner][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${fileName}`);
+                    console.info(`[VideoScanner][SCRAPE] fix-missing 元数据完整，跳过 fileName=${fileName}`);
+                    capturedInfo.scrapeSkipped = true;
+                    return;
                   }
+                  console.info(`[VideoScanner][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${fileName}`);
                 }
               }
               // overwrite: 不跳过，强制重新刮削（upsertScrapeInfo 已是 upsert）
@@ -714,31 +701,17 @@ export class SMBAdapter implements ISourceAdapter {
                 return;
               }
             } else if (capturedMode === 'fix-missing') {
+              // fix-missing: scrape_info 存在且 ID 已关联就跳过，不检查额外字段
               if (existing) {
                 const isComplete = existing.mediaType === 'movie'
                   ? existing.movieId !== undefined
                   : existing.tvSeriesId !== undefined;
                 if (isComplete) {
-                  // 额外检查 origin_country_json 是否已填充（DB v7 新增字段，老数据为 NULL）
-                  let hasCountry = false;
-                  try {
-                    const dbInst = FileSourceDatabase.getInstance();
-                    if (existing.mediaType === 'movie' && existing.movieId !== undefined) {
-                      hasCountry = await dbInst.hasMovieOriginCountry(existing.movieId);
-                    } else if (existing.tvSeriesId !== undefined) {
-                      hasCountry = await dbInst.hasTvSeriesOriginCountry(existing.tvSeriesId);
-                    }
-                  } catch {
-                    hasCountry = false;
-                  }
-                  if (hasCountry) {
-                    console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据完整，跳过 fileName=${capturedInfo.fileName}`);
-                    return;
-                  }
-                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing origin_country_json 缺失，重新刮削 fileName=${capturedInfo.fileName}`);
-                } else {
-                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${capturedInfo.fileName}`);
+                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据完整，跳过 fileName=${capturedInfo.fileName}`);
+                  capturedInfo.scrapeSkipped = true;
+                  return;
                 }
+                console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${capturedInfo.fileName}`);
               }
             }
             // overwrite: 不跳过，强制重新刮削（upsertScrapeInfo 已是 upsert）
@@ -1070,12 +1043,14 @@ export class VideoScannerUtil {
     const elapsedMs = Date.now() - startTime;
     const processedVideos = allVideos.filter((video: VideoFileInfo) => video.wasProcessed !== false).length;
     const skippedVideos = allVideos.length - processedVideos;
+    const scrapeSkippedVideos = allVideos.filter((video: VideoFileInfo) => video.scrapeSkipped === true).length;
     console.info(`[VideoScanner] ======== 扫描完成 ========`);
     console.info(`[VideoScanner][STATS] 总耗时: ${elapsedMs} ms`);
     console.info(`[VideoScanner][STATS] 扫描目录总数: ${totalDirectories}`);
     console.info(`[VideoScanner][STATS] 发现视频总数（去重后）: ${allVideos.length}`);
     console.info(`[VideoScanner][STATS] 本轮处理视频数: ${processedVideos}`);
     console.info(`[VideoScanner][STATS] 本轮跳过未变化视频数: ${skippedVideos}`);
+    console.info(`[VideoScanner][STATS] 本轮跳过刮削（元数据完整）: ${scrapeSkippedVideos}`);
     for (const stat of perSourceStats) {
       console.info(
         `[VideoScanner][STATS] 文件源="${stat.sourceName}" (${stat.sourceType}) | ` +
@@ -1105,6 +1080,7 @@ export class VideoScannerUtil {
       totalVideos: allVideos.length,
       processedVideos,
       skippedVideos,
+      scrapeSkippedVideos,
       perSourceStats,
       elapsedMs,
       videos: allVideos

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -1057,6 +1057,9 @@ export class VideoScannerUtil {
     }
     console.info(`[VideoScanner] ===========================`);
 
+    // 清理孤立 scrape_info（由历史 INSERT OR REPLACE upsertVideo 产生的无效引用）
+    await FileSourceDatabase.getInstance().cleanupOrphanedScrapeInfo();
+
     return {
       totalDirectories,
       totalVideos: allVideos.length,

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -493,10 +493,15 @@ export class WebDAVAdapter implements ISourceAdapter {
     if (!existingVideo) {
       return false;
     }
-    if (!existingVideo.lastModified || !currentInfo.lastModified) {
-      return false;
+    // 优先用 lastModified 比较
+    if (existingVideo.lastModified && currentInfo.lastModified) {
+      return existingVideo.lastModified === currentInfo.lastModified;
     }
-    return existingVideo.lastModified === currentInfo.lastModified;
+    // lastModified 不可用时（部分 WebDAV 服务器不返回 Last-Modified），用文件大小兜底
+    if (existingVideo.fileSize !== undefined && currentInfo.fileSize !== undefined) {
+      return existingVideo.fileSize === currentInfo.fileSize;
+    }
+    return false;
   }
 
   private toRelativePath(fullPath: string): string {
@@ -567,10 +572,15 @@ export class SMBAdapter implements ISourceAdapter {
     if (!existing) {
       return false;
     }
-    if (!existing.lastModified || !info.lastModified) {
-      return false;
+    // 优先用 lastModified 比较；SMB 源 lastModifiedMs=0 时 lastModified 为 undefined，降级用文件大小
+    if (existing.lastModified && info.lastModified) {
+      return existing.lastModified === info.lastModified;
     }
-    return existing.lastModified === info.lastModified;
+    // lastModified 不可用（SMB 库未返回有效时间戳），用文件大小作为变化检测后备
+    if (existing.fileSize !== undefined && info.fileSize !== undefined) {
+      return existing.fileSize === info.fileSize;
+    }
+    return false;
   }
 
   async scan(directoryPath: string, options: ScanOptions): Promise<VideoFileInfo[]> {

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -288,17 +288,34 @@ export class WebDAVAdapter implements ISourceAdapter {
                   return;
                 }
               } else if (capturedMode === 'fix-missing') {
-                // fix-missing: scrape_info 存在且 ID 已关联就跳过，不检查额外字段
+                // fix-missing: scrape_info 存在且 ID 已关联，且海报不为空，才跳过
                 if (existing) {
                   const isComplete = existing.mediaType === 'movie'
                     ? existing.movieId !== undefined
                     : existing.tvSeriesId !== undefined;
                   if (isComplete) {
-                    console.info(`[VideoScanner][SCRAPE] fix-missing 元数据完整，跳过 fileName=${fileName}`);
-                    capturedInfo.scrapeSkipped = true;
-                    return;
+                    let hasPoster = false;
+                    try {
+                      const db = FileSourceDatabase.getInstance();
+                      if (existing.mediaType === 'movie' && existing.movieId !== undefined) {
+                        const movie = await db.getMovieById(existing.movieId);
+                        hasPoster = !!(movie?.posterUrl);
+                      } else if (existing.tvSeriesId !== undefined) {
+                        const series = await db.getTvSeriesById(existing.tvSeriesId);
+                        hasPoster = !!(series?.posterUrl);
+                      }
+                    } catch {
+                      hasPoster = true; // 查询失败则保守跳过
+                    }
+                    if (hasPoster) {
+                      console.info(`[VideoScanner][SCRAPE] fix-missing 元数据完整，跳过 fileName=${fileName}`);
+                      capturedInfo.scrapeSkipped = true;
+                      return;
+                    }
+                    console.info(`[VideoScanner][SCRAPE] fix-missing 海报缺失，重新刮削 fileName=${fileName}`);
+                  } else {
+                    console.info(`[VideoScanner][SCRAPE] fix-missing 元数据不完整（ID未关联），重新刮削 fileName=${fileName}`);
                   }
-                  console.info(`[VideoScanner][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${fileName}`);
                 }
               }
               // overwrite: 不跳过，强制重新刮削（upsertScrapeInfo 已是 upsert）
@@ -701,17 +718,34 @@ export class SMBAdapter implements ISourceAdapter {
                 return;
               }
             } else if (capturedMode === 'fix-missing') {
-              // fix-missing: scrape_info 存在且 ID 已关联就跳过，不检查额外字段
+              // fix-missing: scrape_info 存在且 ID 已关联，且海报不为空，才跳过
               if (existing) {
                 const isComplete = existing.mediaType === 'movie'
                   ? existing.movieId !== undefined
                   : existing.tvSeriesId !== undefined;
                 if (isComplete) {
-                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据完整，跳过 fileName=${capturedInfo.fileName}`);
-                  capturedInfo.scrapeSkipped = true;
-                  return;
+                  let hasPoster = false;
+                  try {
+                    const db = FileSourceDatabase.getInstance();
+                    if (existing.mediaType === 'movie' && existing.movieId !== undefined) {
+                      const movie = await db.getMovieById(existing.movieId);
+                      hasPoster = !!(movie?.posterUrl);
+                    } else if (existing.tvSeriesId !== undefined) {
+                      const series = await db.getTvSeriesById(existing.tvSeriesId);
+                      hasPoster = !!(series?.posterUrl);
+                    }
+                  } catch {
+                    hasPoster = true; // 查询失败则保守跳过
+                  }
+                  if (hasPoster) {
+                    console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据完整，跳过 fileName=${capturedInfo.fileName}`);
+                    capturedInfo.scrapeSkipped = true;
+                    return;
+                  }
+                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 海报缺失，重新刮削 fileName=${capturedInfo.fileName}`);
+                } else {
+                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据不完整（ID未关联），重新刮削 fileName=${capturedInfo.fileName}`);
                 }
-                console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${capturedInfo.fileName}`);
               }
             }
             // overwrite: 不跳过，强制重新刮削（upsertScrapeInfo 已是 upsert）

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -973,9 +973,13 @@ export class VideoScannerUtil {
 
     // 全量覆盖模式：先清空所有源的 scrape_info，确保重刮前无历史垃圾数据
     if (scanOptions.mode === 'overwrite') {
-      const sourceIds = fileSources
-        .map((s: FileSource) => s.id)
-        .filter((id: number | undefined): id is number => id !== undefined && id > 0);
+      const sourceIds: number[] = [];
+      for (const s of fileSources) {
+        const sid = s.id;
+        if (sid !== undefined && sid > 0) {
+          sourceIds.push(sid);
+        }
+      }
       if (sourceIds.length > 0) {
         await db.clearScrapeInfoForSources(sourceIds);
         console.info(`[VideoScanner] 全量覆盖预清空完成，已清除 ${sourceIds.length} 个文件源的 scrape_info`);

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -341,7 +341,9 @@ export class WebDAVAdapter implements ISourceAdapter {
                 if (existingMovie && existingMovie.id !== undefined) {
                   movieId = existingMovie.id;
                   console.info(`[VideoScanner][SCRAPE] 电影复用已有记录 movieId=${movieId} title="${movie.title}" 已有posterUrl=${existingMovie.posterUrl ? 'Y' : 'null'}`);
-                  if (!existingMovie.posterUrl && movie.posterUrl) {
+                  const needsUpdate = (!existingMovie.posterUrl && movie.posterUrl) ||
+                    (!existingMovie.originCountryJson && movie.originCountryJson);
+                  if (needsUpdate) {
                     const updateEntity: MovieEntity = {
                       id: existingMovie.id,
                       provider: movie.provider, providerId: movie.providerId,
@@ -357,7 +359,7 @@ export class WebDAVAdapter implements ISourceAdapter {
                       scrapedAt: Date.now()
                     };
                     await db.upsertMovie(updateEntity);
-                    console.info(`[VideoScanner][SCRAPE] 电影复用更新 posterUrl movieId=${movieId}`);
+                    console.info(`[VideoScanner][SCRAPE] 电影复用更新元数据 movieId=${movieId}`);
                   }
                 } else {
                   const movieEntity: MovieEntity = {

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -332,7 +332,8 @@ export class WebDAVAdapter implements ISourceAdapter {
                       posterUrl: movie.posterUrl, backdropUrl: movie.backdropUrl,
                       genresJson: movie.genresJson, castJson: movie.castJson,
                       directorsJson: movie.directorsJson, runtime: movie.runtime,
-                      originalLanguage: movie.originalLanguage, rawJson: movie.rawJson,
+                      originalLanguage: movie.originalLanguage,
+                      originCountryJson: movie.originCountryJson, rawJson: movie.rawJson,
                       scrapedAt: Date.now()
                     };
                     await db.upsertMovie(updateEntity);
@@ -348,7 +349,8 @@ export class WebDAVAdapter implements ISourceAdapter {
                     posterUrl: movie.posterUrl, backdropUrl: movie.backdropUrl,
                     genresJson: movie.genresJson, castJson: movie.castJson,
                     directorsJson: movie.directorsJson, runtime: movie.runtime,
-                    originalLanguage: movie.originalLanguage, rawJson: movie.rawJson,
+                    originalLanguage: movie.originalLanguage,
+                    originCountryJson: movie.originCountryJson, rawJson: movie.rawJson,
                     scrapedAt: Date.now()
                   };
                   movieId = await db.upsertMovie(movieEntity);
@@ -393,7 +395,8 @@ export class WebDAVAdapter implements ISourceAdapter {
                     posterUrl: series.posterUrl, backdropUrl: series.backdropUrl,
                     genresJson: series.genresJson, castJson: series.castJson,
                     numberOfSeasons: series.numberOfSeasons,
-                    originalLanguage: series.originalLanguage, rawJson: series.rawJson,
+                    originalLanguage: series.originalLanguage,
+                    originCountryJson: series.originCountryJson, rawJson: series.rawJson,
                     scrapedAt: Date.now()
                   };
                   seriesId = await db.upsertTvSeries(seriesEntity);
@@ -729,7 +732,8 @@ export class SMBAdapter implements ISourceAdapter {
                     posterUrl: movie.posterUrl, backdropUrl: movie.backdropUrl,
                     genresJson: movie.genresJson, castJson: movie.castJson,
                     directorsJson: movie.directorsJson, runtime: movie.runtime,
-                    originalLanguage: movie.originalLanguage, rawJson: movie.rawJson,
+                    originalLanguage: movie.originalLanguage,
+                    originCountryJson: movie.originCountryJson, rawJson: movie.rawJson,
                     scrapedAt: Date.now()
                   };
                   await db.upsertMovie(updateEntity);
@@ -745,7 +749,8 @@ export class SMBAdapter implements ISourceAdapter {
                   posterUrl: movie.posterUrl, backdropUrl: movie.backdropUrl,
                   genresJson: movie.genresJson, castJson: movie.castJson,
                   directorsJson: movie.directorsJson, runtime: movie.runtime,
-                  originalLanguage: movie.originalLanguage, rawJson: movie.rawJson,
+                  originalLanguage: movie.originalLanguage,
+                  originCountryJson: movie.originCountryJson, rawJson: movie.rawJson,
                   scrapedAt: Date.now()
                 };
                 movieId = await db.upsertMovie(movieEntity);
@@ -786,7 +791,8 @@ export class SMBAdapter implements ISourceAdapter {
                   posterUrl: series.posterUrl, backdropUrl: series.backdropUrl,
                   genresJson: series.genresJson, castJson: series.castJson,
                   numberOfSeasons: series.numberOfSeasons,
-                  originalLanguage: series.originalLanguage, rawJson: series.rawJson,
+                  originalLanguage: series.originalLanguage,
+                  originCountryJson: series.originCountryJson, rawJson: series.rawJson,
                   scrapedAt: Date.now()
                 };
                 seriesId = await db.upsertTvSeries(seriesEntity);

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -43,12 +43,14 @@ export interface ScanResult {
   videos: VideoFileInfo[];
 }
 
+export type ScanMode = 'incremental' | 'fix-missing' | 'overwrite';
+
 export interface ScanOptions {
   maxDepth: number;
-  incremental: boolean;
+  mode: ScanMode;
 }
 
-const DEFAULT_SCAN_OPTIONS: ScanOptions = { maxDepth: 5, incremental: false };
+const DEFAULT_SCAN_OPTIONS: ScanOptions = { maxDepth: 5, mode: 'incremental' };
 
 // ─────────────────────────────────────────────
 // 视频扩展名白名单
@@ -130,7 +132,7 @@ export class WebDAVAdapter implements ISourceAdapter {
     console.info(`[VideoScanner][WebDAV] 开始扫描目录: ${directoryPath} 最大深度: ${options.maxDepth}`);
     const results: VideoFileInfo[] = [];
     const processingTasks: Promise<void>[] = [];
-    await this.scanDir(directoryPath, directoryPath, 0, options.maxDepth, options.incremental, results, processingTasks);
+    await this.scanDir(directoryPath, directoryPath, 0, options.maxDepth, options.mode, results, processingTasks);
     // 等待所有 ffprobe + 视频入库任务完成，确保 scan() 返回时 DB 已有数据
     if (processingTasks.length > 0) {
       console.info(`[VideoScanner][WebDAV] 等待 ${processingTasks.length} 个视频处理任务完成...`);
@@ -145,7 +147,7 @@ export class WebDAVAdapter implements ISourceAdapter {
     currentPath: string,
     depth: number,
     maxDepth: number,
-    incremental: boolean,
+    mode: ScanMode,
     results: VideoFileInfo[],
     processingTasks: Promise<void>[]
   ): Promise<void> {
@@ -172,7 +174,7 @@ export class WebDAVAdapter implements ISourceAdapter {
           console.info(`[VideoScanner][MAX_DEPTH] 已达最大深度 ${maxDepth}，跳过子目录: ${relativePath}`);
           continue;
         }
-        await this.scanDir(rootPath, relativePath, depth + 1, maxDepth, incremental, results, processingTasks);
+        await this.scanDir(rootPath, relativePath, depth + 1, maxDepth, mode, results, processingTasks);
       } else {
         const fileName = resource.displayName || this.extractFileName(decodedHref);
         if (isVideoFile(fileName, resource.contentType)) {
@@ -198,10 +200,10 @@ export class WebDAVAdapter implements ISourceAdapter {
 
           results.push(info);
 
-          const existingVideo = incremental
+          const existingVideo = (mode === 'incremental')
             ? await FileSourceDatabase.getInstance().getVideoByPath(relativePath)
             : null;
-          if (incremental && this.canSkipIncrementalProcessing(existingVideo, info)) {
+          if (mode === 'incremental' && this.canSkipIncrementalProcessing(existingVideo, info)) {
             info.wasProcessed = false;
             await FileSourceDatabase.getInstance().markVideoUpdatedByPath(relativePath);
             console.info(
@@ -217,6 +219,7 @@ export class WebDAVAdapter implements ISourceAdapter {
           const fullUrl = this.client.getFullUrl(relativePath);
           const capturedInfo = info;
           const capturedScrapeClient = this.scrapeClient;
+          const capturedMode = mode;
 
           const processingTask: Promise<void> = FfprobeUtil.probe(fullUrl, httpHeader).then(async (videoInfo) => {
             if (videoInfo.success) {
@@ -270,18 +273,34 @@ export class WebDAVAdapter implements ISourceAdapter {
               return;
             }
 
-            // 刮削（已有记录跳过）
+            // 刮削跳过判断（三种模式路由）
             if (!capturedScrapeClient) {
               return;
             }
             try {
               const existing = await FileSourceDatabase.getInstance().getScrapeInfoByVideoId(videoId);
-              if (existing) {
-                console.info(`[VideoScanner][SCRAPE] 已有刮削记录，跳过 fileName=${fileName}`);
-                return;
+              if (capturedMode === 'incremental') {
+                // incremental: 有任何刮削记录就跳过
+                if (existing) {
+                  console.info(`[VideoScanner][SCRAPE] incremental 已有刮削记录，跳过 fileName=${fileName}`);
+                  return;
+                }
+              } else if (capturedMode === 'fix-missing') {
+                // fix-missing: 仅在 scrape_info 完整时跳过（已有 movieId 或 tvSeriesId）
+                if (existing) {
+                  const isComplete = existing.mediaType === 'movie'
+                    ? existing.movieId !== undefined
+                    : existing.tvSeriesId !== undefined;
+                  if (isComplete) {
+                    console.info(`[VideoScanner][SCRAPE] fix-missing 元数据完整，跳过 fileName=${fileName}`);
+                    return;
+                  }
+                  console.info(`[VideoScanner][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${fileName}`);
+                }
               }
+              // overwrite: 不跳过，强制重新刮削（upsertScrapeInfo 已是 upsert）
             } catch {
-              // 查询失败继续
+              // 查询失败继续刮削
             }
 
             console.info(`[VideoScanner][SCRAPE] 开始刮削 fileName=${fileName}`);
@@ -540,7 +559,7 @@ export class SMBAdapter implements ISourceAdapter {
     console.info(`[VideoScanner][SMB] 开始扫描: ${rootPath} 最大深度: ${options.maxDepth}`);
     const results: VideoFileInfo[] = [];
     const processingTasks: Promise<void>[] = [];
-    await this.scanDir(rootPath, rootPath, 0, options.maxDepth, options.incremental, results, processingTasks);
+    await this.scanDir(rootPath, rootPath, 0, options.maxDepth, options.mode, results, processingTasks);
     await Promise.allSettled(processingTasks);
     return results;
   }
@@ -550,7 +569,7 @@ export class SMBAdapter implements ISourceAdapter {
     dirPath: string,
     currentDepth: number,
     maxDepth: number,
-    incremental: boolean,
+    mode: ScanMode,
     results: VideoFileInfo[],
     processingTasks: Promise<void>[]
   ): Promise<void> {
@@ -567,7 +586,7 @@ export class SMBAdapter implements ISourceAdapter {
 
     for (const file of listResult.files) {
       if (file.isDirectory) {
-        await this.scanDir(rootPath, file.path, currentDepth + 1, maxDepth, incremental, results, processingTasks);
+        await this.scanDir(rootPath, file.path, currentDepth + 1, maxDepth, mode, results, processingTasks);
       } else if (isVideoFile(file.name)) {
         const info: VideoFileInfo = {
           sourceId: this.fileSource.id ?? 0,
@@ -586,7 +605,7 @@ export class SMBAdapter implements ISourceAdapter {
         results.push(info);
 
         // 增量跳过：文件未变化则仅更新 updated_at，不重新处理
-        if (incremental) {
+        if (mode === 'incremental') {
           let existing: VideoEntity | null = null;
           try {
             existing = await FileSourceDatabase.getInstance().getVideoByPath(file.path);
@@ -608,6 +627,7 @@ export class SMBAdapter implements ISourceAdapter {
         // 异步处理：媒体信息抓取 + 入库 + 刮削
         const capturedInfo = info;
         const capturedScrapeClient = this.scrapeClient;
+        const capturedMode = mode;
         const smbUrl = this.buildSmbUrl(file.path);
         const maskedUrl = this.maskUrl(smbUrl);
 
@@ -659,10 +679,24 @@ export class SMBAdapter implements ISourceAdapter {
           }
           try {
             const existing = await FileSourceDatabase.getInstance().getScrapeInfoByVideoId(videoId);
-            if (existing) {
-              console.info(`[VideoScanner][SMB][SCRAPE] 已有刮削记录，跳过 fileName=${capturedInfo.fileName}`);
-              return;
+            if (capturedMode === 'incremental') {
+              if (existing) {
+                console.info(`[VideoScanner][SMB][SCRAPE] incremental 已有刮削记录，跳过 fileName=${capturedInfo.fileName}`);
+                return;
+              }
+            } else if (capturedMode === 'fix-missing') {
+              if (existing) {
+                const isComplete = existing.mediaType === 'movie'
+                  ? existing.movieId !== undefined
+                  : existing.tvSeriesId !== undefined;
+                if (isComplete) {
+                  console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据完整，跳过 fileName=${capturedInfo.fileName}`);
+                  return;
+                }
+                console.info(`[VideoScanner][SMB][SCRAPE] fix-missing 元数据不完整，重新刮削 fileName=${capturedInfo.fileName}`);
+              }
             }
+            // overwrite: 不跳过，强制重新刮削（upsertScrapeInfo 已是 upsert）
           } catch {
             // 查询失败继续刮削
           }
@@ -873,13 +907,13 @@ export class VideoScannerUtil {
   static async scan(context: Context, scrapeClient?: ScrapeClient, options?: Partial<ScanOptions>): Promise<ScanResult> {
     const scanOptions: ScanOptions = {
       maxDepth: (options?.maxDepth !== undefined) ? options.maxDepth : DEFAULT_SCAN_OPTIONS.maxDepth,
-      incremental: (options?.incremental !== undefined) ? options.incremental : DEFAULT_SCAN_OPTIONS.incremental
+      mode: (options?.mode !== undefined) ? options.mode : DEFAULT_SCAN_OPTIONS.mode
     };
 
     const startTime = Date.now();
     console.info(`[VideoScanner] ======== 开始视频扫描 ========`);
     console.info(
-      `[VideoScanner] 扫描参数: maxDepth=${scanOptions.maxDepth}, 增量=${scanOptions.incremental ? '是' : '否'}, 刮削=${scrapeClient ? '开启' : '关闭'}`
+      `[VideoScanner] 扫描参数: maxDepth=${scanOptions.maxDepth}, mode=${scanOptions.mode}, 刮削=${scrapeClient ? '开启' : '关闭'}`
     );
 
     const db = FileSourceDatabase.getInstance(context);

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -972,6 +972,8 @@ export class VideoScannerUtil {
     console.info(`[VideoScanner] 共找到 ${fileSources.length} 个文件源`);
 
     // 全量覆盖模式：先清空所有源的 scrape_info，确保重刮前无历史垃圾数据
+    // 同时记录哪些文件源参与了本次全量扫描（仅记录 sourceId，实际是否成功扫到由 seenPaths 决定）
+    const overwriteSourceIds: number[] = [];
     if (scanOptions.mode === 'overwrite') {
       const sourceIds: number[] = [];
       for (const s of fileSources) {
@@ -983,8 +985,14 @@ export class VideoScannerUtil {
       if (sourceIds.length > 0) {
         await db.clearScrapeInfoForSources(sourceIds);
         console.info(`[VideoScanner] 全量覆盖预清空完成，已清除 ${sourceIds.length} 个文件源的 scrape_info`);
+        for (const sid of sourceIds) {
+          overwriteSourceIds.push(sid);
+        }
       }
     }
+
+    // 成功扫描到至少一个文件的文件源 ID（用于鬼记录清理，避免扫描失败时误删全部记录）
+    const successfullyScannedSourceIds = new Set<number>();
 
     const seenPaths = new Set<string>();
     const allVideos: VideoFileInfo[] = [];
@@ -1045,6 +1053,10 @@ export class VideoScannerUtil {
             seenPaths.add(video.filePath);
             allVideos.push(video);
             stat.videosFound++;
+            // 标记该文件源已成功扫到文件（用于鬼记录清理保护）
+            if (fileSource.id !== undefined) {
+              successfullyScannedSourceIds.add(fileSource.id);
+            }
           } else {
             console.info(`[VideoScanner] 重复路径，已跳过: ${video.filePath}`);
           }
@@ -1074,6 +1086,19 @@ export class VideoScannerUtil {
 
     // 清理孤立 scrape_info（由历史 INSERT OR REPLACE upsertVideo 产生的无效引用）
     await FileSourceDatabase.getInstance().cleanupOrphanedScrapeInfo();
+
+    // 全量覆盖模式：清理鬼记录（本轮未扫到、但仍留在 videos 表中的旧文件记录）
+    // 仅清理成功扫描到文件的文件源，避免扫描失败时误删全部记录
+    if (scanOptions.mode === 'overwrite' && overwriteSourceIds.length > 0) {
+      const safeSourceIds = overwriteSourceIds.filter(sid => successfullyScannedSourceIds.has(sid));
+      if (safeSourceIds.length > 0) {
+        const foundPaths = Array.from(seenPaths);
+        await db.deleteGhostVideosForSources(safeSourceIds, foundPaths);
+        console.info(`[VideoScanner] 鬼记录清理完成，有效文件源=${safeSourceIds.length} 个，有效路径=${foundPaths.length} 个`);
+      } else {
+        console.warn(`[VideoScanner] 鬼记录清理跳过：所有文件源均未成功扫到文件`);
+      }
+    }
 
     return {
       totalDirectories,

--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -82,16 +82,6 @@
           ],
           "when": "always"
         }
-      },
-      {
-        "name": "ohos.permission.FILE_ACCESS_PERSIST",
-        "reason": "$string:reason_file_access_persist",
-        "usedScene": {
-          "abilities": [
-            "EntryAbility"
-          ],
-          "when": "always"
-        }
       }
     ]
   }


### PR DESCRIPTION
## 关联 Issue
Closes #135

## 变更概览

### 子任务 1：VideoScannerUtil 三种扫描模式重构 + MediaLibraryTab UI
- 新增 `ScanMode` 类型：`'incremental' | 'fix-missing' | 'overwrite'`
- `ScanOptions.incremental: boolean` → `ScanOptions.mode: ScanMode`
- **增量模式**（`incremental`）：文件未变更则跳过，与原逻辑一致
- **补全模式**（`fix-missing`）：重新刮削 `scrape_info` 缺失、`tv_series_id IS NULL`、`poster_url IS NULL` 的记录
- **覆盖模式**（`overwrite`）：强制全量重刮，upsert 覆盖已有数据，触发二次确认弹窗
- UI 三按钮：「扫描新增」「补全元数据」「全量覆盖」

### 子任务 2：DB v7 迁移 + ScrapeClient 地区字段
- `DB_VERSION` 6 → 7，`onUpgrade` 添加迁移语句
- `movies` / `tv_series` 表新增 `origin_country_json TEXT`（格式：`["CN","HK"]`）
- `TmdbMovieDetail` 新增 `production_countries`，`TmdbTvDetail` 新增 `origin_country`
- `MovieMetadata` / `TvSeriesMetadata` 新增 `originCountryJson`，刮削时 JSON 序列化国家代码

### 子任务 3：MediaResultPage 地区过滤 Chip
- `SearchMediaOptions` 新增 `originCountry?: string`
- `searchMediaItems` SQL 加入 `COALESCE(m.origin_country_json, ts.origin_country_json) LIKE ?`
- FilterPanel 新增第 7 行「地区」筛选（10 个选项：CN/HK/TW/JP/KR/US/GB/FR/DE + 全部）

## 验收要点
- [ ] 三种扫描模式行为边界清晰
- [ ] 补全模式可修复 tv_series_id=NULL 等脏数据
- [ ] 全量覆盖有二次确认弹窗
- [ ] 重扫后地区字段正确写入 DB
- [ ] 地区过滤与类型/年份/进度筛选可正交叠加

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Region filter in media search to filter by production country.
  * New "Overwrite All Metadata" scan mode with confirmation.

* **Improvements**
  * Scan UI and controls updated for incremental, fix-missing, and overwrite modes.
  * Origin-country metadata is now captured, stored, and applied to searches and re-scrape decisions.
  * Scanning adds post-run cleanup of orphaned metadata and safer metadata writes to preserve IDs.

* **Bug Fixes**
  * Search excludes empty TV/episode items missing title and poster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->