### PR TITLE
新增: media_progress 表 is_watched 标记，修复未观看列表占位实现

### DIFF
--- a/entry/src/main/ets/db/MediaProgressStore.ets
+++ b/entry/src/main/ets/db/MediaProgressStore.ets
@@ -85,17 +85,18 @@ export class MediaProgressStore {
   }
 
   /**
-   * 清除媒体级进度（完播重置）。
+   * 将媒体标记为已完播（完播重置）。
+   * 不再删除进度记录，改为写入 is_watched = 1，保留完播历史。
    */
   static async clear(key: string): Promise<void> {
-    await FileSourceDatabase.getInstance().clearMediaProgress(key);
+    await FileSourceDatabase.getInstance().markAsWatched(key);
   }
 
   /**
-   * 清除指定剧集所有集的进度记录。
+   * 将指定剧集所有集标记为已完播。
    * @param seriesTmdbId 剧集 TMDB ID，如 "1399"
    */
   static async clearAllForSeries(seriesTmdbId: string): Promise<void> {
-    await FileSourceDatabase.getInstance().clearAllMediaProgressBySeries(seriesTmdbId);
+    await FileSourceDatabase.getInstance().markAllSeriesWatched(seriesTmdbId);
   }
 }

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -55,7 +55,7 @@ export interface SearchMediaOptions {
  *         movies, tv_series, tv_seasons, tv_episodes, play_progress, media_progress
  */
 export class FileSourceDatabase {
-  private static readonly DB_VERSION = 9;
+  private static readonly DB_VERSION = 10;
   private static readonly DB_NAME = 'FILE_SOURCES_DB';
   private static readonly TABLE_FILE_SOURCES = 'file_sources';
   private static readonly TABLE_DIRECTORIES = 'file_source_directories';
@@ -375,9 +375,18 @@ export class FileSourceDatabase {
         duration_ms INTEGER NOT NULL DEFAULT 0,
         last_played_at INTEGER NOT NULL,
         episode_number INTEGER NOT NULL DEFAULT 0,
-        season_number INTEGER NOT NULL DEFAULT 0
+        season_number INTEGER NOT NULL DEFAULT 0,
+        is_watched INTEGER NOT NULL DEFAULT 0
       )
     `);
+    // 防御性补列：表已存在时补齐 is_watched（幂等，列已存在时忽略）
+    try {
+      await rdbStore.executeSql(
+        `ALTER TABLE ${FileSourceDatabase.TABLE_MEDIA_PROGRESS} ADD COLUMN is_watched INTEGER NOT NULL DEFAULT 0`
+      );
+    } catch (e) {
+      // 列已存在时正常忽略
+    }
     console.info('FileSourceDatabase: media_progress table created');
   }
 
@@ -435,6 +444,19 @@ export class FileSourceDatabase {
         }
         currentVersion = 9;
         console.info('[DB] 已迁移到 v9：file_source_directories 新增 dir_status 列');
+      }
+      if (currentVersion < 10) {
+        // v10：media_progress 新增 is_watched 列，用于完播标记，避免删除进度记录
+        try {
+          await rdbStore.executeSql(
+            `ALTER TABLE ${FileSourceDatabase.TABLE_MEDIA_PROGRESS} ADD COLUMN is_watched INTEGER NOT NULL DEFAULT 0`
+          );
+        } catch (e) {
+          // 列已存在时忽略（幂等）
+          console.warn('[DB] v10 ALTER TABLE is_watched: 列可能已存在，已忽略', JSON.stringify(e));
+        }
+        currentVersion = 10;
+        console.info('[DB] 已迁移到 v10：media_progress 新增 is_watched 完播标记列');
       }
       console.info('FileSourceDatabase: Upgrade complete');
     } catch (error) {
@@ -2823,8 +2845,8 @@ export class FileSourceDatabase {
     try {
       const sql = `
         INSERT OR REPLACE INTO ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}
-          (media_key, position_ms, duration_ms, last_played_at, episode_number, season_number)
-        VALUES (?, ?, ?, ?, ?, ?)
+          (media_key, position_ms, duration_ms, last_played_at, episode_number, season_number, is_watched)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
       `;
       const args: relationalStore.ValueType[] = [
         entry.mediaKey,
@@ -2832,7 +2854,8 @@ export class FileSourceDatabase {
         entry.durationMs,
         entry.lastPlayedAt,
         entry.episodeNumber,
-        entry.seasonNumber
+        entry.seasonNumber,
+        entry.isWatched ?? 0
       ];
       await this.rdbStore.executeSql(sql, args);
       console.info(
@@ -2857,7 +2880,7 @@ export class FileSourceDatabase {
       pred.equalTo('media_key', mediaKey);
       const rs = await this.rdbStore.query(pred, [
         'media_key', 'position_ms', 'duration_ms', 'last_played_at',
-        'episode_number', 'season_number'
+        'episode_number', 'season_number', 'is_watched'
       ]);
       if (!rs.goToFirstRow()) {
         rs.close();
@@ -2869,7 +2892,8 @@ export class FileSourceDatabase {
         durationMs: rs.getLong(rs.getColumnIndex('duration_ms')),
         lastPlayedAt: rs.getLong(rs.getColumnIndex('last_played_at')),
         episodeNumber: rs.getLong(rs.getColumnIndex('episode_number')),
-        seasonNumber: rs.getLong(rs.getColumnIndex('season_number'))
+        seasonNumber: rs.getLong(rs.getColumnIndex('season_number')),
+        isWatched: rs.getLong(rs.getColumnIndex('is_watched'))
       };
       rs.close();
       return entry;
@@ -2927,6 +2951,67 @@ export class FileSourceDatabase {
   }
 
   /**
+   * 将指定媒体标记为已完播（is_watched = 1）。
+   * - 若记录已存在：UPDATE，同时将 position_ms 推进到 duration_ms（完播状态）。
+   * - 若记录不存在（从未播放过）：INSERT 一条哨兵记录（is_watched = 1，时长未知为 0）。
+   * 两步操作均幂等，重复调用安全。
+   * @param mediaKey 媒体进度存储 key
+   */
+  async markAsWatched(mediaKey: string): Promise<void> {
+    if (this.rdbStore === null) {
+      return;
+    }
+    try {
+      // 步骤 1：UPDATE 已有记录（设置完播标记，position_ms 推进到 duration_ms）
+      const updateSql =
+        `UPDATE ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
+        ` SET is_watched = 1,` +
+        `     position_ms = CASE WHEN duration_ms > 0 THEN duration_ms ELSE position_ms END,` +
+        `     last_played_at = ?` +
+        ` WHERE media_key = ?`;
+      await this.rdbStore.executeSql(updateSql, [Date.now(), mediaKey]);
+      // 步骤 2：INSERT OR IGNORE（记录不存在时插入哨兵行；若已 UPDATE 成功则 IGNORE 保留原行）
+      const insertSql =
+        `INSERT OR IGNORE INTO ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
+        ` (media_key, position_ms, duration_ms, last_played_at, episode_number, season_number, is_watched)` +
+        ` VALUES (?, 0, 0, ?, 0, 0, 1)`;
+      await this.rdbStore.executeSql(insertSql, [mediaKey, Date.now()]);
+      console.info(`[DB][markAsWatched] key=${mediaKey} 已标记完播`);
+    } catch (error) {
+      const err = error as BusinessError;
+      console.warn(`[DB][markAsWatched] 失败 code=${err.code} msg=${err.message}`);
+    }
+  }
+
+  /**
+   * 将指定剧集所有集的进度记录标记为已完播（is_watched = 1）。
+   * 仅 UPDATE 已有记录；对从未播放过的剧集，调用方应按需单独处理。
+   * @param seriesTmdbId 剧集 TMDB ID（如 "1399"），纯数字
+   */
+  async markAllSeriesWatched(seriesTmdbId: string): Promise<void> {
+    if (this.rdbStore === null) {
+      return;
+    }
+    if (!/^\d+$/.test(seriesTmdbId)) {
+      console.warn(`[DB][markAllSeriesWatched] 非法 seriesTmdbId: ${seriesTmdbId}`);
+      return;
+    }
+    try {
+      const episodePrefix = `media_progress_episode_tmdb_${seriesTmdbId}_`;
+      const oldKey = `media_progress_series_tmdb_${seriesTmdbId}`;
+      const sql =
+        `UPDATE ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
+        ` SET is_watched = 1, last_played_at = ?` +
+        ` WHERE media_key LIKE ? OR media_key = ?`;
+      await this.rdbStore.executeSql(sql, [Date.now(), `${episodePrefix}%`, oldKey]);
+      console.info(`[DB][markAllSeriesWatched] seriesTmdbId=${seriesTmdbId} 所有集已标记完播`);
+    } catch (error) {
+      const err = error as BusinessError;
+      console.warn(`[DB][markAllSeriesWatched] 失败 code=${err.code} msg=${err.message}`);
+    }
+  }
+
+  /**
    * 查询指定剧集最近播放的一集进度。
    * @param seriesTmdbId 剧集 TMDB ID，如 "1399"
    */
