### PR TITLE
新增: 倍速播放支持（AVPlayer/IJK/Native 三路统一）

### DIFF
--- a/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
@@ -233,6 +233,32 @@ export class AVPlayerAdapter implements IPlayer {
     // no-op: 延迟偏移由上层 SRT 查找逻辑处理
   }
 
+  /**
+   * 设置播放速率。
+   * 将浮点速率映射到 media.PlaybackSpeed 枚举后调用 AVPlayer.setSpeed()。
+   * 支持：0.5 / 0.75 / 1.0 / 1.25 / 1.5 / 2.0；其余值回退到正常速度。
+   */
+  setPlaybackSpeed(speed: number): void {
+    if (!this.avPlayer) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG, `setPlaybackSpeed(${speed}) 忽略：AVPlayer 未初始化`);
+      return;
+    }
+    const playbackSpeed = this.speedToPlaybackSpeed(speed);
+    this.avPlayer.setSpeed(playbackSpeed);
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG, `setPlaybackSpeed: speed=${speed} enum=${playbackSpeed}`);
+  }
+
+  /** 将浮点速率映射到 media.PlaybackSpeed 枚举，不支持的值回退到 1.0x */
+  private speedToPlaybackSpeed(speed: number): media.PlaybackSpeed {
+    if (speed === 0.5) { return media.PlaybackSpeed.SPEED_FORWARD_0_50_X; }
+    if (speed === 0.75) { return media.PlaybackSpeed.SPEED_FORWARD_0_75_X; }
+    if (speed === 1.25) { return media.PlaybackSpeed.SPEED_FORWARD_1_25_X; }
+    if (speed === 1.5) { return media.PlaybackSpeed.SPEED_FORWARD_1_50_X; }
+    if (speed === 2.0) { return media.PlaybackSpeed.SPEED_FORWARD_2_00_X; }
+    // 默认/未知速率回退到 1.0x
+    return media.PlaybackSpeed.SPEED_FORWARD_1_00_X;
+  }
+
   // ─── 事件回调注册 ───
 
   onReady(callback: () => void): void {

--- a/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
@@ -244,8 +244,20 @@ export class AVPlayerAdapter implements IPlayer {
       return;
     }
     const playbackSpeed = this.speedToPlaybackSpeed(speed);
-    this.avPlayer.setSpeed(playbackSpeed);
-    hilog.info(CommonConstants.LOG_DOMAIN, TAG, `setPlaybackSpeed: speed=${speed} enum=${playbackSpeed}`);
+    try {
+      this.avPlayer.setSpeed(playbackSpeed);
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG, `setPlaybackSpeed: speed=${speed} enum=${playbackSpeed}`);
+    } catch (e) {
+      const err = e as BusinessError;
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `setSpeed 异常，降级为 1.0x: code=${err.code} msg=${err.message}`);
+      // 降级：回退到正常速度，避免异常中断调用方后续流程
+      try {
+        this.avPlayer.setSpeed(media.PlaybackSpeed.SPEED_FORWARD_1_00_X);
+      } catch (_) {
+        // 降级也失败时静默忽略（播放器可能未就绪或已 release）
+      }
+    }
   }
 
   /** 将浮点速率映射到 media.PlaybackSpeed 枚举，不支持的值回退到 1.0x */

--- a/entry/src/main/ets/components/core/player/FfmpegPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/FfmpegPlayerAdapter.ets
@@ -156,6 +156,15 @@ export class FfmpegPlayerAdapter implements IPlayer {
   setSubtitleDelay(_delayMs: number): void {
   }
 
+  /**
+   * FfmpegPlayerAdapter 不支持运行时倍速设置（纯音频渲染路径无变速能力）。
+   * 降级处理：打印警告日志，不崩溃。
+   */
+  setPlaybackSpeed(speed: number): void {
+    hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+      `setPlaybackSpeed(${speed}) 在 ffmpeg 后端暂不支持，已跳过`);
+  }
+
   onReady(callback: () => void): void {
     this._onReadyCb = callback;
   }

