### PR TITLE
重构: 提取 NAPI bridge helper 与 PresetTrack 转换方法（#95 + #96）

### DIFF
--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -943,32 +943,14 @@ export struct SeasonDetailPage {
             dbHasAudioData = true;
             if (videoEntity.audioTracksJson.length > 0) {
               const tracks = JSON.parse(videoEntity.audioTracksJson) as FfprobeTrack[];
-              for (let i = 0; i < tracks.length; i++) {
-                const t = tracks[i];
-                const item: PresetAudioTrack = {
-                  trackIndex: t.index,
-                  displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
-                  language: t.language,
-                  mimeType: t.codecName
-                };
-                presetAudioTracks.push(item);
-              }
+              presetAudioTracks = FfprobeUtil.toPresetAudioTracks(tracks);
             }
           }
           if (videoEntity.subtitleTracksJson !== null && videoEntity.subtitleTracksJson !== undefined) {
             dbHasSubtitleData = true;
             if (videoEntity.subtitleTracksJson.length > 0) {
               const subTracks = JSON.parse(videoEntity.subtitleTracksJson) as FfprobeTrack[];
-              for (let i = 0; i < subTracks.length; i++) {
-                const t = subTracks[i];
-                const item: PresetSubtitleTrack = {
-                  trackIndex: t.index,
-                  displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),
-                  language: t.language,
-                  codecName: t.codecName
-                };
-                presetSubtitleTracks.push(item);
-              }
+              presetSubtitleTracks = FfprobeUtil.toPresetSubtitleTracks(subTracks);
             }
           }
         }
@@ -985,28 +967,10 @@ export struct SeasonDetailPage {
               durationHintMs = probeResult.durationMs;
             }
             if (!dbHasAudioData) {
-              for (let i = 0; i < probeResult.audioTracks.length; i++) {
-                const t = probeResult.audioTracks[i];
-                const item: PresetAudioTrack = {
-                  trackIndex: t.index,
-                  displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
-                  language: t.language,
-                  mimeType: t.codecName
-                };
-                presetAudioTracks.push(item);
-              }
+              presetAudioTracks = FfprobeUtil.toPresetAudioTracks(probeResult.audioTracks);
             }
             if (!dbHasSubtitleData) {
-              for (let i = 0; i < probeResult.subtitleTracks.length; i++) {
-                const t = probeResult.subtitleTracks[i];
-                const item: PresetSubtitleTrack = {
-                  trackIndex: t.index,
-                  displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),
-                  language: t.language,
-                  codecName: t.codecName
-                };
-                presetSubtitleTracks.push(item);
-              }
+              presetSubtitleTracks = FfprobeUtil.toPresetSubtitleTracks(probeResult.subtitleTracks);
             }
           }
         } catch (e) {

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -740,32 +740,14 @@ export struct SeriesDetailPage {
             dbHasAudioData = true;
             if (videoEntity.audioTracksJson.length > 0) {
               const tracks = JSON.parse(videoEntity.audioTracksJson) as FfprobeTrack[];
-              for (let i = 0; i < tracks.length; i++) {
-                const t = tracks[i];
-                const item: PresetAudioTrack = {
-                  trackIndex: t.index,
-                  displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
-                  language: t.language,
-                  mimeType: t.codecName
-                };
-                presetAudioTracks.push(item);
-              }
+              presetAudioTracks = FfprobeUtil.toPresetAudioTracks(tracks);
             }
           }
           if (videoEntity.subtitleTracksJson !== null && videoEntity.subtitleTracksJson !== undefined) {
             dbHasSubtitleData = true;
             if (videoEntity.subtitleTracksJson.length > 0) {
               const subTracks = JSON.parse(videoEntity.subtitleTracksJson) as FfprobeTrack[];
-              for (let i = 0; i < subTracks.length; i++) {
-                const t = subTracks[i];
-                const item: PresetSubtitleTrack = {
-                  trackIndex: t.index,
-                  displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),
-                  language: t.language,
-                  codecName: t.codecName
-                };
-                presetSubtitleTracks.push(item);
-              }
+              presetSubtitleTracks = FfprobeUtil.toPresetSubtitleTracks(subTracks);
             }
           }
         }
