### PR TITLE
新增: 文件不存在时弹窗提示并删除集元数据

### DIFF
--- a/entry/src/main/ets/components/core/player/Constants.ets
+++ b/entry/src/main/ets/components/core/player/Constants.ets
@@ -103,4 +103,9 @@ export class PlayerEvents {
     eventId: 15,
     priority: emitter.EventPriority.HIGH
   };
+  /** 文件无法访问（prepare 前 IO Resource Not Found），携带 videoId */
+  static readonly FILE_INACCESSIBLE: emitter.InnerEvent = {
+    eventId: 16,
+    priority: emitter.EventPriority.HIGH
+  };
 }

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -233,6 +233,8 @@ export class VideoPlayerController {
   private lastTimeUpdateMs: number = -1;
   /** duration 未就绪时 seek 的诊断日志节流 */
   private lastSeekDurationUnknownLogMs: number = 0;
+  /** prepare 成功标志：首次 onPlayerReady 后置 true，每次 initPlayer 重置 */
+  private hasPrepared: boolean = false;
   /** native seek 诊断开关（默认关闭） */
   private nativeSeekDiagLogEnabled: boolean = DEFAULT_NATIVE_SEEK_DIAG_LOG_ENABLED;
   /** native 初始化就绪保护定时器：超时后自动回退到 ijkplayer */
@@ -296,6 +298,7 @@ export class VideoPlayerController {
     this.playbackSessionId += 1;
     const currentSessionId = this.playbackSessionId;
     this.metricsLoadStartMs = Date.now();
+    this.hasPrepared = false;
     this.name = videoData.name || ''
     this.currentVideoData = videoData;
     this.surfaceId = surfaceId;
@@ -608,6 +611,13 @@ export class VideoPlayerController {
       if (this.backend === 'native') {
         this.fallbackNativeToIjk('native_error_callback', 'native 错误回调触发，已自动回退到 IJK 播放', error.message);
         return;
+      }
+      // prepare 前的 IO 文件不存在错误：通知上层页面提示用户删除元数据
+      if (!this.hasPrepared && error.message.toLowerCase().includes('io resource not found')) {
+        const videoId = this.progressContext?.videoId ?? -1;
+        if (videoId > 0) {
+          emitter.emit(PlayerEvents.FILE_INACCESSIBLE, { data: { videoId: videoId } });
+        }
       }
       this.isLoading = false;
       this.lastErrorMessage = this.normalizePlayerError(error.message);
@@ -1620,6 +1630,7 @@ export class VideoPlayerController {
   /** prepared 后回调：读取 duration、加载字幕轨道和音轨 */
   private async onPlayerReady(): Promise<void> {
     this.clearNativeReadyGuardTimer();
+    this.hasPrepared = true;
     const playerDuration = this.player?.duration ?? 0;
     this.duration = playerDuration > 0
       ? playerDuration

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -1647,6 +1647,26 @@ export class FileSourceDatabase {
     }
   }
 
+  /**
+   * 删除单个视频的全部本地记录（scrape_info + play_progress + videos）。
+   * 用于"文件已删除/移动"场景，用户确认后清理孤立元数据。
+   */
+  async deleteVideoWithScrapeInfo(videoId: number): Promise<void> {
+    if (!this.rdbStore) { return; }
+    try {
+      const id: relationalStore.ValueType = videoId;
+      await this.rdbStore.executeSql(
+        `DELETE FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} WHERE video_id = ?`, [id]);
+      await this.rdbStore.executeSql(
+        `DELETE FROM ${FileSourceDatabase.TABLE_PLAY_PROGRESS} WHERE video_id = ?`, [id]);
+      await this.rdbStore.executeSql(
+        `DELETE FROM ${FileSourceDatabase.TABLE_VIDEOS} WHERE id = ?`, [id]);
+      console.info(`[DB][deleteVideoWithScrapeInfo] videoId=${videoId} 已删除`);
+    } catch (e) {
+      console.warn('[DB][deleteVideoWithScrapeInfo] 失败: ' + JSON.stringify(e));
+    }
+  }
+
   async getScrapeInfoByVideoId(videoId: number): Promise<ScrapeInfoEntity | null> {
     if (this.rdbStore === null) { return null; }
     let rs: relationalStore.ResultSet | null = null;

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -1001,10 +1001,65 @@ export struct SeasonDetailPage {
         mediaKey: mKey,
         startPositionMs: startPositionMs > 0 ? startPositionMs : undefined
       };
-      this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
+      this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param, (popInfo: PopInfo) => {
+        if (popInfo.result !== null && popInfo.result !== undefined) {
+          const r = popInfo.result as Record<string, Object>;
+          if (r['fileNotFound'] === true) {
+            const vid = r['videoId'] as number;
+            if (vid > 0) { this.confirmDeleteEpisodeRecord(vid); }
+          }
+        }
+      });
     } catch (e) {
       console.error('[SeasonDetailPage] playEpisode failed', JSON.stringify(e));
     }
+  }
+
+  /** 弹窗询问用户是否删除文件不存在的集记录 */
+  private confirmDeleteEpisodeRecord(videoId: number): void {
+    AlertDialog.show({
+      title: '文件无法播放',
+      message: '视频文件可能已被删除或移动，无法打开。是否删除该集的本地记录和元数据？',
+      autoCancel: true,
+      primaryButton: {
+        value: '删除记录',
+        fontColor: '#FF5252',
+        action: () => {
+          FileSourceDatabase.getInstance().deleteVideoWithScrapeInfo(videoId)
+            .then(() => { this.reloadSeasonEpisodes(); })
+            .catch(() => {});
+        }
+      },
+      secondaryButton: {
+        value: '取消',
+        action: () => {}
+      }
+    });
+  }
+
+  /** 删除后重新从 DB 加载本季集列表 */
+  private reloadSeasonEpisodes(): void {
+    const seriesId = this.seriesEntity?.id;
+    if (seriesId === undefined) { return; }
+    const seasonNumber = this.getSeasonNumber();
+    const db = FileSourceDatabase.getInstance();
+    db.getMediaItemsByTvSeriesId(seriesId).then((allEpisodes) => {
+      const seasonItems: MediaItem[] = allEpisodes.filter((m: MediaItem) => (m.seasonNumber ?? -1) === seasonNumber);
+      db.getEpisodesBySeriesAndSeason(seriesId, seasonNumber).then((episodeEntities) => {
+        const epMap = new Map<number, TvEpisodeEntity>();
+        for (const e of episodeEntities) {
+          epMap.set(e.episodeNumber, e);
+        }
+        const items: SeasonEpisodeItem[] = seasonItems.map((m: MediaItem) => {
+          const item: SeasonEpisodeItem = {
+            mediaItem: m,
+            episodeEntity: epMap.get(m.episodeNumber ?? -1)
+          };
+          return item;
+        });
+        this.seasonEpisodes = items;
+      }).catch(() => {});
+    }).catch(() => {});
   }
 
   // ── Builders ──────────────────────────────────

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -790,10 +790,65 @@ export struct SeriesDetailPage {
         presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined,
         mediaKey: mediaKey
       };
-      this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
+      this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param, (popInfo: PopInfo) => {
+        if (popInfo.result !== null && popInfo.result !== undefined) {
+          const r = popInfo.result as Record<string, Object>;
+          if (r['fileNotFound'] === true) {
+            const vid = r['videoId'] as number;
+            if (vid > 0) { this.confirmDeleteEpisodeRecord(vid); }
+          }
+        }
+      });
     } catch (e) {
       console.error('[SeriesDetailPage] playEpisode failed', JSON.stringify(e));
     }
