### PR TITLE
修復: 畫面比例切換時字幕不隨視頻區域變化 (#143)

### DIFF
--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -164,39 +164,41 @@ export struct VideoPlayer {
   })
 
   /**
-   * 计算属性：自动解析字幕
-   * 当 subtitleUpdateCounter 或 currentSubtitleText 变化时自动重新计算
+   * 字幕解析：监听 subtitleUpdateCounter 变化，解析后写入 controller.parsedSubtitle
+   * 供播放器页独立渲染层（RelativeContainer 顶层）直接读取，
+   * 避免与 XComponent renderFit GPU 合成层共享同一 Stack Surface。
    */
-  @Computed
-  get parsedSubtitle(): ParsedSubtitle | null {
-    const counter = this.controller.subtitleUpdateCounter
+  @Monitor('controller.subtitleUpdateCounter')
+  onSubtitleUpdate(): void {
     const text = this.controller.currentSubtitleText
 
     if (!text || text.trim().length === 0) {
-      return null
+      this.controller.parsedSubtitle = null
+      return
     }
 
     // 相同 raw 文本命中缓存，跳过重复解析（ASS 回调高频时的 CPU 优化）
     if (text === this._lastRawText && this._lastParsedSubtitle !== null) {
-      return this._lastParsedSubtitle
+      this.controller.parsedSubtitle = this._lastParsedSubtitle
+      return
     }
 
-    // 自动检测：是否是 ASS Dialogue 行（有 9 个以上逗号且前段是数字/空字符串）
-    // 如果是，截取第 9 个逗号后的纯文本；否则直接当纯文本渲染
     const pureText = this.extractSubtitleText(text)
 
     if (pureText.trim().length === 0) {
       this._lastRawText = text
       this._lastParsedSubtitle = null
-      return null
+      this.controller.parsedSubtitle = null
+      return
     }
 
+    const counter = this.controller.subtitleUpdateCounter
     const parsed = SubtitleParserFactory.parse(pureText)
     this.convertFontSize(parsed)
     console.log(`[VideoPlayer] counter=${counter} lines=${parsed.lines.length}`)
     this._lastRawText = text
     this._lastParsedSubtitle = parsed
-    return parsed
+    this.controller.parsedSubtitle = parsed
   }
 
   /**
@@ -343,13 +345,13 @@ export struct VideoPlayer {
   }
 
   /**
-   * 字幕渲染器 - 纯 UI 渲染
+   * 字幕渲染器 - 纯 UI 渲染（保留供备用；主渲染路径已移至播放器页独立层）
    */
   @Builder
   SubtitleRenderer() {
-    if (this.parsedSubtitle && this.parsedSubtitle.lines.length > 0) {
+    if (this.controller.parsedSubtitle && this.controller.parsedSubtitle.lines.length > 0) {
       Column({ space: 6 }) {
-        ForEach(this.parsedSubtitle.lines, (line: SubtitleSegment[], lineIndex: number) => {
+        ForEach(this.controller.parsedSubtitle.lines, (line: SubtitleSegment[], lineIndex: number) => {
           Text(this.mergeSubtitleLineText(line))
             .fontSize(30)
             .lineHeight(34)
@@ -365,9 +367,6 @@ export struct VideoPlayer {
         }, (line: SubtitleSegment[], index: number) => `line-${index}-${this.controller.subtitleUpdateCounter}`)
       }
       .padding({ left: 20, right: 20, top: 8, bottom: 8 })
-      .onAreaChange((oldArea: Area, newArea: Area) => {
-        console.info(`[字幕Column实际尺寸] ${JSON.stringify(oldArea)} → ${JSON.stringify(newArea)}`)
-      })
     }
   }
 
@@ -566,29 +565,12 @@ export struct VideoPlayer {
         })
       }
 
-      // 字幕显示层 - 使用字幕渲染器支持多种格式
-      // position({x:0,y:0}) 确保相对 Stack 左上角绝对定位，
-      // 避免 Stack 默认居中对齐在 renderFit 切换时造成字幕抖动/偏移
-      Row() {
-        this.SubtitleRenderer()
-      }
-      .width('100%')
-      .height('100%')
-      .position({ x: 0, y: 0 })
-      .padding({ left: 40, right: 40, bottom: 80 })
-      .justifyContent(FlexAlign.Center)
-      .alignItems(VerticalAlign.Bottom)
-      .hitTestBehavior(HitTestMode.Transparent)
-      .onAreaChange((oldArea: Area, newArea: Area) => {
-        console.info(`[字幕Row尺寸] ${JSON.stringify(oldArea)} → ${JSON.stringify(newArea)}`)
-      })
+      // 字幕显示层已移至播放器页 RelativeContainer 顶层（独立于 XComponent GPU 合成层）
+
     }
     .width('100%')
     .height('100%')
     .backgroundColor(Color.Black)
-    .onAreaChange((oldArea: Area, newArea: Area) => {
-      console.info(`[VideoPlayer外层Stack尺寸] ${JSON.stringify(oldArea)} → ${JSON.stringify(newArea)}`)
-    })
   }
 
   aboutToAppear(): void {

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -564,11 +564,14 @@ export struct VideoPlayer {
       }
 
       // 字幕显示层 - 使用字幕渲染器支持多种格式
+      // position({x:0,y:0}) 确保相对 Stack 左上角绝对定位，
+      // 避免 Stack 默认居中对齐在 renderFit 切换时造成字幕抖动/偏移
       Row() {
         this.SubtitleRenderer()
       }
       .width('100%')
       .height('100%')
+      .position({ x: 0, y: 0 })
       .padding({ left: 40, right: 40, bottom: 80 })
       .justifyContent(FlexAlign.Center)
       .alignItems(VerticalAlign.Bottom)

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -37,7 +37,7 @@ export struct VideoPlayer {
   @Monitor('controller.aspectRatioMode')
   onAspectRatioModeChange(): void {
     this.aspectRatioMode = this.controller.aspectRatioMode
-    console.info(`[VideoPlayer] 画面比例变更 → ${this.aspectRatioMode}`)
+    console.info(`[VideoPlayer] 画面比例变更 → mode=${this.aspectRatioMode}, renderFit=${this.toRenderFit(this.aspectRatioMode)}`)
   }
 
   /** 将画面比例模式映射到 XComponent.renderFit */
@@ -365,6 +365,9 @@ export struct VideoPlayer {
         }, (line: SubtitleSegment[], index: number) => `line-${index}-${this.controller.subtitleUpdateCounter}`)
       }
       .padding({ left: 20, right: 20, top: 8, bottom: 8 })
+      .onAreaChange((oldArea: Area, newArea: Area) => {
+        console.info(`[字幕Column实际尺寸] ${JSON.stringify(oldArea)} → ${JSON.stringify(newArea)}`)
+      })
     }
   }
 