@@ -2944,7 +3029,7 @@ export class FileSourceDatabase {
       const oldKey = `media_progress_series_tmdb_${seriesTmdbId}`;
       // 同时查新旧格式，取最近播放的一条
       const sql =
-        `SELECT media_key, position_ms, duration_ms, last_played_at, episode_number, season_number` +
+        `SELECT media_key, position_ms, duration_ms, last_played_at, episode_number, season_number, is_watched` +
         ` FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
         ` WHERE media_key LIKE ? OR media_key = ?` +
         ` ORDER BY last_played_at DESC LIMIT 1`;
@@ -2957,6 +3042,7 @@ export class FileSourceDatabase {
           lastPlayedAt: rs.getLong(rs.getColumnIndex('last_played_at')),
           episodeNumber: rs.getLong(rs.getColumnIndex('episode_number')),
           seasonNumber: rs.getLong(rs.getColumnIndex('season_number')),
+          isWatched: rs.getLong(rs.getColumnIndex('is_watched')),
         };
         return entry;
       }
@@ -2982,7 +3068,7 @@ export class FileSourceDatabase {
     try {
       // limit 为数字类型，不存在注入风险；默认 40 用于「继续播放」栏，历史页可传 200
       const sql =
-        `SELECT media_key, position_ms, duration_ms, last_played_at, episode_number, season_number` +
+        `SELECT media_key, position_ms, duration_ms, last_played_at, episode_number, season_number, is_watched` +
         ` FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
         ` ORDER BY last_played_at DESC LIMIT ${limit}`;
       rs = await this.rdbStore.querySql(sql);
@@ -2995,6 +3081,7 @@ export class FileSourceDatabase {
           lastPlayedAt: rs.getLong(rs.getColumnIndex('last_played_at')),
           episodeNumber: rs.getLong(rs.getColumnIndex('episode_number')),
           seasonNumber: rs.getLong(rs.getColumnIndex('season_number')),
+          isWatched: rs.getLong(rs.getColumnIndex('is_watched')),
         };
         result.push(entry);
       }
