### PR TITLE
新增: 進入已刪除目錄時提示用戶清理 (#145)

### DIFF
--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -11,6 +11,23 @@ import { ImagePreviewDialog } from "../../components/core/file/ImagePreview";
 import { FfprobeUtil, FfprobeTrack } from "../../utils/FfprobeUtil";
 import { PresetAudioTrack, PresetSubtitleTrack } from "../../components/core/player/VideoData";
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
+import { DirStatus } from "../../db/models/FileSourceEntity";
+
+/**
+ * 文件浏览页路由参数
+ * 兼容旧版仅传 WebDAVConfig 的调用方，新增 dir 元信息用于删除目录检测
+ */
+export interface FileExplorerPageParam {
+  config: WebDAVConfig;
+  /** file_source_directories 主键，清理时必填 */
+  dirId?: number;
+  /** 所属文件源 id，清理时必填 */
+  sourceId?: number;
+  /** 目录路径，用于 DB 清理 */
+  directoryPath?: string;
+  /** 目录可达性状态，'missing' 时触发清理 Dialog */
+  dirStatus?: DirStatus;
+}
 
 const config: WebDAVConfig = {
   baseUrl: 'http://www.baidu.com',
@@ -23,6 +40,11 @@ export struct FileExplorerPage {
   static PAGE_NAME = "fileExplorerPage"
   client: WebDAVClient = new WebDAVClient(config)
   @Local imagePath: string = ''
+  @Local showMissingDirDialog: boolean = false
+  @Local isCleaningUp: boolean = false
+  private cachedDirId: number = 0
+  private cachedSourceId: number = 0
+  private cachedDirectoryPath: string = ''
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack()
   private fileExplorerController = new FileExplorerController({
     resources: [],
@@ -51,13 +73,74 @@ export struct FileExplorerPage {
             }
           }
         })
+
+        // ── 已删除目录提示 Dialog ──────────────────────────────
+        if (this.showMissingDirDialog) {
+          Column() {
+            Column() {
+              Text('目录不存在')
+                .fontSize(24)
+                .fontWeight(FontWeight.Bold)
+                .fontColor('#FFFFFF')
+              Text('此目录在服务器上已不存在，是否立即清理相关数据？')
+                .fontSize(18)
+                .fontColor('#CCCCCC')
+                .margin({ top: 16 })
+                .textAlign(TextAlign.Center)
+              Row({ space: 24 }) {
+                Button('取消')
+                  .fontSize(18)
+                  .fontColor('#FFFFFF')
+                  .backgroundColor('#555555')
+                  .borderRadius(8)
+                  .width(120)
+                  .height(48)
+                  .enabled(!this.isCleaningUp)
+                  .onClick(() => {
+                    this.showMissingDirDialog = false
+                  })
+                Button(this.isCleaningUp ? '清理中...' : '清理')
+                  .fontSize(18)
+                  .fontColor('#FFFFFF')
+                  .backgroundColor('#E53935')
+                  .borderRadius(8)
+                  .width(120)
+                  .height(48)
+                  .enabled(!this.isCleaningUp)
+                  .onClick(() => {
+                    this.confirmCleanup()
+                  })
+              }
+              .margin({ top: 24 })
+            }
+            .padding(32)
+            .borderRadius(12)
+            .backgroundColor('#2C2C2C')
+            .width(460)
+          }
+          .width('100%')
+          .height('100%')
+          .backgroundColor('#80000000')
+          .justifyContent(FlexAlign.Center)
+          .alignItems(HorizontalAlign.Center)
+          .onClick(() => {
+            // 拦截蒙层点击穿透
+          })
+        }
       }
       .width('100%')
       .height('100%')
     }
     .onReady((context) => {
-      const param = context.pathInfo.param as WebDAVConfig
-      this.client = new WebDAVClient(param)
+      const param = context.pathInfo.param as FileExplorerPageParam
+      this.client = new WebDAVClient(param.config)
+      this.cachedDirId = param.dirId ?? 0
+      this.cachedSourceId = param.sourceId ?? 0
+      this.cachedDirectoryPath = param.directoryPath ?? ''
+      if (param.dirStatus === 'missing') {
+        this.showMissingDirDialog = true
+        return
+      }
       this.changePath(this.fileExplorerController.currentPath)
     })
     .onBackPressed(() => {
@@ -71,6 +154,27 @@ export struct FileExplorerPage {
     })
     .mode(NavDestinationMode.DIALOG)
     .hideTitleBar(true)
+  }
+
+  /**
+   * 确认清理已删除目录：调用 DB 清理方法后返回上一页
+   */
+  private confirmCleanup(): void {
+    this.isCleaningUp = true
+    const dirId = this.cachedDirId
+    const sourceId = this.cachedSourceId
+    const directoryPath = this.cachedDirectoryPath
+    const db = FileSourceDatabase.getInstance()
+    db.clearMediaAndDirectoryForDir(dirId, sourceId, directoryPath)
+      .then((): void => {
+        this.pageStack.pop(true)
+      })
+      .catch((): void => {
+        console.error('[FileExplorerPage][confirmCleanup] 清理失败')
+        IBestToast.show('清理失败，请重试')
+        this.isCleaningUp = false
+        this.showMissingDirDialog = false
+      })
   }
 
   private previewImage(path: string, displayName: string) {

--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -12,6 +12,7 @@ import { FfprobeUtil, FfprobeTrack } from "../../utils/FfprobeUtil";
 import { PresetAudioTrack, PresetSubtitleTrack } from "../../components/core/player/VideoData";
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { DirStatus } from "../../db/models/FileSourceEntity";
+import { FileSourceStore } from "../../stores/files/FileSourceStore";
 
 /**
  * 文件浏览页路由参数
@@ -157,15 +158,14 @@ export struct FileExplorerPage {
   }
 
   /**
-   * 确认清理已删除目录：调用 DB 清理方法后返回上一页
+   * 确认清理已删除目录：更新 FileSourceModel 缓存并返回上一页
    */
   private confirmCleanup(): void {
     this.isCleaningUp = true
     const dirId = this.cachedDirId
     const sourceId = this.cachedSourceId
     const directoryPath = this.cachedDirectoryPath
-    const db = FileSourceDatabase.getInstance()
-    db.clearMediaAndDirectoryForDir(dirId, sourceId, directoryPath)
+    FileSourceStore.getState().clearMissingDirectory(dirId, sourceId, directoryPath)
       .then((): void => {
         this.pageStack.pop(true)
       })

--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -134,6 +134,11 @@ export struct FileExplorerPage {
     }
     .onReady((context) => {
       const param = context.pathInfo.param as FileExplorerPageParam
+      if (!param || !param.config) {
+        console.error('[FileExplorerPage] onReady: 路由参数为空，无法初始化')
+        IBestToast.show('页面参数缺失，请重新进入')
+        return
+      }
       this.client = new WebDAVClient(param.config)
       this.cachedDirId = param.dirId ?? 0
       this.cachedSourceId = param.sourceId ?? 0
@@ -161,6 +166,12 @@ export struct FileExplorerPage {
    * 确认清理已删除目录：更新 FileSourceModel 缓存并返回上一页
    */
   private confirmCleanup(): void {
+    // 必填字段校验，防止误删
+    if (this.cachedDirId <= 0 || this.cachedSourceId <= 0 || this.cachedDirectoryPath.length === 0) {
+      console.error('[FileExplorerPage][confirmCleanup] 参数不完整，中止清理')
+      IBestToast.show('目录信息不完整，无法清理')
+      return
+    }
     this.isCleaningUp = true
     const dirId = this.cachedDirId
     const sourceId = this.cachedSourceId
@@ -172,8 +183,8 @@ export struct FileExplorerPage {
       .catch((): void => {
         console.error('[FileExplorerPage][confirmCleanup] 清理失败')
         IBestToast.show('清理失败，请重试')
+        // 保持 Dialog 打开，允许用户重试
         this.isCleaningUp = false
-        this.showMissingDirDialog = false
       })
   }
 

--- a/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
@@ -1,7 +1,7 @@
 import { LengthMetrics } from "@kit.ArkUI"
 import { BusinessError } from '@kit.BasicServicesKit'
 import { WebDAVConfig } from "../../../lib/WebDAVClient"
-import { FileExplorerPage } from "../../files"
+import { FileExplorerPage, FileExplorerPageParam } from "../../files"
 import { SmbFileExplorerPage, SmbFileExplorerPageParam } from "../../files/SmbFileExplorerPage"
 import promptAction from '@ohos.promptAction'
 import { FileSource, FileSourceType, WebDAVSourceConfig, SMBSourceConfig } from "../../../db/models/FileSourceEntity"
@@ -110,11 +110,18 @@ export struct FileSourceTab {
    */
   private handleDirectoryClick(item: DirectoryItem): void {
     if (item.fileSource.type === FileSourceType.WEBDAV) {
-      const config = this.buildWebDAVConfigForDirectory(item)
-      if (config) {
+      const webdavConfig = this.buildWebDAVConfigForDirectory(item)
+      if (webdavConfig) {
+        const param: FileExplorerPageParam = {
+          config: webdavConfig,
+          dirId: item.dirId,
+          sourceId: item.fileSource.id,
+          directoryPath: item.directoryPath,
+          dirStatus: item.dirStatus
+        }
         this.pageStack.pushPath({
           name: FileExplorerPage.PAGE_NAME,
-          param: config as WebDAVConfig
+          param: param
         }, false)
       }
     } else if (item.fileSource.type === FileSourceType.SMB) {


### PR DESCRIPTION
## 變更說明

補充 #137（PR #140）未覆蓋的交互場景：用戶從文件源列表進入已被服務器端刪除的目錄時，給予清理引導。

### 改動內容

**`FileExplorerPage`（pages/files/index.ets）**
- 路由參數新增 `dirStatus` 字段
- 進入時若 `dirStatus === 'missing'` 立即彈出確認 Dialog，不加載目錄內容
- 確認清理後調用既有 `clearMediaAndDirectoryForDir()`（含事務），返回上一頁
- Dialog 蒙層加 `.onClick(() => {})` 防點擊穿透

**`FileSourceTab.ets`**
- `handleDirectoryClick` 攜帶 `dirId / sourceId / directoryPath / dirStatus` 跳轉

### 依賴
- 依賴 #137 / PR #140 已合併的 `dir_status` 列與 `clearMediaAndDirectoryForDir()` 方法

Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a missing directory detection modal with options to cancel or clean up unavailable directories
  * Cleanup operations display a loading state during processing with disabled buttons
  * Successful cleanup automatically closes the page; errors display a notification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->