### PR TITLE
优化: 继续播放按钮对不支持协议给出 Toast 提示

### DIFF
--- a/entry/src/main/ets/components/media/ContinueWatchCard.ets
+++ b/entry/src/main/ets/components/media/ContinueWatchCard.ets
@@ -16,8 +16,9 @@
 import { ContinueWatchingItem } from '../../db/models/MediaEntity';
 import { PlayerPageParam, PlayerPage } from '../../pages/player/index';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
-import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntity';
+import { FileSourceType, FileSourceTypeLabels, SMBSourceConfig } from '../../db/models/FileSourceEntity';
 import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient';
+import promptAction from '@ohos.promptAction';
 
 // ─── 卡片尺寸常量 ────────────────────────────────
 const CARD_W = 320;
@@ -150,7 +151,9 @@ export struct ContinueWatchCard {
         const authHeader = client.getAuthHeaderPublic();
         httpHeader = authHeader.length > 0 ? { 'Authorization': authHeader } : {};
       } else {
+        const typeName = FileSourceTypeLabels.getLabel(fileSource.type);
         console.warn('[ContinueWatchCard] 不支持的文件源类型: ' + fileSource.type.toString());
+        promptAction.showToast({ message: typeName + ' 暂不支持继续播放' });
         return;
       }
 


### PR DESCRIPTION
## 变更说明

为继续播放（ContinueWatchCard）的「继续播放」按钮补充用户反馈：当文件源协议暂不支持直接跳转播放时，给出友好的 Toast 提示，避免用户点击无反应。

目前 WebDAV 和 SMB 协议已正常支持继续播放。其他协议的统一 resolver 支持将在后续里程碑实现。

> **注意**：本 PR **不** closes #110，统一 resolver 实现列入下一里程碑。