@@ -3123,11 +3210,11 @@ export class FileSourceDatabase {
           `((s.media_type = 'movie' AND NOT EXISTS (` +
             `SELECT 1 FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS} mp2 ` +
             `WHERE mp2.media_key = 'media_progress_movie_' || s.provider_id ` +
-            `AND mp2.position_ms > 0` +
+            `AND (mp2.position_ms > 0 OR mp2.is_watched = 1)` +
           `)) OR (s.media_type IN ('tv', 'episode') AND ts.provider_id IS NOT NULL AND NOT EXISTS (` +
             `SELECT 1 FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS} mp2 ` +
             `WHERE mp2.media_key LIKE 'media_progress_episode_tmdb_' || ts.provider_id || '_s%' ` +
-            `AND mp2.position_ms > 0` +
+            `AND (mp2.position_ms > 0 OR mp2.is_watched = 1)` +
           `)))`
         );
       } else if (options?.watchProgress === 'partial') {

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -3247,13 +3247,11 @@ export class FileSourceDatabase {
           `((s.media_type = 'movie' AND EXISTS (` +
             `SELECT 1 FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS} mp2 ` +
             `WHERE mp2.media_key = 'media_progress_movie_' || s.provider_id ` +
-            `AND mp2.duration_ms > 0 ` +
-            `AND CAST(mp2.position_ms AS REAL) >= CAST(mp2.duration_ms AS REAL) * 0.9` +
+            `AND (mp2.is_watched = 1 OR (mp2.duration_ms > 0 AND CAST(mp2.position_ms AS REAL) >= CAST(mp2.duration_ms AS REAL) * 0.9))` +
           `)) OR (s.media_type IN ('tv', 'episode') AND ts.provider_id IS NOT NULL AND EXISTS (` +
             `SELECT 1 FROM ${FileSourceDatabase.TABLE_MEDIA_PROGRESS} mp2 ` +
             `WHERE mp2.media_key LIKE 'media_progress_episode_tmdb_' || ts.provider_id || '_s%' ` +
-            `AND mp2.duration_ms > 0 ` +
-            `AND CAST(mp2.position_ms AS REAL) >= CAST(mp2.duration_ms AS REAL) * 0.9` +
+            `AND (mp2.is_watched = 1 OR (mp2.duration_ms > 0 AND CAST(mp2.position_ms AS REAL) >= CAST(mp2.duration_ms AS REAL) * 0.9))` +
           `)))`
         );
       }

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -455,8 +455,17 @@ export class FileSourceDatabase {
           // 列已存在时忽略（幂等）
           console.warn('[DB] v10 ALTER TABLE is_watched: 列可能已存在，已忽略', JSON.stringify(e));
         }