--- a/entry/src/main/ets/components/core/player/IPlayer.ets
+++ b/entry/src/main/ets/components/core/player/IPlayer.ets
@@ -57,6 +57,13 @@ export interface IPlayer {
    */
   setSubtitleDelay(delayMs: number): void;
 
+  /**
+   * 设置播放速率（倍速）。
+   * 支持档位：0.5 / 0.75 / 1.0 / 1.25 / 1.5 / 2.0。
+   * 不支持的后端实现为空桩，打印警告日志，不抛异常。
+   */
+  setPlaybackSpeed(speed: number): void;
+
   // ─── 事件回调 ───
   onReady(callback: () => void): void;
   onPlay(callback: () => void): void;

--- a/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
@@ -514,6 +514,10 @@ export class IjkPlayerAdapter implements IPlayer {
     // 必须设为 1，否则 stream_component_open 会跳过 AVMEDIA_TYPE_SUBTITLE 分支，onTimedText 永远不会触发
     this.ijk.setOptionLong(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'subtitle', '1');
 
+    // ── 变速不变调 ──
+    // 必须在 prepare 前开启，否则 setSpeed() 调用成功但播放速率不变
+    this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'soundtouch', '1');
+
     // ── 缓冲控制 ──
     this.ijk.setOption(IjkMediaPlayer.OPT_CATEGORY_PLAYER, 'max_cached_duration', '1500');
     // infbuf=1 可能导致长播时缓冲无上限增长，增加系统回收/强杀风险。

--- a/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
@@ -458,6 +458,20 @@ export class IjkPlayerAdapter implements IPlayer {
       `setSubtitleDelay: 延迟已由 VideoPlayerController 层处理`);
   }
 
+  /**
+   * 设置播放速率。
+   * 直接调用 IjkMediaPlayer.setSpeed(speed.toString())，支持变速不变调（ijkplayer 内部处理）。
+   */
+  setPlaybackSpeed(speed: number): void {
+    try {
+      this.ijk.setSpeed(speed.toString());
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG, `setPlaybackSpeed: speed=${speed}`);
+    } catch (e) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `setPlaybackSpeed(${speed}) 失败: ${(e as Error).message}`);
+    }
+  }
+
   // ─── 事件回调注册 ───
 
   onReady(callback: () => void): void { this._onReadyCb = callback; }

--- a/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/IjkPlayerAdapter.ets
@@ -14,6 +14,7 @@ import type { OnVideoSizeChangedListener } from '@yaoshining/ijkplayer';
 import type { OnTimedTextListener } from '@yaoshining/ijkplayer';
 import { DeviceCapabilityUtil, type IjkHwDecodeSupport } from '../../../utils/DeviceCapabilityUtil';
 import { AppPreferences, PrefKey } from '../../../utils/AppPreferences';
+import { BusinessError } from '@kit.BasicServicesKit';
 
 const TAG = '[IjkPlayerAdapter]';
 const ENABLE_IJK_INFO_CALLBACK = false;
@@ -467,8 +468,9 @@ export class IjkPlayerAdapter implements IPlayer {
       this.ijk.setSpeed(speed.toString());
       hilog.info(CommonConstants.LOG_DOMAIN, TAG, `setPlaybackSpeed: speed=${speed}`);
     } catch (e) {
+      const err = e as BusinessError;
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-        `setPlaybackSpeed(${speed}) 失败: ${(e as Error).message}`);
+        `setPlaybackSpeed(${speed}) 失败: ${err.message ?? 'unknown error'}`);
     }
   }
 

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -686,6 +686,15 @@ export class VidAllPlayerAdapter implements IPlayer {
   setSubtitleDelay(_delayMs: number): void {
   }
 
+  /**
+   * VidAllPlayerAdapter（Native NAPI）当前 bridge 接口尚未暴露 setSpeed。
+   * 降级处理：打印警告日志，不崩溃。后续 C++ 接口扩展后可在此接入。
+   */
+  setPlaybackSpeed(speed: number): void {
+    hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+      `setPlaybackSpeed(${speed}) 在 native 后端暂不支持（NAPI bridge 尚未实现），已跳过`);
+  }
+
   onReady(callback: () => void): void {
     this._onReadyCb = callback;
   }

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -584,18 +584,32 @@ interface AspectRatioOption {
   mode: AspectRatioMode;
 }
 