@@ -782,28 +764,10 @@ export struct SeriesDetailPage {
               durationHintMs = probeResult.durationMs;
             }
             if (!dbHasAudioData) {
-              for (let i = 0; i < probeResult.audioTracks.length; i++) {
-                const t = probeResult.audioTracks[i];
-                const item: PresetAudioTrack = {
-                  trackIndex: t.index,
-                  displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
-                  language: t.language,
-                  mimeType: t.codecName
-                };
-                presetAudioTracks.push(item);
-              }
+              presetAudioTracks = FfprobeUtil.toPresetAudioTracks(probeResult.audioTracks);
             }
             if (!dbHasSubtitleData) {
-              for (let i = 0; i < probeResult.subtitleTracks.length; i++) {
-                const t = probeResult.subtitleTracks[i];
-                const item: PresetSubtitleTrack = {
-                  trackIndex: t.index,
-                  displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),
-                  language: t.language,
-                  codecName: t.codecName
-                };
-                presetSubtitleTracks.push(item);
-              }
+              presetSubtitleTracks = FfprobeUtil.toPresetSubtitleTracks(probeResult.subtitleTracks);
             }
           }
         } catch (e) {

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -211,26 +211,8 @@ export struct SmbFileExplorerPage {
           '[SmbExplorer] 轨道探测成功: 音轨=' + probeResult.audioTracks.length.toString() +
           ' 字幕轨=' + probeResult.subtitleTracks.length.toString()
         )
-        for (let i = 0; i < probeResult.audioTracks.length; i++) {
-          const t = probeResult.audioTracks[i]
-          const item: PresetAudioTrack = {
-            trackIndex: t.index,
-            displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
-            language: t.language,
-            mimeType: undefined   // codec 名不是 MIME type，下游用 codecName 匹配即可
-          }
-          presetAudioTracks.push(item)
-        }
-        for (let i = 0; i < probeResult.subtitleTracks.length; i++) {
-          const t = probeResult.subtitleTracks[i]
-          const item: PresetSubtitleTrack = {
-            trackIndex: t.index,
-            displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),
-            language: t.language,
-            codecName: t.codecName
-          }
-          presetSubtitleTracks.push(item)
-        }
+        presetAudioTracks = FfprobeUtil.toPresetAudioTracks(probeResult.audioTracks)
+        presetSubtitleTracks = FfprobeUtil.toPresetSubtitleTracks(probeResult.subtitleTracks)
       } else {
         console.warn('[SmbExplorer] 轨道探测未成功（降级为空轨道）: ' + (probeResult.errorMessage ?? '(未知原因)'))
       }