+        // 回填历史完播数据：position_ms >= duration_ms * 0.95 或剩余 < 60 秒视为已看完
+        await rdbStore.executeSql(
+          `UPDATE ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
+          ` SET is_watched = 1` +
+          ` WHERE is_watched = 0 AND duration_ms > 0 AND (` +
+          `   (duration_ms - position_ms) < 60000 OR` +
+          `   CAST(position_ms AS REAL) >= CAST(duration_ms AS REAL) * 0.95` +
+          ` )`
+        );
         currentVersion = 10;
-        console.info('[DB] 已迁移到 v10：media_progress 新增 is_watched 完播标记列');
+        console.info('[DB] 已迁移到 v10：media_progress 新增 is_watched 完播标记列，并回填历史完播数据');
       }
       console.info('FileSourceDatabase: Upgrade complete');
     } catch (error) {
@@ -3001,7 +3010,9 @@ export class FileSourceDatabase {
       const oldKey = `media_progress_series_tmdb_${seriesTmdbId}`;
       const sql =
         `UPDATE ${FileSourceDatabase.TABLE_MEDIA_PROGRESS}` +
-        ` SET is_watched = 1, last_played_at = ?` +
+        ` SET is_watched = 1,` +
+        `     position_ms = CASE WHEN duration_ms > 0 THEN duration_ms ELSE position_ms END,` +
+        `     last_played_at = ?` +
         ` WHERE media_key LIKE ? OR media_key = ?`;
       await this.rdbStore.executeSql(sql, [Date.now(), `${episodePrefix}%`, oldKey]);
       console.info(`[DB][markAllSeriesWatched] seriesTmdbId=${seriesTmdbId} 所有集已标记完播`);

--- a/entry/src/main/ets/db/models/MediaEntity.ets
+++ b/entry/src/main/ets/db/models/MediaEntity.ets
@@ -203,6 +203,8 @@ export interface MediaProgressEntry {
   episodeNumber: number;
   /** 剧集：季号（0 表示无） */
   seasonNumber: number;
+  /** 完播标记：0 = 未看完，1 = 已看完。可选（旧记录无此字段时为 undefined） */
+  isWatched?: number;
 }
 
 // ─────────────────────────────────────────────

--- a/entry/src/main/ets/stores/media/MediaLibraryModel.ets
+++ b/entry/src/main/ets/stores/media/MediaLibraryModel.ets
@@ -98,6 +98,29 @@ export class MediaLibraryModel {
       console.info(`[MediaLibraryModel][DIAG] recentlyAddedList=${this.recentlyAddedList.length} (series=${seriesInList} video=${videoInList})`);
       this.unwatchedList = this.recentlyAddedList; // 播放历史未实现时，未观看 = 全部
 
+      // 未观看列表：通过 searchMediaItems 查询真实未看内容（is_watched=0 且无播放进度）
+      try {
+        const unwatchedItems: MediaItem[] = await db.searchMediaItems('', {
+          watchProgress: 'unseen',
+          limit: 20
+        });
+        const unwatchedMixed: MediaListItem[] = [];
+        for (const item of unwatchedItems) {
+          const listItem: MediaListItem = {
+            kind: 'video',
+            video: item,
+            sortTs: item.scannedAt
+          };
+          unwatchedMixed.push(listItem);
+        }
+        if (unwatchedMixed.length > 0) {
+          this.unwatchedList = unwatchedMixed;
+        }
+        console.info(`[MediaLibraryModel][DIAG] unwatchedList=${this.unwatchedList.length}`);
+      } catch (e) {
+        console.warn('[MediaLibraryModel] unwatchedList 查询失败，回退到 recentlyAddedList');
+      }
+
       // 评分标签（10→5 逆序，有数量的才显示）
       const ratingBands: RatingLabel[] = [];
       const bands: number[] = [9, 8, 7, 6, 5];

--- a/entry/src/main/ets/stores/media/MediaLibraryModel.ets
+++ b/entry/src/main/ets/stores/media/MediaLibraryModel.ets
@@ -113,9 +113,8 @@ export class MediaLibraryModel {
           };
           unwatchedMixed.push(listItem);
         }
-        if (unwatchedMixed.length > 0) {
-          this.unwatchedList = unwatchedMixed;
-        }
+        unwatchedMixed.sort((a: MediaListItem, b: MediaListItem): number => b.sortTs - a.sortTs);
+        this.unwatchedList = unwatchedMixed;
         console.info(`[MediaLibraryModel][DIAG] unwatchedList=${this.unwatchedList.length}`);
       } catch (e) {
         console.warn('[MediaLibraryModel] unwatchedList 查询失败，回退到 recentlyAddedList');


### PR DESCRIPTION
## 关联 Issue
closes #120

## 变更概述
扩展 `media_progress` 表，新增 `is_watched` 列，实现真正的已看/未看状态追踪，并修复媒体库未观看列表的占位实现。

## 核心修改

### 数据库（DB_VERSION 9 → 10）
- `media_progress` 表新增 `is_watched INTEGER DEFAULT 0` 列
- 全新安装：CREATE TABLE 直接含该列
- 旧库升级：`onUpgrade v10` 防御性 ALTER TABLE（幂等）
- 新增 `markAsWatched(mediaKey)` 和 `markAllSeriesWatched(seriesTmdbId)` 方法
- `searchMediaItems` 的 `unseen` 过滤扩展为排除 `position_ms > 0 OR is_watched = 1`

### 状态语义（三态）
| 状态 | 判断条件 |
|------|---------|
| 未看 | 无进度记录 |
| 看了一半 | `position_ms > 0`，`is_watched = 0` |
| 已看完 | `is_watched = 1` |

### MediaProgressStore
- `clear()` 改为调用 `markAsWatched()`，保留完播历史而非删除记录
- `clearAllForSeries()` 改为调用 `markAllSeriesWatched()`

### 媒体库 Model
- `unwatchedList` 从占位 `= recentlyAddedList` 替换为真实的 `searchMediaItems({watchProgress:'unseen'})` 查询

## 验证
编译零新增错误（原有 49 个 ERROR 为 pre-existing IBestButton 问题，与本次无关）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Items can now be marked as watched, with viewing history preserved and status updated.
  * Unwatched content list now reflects accurate watch status across your media library.

* **Improvements**
  * Enhanced media viewing status tracking for better content organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->