+interface SpeedOption {
+  label: string;
+  speed: number;
+}
+
 @CustomDialog
 export struct PlayerSettingsDialog {
   controller: CustomDialogController
   @Require videoController: VideoPlayerController
   @Require onOpenSubtitleSelector: () => void
-  @State selectedPlaybackRateIndex: number = 1
+  @State selectedPlaybackRateIndex: number = 2
   @State private currentAspectRatioMode: AspectRatioMode = AspectRatioMode.FIT
   @State private arFocusedIndex: number = -1
+  @State private speedFocusedIndex: number = -1
   private readonly aspectRatioOptions: AspectRatioOption[] = [
     { label: '适应', mode: AspectRatioMode.FIT },
     { label: '填充', mode: AspectRatioMode.FILL },
     { label: '拉伸', mode: AspectRatioMode.STRETCH },
+  ]
+  private readonly speedOptions: SpeedOption[] = [
+    { label: '0.5x', speed: 0.5 },
+    { label: '0.75x', speed: 0.75 },
+    { label: '1.0x', speed: 1.0 },
+    { label: '1.25x', speed: 1.25 },
+    { label: '1.5x', speed: 1.5 },
+    { label: '2.0x', speed: 2.0 },
   ]
   @State private aiEnhanceOn: boolean = true
   @State private aiEnhanceQuality: VpeQualityLevel = 'medium'
@@ -605,10 +619,22 @@ export struct PlayerSettingsDialog {
     this.aiEnhanceQuality = this.videoController.aiEnhanceQuality;
     this.currentAspectRatioMode = this.videoController.aspectRatioMode;
     this.arFocusedIndex = -1;
+    this.speedFocusedIndex = -1;
+    // 从控制器同步当前播放速率，找到匹配的 index（默认回退到 1.0x = index 2）
+    const currentSpeed = this.videoController.playbackSpeed;
+    let matchIdx = 2;
+    for (let i = 0; i < this.speedOptions.length; i++) {
+      if (this.speedOptions[i].speed === currentSpeed) {
+        matchIdx = i;
+        break;
+      }
+    }
+    this.selectedPlaybackRateIndex = matchIdx;
   }
 
   aboutToDisappear(): void {
     this.arFocusedIndex = -1;
+    this.speedFocusedIndex = -1;
   }
 
   @Builder
@@ -640,19 +666,38 @@ export struct PlayerSettingsDialog {
               .alignSelf(ItemAlign.Start)
 
             Row({ space: 12 }) {
-              Row() {
-                this.SettingsChip('0.75x', this.selectedPlaybackRateIndex === 0)
-              }
-              .onClick(() => {
-                this.selectedPlaybackRateIndex = 0
-              })
-
-              Row() {
-                this.SettingsChip('1.0x', this.selectedPlaybackRateIndex === 1)
-              }
-              .onClick(() => {
-                this.selectedPlaybackRateIndex = 1
-              })
+              ForEach(this.speedOptions, (opt: SpeedOption, idx: number) => {
+                Row() {
+                  Text(opt.label)
+                    .fontSize(26)
+                    .fontColor(this.selectedPlaybackRateIndex === idx ? '#F3F7FF' : '#D7DCE7')
+                    .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                    .backgroundColor(this.selectedPlaybackRateIndex === idx
+                      ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                    .borderRadius("50%")
+                    .border({
+                      width: this.selectedPlaybackRateIndex === idx ? 2 : 1,
+                      color: this.selectedPlaybackRateIndex === idx ? '#fffefe' : '#45ffffff'
+                    })
+                    .shadow({
+                      radius: this.selectedPlaybackRateIndex === idx ? 8 : 0,
+                      color: this.selectedPlaybackRateIndex === idx ? '#33597FB8' : '#00ffffff'
+                    })
+                }
+                .focusable(true)
+                .onFocus(() => { this.speedFocusedIndex = idx })
+                .onBlur(() => { this.speedFocusedIndex = -1 })
+                .borderRadius(99)
+                .padding(this.speedFocusedIndex === idx ? 2 : 0)
+                .border({
+                  width: this.speedFocusedIndex === idx ? 2 : 0,
+                  color: this.speedFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
+                })
+                .onClick(() => {
+                  this.selectedPlaybackRateIndex = idx
+                  this.videoController.setPlaybackSpeed(opt.speed)
+                })
+              }, (opt: SpeedOption) => opt.speed.toString())
             }
             .justifyContent(FlexAlign.Start)
             .width('100%')

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -203,6 +203,8 @@ export class VideoPlayerController {
   @Trace sourceProtocol: string = '';
   /** 画面比例模式，默认为适应（等比保留黑边） */
   @Trace aspectRatioMode: AspectRatioMode = AspectRatioMode.FIT;
+  /** 当前播放速率，默认 1.0（正常速度）。支持档位：0.5/0.75/1.0/1.25/1.5/2.0 */
+  @Trace playbackSpeed: number = 1.0;
   private subtitleAdapter: ISubtitleBridgeAdapter = new NoSubtitleBridgeAdapter();
   private currentVideoData?: VideoData;
   private timeToSeek = -1
@@ -757,6 +759,21 @@ export class VideoPlayerController {
     this.aspectRatioMode = mode;
     const modeNames: string[] = ['FIT', 'FILL', 'STRETCH'];
     console.info(`[VideoPlayer] aspectRatioMode → ${modeNames[mode] ?? mode}`);
+  }
+
+  /**
+   * 设置播放速率（倍速）。
+   *
+   * 支持档位：0.5 / 0.75 / 1.0 / 1.25 / 1.5 / 2.0。
+   * 通过 IPlayer 接口向当前内核分发，各后端自行实现或降级。
+   * 速率会在 onPlayerReady 后重新应用，确保后端切换后倍速设置不丢失。
+   */
+  setPlaybackSpeed(speed: number): void {
+    this.playbackSpeed = speed;
+    if (this.player) {
+      this.player.setPlaybackSpeed(speed);
+    }
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG, `setPlaybackSpeed: speed=${speed} backend=${this.backend}`);
   }
 
   /**
@@ -1615,6 +1632,12 @@ export class VideoPlayerController {
       this.pendingBackendResumePlay = false;
     }
     emitter.emit(PlayerEvents.PREPARED);
+    // 重新应用播放速率（后端切换或重新 init 后，保持用户设置的倍速）
+    if (this.playbackSpeed !== 1.0 && this.player) {
+      this.player.setPlaybackSpeed(this.playbackSpeed);
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        `onPlayerReady: 重新应用播放速率 speed=${this.playbackSpeed}`);
+    }
     await this.loadSubtitleTracks();
     await this.loadAudioTracks();
     if (resumeTimeMs > 0 && this.player) {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -59,6 +59,8 @@ const FFMPEG_PREVIEW_STALL_STEP_MAX_MS = 1200;
 const FFMPEG_PREVIEW_DECODE_RETRY_DELAY_MS = 400;
 const FFMPEG_PREVIEW_EXTRACT_STUCK_MS = 1500;
 const FFMPEG_PREVIEW_EXTRACT_HARD_TIMEOUT_MS = 6500;
+/** 支持的播放速率白名单；控制器层对外输入做归一化，避免后端静默降级导致 UI 显示不一致 */
+const SUPPORTED_SPEEDS: number[] = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
 const FFMPEG_PREVIEW_SINGLE_FRAME_INTERVAL_MS = 180;
 const FFMPEG_PREVIEW_FORCE_RESTART_INTERVAL_MS = 2200;
 const FFMPEG_PREVIEW_FORCE_RESTART_LAG_MS = 1800;
@@ -769,11 +771,17 @@ export class VideoPlayerController {
    * 速率会在 onPlayerReady 后重新应用，确保后端切换后倍速设置不丢失。
    */
   setPlaybackSpeed(speed: number): void {
-    this.playbackSpeed = speed;
-    if (this.player) {
-      this.player.setPlaybackSpeed(speed);
+    // 白名单归一化：不在支持档位的值回退到 1.0x，避免后端静默降级与 UI 显示不一致
+    const normalizedSpeed = SUPPORTED_SPEEDS.includes(speed) ? speed : 1.0;
+    if (normalizedSpeed !== speed) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `setPlaybackSpeed: speed=${speed} 不在支持列表，归一化为 1.0`);
     }
-    hilog.info(CommonConstants.LOG_DOMAIN, TAG, `setPlaybackSpeed: speed=${speed} backend=${this.backend}`);
+    this.playbackSpeed = normalizedSpeed;
+    if (this.player) {
+      this.player.setPlaybackSpeed(normalizedSpeed);
+    }
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG, `setPlaybackSpeed: speed=${normalizedSpeed} backend=${this.backend}`);
   }
 
   /**


### PR DESCRIPTION
closes #90

## 实现内容

新增倍速播放功能，支持 0.5×、0.75×、1×、1.25×、1.5×、2× 六档切换。

### 三路实现

| 后端 | 实现方式 |
|------|---------|
| AVPlayer | `avPlayer.setSpeed(media.PlaybackSpeed)` — 枚举映射覆盖全部 6 档 |
| IJKPlayer | `ijk.setSpeed(speed.toString())` — 内部 SoundTouch 变速不变调 |
| Native/FFmpeg | 优雅降级，warn 日志，不崩溃（NAPI bridge 暂未暴露 setSpeed） |

### 核心变更

- `IPlayer`: 新增 `setPlaybackSpeed(speed: number): void` 接口方法
- `VideoPlayerController`: `@Trace playbackSpeed`属性 + `setPlaybackSpeed()` 方法，`onPlayerReady` 后自动重新应用（后端切换不丢失设置）
- `PlayerSettingsDialog`: 倍速选择从 2 档扩展为 6 档 ForEach，TV 遥控焦点环完整实现，`aboutToAppear` 同步控制器当前速率

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playback speed control with six options: 0.5x, 0.75x, 1.0x, 1.25x, 1.5x, 2.0x
  * Dynamic speed selection UI with focus/navigation and direct apply on selection
  * Speed preference persists across playback sessions and player restarts

* **Bug Fixes / Behavior**
  * Graceful fallback for players that don’t support runtime speed changes (no crashes; logs warning)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->