### PR TITLE
修复: 剧集详情页同一集多版本文件重复显示问题

### DIFF
--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -2033,13 +2033,22 @@ export class FileSourceDatabase {
       // - episode_id IS NULL 的行（未刮削集）均保留，不纳入去重
       const SCRAPE = FileSourceDatabase.TABLE_SCRAPE_INFO;
       const VIDEOS = FileSourceDatabase.TABLE_VIDEOS;
+      // 两步 CTE：先按 episode_id 找最大 file_size，再在相同 file_size 内取最大 video_id。
+      // 避免将两字段打包成单一 rank_key（超出 SQLite 64 位整数安全范围时会转浮点，精度丢失）。
       const sql =
-        `WITH best_vid AS (` +
+        `WITH best_size AS (` +
         `  SELECT si.episode_id,` +
-        `         MAX(COALESCE(vi.file_size, 0) * 100000000 + si.video_id) AS rank_key,` +
-        `         MAX(si.video_id) AS max_vid_fallback` +
+        `         MAX(COALESCE(vi.file_size, 0)) AS max_file_size` +
         `  FROM ${SCRAPE} si` +
         `  JOIN ${VIDEOS} vi ON si.video_id = vi.id` +
+        `  WHERE si.tv_series_id = ? AND si.episode_id IS NOT NULL` +
+        `  GROUP BY si.episode_id` +
+        `), best_vid AS (` +
+        `  SELECT si.episode_id, MAX(si.video_id) AS best_video_id` +
+        `  FROM ${SCRAPE} si` +
+        `  JOIN ${VIDEOS} vi ON si.video_id = vi.id` +
+        `  JOIN best_size bs ON bs.episode_id = si.episode_id` +
+        `                    AND COALESCE(vi.file_size, 0) = bs.max_file_size` +
         `  WHERE si.tv_series_id = ? AND si.episode_id IS NOT NULL` +
         `  GROUP BY si.episode_id` +
         `)` +
@@ -2050,11 +2059,11 @@ export class FileSourceDatabase {
         `     OR EXISTS (` +
         `       SELECT 1 FROM best_vid bv` +
         `       WHERE bv.episode_id = s.episode_id` +
-        `         AND (COALESCE(v.file_size, 0) * 100000000 + s.video_id) = bv.rank_key` +
+        `         AND s.video_id = bv.best_video_id` +
         `     )` +
         `   )` +
         ` ORDER BY COALESCE(s.season_number, 0) ASC, COALESCE(s.episode_number, 0) ASC`;
-      rs = await this.rdbStore.querySql(sql, [seriesId, seriesId]);
+      rs = await this.rdbStore.querySql(sql, [seriesId, seriesId, seriesId]);
       const items: MediaItem[] = [];
       while (rs.goToNextRow()) { items.push(this.parseMediaItem(rs)); }
       return items;

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -2017,10 +2017,21 @@ export class FileSourceDatabase {
     if (this.rdbStore === null) { return []; }
     let rs: relationalStore.ResultSet | null = null;
     try {
+      // 同一 episode_id 可能对应多个版本文件（如 4K 和 HDR），只保留 file_size 最大的那个
+      // NOT EXISTS 子查询：若存在同 episode_id 且 file_size 更大（或同大但 video_id 更高）的行，则排除当前行
       const sql = this.mediaItemSql +
-        ' WHERE s.tv_series_id = ?' +
-        ' ORDER BY COALESCE(s.season_number, 0) ASC, COALESCE(s.episode_number, 0) ASC';
-      rs = await this.rdbStore.querySql(sql, [seriesId]);
+        ` WHERE s.tv_series_id = ?` +
+        ` AND NOT EXISTS (` +
+        `   SELECT 1 FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} si2` +
+        `   JOIN ${FileSourceDatabase.TABLE_VIDEOS} vi2 ON si2.video_id = vi2.id` +
+        `   WHERE si2.tv_series_id = ?` +
+        `     AND si2.episode_id IS NOT NULL` +
+        `     AND si2.episode_id = s.episode_id` +
+        `     AND (vi2.file_size > v.file_size` +
+        `          OR (vi2.file_size = v.file_size AND si2.video_id > s.video_id))` +
+        ` )` +
+        ` ORDER BY COALESCE(s.season_number, 0) ASC, COALESCE(s.episode_number, 0) ASC`;
+      rs = await this.rdbStore.querySql(sql, [seriesId, seriesId]);
       const items: MediaItem[] = [];
       while (rs.goToNextRow()) { items.push(this.parseMediaItem(rs)); }
       return items;

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -1574,6 +1574,15 @@ export class FileSourceDatabase {
     }
     // 同时确保新表（movies/tv_series/tv_seasons/tv_episodes）存在
     await this.createMediaTablesV3(rdbStore);
+    // 确保 (tv_series_id, episode_id) 索引存在，供多版本去重查询使用
+    try {
+      await rdbStore.executeSql(
+        `CREATE INDEX IF NOT EXISTS idx_scrape_info_tvs_ep` +
+        ` ON ${FileSourceDatabase.TABLE_SCRAPE_INFO}(tv_series_id, episode_id)`
+      );
+    } catch {
+      // 索引已存在时忽略
+    }
   }
 
   /**
@@ -2018,18 +2027,32 @@ export class FileSourceDatabase {
     let rs: relationalStore.ResultSet | null = null;
     try {
       // 同一 episode_id 可能对应多个版本文件（如 4K 和 HDR），只保留 file_size 最大的那个
-      // NOT EXISTS 子查询：若存在同 episode_id 且 file_size 更大（或同大但 video_id 更高）的行，则排除当前行
-      const sql = this.mediaItemSql +
+      // 用 CTE 先聚合出每个 episode_id 应保留的 video_id（NULL 安全，避免 NOT EXISTS 的 N×N 扫描）：
+      // - COALESCE(file_size, 0) 处理 file_size 为 NULL 的情况
+      // - 同大时以 video_id 较大者（较新扫描）为准
+      // - episode_id IS NULL 的行（未刮削集）均保留，不纳入去重
+      const SCRAPE = FileSourceDatabase.TABLE_SCRAPE_INFO;
+      const VIDEOS = FileSourceDatabase.TABLE_VIDEOS;
+      const sql =
+        `WITH best_vid AS (` +
+        `  SELECT si.episode_id,` +
+        `         MAX(COALESCE(vi.file_size, 0) * 100000000 + si.video_id) AS rank_key,` +
+        `         MAX(si.video_id) AS max_vid_fallback` +
+        `  FROM ${SCRAPE} si` +
+        `  JOIN ${VIDEOS} vi ON si.video_id = vi.id` +
+        `  WHERE si.tv_series_id = ? AND si.episode_id IS NOT NULL` +
+        `  GROUP BY si.episode_id` +
+        `)` +
+        this.mediaItemSql +
         ` WHERE s.tv_series_id = ?` +
-        ` AND NOT EXISTS (` +
-        `   SELECT 1 FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} si2` +
-        `   JOIN ${FileSourceDatabase.TABLE_VIDEOS} vi2 ON si2.video_id = vi2.id` +
-        `   WHERE si2.tv_series_id = ?` +
-        `     AND si2.episode_id IS NOT NULL` +
-        `     AND si2.episode_id = s.episode_id` +
-        `     AND (vi2.file_size > v.file_size` +
-        `          OR (vi2.file_size = v.file_size AND si2.video_id > s.video_id))` +
-        ` )` +
+        `   AND (` +
+        `     s.episode_id IS NULL` +
+        `     OR EXISTS (` +
+        `       SELECT 1 FROM best_vid bv` +
+        `       WHERE bv.episode_id = s.episode_id` +
+        `         AND (COALESCE(v.file_size, 0) * 100000000 + s.video_id) = bv.rank_key` +
+        `     )` +
+        `   )` +
         ` ORDER BY COALESCE(s.season_number, 0) ASC, COALESCE(s.episode_number, 0) ASC`;
       rs = await this.rdbStore.querySql(sql, [seriesId, seriesId]);
       const items: MediaItem[] = [];


### PR DESCRIPTION
## 问题

月鳞绮纪等剧集中，E07/E09/E13/E14 集各有两个画质版本文件（如 `S01E07 4K60FPS.mp4` 和 `S01E07 4KHQHDR60FPS.mp4`），两个文件被分别刮削后均指向同一 TMDB episode，导致集列表重复显示同一集。

## 根本原因

`getMediaItemsByTvSeriesId` 直接 JOIN `scrape_info` 无去重，一个 `episode_id` 对应多条视频记录时全部返回。

## 修复方案

在查询中加入 NOT EXISTS 子查询，对同一 `episode_id` 只保留 `file_size` 最大（最优画质）的版本：

- 如果存在同 episode_id 且 file_size 更大的另一个文件，当前行被排除
- 同大时以 video_id 较大者（较新扫描）为准
- episode_id 为 NULL 的行不受影响（仍全部保留）

## 影响范围

- `SeriesDetailPage` 集列表
- `SeasonDetailPage` 集列表
- 仅影响读取展示，不修改已有刮削数据


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed episode-level deduplication so only the highest-quality video is shown per TV episode, preserving ordering by season and episode.

* **Chores**
  * Added a database index to improve performance of TV series lookups, with safeguards to avoid index-creation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->