+  }
+
+  /** 弹窗询问用户是否删除文件不存在的集记录 */
+  private confirmDeleteEpisodeRecord(videoId: number): void {
+    AlertDialog.show({
+      title: '文件无法播放',
+      message: '视频文件可能已被删除或移动，无法打开。是否删除该集的本地记录和元数据？',
+      autoCancel: true,
+      primaryButton: {
+        value: '删除记录',
+        fontColor: '#FF5252',
+        action: () => {
+          FileSourceDatabase.getInstance().deleteVideoWithScrapeInfo(videoId)
+            .then(() => { this.reloadEpisodes(); })
+            .catch(() => {});
+        }
+      },
+      secondaryButton: {
+        value: '取消',
+        action: () => {}
+      }
+    });
+  }
+
+  /** 删除后重新从 DB 加载集列表（不重新刮削，仅刷新本地数据） */
+  private reloadEpisodes(): void {
+    const seriesId = this.seriesEntity?.id;
+    if (seriesId === undefined) { return; }
+    FileSourceDatabase.getInstance().getMediaItemsByTvSeriesId(seriesId).then((allEpisodes) => {
+      if (this.group !== undefined) {
+        const updated: SeriesGroup = {
+          title: this.group.title,
+          tvSeriesId: this.group.tvSeriesId,
+          seasonLabel: this.group.seasonLabel,
+          posterUrl: this.group.posterUrl,
+          posterLocalPath: this.group.posterLocalPath,
+          backdropUrl: this.group.backdropUrl,
+          seasonNumber: this.group.seasonNumber,
+          seasonPosterUrl: this.group.seasonPosterUrl,
+          rating: this.group.rating,
+          episodeCount: allEpisodes.length,
+          episodes: allEpisodes,
+          latestScannedAt: this.group.latestScannedAt
+        };
+        this.group = updated;
+      }
+    }).catch(() => {});
   }
 
   /** 进度百分比（0~1） */

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -70,6 +70,8 @@ export struct PlayerPage {
   private currentMediaEpisode: number = 0;
   /** media_progress 周期写入定时器 ID，-1 表示未启动 */
   private mediaProgressTimerId: number = -1;
+  /** 文件不存在时待 pop 的 videoId（-1 表示无） */
+  private fileNotFoundVideoId: number = -1;
 
   /** 合并字幕行中各 Segment 的文本 */
   private mergeSubtitleLineText(line: SubtitleSegment[]): string {
@@ -265,6 +267,16 @@ export struct PlayerPage {
           }
         }
       });
