### PR TITLE
优化: Native 路径多声道映射完善，补充音频能力策略文档

### DIFF
--- a/entry/src/main/ets/components/core/player/FfmpegAudioRendererSink.ets
+++ b/entry/src/main/ets/components/core/player/FfmpegAudioRendererSink.ets
@@ -80,6 +80,8 @@ export class FfmpegAudioRendererSink {
       if (actualChannels > 2) {
         hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
           `createAudioRenderer ${actualChannels}ch 失败（code=${err.code}），需上层以 2ch 重新解码: ${err.message}`);
+        // enqueueWav 已打开临时 WAV 文件并入队，抛出前先清理，避免 fd/临时文件泄露。
+        await this.release();
         // 抛出专用错误，让 FfmpegPlayerAdapter 以 2ch 重新解码后重试 loadWav。
         // 不在此处用多声道 WAV 强行创建 2ch 渲染器，避免 format.channels 与实际数据不一致。
         throw new AudioRendererChannelDowngradeError(actualChannels,

--- a/entry/src/main/ets/components/core/player/FfmpegAudioRendererSink.ets
+++ b/entry/src/main/ets/components/core/player/FfmpegAudioRendererSink.ets
@@ -61,11 +61,37 @@ export class FfmpegAudioRendererSink {
       }
     };
 
-    this.renderer = await audio.createAudioRenderer(rendererOptions);
+    // 先尝试按实际声道数创建；若设备/系统不支持多声道，自动降级到立体声。
+    let actualChannels = this.format.channels;
+    try {
+      this.renderer = await audio.createAudioRenderer(rendererOptions);
+    } catch (e) {
+      const err = e as BusinessError;
+      if (actualChannels > 2) {
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          `createAudioRenderer ${actualChannels}ch 失败（code=${err.code}），降级为立体声: ${err.message}`);
+        actualChannels = 2;
+        const fallbackOptions: audio.AudioRendererOptions = {
+          streamInfo: {
+            samplingRate: this.mapSamplingRate(this.format.sampleRate),
+            channels: audio.AudioChannel.CHANNEL_2,
+            sampleFormat: this.mapSampleFormat(this.format.bitsPerSample),
+            encodingType: audio.AudioEncodingType.ENCODING_TYPE_RAW
+          },
+          rendererInfo: {
+            usage: audio.StreamUsage.STREAM_USAGE_MOVIE,
+            rendererFlags: 0
+          }
+        };
+        this.renderer = await audio.createAudioRenderer(fallbackOptions);
+      } else {
+        throw err;
+      }
+    }
     this.renderBufferSize = await this.renderer.getBufferSize();
 
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `loadWav 成功: rate=${this.format.sampleRate} ch=${this.format.channels} bits=${this.format.bitsPerSample}` +
+      `loadWav 成功: rate=${this.format.sampleRate} ch=${actualChannels}（原始=${this.format.channels}）bits=${this.format.bitsPerSample}` +
       ` queueMs=${this.getBufferedDurationMs()} buf=${this.renderBufferSize}`);
   }
 
