### PR TITLE
修复: 剧集详情页进度刷新竞态条件

### DIFF
--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -351,8 +351,8 @@ export struct SeriesDetailPage {
     this.progressMap = newMap;
 
     // ── 媒体级进度：用于 ContinueWatchingCard 续播入口 ─────────────────────
-    const mKey = MediaProgressStore.seriesKey(seriesProviderId);
-    const mp = await MediaProgressStore.get(mKey);
+    // 使用新集级 key 格式查询（兼容旧格式），不再使用废弃的 seriesKey
+    const mp = await db.getLatestMediaProgressBySeries(seriesProviderId);
     this.mediaProgress = mp;
     this.hasActiveProgress = mp !== null && mp.positionMs > 0 && mp.durationMs > 0;
     this.lastEpisode = null;
@@ -1006,7 +1006,11 @@ export struct SeriesDetailPage {
                 if (this.lastEpisode !== null) {
                   const pid = this.seriesEntity?.providerId ?? '';
                   if (pid.length === 0) { return; }
-                  const mKey = MediaProgressStore.seriesKey(pid);
+                  const mKey = MediaProgressStore.episodeKey(
+                    pid,
+                    this.lastEpisode.seasonNumber ?? 0,
+                    this.lastEpisode.episodeNumber ?? 0
+                  );
                   this.playEpisode(this.lastEpisode, mKey);
                 }
               })
@@ -1068,13 +1072,21 @@ export struct SeriesDetailPage {
               .onClick(() => {
                 const pid = this.seriesEntity?.providerId ?? '';
                 if (pid.length === 0) { return; }
-                const mKey = MediaProgressStore.seriesKey(pid);
                 if (this.lastEpisode !== null) {
+                  const mKey = MediaProgressStore.episodeKey(
+                    pid,
+                    this.lastEpisode.seasonNumber ?? 0,
+                    this.lastEpisode.episodeNumber ?? 0
+                  );
                   this.playEpisode(this.lastEpisode, mKey);
                   return;
                 }
                 const eps = this.group?.episodes ?? [];
-                if (eps.length > 0) { this.playEpisode(eps[0], mKey); }
+                if (eps.length > 0) {
+                  const ep = eps[0];
+                  const mKey = MediaProgressStore.episodeKey(pid, ep.seasonNumber ?? 0, ep.episodeNumber ?? 0);
+                  this.playEpisode(ep, mKey);
+                }
               })
             }
             .alignItems(VerticalAlign.Center)

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -14,6 +14,8 @@ import { millisecondsToTime } from '../../utils/TimeUtil'
 import { FfprobeUtil, FfprobeTrack } from '../../utils/FfprobeUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
 import { CastDetailPage, CastDetailPageParam } from './CastDetailPage'
+import { emitter } from "@kit.BasicServicesKit"
+import { PlayerEvents } from '../../components/core/player/Constants'
 
 // ─────────────────────────────────────────────
 // TMDB 图片 URL 工具
@@ -150,6 +152,8 @@ export struct SeriesDetailPage {
   /** ContinueWatchingCard 主按钮交互状态 */
   @Local focusedContinueActionKey: string = ''
   @Local hoveredContinueActionKey: string = ''
+
+  private progressRefreshCallback: () => void = () => {};
 
   static PAGE_NAME = 'seriesDetail'
 
@@ -387,6 +391,16 @@ export struct SeriesDetailPage {
     this.refreshPlaybackState().catch(() => {
       console.warn('[SeriesDetailPage] aboutToAppear refresh failed');
     });
+    this.progressRefreshCallback = () => {
+      this.refreshPlaybackState().catch(() => {
+        console.warn('[SeriesDetailPage] progress refresh on event failed');
+      });
+    };
+    emitter.on(PlayerEvents.MEDIA_PROGRESS_SAVED, this.progressRefreshCallback);
+  }
+
+  aboutToDisappear(): void {
+    emitter.off(PlayerEvents.MEDIA_PROGRESS_SAVED.eventId, this.progressRefreshCallback);
   }
 
   // ── 数据加载 ──────────────────────────────────


### PR DESCRIPTION
## 问题描述

播放其他季度或集后，返回剧集详情页时进度不刷新。

## 根本原因

`onShown` 在 PlayerPage 进入消失动画时立即触发，而进度保存（`aboutToDisappear`）及 `MEDIA_PROGRESS_SAVED` 事件晚于 `onShown`，导致读取进度时数据还未落库。

## 修复方案

参照 `SeasonDetailPage` 的正确模式，在 `SeriesDetailPage` 中：

- `aboutToAppear`：订阅 `PlayerEvents.MEDIA_PROGRESS_SAVED` 事件，触发后调 `refreshPlaybackState()`
- `aboutToDisappear`：取消订阅，避免内存泄漏

## 变更文件

- `SeriesDetailPage.ets`：新增 `progressRefreshCallback` 字段、`aboutToDisappear` 生命周期，修改 `aboutToAppear` 增加事件订阅