+      // 订阅文件不存在事件：记录 videoId 并自动退出播放页
+      emitter.on(PlayerEvents.FILE_INACCESSIBLE, (event: emitter.EventData) => {
+        const data = event.data as Record<string, number>;
+        this.fileNotFoundVideoId = data?.['videoId'] ?? -1;
+        const popResult: Record<string, Object> = {
+          'fileNotFound': true as Object,
+          'videoId': (this.fileNotFoundVideoId as Object)
+        };
+        this.pageStack.pop(popResult);
+      });
 
       // 每 10 秒写入一次 media_progress，避免退出时异步写与 onShown 读产生竞态
       this.mediaProgressTimerId = setInterval(() => {
@@ -398,6 +410,7 @@ export struct PlayerPage {
 
   aboutToDisappear(): void {
     emitter.off(PlayerEvents.APP_BACKGROUND.eventId)
+    emitter.off(PlayerEvents.FILE_INACCESSIBLE.eventId)
     if (this.mediaProgressTimerId >= 0) {
       clearInterval(this.mediaProgressTimerId);
       this.mediaProgressTimerId = -1;


### PR DESCRIPTION
## 功能说明

播放时若文件已被删除或移动，AVPlayer 会报 `IO Resource Not Found` 错误。本 PR 实现：在这种情况下自动退出播放页并弹窗询问用户是否删除该集的本地记录。

## 改动点

- **Constants.ets**：新增 `FILE_INACCESSIBLE` 事件（eventId: 16）
- **VideoPlayerController.ets**：新增 `hasPrepared` 标志，prepare 成功后置 true；若 prepare 前 IO 错误则发射 `FILE_INACCESSIBLE` 事件（携带 videoId）
- **PlayerPage/index.ets**：订阅 `FILE_INACCESSIBLE`，自动调用 `pageStack.pop(result)` 将 `{ fileNotFound: true, videoId }` 返回给上层
- **FileSourceDatabase.ets**：新增 `deleteVideoWithScrapeInfo(videoId)`，删除 scrape_info + play_progress + videos 三表记录
- **SeriesDetailPage.ets / SeasonDetailPage.ets**：`pushPathByName` 改为带 onPop 回调，收到 fileNotFound 后弹 AlertDialog，确认后删除记录并刷新集列表

## 触发条件

仅在 AVPlayer 后端（非 native/IJK）首次 prepare 前发生 `IO resource not found` 错误时触发，其他错误类型不受影响。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Player now automatically detects when video files become inaccessible and closes gracefully
  * Added confirmation dialog to delete episode records for missing files with one click
  * Episode lists automatically refresh after removing unavailable file records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->