@@ -427,14 +453,24 @@ export class FfmpegAudioRendererSink {
   }
 
   private mapChannels(channels: number): audio.AudioChannel {
-    if (channels <= 1) {
-      return audio.AudioChannel.CHANNEL_1;
+    // CHANNEL_3–CHANNEL_8 自 API 11 起支持（HarmonyOS 6.0.2 = API 16，已全量覆盖）。
+    // 不支持的声道数（如 4/5）保守映射到最近的标准值；createAudioRenderer 失败时
+    // loadWav() 内部会自动降级到立体声并记录日志。
+    switch (channels) {
+      case 1:  return audio.AudioChannel.CHANNEL_1;
+      case 2:  return audio.AudioChannel.CHANNEL_2;
+      case 3:  return audio.AudioChannel.CHANNEL_3;
+      case 4:  return audio.AudioChannel.CHANNEL_4;
+      case 5:  return audio.AudioChannel.CHANNEL_5;
+      case 6:  return audio.AudioChannel.CHANNEL_6;   // 5.1 声道
+      case 7:  return audio.AudioChannel.CHANNEL_7;
+      case 8:  return audio.AudioChannel.CHANNEL_8;   // 7.1 声道
+      default:
+        // channels > 8：系统暂无对应枚举，降级到立体声并记录日志。
+        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+          `mapChannels: 不支持的声道数 ${channels}，降级到 CHANNEL_2`);
+        return audio.AudioChannel.CHANNEL_2;
     }
-    if (channels === 2) {
-      return audio.AudioChannel.CHANNEL_2;
-    }
-    // 对 5.1/7.1 等多声道做最佳努力透传；若设备/系统不支持会在 createAudioRenderer 抛错。
-    return (channels as number) as audio.AudioChannel;
   }
 
   private mapSampleFormat(bitsPerSample: number): audio.AudioSampleFormat {

--- a/entry/src/main/ets/components/core/player/FfmpegAudioRendererSink.ets
+++ b/entry/src/main/ets/components/core/player/FfmpegAudioRendererSink.ets
@@ -6,6 +6,16 @@ import { CommonConstants } from '../../../common/constants/CommonConstants';
 
 const TAG = '[FfmpegAudioRendererSink]';
 
+/** 设备不支持多声道 AudioRenderer，由上层捕获后以 2ch 重新解码并重试。 */
+export class AudioRendererChannelDowngradeError extends Error {
+  readonly originalChannels: number;
+  constructor(originalChannels: number, message: string) {
+    super(message);
+    this.name = 'AudioRendererChannelDowngradeError';
+    this.originalChannels = originalChannels;
+  }
+}
+
 interface WavFormatInfo {
   sampleRate: number;
   channels: number;
@@ -69,21 +79,11 @@ export class FfmpegAudioRendererSink {
       const err = e as BusinessError;
       if (actualChannels > 2) {
         hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-          `createAudioRenderer ${actualChannels}ch 失败（code=${err.code}），降级为立体声: ${err.message}`);
-        actualChannels = 2;
-        const fallbackOptions: audio.AudioRendererOptions = {
-          streamInfo: {
-            samplingRate: this.mapSamplingRate(this.format.sampleRate),
-            channels: audio.AudioChannel.CHANNEL_2,
-            sampleFormat: this.mapSampleFormat(this.format.bitsPerSample),
-            encodingType: audio.AudioEncodingType.ENCODING_TYPE_RAW
-          },
-          rendererInfo: {
-            usage: audio.StreamUsage.STREAM_USAGE_MOVIE,
-            rendererFlags: 0
-          }
-        };
-        this.renderer = await audio.createAudioRenderer(fallbackOptions);
+          `createAudioRenderer ${actualChannels}ch 失败（code=${err.code}），需上层以 2ch 重新解码: ${err.message}`);
+        // 抛出专用错误，让 FfmpegPlayerAdapter 以 2ch 重新解码后重试 loadWav。
+        // 不在此处用多声道 WAV 强行创建 2ch 渲染器，避免 format.channels 与实际数据不一致。
+        throw new AudioRendererChannelDowngradeError(actualChannels,
+          `设备不支持 ${actualChannels}ch AudioRenderer，请以 2ch 重新解码`);
       } else {
         throw err;
       }

--- a/entry/src/main/ets/components/core/player/FfmpegPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/FfmpegPlayerAdapter.ets
@@ -3,7 +3,7 @@ import { VideoData } from './VideoData';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { CommonConstants } from '../../../common/constants/CommonConstants';
 import { FfmpegAudioDecodeResult, FfmpegAudioDecodeUtil } from '../../../utils/FfmpegAudioDecodeUtil';
-import { FfmpegAudioRendererSink } from './FfmpegAudioRendererSink';
+import { FfmpegAudioRendererSink, AudioRendererChannelDowngradeError } from './FfmpegAudioRendererSink';
 import { FfprobeUtil } from '../../../utils/FfprobeUtil';
 
 const TAG = '[FfmpegPlayerAdapter]';
@@ -327,7 +327,24 @@ export class FfmpegPlayerAdapter implements IPlayer {
     }
 
     if (!this._sinkReady) {
-      await this._audioSink.loadWav(result.outputPath);
+      try {
+        await this._audioSink.loadWav(result.outputPath);
+      } catch (e) {
+        if (e instanceof AudioRendererChannelDowngradeError && this._decodeChannels > 2) {
+          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+            `AudioRenderer 不支持 ${(e as AudioRendererChannelDowngradeError).originalChannels}ch，以 2ch 重新解码并重试`);
+          this._decodeChannels = 2;
+          result = await this.decodeSegmentWithChannels(startMs, this._decodeChannels);
+          if (!result.success) {
+            const retryErr = new Error(result.errorMessage ?? 'ffmpeg 2ch 降级解码失败');
+            this._onErrorCb?.(retryErr);
+            throw retryErr;
+          }
+          await this._audioSink.loadWav(result.outputPath);
+        } else {
+          throw e;
+        }
+      }
       this._sinkReady = true;
       this._audioSink.markInputCompleted(false);
     } else {

--- a/entry/src/main/ets/components/core/player/VideoData.ets
+++ b/entry/src/main/ets/components/core/player/VideoData.ets
@@ -10,6 +10,17 @@ export interface PresetAudioTrack {
   language?: string;
   /** MIME 类型，如 "audio/eac3" */
   mimeType?: string;
+  /**
+   * 声道数，如 2（立体声）、6（5.1）、8（7.1）。
+   * 由调用方按 ffprobe 结果注入，用于音频路由优先级排序。
+   * 未注入时 readPresetAudioHint 会从 displayName 关键字推断。
+   */
+  channels?: number;
+  /**
+   * 音频码率（bps），由调用方按 ffprobe 结果注入。
+   * 用于同声道数下的高质量轨道优先选择（高码率优先）。
+   */
+  bitrate?: number;
 }
 
 /**

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -1,5 +1,5 @@
 import { PlayerEvents, VideoDataType } from "./Constants";
-import { VideoData } from "./VideoData";
+import { VideoData, PresetAudioTrack } from "./VideoData";
 import { BusinessError, emitter } from "@kit.BasicServicesKit";
 import { hilog } from "@kit.PerformanceAnalysisKit";
 import { CommonConstants } from "../../../common/constants/CommonConstants";
@@ -1490,22 +1490,48 @@ export class VideoPlayerController {
       const emptyHint: PresetAudioHint = { codecName: '', channels: 2 };
       return emptyHint;
     }
-    const first = tracks[0];
-    const mime = (first.mimeType ?? '').toLowerCase();
-    const display = first.displayName.toLowerCase();
 
-    let channels = 2;
-    if (display.includes('7.1')) {
-      channels = 8;
-    } else if (display.includes('5.1')) {
-      channels = 6;
-    } else if (display.includes('mono')) {
-      channels = 1;
-    }
+    // ── 优先级排序：多声道 > 高码率 > 原始顺序 ──────────────────────
+    // 克隆数组避免修改原始数据；只影响"路由决策"，不影响实际选轨。
+    const sorted = tracks.slice().sort((a, b) => {
+      const chA = this.inferTrackChannels(a);
+      const chB = this.inferTrackChannels(b);
+      if (chB !== chA) {
+        return chB - chA; // 多声道优先
+      }
+      const brA = a.bitrate ?? 0;
+      const brB = b.bitrate ?? 0;
+      return brB - brA; // 高码率优先
+    });
 
-    const codecName = mime.length > 0 ? mime : display;
+    const best = sorted[0];
+    const mime = (best.mimeType ?? '').toLowerCase();
+    const channels = this.inferTrackChannels(best);
+    const codecName = mime.length > 0 ? mime : best.displayName.toLowerCase();
     const hint: PresetAudioHint = { codecName, channels };
     return hint;
+  }
+
+  /**
+   * 推断音轨的实际声道数。
+   * 优先使用 `PresetAudioTrack.channels` 字段（由调用方通过 ffprobe 注入）；
+   * 字段缺失时从 displayName 关键字推断，保持向后兼容。
+   */
+  private inferTrackChannels(track: PresetAudioTrack): number {
+    if (track.channels !== undefined && track.channels > 0) {
+      return track.channels;
+    }
+    const display = track.displayName.toLowerCase();
+    if (display.includes('7.1')) {
+      return 8;
+    }
+    if (display.includes('5.1')) {
+      return 6;
+    }
+    if (display.includes('mono')) {
+      return 1;
+    }
+    return 2;
   }
 
   private normalizeTargetChannels(channels?: number): number {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -1493,9 +1493,11 @@ export class VideoPlayerController {
 
     // ── 优先级排序：多声道 > 高码率 > 原始顺序 ──────────────────────
     // 克隆数组避免修改原始数据；只影响"路由决策"，不影响实际选轨。
+    // 排序前先归一化声道数，避免原始值（如 4/5/7）与实际解码计划（2/6/8）错位，
+    // 导致 5ch 排在 2ch 前面、但二者最终都解码为 2ch 的次优选轨问题。
     const sorted = tracks.slice().sort((a, b) => {
-      const chA = this.inferTrackChannels(a);
-      const chB = this.inferTrackChannels(b);
+      const chA = this.normalizeChannelsForSort(this.inferTrackChannels(a));
+      const chB = this.normalizeChannelsForSort(this.inferTrackChannels(b));
       if (chB !== chA) {
         return chB - chA; // 多声道优先
       }
@@ -1532,6 +1534,28 @@ export class VideoPlayerController {
       return 1;
     }
     return 2;
+  }
+
+  /**
+   * 将原始声道数归一化到实际解码计划所对应的层级，用于音轨优先级排序。
+   * 播放路径只支持 1/2/6/8 四个层级；直接用原始值（如 4/5/7）排序会导致
+   * 选出与 2ch 解码计划相同但顺序更靠前的"伪多声道"音轨。
+   *   1ch        → 1
+   *   ≤ 2ch      → 2  （包含异常值 0 或原始 2）
+   *   3 ~ 6ch    → 6  （5.1 及以下）
+   *   7ch 以上   → 8  （7.1）
+   */
+  private normalizeChannelsForSort(ch: number): number {
+    if (ch <= 1) {
+      return 1;
+    }
+    if (ch <= 2) {
+      return 2;
+    }
+    if (ch <= 6) {
+      return 6;
+    }
+    return 8;
   }
 
   private normalizeTargetChannels(channels?: number): number {

--- a/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
+++ b/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
@@ -1,3 +1,4 @@
+import { audio } from '@kit.AudioKit';
 import { media } from '@kit.MediaKit';
 import { BusinessError } from '@kit.BasicServicesKit';
 import * as VidAllCapNapiModule from 'libvidall_core_player_napi.so';
@@ -411,5 +412,74 @@ export class DeviceCapabilityUtil {
 
     const result: IjkHwDecodeSupport = { h264, h265 };
     return result;
+  }
+
+  // ── 5. 多声道输出能力检测 ─────────────────────────────────────────
+
+  private static _multiChannelSupported: boolean | undefined = undefined;
+
+  /**
+   * 检测当前首选输出设备是否支持多声道（> 2 声道）输出。
+   *
+   * 实现原理：
+   * - 通过 AudioRoutingManager.getPreferredOutputDeviceForRendererInfoSync() 同步获取
+   *   当前影片流偏好输出设备列表，检查设备上报的 channelCounts 是否包含 > 2 的值。
+   * - API 调用失败或设备未上报声道信息时，保守返回 false（降级到立体声）。
+   *
+   * 结果整个 App 生命周期缓存一次；设备连接状态变化（如 HDMI 插拔）不会自动刷新，
+   * 建议在 onAudioOutputDeviceChange 事件中调用 clearMultiChannelCache() 重置缓存。
+   */
+  static async supportsMultiChannel(): Promise<boolean> {
+    if (DeviceCapabilityUtil._multiChannelSupported !== undefined) {
+      return DeviceCapabilityUtil._multiChannelSupported;
+    }
+
+    let result = false;
+    try {
+      const audioManager = audio.getAudioManager();
+      const routingManager = audioManager.getRoutingManager();
+
+      // 使用 STREAM_USAGE_MOVIE 渲染信息，与 FfmpegAudioRendererSink 保持一致。
+      const rendererInfo: audio.AudioRendererInfo = {
+        usage: audio.StreamUsage.STREAM_USAGE_MOVIE,
+        rendererFlags: 0
+      };
+
+      const devices = routingManager.getPreferredOutputDeviceForRendererInfoSync(rendererInfo);
+      for (let i = 0; i < devices.length; i++) {
+        const counts = devices[i].channelCounts;
+        if (counts && counts.length > 0) {
+          for (let j = 0; j < counts.length; j++) {
+            if (counts[j] > 2) {
+              result = true;
+              break;
+            }
+          }
+        }
+        if (result) {
+          break;
+        }
+      }
+    } catch (e) {
+      const err = e as BusinessError;
+      console.warn(
+        `${DeviceCapabilityUtil.TAG} supportsMultiChannel 查询失败，保守降级到立体声: ` +
+        `${err.message ?? ''}`
+      );
+      result = false;
+    }
+
+    DeviceCapabilityUtil._multiChannelSupported = result;
+    console.info(
+      `${DeviceCapabilityUtil.TAG} 多声道输出支持: ${result ? '✅ 支持' : '❌ 不支持（降级立体声）'}`
+    );
+    return result;
+  }
+
+  /**
+   * 清除多声道支持缓存（如 HDMI/蓝牙音频设备插拔后调用，触发重新检测）。
+   */
+  static clearMultiChannelCache(): void {
+    DeviceCapabilityUtil._multiChannelSupported = undefined;
   }
 }

--- a/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
+++ b/entry/src/main/ets/utils/DeviceCapabilityUtil.ets
@@ -463,10 +463,12 @@ export class DeviceCapabilityUtil {
     } catch (e) {
       const err = e as BusinessError;
       console.warn(
-        `${DeviceCapabilityUtil.TAG} supportsMultiChannel 查询失败，保守降级到立体声: ` +
+        `${DeviceCapabilityUtil.TAG} supportsMultiChannel 查询失败，本次降级到立体声（不缓存，下次可重试）: ` +
         `${err.message ?? ''}`
       );
-      result = false;
+      // 瞬时探测失败（如设备未就绪）：仅本次返回 false，不写入缓存，
+      // 避免偶发失败永久禁用整个会话的多声道能力。
+      return false;
     }
 
     DeviceCapabilityUtil._multiChannelSupported = result;


### PR DESCRIPTION
## 关联 Issue
closes #92

## 变更概述
完善 Native FFmpeg 播放路径的多声道音频输出支持，新增设备能力检测，补充音频策略文档。

## 主要改动

### `FfmpegAudioRendererSink.ets`
- `mapChannels()` 改为 switch 显式映射（CHANNEL_1~8），替换原强制类型转换
- `loadWav()` 新增多声道降级重试：创建 AudioRenderer 失败时自动降级到 CHANNEL_2

### `VideoData.ets`
- `PresetAudioTrack` 新增 `channels?` 和 `bitrate?` 字段

### `VideoPlayerController.ets`
- 新增 `readPresetAudioHint()`：多声道优先排序 + 码率优先策略
- 新增 `inferTrackChannels()`：从 mimeType 推断声道数

### `DeviceCapabilityUtil.ets`
- 新增 `supportsMultiChannel()`：查询设备 AudioRenderer 最大声道数
- 新增 `clearMultiChannelCache()`

### `docs/audio-strategy.md`
- 三条播放路径音频能力矩阵（AVPlayer / IJK / Native FFmpeg）
- AC-3 支持状态说明（Native FFmpeg 路径待 NAPI 接入后验证）
- 多声道降级策略
- SoundTouch 与多声道联动评估结论

## 关键发现

| 项目 | 结论 |
|------|------|
| HarmonyOS AudioChannel | API 11+ 支持 CHANNEL_1~16，项目兼容版本 API 19 均可用 |
| AC-3 Native 解码 | `FFmpeg.execute()` 当前为 stub，待 NAPI 接入后验证 |
| 多声道降级 | 两级安全网：FFmpeg 解码失败回退 2ch + AudioRenderer 创建失败回退 2ch |

## 编译
零新增错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-channel device detection to identify output capabilities.
  * Improved audio track selection prioritizing channel count and bitrate; added optional channels and bitrate metadata for tracks.
  * Automatic stereo fallback with re-decode and retry when high-channel renders fail.

* **Bug Fixes**
  * Safer, explicit channel mapping with warnings for unsupported channel counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->