--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -152,20 +152,7 @@ export struct FileExplorerPage {
           if (videoEntity.audioTracksJson.length > 0) {
             const tracks = JSON.parse(videoEntity.audioTracksJson) as FfprobeTrack[];
             console.info(`[playVideo] DB 音轨 JSON 解析: 共 ${tracks.length} 条`);
-            for (let i = 0; i < tracks.length; i++) {
-              const t = tracks[i];
-              const item: PresetAudioTrack = {
-                trackIndex: t.index,
-                displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
-                language: t.language,
-                mimeType: t.codecName
-              };
-              presetAudioTracks.push(item);
-              console.info(
-                `[playVideo]   音轨[${i}]: trackIndex=${t.index} codec=${t.codecName}` +
-                ` lang=${t.language || '(无)'} displayName="${item.displayName}"`
-              );
-            }
+            presetAudioTracks = FfprobeUtil.toPresetAudioTracks(tracks);
           } else {
             console.info(`[playVideo] DB 音轨 JSON 为空字符串，视为已扫描无音轨`);
           }
@@ -178,20 +165,7 @@ export struct FileExplorerPage {
           if (videoEntity.subtitleTracksJson.length > 0) {
             const subTracks = JSON.parse(videoEntity.subtitleTracksJson) as FfprobeTrack[];
             console.info(`[playVideo] DB 字幕轨 JSON 解析: 共 ${subTracks.length} 条`);
-            for (let i = 0; i < subTracks.length; i++) {
-              const t = subTracks[i];
-              const item: PresetSubtitleTrack = {
-                trackIndex: t.index,
-                displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),
-                language: t.language,
-                codecName: t.codecName
-              };
-              presetSubtitleTracks.push(item);
-              console.info(
-                `[playVideo]   字幕轨[${i}]: trackIndex=${t.index} codec=${t.codecName}` +
-                ` lang=${t.language || '(无)'} displayName="${item.displayName}"`
-              );
-            }
+            presetSubtitleTracks = FfprobeUtil.toPresetSubtitleTracks(subTracks);
           } else {
             console.info(`[playVideo] DB 字幕轨 JSON 为空字符串，视为已扫描无内嵌字幕`);
           }
@@ -238,36 +212,8 @@ export struct FileExplorerPage {
               durationHintMs = probeResult.durationMs;
             }
             // 实时策略下，probe 成功后以 probe 结果覆盖轨道列表。
-            presetAudioTracks = [];
-            presetSubtitleTracks = [];
-            for (let i = 0; i < probeResult.audioTracks.length; i++) {
-              const t = probeResult.audioTracks[i];
-              const item: PresetAudioTrack = {
-                trackIndex: t.index,
-                displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
-                language: t.language,
-                mimeType: t.codecName
-              };
-              presetAudioTracks.push(item);
-              console.info(
-                `[playVideo]   ffprobe 音轨[${i}]: trackIndex=${t.index}` +
-                ` codec=${t.codecName} lang=${t.language || '(无)'} displayName="${item.displayName}"`
-              );
-            }
-            for (let i = 0; i < probeResult.subtitleTracks.length; i++) {
-              const t = probeResult.subtitleTracks[i];
-              const item: PresetSubtitleTrack = {
-                trackIndex: t.index,
-                displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),
-                language: t.language,
-                codecName: t.codecName
-              };
-              presetSubtitleTracks.push(item);
-              console.info(
-                `[playVideo]   ffprobe 字幕轨[${i}]: trackIndex=${t.index}` +
-                ` codec=${t.codecName} lang=${t.language || '(无)'} displayName="${item.displayName}"`
-              );
-            }
+            presetAudioTracks = FfprobeUtil.toPresetAudioTracks(probeResult.audioTracks);
+            presetSubtitleTracks = FfprobeUtil.toPresetSubtitleTracks(probeResult.subtitleTracks);
           } else {
             console.warn('[playVideo] ffprobe 成功但未返回有效轨道/时长，保留 DB 结果作为兜底');
           }

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -836,8 +836,8 @@ export class FfprobeUtil {
    * mimeType 留 undefined：codecName 是解码器名（如 "eac3"），不是 MIME type（如 "audio/eac3"），
    * 下游逻辑应通过 codecName 字段匹配，不依赖 mimeType。
    */
-  static toPresetAudioTracks(tracks: FfprobeTrack[]): PresetAudioTrack[] {
-    if (tracks.length === 0) {
+  static toPresetAudioTracks(tracks: FfprobeTrack[] | null | undefined): PresetAudioTrack[] {
+    if (!tracks || tracks.length === 0) {
       return [];
     }
     const result: PresetAudioTrack[] = [];
@@ -862,8 +862,8 @@ export class FfprobeUtil {
    * 适用于 probe()/probeSmb() 返回的 FfprobeResult.subtitleTracks，
    * 以及数据库 JSON 反序列化得到的 FfprobeTrack[]。
    */
-  static toPresetSubtitleTracks(tracks: FfprobeTrack[]): PresetSubtitleTrack[] {
-    if (tracks.length === 0) {
+  static toPresetSubtitleTracks(tracks: FfprobeTrack[] | null | undefined): PresetSubtitleTrack[] {
+    if (!tracks || tracks.length === 0) {
       return [];
     }
     const result: PresetSubtitleTrack[] = [];

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -1,6 +1,7 @@
 import { BusinessError } from '@kit.BasicServicesKit';
 import hilog from '@ohos.hilog';
 import * as VidAllCorePlayerNapiModule from 'libvidall_core_player_napi.so';
+import { PresetAudioTrack, PresetSubtitleTrack } from '../components/core/player/VideoData';
 
 export type HdrType = 'HDR10' | 'HLG' | 'DOLBY_VISION' | 'SDR';
 
@@ -9,20 +10,37 @@ interface FfprobeNapiBridge {
   extractSubtitleEntries: (url: string, headerLines: string, streamIndex: number, timeoutMs: number) => Promise<string>;
 }
 
-interface FfprobeNapiBridgeModule {
-  default?: FfprobeNapiBridge;
+// ─────────────────────────────────────────────
+// NAPI 模块解析工具（Issue #95：消除 bridge 获取重复逻辑）
+// ─────────────────────────────────────────────
+
+/** 统一 NAPI .so 模块 default 导出与直接导出两种格式的辅助接口 */
+interface NapiModuleWithDefault {
+  default?: object;
+}
+
+/**
+ * 从 NAPI .so 模块中解析桥接对象，兼容 default 导出与直接导出两种格式。
+ * @param soModule  import * as Xxx from 'xxx.so' 加载的模块（转为 object | undefined）
+ * @param soName    .so 文件名（用于错误提示）
+ * @returns 桥接对象本体（调用方负责 cast 到具体接口类型）
+ */
+function resolveNapiBridge(soModule: object | undefined, soName: string): object {
+  if (soModule === undefined) {
+    throw new Error(`${soName} 未加载`);
+  }
+  const withDefault = soModule as NapiModuleWithDefault;
+  if (withDefault.default !== undefined) {
+    return withDefault.default;
+  }
+  return soModule;
 }
 
 function getVidAllCorePlayerNapi(): FfprobeNapiBridge {
-  const bridgeModule = VidAllCorePlayerNapiModule as FfprobeNapiBridgeModule | FfprobeNapiBridge | undefined;
-  if (bridgeModule === undefined) {
-    throw new Error('libvidall_core_player_napi.so 未加载');
-  }
-  const defaultBridge = (bridgeModule as FfprobeNapiBridgeModule).default;
-  if (defaultBridge !== undefined) {
-    return defaultBridge as FfprobeNapiBridge;
-  }
-  return bridgeModule as FfprobeNapiBridge;
+  return resolveNapiBridge(
+    VidAllCorePlayerNapiModule as object | undefined,
+    'libvidall_core_player_napi.so'
+  ) as FfprobeNapiBridge;
 }
 
 // ─────────────────────────────────────────────
@@ -52,20 +70,11 @@ interface SmbProbeNapiBridge {
   release: (handle: number, keepProxy?: boolean) => void;
 }
 
-interface SmbProbeNapiBridgeModule {
-  default?: SmbProbeNapiBridge;
-}
-
 function getSmbProbeNapi(): SmbProbeNapiBridge {
-  const bridgeModule = VidAllCorePlayerNapiModule as SmbProbeNapiBridgeModule | SmbProbeNapiBridge | undefined;
-  if (bridgeModule === undefined) {
-    throw new Error('libvidall_core_player_napi.so 未加载');
-  }
-  const defaultBridge = (bridgeModule as SmbProbeNapiBridgeModule).default;
-  if (defaultBridge !== undefined) {
-    return defaultBridge as SmbProbeNapiBridge;
-  }
-  return bridgeModule as SmbProbeNapiBridge;
+  return resolveNapiBridge(
+    VidAllCorePlayerNapiModule as object | undefined,
+    'libvidall_core_player_napi.so'
+  ) as SmbProbeNapiBridge;
 }
 
 // ─────────────────────────────────────────────
@@ -817,6 +826,46 @@ export class FfprobeUtil {
 
     // 非中文无 title 时，保留最弱兜底信息
     return `轨道${index + 1}`;
+  }
+
+  /**
+   * 将 FfprobeTrack 列表转换为 PresetAudioTrack[]（Issue #96）。
+   * 适用于 probe()/probeSmb() 返回的 FfprobeResult.audioTracks，
+   * 以及数据库 JSON 反序列化得到的 FfprobeTrack[]。
+   */
+  static toPresetAudioTracks(tracks: FfprobeTrack[]): PresetAudioTrack[] {
+    const result: PresetAudioTrack[] = [];
+    for (let i = 0; i < tracks.length; i++) {
+      const t = tracks[i];
+      const item: PresetAudioTrack = {
+        trackIndex: t.index,
+        displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
+        language: t.language,
+        mimeType: t.codecName
+      };
+      result.push(item);
+    }
+    return result;
+  }
+
+  /**
+   * 将 FfprobeTrack 列表转换为 PresetSubtitleTrack[]（Issue #96）。
+   * 适用于 probe()/probeSmb() 返回的 FfprobeResult.subtitleTracks，
+   * 以及数据库 JSON 反序列化得到的 FfprobeTrack[]。
+   */
+  static toPresetSubtitleTracks(tracks: FfprobeTrack[]): PresetSubtitleTrack[] {
+    const result: PresetSubtitleTrack[] = [];
+    for (let i = 0; i < tracks.length; i++) {
+      const t = tracks[i];
+      const item: PresetSubtitleTrack = {
+        trackIndex: t.index,
+        displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),
+        language: t.language,
+        codecName: t.codecName
+      };
+      result.push(item);
+    }
+    return result;
   }
 
   /**

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -829,19 +829,27 @@ export class FfprobeUtil {
   }
 
   /**
-   * 将 FfprobeTrack 列表转换为 PresetAudioTrack[]（Issue #96）。
+   * 将 ffprobe 音轨列表转换为播放器预设音轨格式。
+   * 注意：入参为 FfprobeTrack[]（而非 FfprobeResult），调用方自行从 result.audioTracks 传入。
    * 适用于 probe()/probeSmb() 返回的 FfprobeResult.audioTracks，
    * 以及数据库 JSON 反序列化得到的 FfprobeTrack[]。
+   * mimeType 留 undefined：codecName 是解码器名（如 "eac3"），不是 MIME type（如 "audio/eac3"），
+   * 下游逻辑应通过 codecName 字段匹配，不依赖 mimeType。
    */
   static toPresetAudioTracks(tracks: FfprobeTrack[]): PresetAudioTrack[] {
+    if (tracks.length === 0) {
+      return [];
+    }
     const result: PresetAudioTrack[] = [];
     for (let i = 0; i < tracks.length; i++) {
       const t = tracks[i];
+      console.info(`[FfprobeUtil] 音轨[${i}]: trackIndex=${t.index} codec=${t.codecName} lang=${t.language ?? '(无)'}`);
       const item: PresetAudioTrack = {
         trackIndex: t.index,
         displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
         language: t.language,
-        mimeType: t.codecName
+        // codecName 是解码器名，不是 MIME type，下游用 codecName 匹配即可
+        mimeType: undefined
       };
       result.push(item);
     }
@@ -849,14 +857,19 @@ export class FfprobeUtil {
   }
 
   /**
-   * 将 FfprobeTrack 列表转换为 PresetSubtitleTrack[]（Issue #96）。
+   * 将 ffprobe 字幕轨列表转换为播放器预设字幕轨格式。
+   * 注意：入参为 FfprobeTrack[]（而非 FfprobeResult），调用方自行从 result.subtitleTracks 传入。
    * 适用于 probe()/probeSmb() 返回的 FfprobeResult.subtitleTracks，
    * 以及数据库 JSON 反序列化得到的 FfprobeTrack[]。
    */
   static toPresetSubtitleTracks(tracks: FfprobeTrack[]): PresetSubtitleTrack[] {
+    if (tracks.length === 0) {
+      return [];
+    }
     const result: PresetSubtitleTrack[] = [];
     for (let i = 0; i < tracks.length; i++) {
       const t = tracks[i];
+      console.info(`[FfprobeUtil] 字幕轨[${i}]: trackIndex=${t.index} codec=${t.codecName} lang=${t.language ?? '(无)'}`);
       const item: PresetSubtitleTrack = {
         trackIndex: t.index,
         displayName: FfprobeUtil.buildSubtitleTrackDisplayName(t, i),


### PR DESCRIPTION
## 概述

消除两处重复逻辑，提升可维护性。两个技术债一并处理。

## 变更内容

### Issue #95 — NAPI bridge 重构
- `FfprobeUtil.ets`：提取 `resolveNapiBridge(soModule, soName)` 通用函数
- `getVidAllCorePlayerNapi()` / `getSmbProbeNapi()` 均改为一行调用，消除 6 行重复代码

### Issue #96 — FfprobeResult → PresetTrack helper
- `FfprobeUtil.ets`：新增静态方法 `toPresetAudioTracks()` / `toPresetSubtitleTracks()`
- 4 个调用方统一改为调用静态方法，消除约 **140 行**重复循环代码

## QA 验证
- ✅ BUILD SUCCESSFUL（无 ERROR/WARNING）
- ✅ 工作区清洁，两次独立提交

Closes #95
Closes #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated audio and subtitle track conversion into centralized utility logic used across the app, replacing duplicated inline construction.  
  * Ensures consistent handling of audio/subtitle tracks in all playback and detail views.  
  * No user-facing behavior changes; improves maintainability and reduces duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->