@@ -576,10 +579,16 @@ export struct VideoPlayer {
       .justifyContent(FlexAlign.Center)
       .alignItems(VerticalAlign.Bottom)
       .hitTestBehavior(HitTestMode.Transparent)
+      .onAreaChange((oldArea: Area, newArea: Area) => {
+        console.info(`[字幕Row尺寸] ${JSON.stringify(oldArea)} → ${JSON.stringify(newArea)}`)
+      })
     }
     .width('100%')
     .height('100%')
     .backgroundColor(Color.Black)
+    .onAreaChange((oldArea: Area, newArea: Area) => {
+      console.info(`[VideoPlayer外层Stack尺寸] ${JSON.stringify(oldArea)} → ${JSON.stringify(newArea)}`)
+    })
   }
 
   aboutToAppear(): void {

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -574,6 +574,8 @@ export struct VideoPlayer {
       .alignItems(VerticalAlign.Bottom)
       .hitTestBehavior(HitTestMode.Transparent)
     }
+    .width('100%')
+    .height('100%')
     .backgroundColor(Color.Black)
   }
 

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -22,6 +22,7 @@ import {
 } from "./SubtitleBridgeAdapter";
 import { SmbAvSubtitleBridgeAdapter } from "./SmbSubtitleBridgeAdapter";
 import { VpeEnhancerUtil, VpeQualityLevel } from "../../../utils/VpeEnhancerUtil";
+import { ParsedSubtitle } from "./SubtitleRenderer";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
 
@@ -193,6 +194,8 @@ export class VideoPlayerController {
    * 作用于外部 SRT/ASS/VTT 字幕时间轴查找，见 onTimeUpdate 回调。
    */
   @Trace subtitleDelayMs: number = 0;
+  /** 当前帧解析后的字幕数据，由 VideoPlayer @Monitor 写入，供播放器页独立渲染层直接读取 */
+  @Trace parsedSubtitle: ParsedSubtitle | null = null;
   /** 音轨列表 */
   @Trace audioTracks: AudioTrackItem[] = [];
   @Trace activeAudioIndex: number = -1;

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -12,6 +12,7 @@ import { MediaProgressStore } from "../../db/MediaProgressStore";
 import { millisecondsToTime } from "../../utils/TimeUtil";
 import { PlayerEvents } from "../../components/core/player/Constants";
 import { emitter } from "@kit.BasicServicesKit";
+import { SubtitleSegment } from "../../components/core/player/SubtitleRenderer";
 
 export interface PlayerPageParam {
   fileUrl?: string;
@@ -69,6 +70,15 @@ export struct PlayerPage {
   private currentMediaEpisode: number = 0;
   /** media_progress 周期写入定时器 ID，-1 表示未启动 */
   private mediaProgressTimerId: number = -1;
+
+  /** 合并字幕行中各 Segment 的文本 */
+  private mergeSubtitleLineText(line: SubtitleSegment[]): string {
+    let merged = ''
+    for (let i = 0; i < line.length; i++) {
+      merged += line[i].text
+    }
+    return merged
+  }
 
   private getBackendDebugText(): string {
     const proto = this.videoPlayerController.sourceProtocol;
@@ -157,6 +167,43 @@ export struct PlayerPage {
               middle: { anchor: '__container__', align: HorizontalAlign.Center }
             })
         }
+
+        // 字幕覆盖层：独立于 VideoPlayer 的 Stack/XComponent 渲染层，
+        // 避免 GPU 合成器把 XComponent Surface 与 ArkUI 覆盖层视为同一 Surface
+        // 导致 renderFit 矩阵变换连同字幕一起扭曲的问题（PR #146 修复）
+        Row() {
+          if (this.videoPlayerController.parsedSubtitle !== null &&
+              this.videoPlayerController.parsedSubtitle.lines.length > 0) {
+            Column({ space: 6 }) {
+              ForEach(
+                this.videoPlayerController.parsedSubtitle.lines,
+                (line: SubtitleSegment[], lineIndex: number) => {
+                  Text(this.mergeSubtitleLineText(line))
+                    .fontSize(30)
+                    .lineHeight(34)
+                    .fontColor(Color.White)
+                    .fontWeight(FontWeight.Normal)
+                    .textAlign(TextAlign.Center)
+                    .textShadow({ radius: 3, offsetX: 3, offsetY: 3, color: Color.Black })
+                },
+                (line: SubtitleSegment[], index: number) =>
+                  `line-${index}-${this.videoPlayerController.subtitleUpdateCounter}`
+              )
+            }
+            .padding({ left: 20, right: 20, top: 8, bottom: 8 })
+          }
+        }
+        .width('100%')
+        .height('100%')
+        .position({ x: 0, y: 0 })
+        .padding({ left: 40, right: 40, bottom: 80 })
+        .justifyContent(FlexAlign.Center)
+        .alignItems(VerticalAlign.Bottom)
+        .hitTestBehavior(HitTestMode.Transparent)
+        .alignRules({
+          center: { anchor: '__container__', align: VerticalAlign.Center },
+          middle: { anchor: '__container__', align: HorizontalAlign.Center }
+        })
 
         if (this.isBackPressedOnce) {
           Text("再次按返回键退出播放")

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -150,6 +150,8 @@ export struct PlayerPage {
             data: this.videoData,
             autoPlay: true
           })
+            .width('100%')
+            .height('100%')
             .alignRules({
               center: { anchor: '__container__', align: VerticalAlign.Center },
               middle: { anchor: '__container__', align: HorizontalAlign.Center }


### PR DESCRIPTION
## 變更說明

修復畫面比例（適應/填充/拉伸）切換時，字幕位置/大小隨視頻畫面扭曲的問題。

### 根因（三輪調查確認）

HarmonyOS TV GPU 合成器把 XComponent Surface 和同一 Stack 內的 ArkUI 覆蓋層視為同一渲染 Surface，`renderFit` 矩陣變換會連同字幕一起扭曲。這屬於平台 GPU 合成層限制，無法通過調整 ArkUI 布局約束解決。

### 修復方案

將字幕 overlay 從 `VideoPlayer.ets` 的 Stack 內部移出，放到 `pages/player/index.ets` 的 RelativeContainer 頂層作為獨立節點，使字幕不再進入 XComponent 的 Surface 合成路徑。

| 文件 | 改動 |
|------|------|
| `VideoPlayerController.ets` | 新增 `@Trace parsedSubtitle` 屬性，統一狀態出口 |
| `VideoPlayer.ets` | 改用 `@Monitor` 寫入 controller；移除字幕 Row overlay |
| `pages/player/index.ets` | 字幕 Row 作為 RelativeContainer 獨立子節點 |

### 驗收
- 三種比例模式（適應/填充/拉伸）下字幕不跟隨視頻區域縮放/扭曲
- BUILD SUCCESSFUL（commit 746c863），零 ERROR

Closes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved subtitle handling so captions update reliably and skip unnecessary re-parsing for smoother display.
* **Bug Fixes**
  * Video player now reliably fills the full available width and height.
  * Subtitle overlay positioning and layering fixed so captions align, size, and remain visible across the player.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->