### PR TITLE
新增: 剧集播放列表功能（PlaybackContext + EpisodeListPanel，Issue #119）

### DIFF
--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -2,17 +2,20 @@ import { PlaybackContextItem, MediaLibraryContext } from './PlaybackContext'
 import { KeyCode } from '@kit.InputKit'
 
 const FIRST_PAGE_SIZE: number = 6
-const EPISODE_CARD_WIDTH: number = 184
-const EPISODE_CARD_HEIGHT: number = 68
-const EPISODE_CARD_RADIUS: number = 22
-const EPISODE_CARD_THUMBNAIL_WIDTH: number = 64
-const EPISODE_CARD_THUMBNAIL_HEIGHT: number = 40
-const EPISODE_CARD_THUMBNAIL_RADIUS: number = 12
+const EPISODE_SECTION_TITLE_FONT_SIZE: number = 32
+const EPISODE_SECTION_TITLE_LEFT_MARGIN: number = 0
+const EPISODE_SECTION_TITLE_BOTTOM_MARGIN: number = 12
+const EPISODE_CARD_WIDTH: number = 200
+const EPISODE_CARD_HEIGHT: number = 130
+const EPISODE_CARD_RADIUS: number = 20
+const EPISODE_CARD_THUMBNAIL_WIDTH: number = 184
+const EPISODE_CARD_THUMBNAIL_HEIGHT: number = 84
+const EPISODE_CARD_THUMBNAIL_RADIUS: number = 16
 const EPISODE_CARD_CONTENT_GAP: number = 10
 const EPISODE_CARD_HORIZONTAL_PADDING: number = 8
-const EPISODE_CARD_RIGHT_PADDING: number = 12
-const EPISODE_CARD_VERTICAL_PADDING: number = 10
-const EPISODE_CARD_LABEL_FONT_SIZE: number = 18
+const EPISODE_CARD_RIGHT_PADDING: number = 8
+const EPISODE_CARD_VERTICAL_PADDING: number = 8
+const EPISODE_CARD_LABEL_FONT_SIZE: number = 20
 const EPISODE_CARD_SCALE_FOCUSED: number = 1.04
 const EPISODE_TAB_SCALE_FOCUSED: number = 1.04
 const EPISODE_PAGE_TAB_HORIZONTAL_PADDING: number = 16
@@ -38,6 +41,7 @@ export interface EpisodeCardStyleState {
   isFocused: boolean
   isHovered: boolean
   isCurrent: boolean
+  useVerticalLayout: boolean
   showFocusOutline: boolean
   showCurrentOutline: boolean
   showLegacyFocusRing: boolean
@@ -65,6 +69,12 @@ export interface EpisodeCardStyleState {
   rightPadding: number
   verticalPadding: number
   labelFontSize: number
+}
+
+export interface EpisodeSectionTitleStyleState {
+  fontSize: number
+  leftMargin: number
+  bottomMargin: number
 }
 
 export interface EpisodePageTabStyleState {
@@ -160,6 +170,7 @@ export function getEpisodeCardStyleState(isFocused: boolean, isCurrent: boolean,
     isFocused,
     isHovered,
     isCurrent,
+    useVerticalLayout: true,
     showFocusOutline: false,
     showCurrentOutline: false,
     showLegacyFocusRing: false,
@@ -187,6 +198,15 @@ export function getEpisodeCardStyleState(isFocused: boolean, isCurrent: boolean,
     rightPadding: EPISODE_CARD_RIGHT_PADDING,
     verticalPadding: EPISODE_CARD_VERTICAL_PADDING,
     labelFontSize: EPISODE_CARD_LABEL_FONT_SIZE
+  }
+  return styleState
+}
+
+export function getEpisodeSectionTitleStyleState(): EpisodeSectionTitleStyleState {
+  const styleState: EpisodeSectionTitleStyleState = {
+    fontSize: EPISODE_SECTION_TITLE_FONT_SIZE,
+    leftMargin: EPISODE_SECTION_TITLE_LEFT_MARGIN,
+    bottomMargin: EPISODE_SECTION_TITLE_BOTTOM_MARGIN
   }
   return styleState
 }
@@ -348,12 +368,22 @@ export struct EpisodeListPanel {
 
   @Builder
   EpisodeCard(item: PlaybackContextItem, index: number) {
-    Row({ space: this.getCardStyleState(item, index).contentGap }) {
-      Stack({ alignContent: Alignment.Center }) {
+    Column({ space: this.getCardStyleState(item, index).contentGap }) {
+      Stack({ alignContent: Alignment.BottomEnd }) {
         Image(item.thumbnailUrl ? item.thumbnailUrl : $r('app.media.empty_folder'))
-          .width(this.getCardStyleState(item, index).thumbnailWidth)
-          .height(this.getCardStyleState(item, index).thumbnailHeight)
+          .width('100%')
+          .height('100%')
           .objectFit(ImageFit.Cover)
+
+        if (this.getCardStyleState(item, index).showWaveIcon) {
+          Row() {
+            this.PlayingWaveIcon()
+          }
+          .padding({ left: 8, right: 8, top: 6, bottom: 6 })
+          .backgroundColor('rgba(6, 14, 24, 0.58)')
+          .borderRadius(12)
+          .margin({ right: 8, bottom: 8 })
+        }
       }
       .width(this.getCardStyleState(item, index).thumbnailWidth)
       .height(this.getCardStyleState(item, index).thumbnailHeight)
@@ -366,21 +396,14 @@ export struct EpisodeListPanel {
         offsetY: 2
       })
 
-      Row({ space: 6 }) {
-        Text('第' + (item.episodeNumber ?? (item.index + 1)).toString() + '集')
-          .fontSize(this.getCardStyleState(item, index).labelFontSize)
-          .fontWeight(this.isCurrentItem(item) ? FontWeight.Medium : FontWeight.Regular)
-          .fontColor(this.getCardStyleState(item, index).labelColor)
-          .maxLines(1)
-          .textOverflow({ overflow: TextOverflow.Ellipsis })
-
-        if (this.getCardStyleState(item, index).showWaveIcon) {
-          this.PlayingWaveIcon()
-        }
-      }
-      .layoutWeight(1)
-      .justifyContent(FlexAlign.Start)
-      .alignItems(VerticalAlign.Center)
+      Text('第' + (item.episodeNumber ?? (item.index + 1)).toString() + '集')
+        .fontSize(this.getCardStyleState(item, index).labelFontSize)
+        .fontWeight(this.isCurrentItem(item) ? FontWeight.Medium : FontWeight.Regular)
+        .fontColor(this.getCardStyleState(item, index).labelColor)
+        .textAlign(TextAlign.Center)
+        .width(this.getCardStyleState(item, index).thumbnailWidth)
+        .maxLines(1)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
     }
     .width(this.getCardStyleState(item, index).layoutWidth)
     .height(this.getCardStyleState(item, index).layoutHeight)
@@ -410,7 +433,7 @@ export struct EpisodeListPanel {
     .onClick(() => {
       this.onSelect(item)
     })
-    .alignItems(VerticalAlign.Center)
+    .alignItems(HorizontalAlign.Center)
   }
 
   // ── build ─────────────────────────────────────────────────────────────────
@@ -419,10 +442,13 @@ export struct EpisodeListPanel {
     Column({ space: 0 }) {
       // 标题行
       Text('选集')
-        .fontSize(56)
-        .fontWeight(FontWeight.Bold)
-        .fontColor('#F3F6FB')
-        .margin({ bottom: 32 })
+        .fontSize(getEpisodeSectionTitleStyleState().fontSize)
+        .fontWeight(FontWeight.Medium)
+        .fontColor('#EFF2FB')
+        .margin({
+          left: getEpisodeSectionTitleStyleState().leftMargin,
+          bottom: getEpisodeSectionTitleStyleState().bottomMargin
+        })
         .alignSelf(ItemAlign.Start)
 
       // 集数卡片横向列表
@@ -440,7 +466,7 @@ export struct EpisodeListPanel {
       .listDirection(Axis.Horizontal)
       .scrollBar(BarState.Off)
       .width('100%')
-      .height(92)
+      .height(154)
       .onKeyEvent((event: KeyEvent) => {
         if (event.type !== KeyType.Down) {
           return

--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -2,6 +2,10 @@ import { PlaybackContextItem, MediaLibraryContext } from './PlaybackContext'
 import { KeyCode } from '@kit.InputKit'
 
 const FIRST_PAGE_SIZE: number = 6
+const EPISODE_CARD_WIDTH: number = 220
+const EPISODE_CARD_HEIGHT: number = 140
+const EPISODE_CARD_RADIUS: number = 26
+const EPISODE_CARD_INNER_OUTLINE_INSET: number = 10
 
 export interface EpisodePageRange {
   pageIndex: number
@@ -23,6 +27,10 @@ export interface EpisodeCardStyleState {
   focusOutlineColor: string
   currentOutlineWidth: number
   currentOutlineColor: string
+  layoutWidth: number
+  layoutHeight: number
+  borderRadius: number
+  currentInnerOutlineInset: number
 }
 
 export interface EpisodePageTabStyleState {
@@ -114,7 +122,11 @@ export function getEpisodeCardStyleState(isFocused: boolean, isCurrent: boolean)
     focusOutlineWidth: isFocused ? 2 : 0,
     focusOutlineColor: isFocused ? '#FFFFFF' : '#00000000',
     currentOutlineWidth: isCurrent ? 2 : 0,
-    currentOutlineColor: isCurrent ? '#A9F4FF' : '#00000000'
+    currentOutlineColor: isCurrent ? '#A9F4FF' : '#00000000',
+    layoutWidth: EPISODE_CARD_WIDTH,
+    layoutHeight: EPISODE_CARD_HEIGHT,
+    borderRadius: EPISODE_CARD_RADIUS,
+    currentInnerOutlineInset: isFocused && isCurrent ? EPISODE_CARD_INNER_OUTLINE_INSET : 0
   }
   return styleState
 }
@@ -211,36 +223,36 @@ export struct EpisodeListPanel {
   EpisodeCard(item: PlaybackContextItem, index: number) {
     Column({ space: 8 }) {
       Stack({ alignContent: Alignment.Center }) {
-        Stack({ alignContent: Alignment.BottomEnd }) {
-          Image(item.thumbnailUrl ? item.thumbnailUrl : $r('app.media.empty_folder'))
-            .width('100%')
-            .height('100%')
-            .objectFit(ImageFit.Cover)
-        }
-        .width(220)
-        .height(140)
-        .borderRadius(26)
-        .border({
-          width: this.getCardStyleState(item, index).currentOutlineWidth,
-          color: this.getCardStyleState(item, index).currentOutlineColor,
-          style: BorderStyle.Solid
-        })
-        .clip(true)
+        Image(item.thumbnailUrl ? item.thumbnailUrl : $r('app.media.empty_folder'))
+          .width('100%')
+          .height('100%')
+          .objectFit(ImageFit.Cover)
 
-        if (this.getCardStyleState(item, index).showFocusOutline) {
+        if (this.getCardStyleState(item, index).showCurrentOutline && this.getCardStyleState(item, index).showFocusOutline) {
           Row()
-            .width(228)
-            .height(148)
-            .borderRadius(30)
+            .width(this.getCardStyleState(item, index).layoutWidth - this.getCardStyleState(item, index).currentInnerOutlineInset * 2)
+            .height(this.getCardStyleState(item, index).layoutHeight - this.getCardStyleState(item, index).currentInnerOutlineInset * 2)
+            .borderRadius(this.getCardStyleState(item, index).borderRadius - this.getCardStyleState(item, index).currentInnerOutlineInset / 2)
             .border({
-              width: this.getCardStyleState(item, index).focusOutlineWidth,
-              color: this.getCardStyleState(item, index).focusOutlineColor,
+              width: this.getCardStyleState(item, index).currentOutlineWidth,
+              color: this.getCardStyleState(item, index).currentOutlineColor,
               style: BorderStyle.Solid
             })
         }
       }
-      .width(228)
-      .height(148)
+      .width(this.getCardStyleState(item, index).layoutWidth)
+      .height(this.getCardStyleState(item, index).layoutHeight)
+      .borderRadius(this.getCardStyleState(item, index).borderRadius)
+      .border({
+        width: this.getCardStyleState(item, index).showFocusOutline
+          ? this.getCardStyleState(item, index).focusOutlineWidth
+          : this.getCardStyleState(item, index).currentOutlineWidth,
+        color: this.getCardStyleState(item, index).showFocusOutline
+          ? this.getCardStyleState(item, index).focusOutlineColor
+          : this.getCardStyleState(item, index).currentOutlineColor,
+        style: BorderStyle.Solid
+      })
+      .clip(true)
       .scale({ x: this.getCardStyleState(item, index).scale, y: this.getCardStyleState(item, index).scale })
       .shadow({
         radius: this.getCardStyleState(item, index).shadowRadius,
@@ -262,7 +274,7 @@ export struct EpisodeListPanel {
         .fontSize(22)
         .fontColor('#F0F4F9')
         .textAlign(TextAlign.Center)
-        .width(220)
+        .width(this.getCardStyleState(item, index).layoutWidth)
         .maxLines(1)
         .textOverflow({ overflow: TextOverflow.Ellipsis })
     }

--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -145,11 +145,13 @@ export struct EpisodeListPanel {
       })
 
       // 集名
-      Text(item.title)
+      Text('第' + (item.episodeNumber ?? (item.index + 1)).toString() + '集')
         .fontSize(22)
         .fontColor('#F0F4F9')
         .textAlign(TextAlign.Center)
         .width(220)
+        .maxLines(1)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
     }
     .alignItems(HorizontalAlign.Center)
   }

--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -1,0 +1,299 @@
+import { PlaybackContextItem, MediaLibraryContext } from './PlaybackContext'
+import { KeyCode } from '@kit.InputKit'
+
+// ── LazyForEach DataSource ──────────────────────────────────────────────────
+
+class EpisodeDataSource implements IDataSource {
+  private dataArray: PlaybackContextItem[] = []
+  private listeners: DataChangeListener[] = []
+
+  constructor(items: PlaybackContextItem[]) {
+    this.dataArray = items
+  }
+
+  totalCount(): number {
+    return this.dataArray.length
+  }
+
+  getData(index: number): Object {
+    return this.dataArray[index]
+  }
+
+  registerDataChangeListener(listener: DataChangeListener): void {
+    this.listeners.push(listener)
+  }
+
+  unregisterDataChangeListener(listener: DataChangeListener): void {
+    const pos = this.listeners.indexOf(listener)
+    if (pos >= 0) {
+      this.listeners.splice(pos, 1)
+    }
+  }
+}
+
+// ── EpisodeListPanel ────────────────────────────────────────────────────────
+
+@Component
+export struct EpisodeListPanel {
+  @Require context: MediaLibraryContext
+  onSelect: (item: PlaybackContextItem) => void = () => {}
+
+  @State private currentPage: number = 0
+  @State private focusedCardIndex: number = 0
+  @State private isPageBarFocused: boolean = false
+  @State private pageBarFocusedIndex: number = 0
+  @State private dataSource: EpisodeDataSource = new EpisodeDataSource([])
+
+  private readonly PAGE_SIZE: number = 6
+
+  aboutToAppear(): void {
+    // 定位到当前播放集所在分页
+    const currentIdx = this.context.currentIndex
+    this.currentPage = Math.floor(currentIdx / this.PAGE_SIZE)
+    this.focusedCardIndex = currentIdx % this.PAGE_SIZE
+    this.dataSource = new EpisodeDataSource(this.getPageItems())
+  }
+
+  // ── 数据辅助方法 ───────────────────────────────────────────────────────────
+
+  private getTotalPages(): number {
+    return Math.max(1, Math.ceil(this.context.items.length / this.PAGE_SIZE))
+  }
+
+  private getPageItems(): PlaybackContextItem[] {
+    const start = this.currentPage * this.PAGE_SIZE
+    const end = Math.min(start + this.PAGE_SIZE, this.context.items.length)
+    const result: PlaybackContextItem[] = []
+    for (let i = start; i < end; i++) {
+      result.push(this.context.items[i])
+    }
+    return result
+  }
+
+  private goToPage(page: number): void {
+    const total = this.getTotalPages()
+    if (page < 0 || page >= total) {
+      return
+    }
+    this.currentPage = page
+    this.focusedCardIndex = 0
+    this.dataSource = new EpisodeDataSource(this.getPageItems())
+  }
+
+  private getPageLabel(page: number): string {
+    const start = page * this.PAGE_SIZE + 1
+    const end = Math.min((page + 1) * this.PAGE_SIZE, this.context.items.length)
+    return `${start}-${end}`
+  }
+
+  private isCurrentItem(item: PlaybackContextItem): boolean {
+    return item.index === this.context.currentIndex
+  }
+
+  /**
+   * 计算卡片宽度：
+   * - 当前播放集：210vp（高亮缩窄）
+   * - 最后一张且下一页存在（edgeCard）：168vp（截断暗示更多内容）
+   * - 普通集：256vp
+   */
+  private getCardWidth(item: PlaybackContextItem, index: number): number {
+    const pageItems = this.getPageItems()
+    if (index === pageItems.length - 1 && this.currentPage < this.getTotalPages() - 1) {
+      return 168
+    }
+    if (this.isCurrentItem(item)) {
+      return 210
+    }
+    return 256
+  }
+
+  private buildPageRange(): number[] {
+    const total = this.getTotalPages()
+    const result: number[] = []
+    for (let i = 0; i < total; i++) {
+      result.push(i)
+    }
+    return result
+  }
+
+  private isFocusRingVisible(index: number): boolean {
+    return this.focusedCardIndex === index && !this.isPageBarFocused
+  }
+
+  // ── 卡片 Builder ──────────────────────────────────────────────────────────
+
+  @Builder
+  EpisodeCard(item: PlaybackContextItem, index: number) {
+    Stack({ alignContent: Alignment.BottomEnd }) {
+      // 卡片主体
+      Column() {
+        Text(`第${item.index + 1}集`)
+          .height(28)
+          .fontSize(24)
+          .fontWeight(FontWeight.Bold)
+          .fontColor('#F0F4F9')
+          .textAlign(TextAlign.Center)
+          .width('100%')
+      }
+      .width(this.getCardWidth(item, index))
+      .height(136)
+      .borderRadius(26)
+      .backgroundColor(
+        this.isCurrentItem(item)
+          ? 'rgba(169, 244, 255, 0.15)'
+          : 'rgba(255, 255, 255, 0.1)'
+      )
+      .border(
+        this.isCurrentItem(item)
+          ? { width: 4, color: '#A9F4FF', style: BorderStyle.Solid }
+          : { width: 0, color: Color.Transparent, style: BorderStyle.Solid }
+      )
+      .justifyContent(FlexAlign.Center)
+      .clip(true)
+      .focusable(true)
+      .onFocus(() => {
+        this.focusedCardIndex = index
+        this.isPageBarFocused = false
+      })
+      .onClick(() => {
+        this.onSelect(item)
+      })
+
+      // 焦点环：叠加在右下角，仅当前焦点卡片显示
+      if (this.isFocusRingVisible(index)) {
+        Ellipse()
+          .width(42)
+          .height(42)
+          .stroke('#FFFFFF')
+          .strokeWidth(5)
+          .fill(Color.Transparent)
+          .margin({ right: 6, bottom: 6 })
+      }
+    }
+  }
+
+  // ── build ─────────────────────────────────────────────────────────────────
+
+  build() {
+    Column({ space: 0 }) {
+      // 标题行
+      Text('选集')
+        .fontSize(56)
+        .fontWeight(FontWeight.Bold)
+        .fontColor('#F3F6FB')
+        .margin({ bottom: 32 })
+        .alignSelf(ItemAlign.Start)
+
+      // 集数卡片横向列表（LazyForEach + 遥控器键盘处理）
+      List({ space: 48 }) {
+        LazyForEach(
+          this.dataSource,
+          (item: Object, index: number) => {
+            ListItem() {
+              this.EpisodeCard(item as PlaybackContextItem, index)
+            }
+          },
+          (item: Object, index: number) => index.toString()
+        )
+      }
+      .listDirection(Axis.Horizontal)
+      .scrollBar(BarState.Off)
+      .width('100%')
+      .height(160)
+      .onKeyEvent((event: KeyEvent) => {
+        if (event.type !== KeyType.Down) {
+          return
+        }
+        const pageItems = this.getPageItems()
+        if (event.keyCode === KeyCode.KEYCODE_DPAD_RIGHT) {
+          // 到达当前页最后一张时翻页
+          if (this.focusedCardIndex >= pageItems.length - 1) {
+            this.goToPage(this.currentPage + 1)
+          }
+        } else if (event.keyCode === KeyCode.KEYCODE_DPAD_LEFT) {
+          // 到达当前页第一张时翻页
+          if (this.focusedCardIndex <= 0) {
+            this.goToPage(this.currentPage - 1)
+          }
+        } else if (event.keyCode === KeyCode.KEYCODE_DPAD_DOWN) {
+          // 向下进入分页范围条
+          this.isPageBarFocused = true
+        }
+      })
+
+      // 分页范围条（多页时才显示）
+      if (this.getTotalPages() > 1) {
+        Row({ space: 58 }) {
+          ForEach(
+            this.buildPageRange(),
+            (pageIdx: number) => {
+              Stack() {
+                // pagerPill 胶囊：焦点在分页条时显示
+                if (this.isPageBarFocused && this.pageBarFocusedIndex === pageIdx) {
+                  Row()
+                    .width(76)
+                    .height(34)
+                    .borderRadius(18)
+                    .backgroundColor('#FFFFFF26')
+                    .border({ width: 2, color: '#FFFFFF66', style: BorderStyle.Solid })
+                }
+
+                // 分页标签 + 激活下划线
+                Column({ space: 6 }) {
+                  Text(this.getPageLabel(pageIdx))
+                    .fontSize(22)
+                    .fontColor(this.currentPage === pageIdx ? '#F3F7FB' : '#D5DDE8')
+                    .fontWeight(FontWeight.Bold)
+
+                  if (this.currentPage === pageIdx) {
+                    Row()
+                      .width(84)
+                      .height(3)
+                      .backgroundColor('#F5F8FC')
+                      .borderRadius(2)
+                  }
+                }
+              }
+              .focusable(true)
+              .onFocus(() => {
+                this.isPageBarFocused = true
+                this.pageBarFocusedIndex = pageIdx
+              })
+              .onBlur(() => {
+                this.isPageBarFocused = false
+              })
+              .onClick(() => {
+                this.goToPage(pageIdx)
+              })
+            },
+            (pageIdx: number) => pageIdx.toString()
+          )
+        }
+        .margin({ top: 32 })
+        .alignSelf(ItemAlign.Start)
+        .onKeyEvent((event: KeyEvent) => {
+          if (event.type !== KeyType.Down) {
+            return
+          }
+          if (event.keyCode === KeyCode.KEYCODE_DPAD_UP) {
+            // 向上回到卡片区
+            this.isPageBarFocused = false
+          } else if (event.keyCode === KeyCode.KEYCODE_DPAD_LEFT && this.pageBarFocusedIndex > 0) {
+            this.pageBarFocusedIndex = this.pageBarFocusedIndex - 1
+            this.goToPage(this.pageBarFocusedIndex)
+          } else if (
+            event.keyCode === KeyCode.KEYCODE_DPAD_RIGHT &&
+            this.pageBarFocusedIndex < this.getTotalPages() - 1
+          ) {
+            this.pageBarFocusedIndex = this.pageBarFocusedIndex + 1
+            this.goToPage(this.pageBarFocusedIndex)
+          }
+        })
+      }
+    }
+    .backgroundColor('#0B1020')
+    .width('100%')
+    .padding({ top: 40, bottom: 40, left: 84 })
+    .alignItems(HorizontalAlign.Start)
+  }
+}

--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -10,6 +10,32 @@ export interface EpisodePageRange {
   label: string
 }
 
+export interface EpisodeCardStyleState {
+  isFocused: boolean
+  isCurrent: boolean
+  showFocusOutline: boolean
+  showCurrentOutline: boolean
+  showLegacyFocusRing: boolean
+  scale: number
+  shadowRadius: number
+  shadowColor: string
+  focusOutlineWidth: number
+  focusOutlineColor: string
+  currentOutlineWidth: number
+  currentOutlineColor: string
+}
+
+export interface EpisodePageTabStyleState {
+  isFocused: boolean
+  isCurrentPage: boolean
+  showFocusPill: boolean
+  showCurrentUnderline: boolean
+  labelColor: string
+  focusPillBackgroundColor: string
+  focusPillBorderColor: string
+  focusPillBorderWidth: number
+}
+
 export function buildEpisodePageRanges(totalCount: number): EpisodePageRange[] {
   const result: EpisodePageRange[] = []
   if (totalCount <= 0) {
@@ -73,6 +99,38 @@ function getEpisodeFocusIndex(currentIndex: number, totalCount: number): number 
   }
   const range = ranges[pageIndex]
   return currentIndex - range.startIndex
+}
+
+export function getEpisodeCardStyleState(isFocused: boolean, isCurrent: boolean): EpisodeCardStyleState {
+  const styleState: EpisodeCardStyleState = {
+    isFocused,
+    isCurrent,
+    showFocusOutline: isFocused,
+    showCurrentOutline: isCurrent,
+    showLegacyFocusRing: false,
+    scale: isFocused ? 1.03 : 1,
+    shadowRadius: isFocused ? 18 : 0,
+    shadowColor: isFocused ? '#33000000' : '#00000000',
+    focusOutlineWidth: isFocused ? 2 : 0,
+    focusOutlineColor: isFocused ? '#FFFFFF' : '#00000000',
+    currentOutlineWidth: isCurrent ? 2 : 0,
+    currentOutlineColor: isCurrent ? '#A9F4FF' : '#00000000'
+  }
+  return styleState
+}
+
+export function getEpisodePageTabStyleState(isFocused: boolean, isCurrentPage: boolean): EpisodePageTabStyleState {
+  const styleState: EpisodePageTabStyleState = {
+    isFocused,
+    isCurrentPage,
+    showFocusPill: isFocused,
+    showCurrentUnderline: isCurrentPage,
+    labelColor: isCurrentPage ? '#F3F7FB' : '#D5DDE8',
+    focusPillBackgroundColor: isFocused ? '#FFFFFF33' : '#00000000',
+    focusPillBorderColor: isFocused ? '#FFFFFFCC' : '#00000000',
+    focusPillBorderWidth: isFocused ? 2 : 0
+  }
+  return styleState
 }
 
 // ── EpisodeListPanel ────────────────────────────────────────────────────────
@@ -139,8 +197,12 @@ export struct EpisodeListPanel {
     return result
   }
 
-  private isFocusRingVisible(index: number): boolean {
-    return this.focusedCardIndex === index && !this.isPageBarFocused
+  private getCardStyleState(item: PlaybackContextItem, index: number): EpisodeCardStyleState {
+    return getEpisodeCardStyleState(this.focusedCardIndex === index && !this.isPageBarFocused, this.isCurrentItem(item))
+  }
+
+  private getPageTabStyleState(pageIdx: number): EpisodePageTabStyleState {
+    return getEpisodePageTabStyleState(this.isPageBarFocused && this.pageBarFocusedIndex === pageIdx, this.currentPage === pageIdx)
   }
 
   // ── 卡片 Builder ──────────────────────────────────────────────────────────
@@ -148,33 +210,44 @@ export struct EpisodeListPanel {
   @Builder
   EpisodeCard(item: PlaybackContextItem, index: number) {
     Column({ space: 8 }) {
-      // 海报卡片主体
-      Stack({ alignContent: Alignment.BottomEnd }) {
-        Image(item.thumbnailUrl ? item.thumbnailUrl : $r('app.media.empty_folder'))
-          .width('100%')
-          .height('100%')
-          .objectFit(ImageFit.Cover)
+      Stack({ alignContent: Alignment.Center }) {
+        Stack({ alignContent: Alignment.BottomEnd }) {
+          Image(item.thumbnailUrl ? item.thumbnailUrl : $r('app.media.empty_folder'))
+            .width('100%')
+            .height('100%')
+            .objectFit(ImageFit.Cover)
+        }
+        .width(220)
+        .height(140)
+        .borderRadius(26)
+        .border({
+          width: this.getCardStyleState(item, index).currentOutlineWidth,
+          color: this.getCardStyleState(item, index).currentOutlineColor,
+          style: BorderStyle.Solid
+        })
+        .clip(true)
 
-        // 焦点环：叠加在右下角，仅当前焦点卡片显示
-        if (this.isFocusRingVisible(index)) {
-          Ellipse()
-            .width(42)
-            .height(42)
-            .stroke('#FFFFFF')
-            .strokeWidth(5)
-            .fill(Color.Transparent)
-            .margin({ right: 6, bottom: 6 })
+        if (this.getCardStyleState(item, index).showFocusOutline) {
+          Row()
+            .width(228)
+            .height(148)
+            .borderRadius(30)
+            .border({
+              width: this.getCardStyleState(item, index).focusOutlineWidth,
+              color: this.getCardStyleState(item, index).focusOutlineColor,
+              style: BorderStyle.Solid
+            })
         }
       }
-      .width(220)
-      .height(140)
-      .borderRadius(26)
-      .border(
-        this.isCurrentItem(item)
-          ? { width: 4, color: '#A9F4FF', style: BorderStyle.Solid }
-          : { width: 0, color: Color.Transparent, style: BorderStyle.Solid }
-      )
-      .clip(true)
+      .width(228)
+      .height(148)
+      .scale({ x: this.getCardStyleState(item, index).scale, y: this.getCardStyleState(item, index).scale })
+      .shadow({
+        radius: this.getCardStyleState(item, index).shadowRadius,
+        color: this.getCardStyleState(item, index).shadowColor,
+        offsetX: 0,
+        offsetY: 8
+      })
       .focusable(true)
       .onFocus(() => {
         this.focusedCardIndex = index
@@ -252,24 +325,27 @@ export struct EpisodeListPanel {
             this.buildPageRange(),
             (pageIdx: number) => {
               Stack() {
-                // pagerPill 胶囊：焦点在分页条时显示
-                if (this.isPageBarFocused && this.pageBarFocusedIndex === pageIdx) {
+                if (this.getPageTabStyleState(pageIdx).showFocusPill) {
                   Row()
                     .width(76)
                     .height(34)
                     .borderRadius(18)
-                    .backgroundColor('#FFFFFF26')
-                    .border({ width: 2, color: '#FFFFFF66', style: BorderStyle.Solid })
+                    .backgroundColor(this.getPageTabStyleState(pageIdx).focusPillBackgroundColor)
+                    .border({
+                      width: this.getPageTabStyleState(pageIdx).focusPillBorderWidth,
+                      color: this.getPageTabStyleState(pageIdx).focusPillBorderColor,
+                      style: BorderStyle.Solid
+                    })
                 }
 
                 // 分页标签 + 激活下划线
                 Column({ space: 6 }) {
                   Text(this.getPageLabel(pageIdx))
                     .fontSize(22)
-                    .fontColor(this.currentPage === pageIdx ? '#F3F7FB' : '#D5DDE8')
+                    .fontColor(this.getPageTabStyleState(pageIdx).labelColor)
                     .fontWeight(FontWeight.Bold)
 
-                  if (this.currentPage === pageIdx) {
+                  if (this.getPageTabStyleState(pageIdx).showCurrentUnderline) {
                     Row()
                       .width(84)
                       .height(3)

--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -2,10 +2,30 @@ import { PlaybackContextItem, MediaLibraryContext } from './PlaybackContext'
 import { KeyCode } from '@kit.InputKit'
 
 const FIRST_PAGE_SIZE: number = 6
-const EPISODE_CARD_WIDTH: number = 220
-const EPISODE_CARD_HEIGHT: number = 140
-const EPISODE_CARD_RADIUS: number = 26
-const EPISODE_CARD_INNER_OUTLINE_INSET: number = 10
+const EPISODE_CARD_WIDTH: number = 184
+const EPISODE_CARD_HEIGHT: number = 68
+const EPISODE_CARD_RADIUS: number = 22
+const EPISODE_CARD_THUMBNAIL_WIDTH: number = 64
+const EPISODE_CARD_THUMBNAIL_HEIGHT: number = 40
+const EPISODE_CARD_THUMBNAIL_RADIUS: number = 12
+const EPISODE_CARD_CONTENT_GAP: number = 10
+const EPISODE_CARD_HORIZONTAL_PADDING: number = 8
+const EPISODE_CARD_RIGHT_PADDING: number = 12
+const EPISODE_CARD_VERTICAL_PADDING: number = 10
+const EPISODE_CARD_LABEL_FONT_SIZE: number = 18
+const EPISODE_CARD_SCALE_FOCUSED: number = 1.04
+const EPISODE_TAB_SCALE_FOCUSED: number = 1.04
+const EPISODE_PAGE_TAB_HORIZONTAL_PADDING: number = 16
+const EPISODE_PAGE_TAB_VERTICAL_PADDING: number = 8
+const EPISODE_PAGE_TAB_RADIUS: number = 20
+const EPISODE_PAGE_TAB_FONT_SIZE: number = 18
+const EPISODE_WAVE_BAR_COUNT: number = 3
+const EPISODE_WAVE_FRAMES: number[][] = [
+  [8, 14, 10],
+  [13, 9, 15],
+  [9, 16, 11],
+  [14, 10, 12]
+]
 
 export interface EpisodePageRange {
   pageIndex: number
@@ -16,32 +36,57 @@ export interface EpisodePageRange {
 
 export interface EpisodeCardStyleState {
   isFocused: boolean
+  isHovered: boolean
   isCurrent: boolean
   showFocusOutline: boolean
   showCurrentOutline: boolean
   showLegacyFocusRing: boolean
+  showWaveIcon: boolean
+  waveBarCount: number
   scale: number
   shadowRadius: number
   shadowColor: string
+  backgroundColor: string
+  labelColor: string
   focusOutlineWidth: number
   focusOutlineColor: string
   currentOutlineWidth: number
   currentOutlineColor: string
+  focusBorderWidth: number
+  currentBorderWidth: number
   layoutWidth: number
   layoutHeight: number
   borderRadius: number
-  currentInnerOutlineInset: number
+  thumbnailWidth: number
+  thumbnailHeight: number
+  thumbnailRadius: number
+  contentGap: number
+  horizontalPadding: number
+  rightPadding: number
+  verticalPadding: number
+  labelFontSize: number
 }
 
 export interface EpisodePageTabStyleState {
   isFocused: boolean
+  isHovered: boolean
   isCurrentPage: boolean
   showFocusPill: boolean
+  showFocusBackground: boolean
   showCurrentUnderline: boolean
   labelColor: string
+  backgroundColor: string
   focusPillBackgroundColor: string
   focusPillBorderColor: string
   focusPillBorderWidth: number
+  focusBorderWidth: number
+  scale: number
+  horizontalPadding: number
+  verticalPadding: number
+  borderRadius: number
+  fontSize: number
+  shadowRadius: number
+  shadowColor: string
 }
 
 export function buildEpisodePageRanges(totalCount: number): EpisodePageRange[] {
@@ -109,38 +154,66 @@ function getEpisodeFocusIndex(currentIndex: number, totalCount: number): number 
   return currentIndex - range.startIndex
 }
 
-export function getEpisodeCardStyleState(isFocused: boolean, isCurrent: boolean): EpisodeCardStyleState {
+export function getEpisodeCardStyleState(isFocused: boolean, isCurrent: boolean, isHovered: boolean = false): EpisodeCardStyleState {
+  const isEmphasized = isFocused || isHovered
   const styleState: EpisodeCardStyleState = {
     isFocused,
+    isHovered,
     isCurrent,
-    showFocusOutline: isFocused,
-    showCurrentOutline: isCurrent,
+    showFocusOutline: false,
+    showCurrentOutline: false,
     showLegacyFocusRing: false,
-    scale: isFocused ? 1.03 : 1,
-    shadowRadius: isFocused ? 18 : 0,
-    shadowColor: isFocused ? '#33000000' : '#00000000',
-    focusOutlineWidth: isFocused ? 2 : 0,
-    focusOutlineColor: isFocused ? '#FFFFFF' : '#00000000',
-    currentOutlineWidth: isCurrent ? 2 : 0,
-    currentOutlineColor: isCurrent ? '#A9F4FF' : '#00000000',
+    showWaveIcon: isCurrent,
+    waveBarCount: EPISODE_WAVE_BAR_COUNT,
+    scale: isEmphasized ? EPISODE_CARD_SCALE_FOCUSED : 1,
+    shadowRadius: isEmphasized ? 12 : 0,
+    shadowColor: isEmphasized ? '#386EA8E0' : '#00000000',
+    backgroundColor: isCurrent ? 'rgba(255, 255, 255, 0.28)' : 'rgba(255, 255, 255, 0.12)',
+    labelColor: isCurrent ? '#F9FCFF' : '#E8EDF5',
+    focusOutlineWidth: 0,
+    focusOutlineColor: '#00000000',
+    currentOutlineWidth: 0,
+    currentOutlineColor: '#00000000',
+    focusBorderWidth: 0,
+    currentBorderWidth: 0,
     layoutWidth: EPISODE_CARD_WIDTH,
     layoutHeight: EPISODE_CARD_HEIGHT,
     borderRadius: EPISODE_CARD_RADIUS,
-    currentInnerOutlineInset: isFocused && isCurrent ? EPISODE_CARD_INNER_OUTLINE_INSET : 0
+    thumbnailWidth: EPISODE_CARD_THUMBNAIL_WIDTH,
+    thumbnailHeight: EPISODE_CARD_THUMBNAIL_HEIGHT,
+    thumbnailRadius: EPISODE_CARD_THUMBNAIL_RADIUS,
+    contentGap: EPISODE_CARD_CONTENT_GAP,
+    horizontalPadding: EPISODE_CARD_HORIZONTAL_PADDING,
+    rightPadding: EPISODE_CARD_RIGHT_PADDING,
+    verticalPadding: EPISODE_CARD_VERTICAL_PADDING,
+    labelFontSize: EPISODE_CARD_LABEL_FONT_SIZE
   }
   return styleState
 }
 
-export function getEpisodePageTabStyleState(isFocused: boolean, isCurrentPage: boolean): EpisodePageTabStyleState {
+export function getEpisodePageTabStyleState(isFocused: boolean, isCurrentPage: boolean, isHovered: boolean = false): EpisodePageTabStyleState {
+  const isEmphasized = isFocused || isHovered
   const styleState: EpisodePageTabStyleState = {
     isFocused,
+    isHovered,
     isCurrentPage,
-    showFocusPill: isFocused,
+    showFocusPill: false,
+    showFocusBackground: isEmphasized || isCurrentPage,
     showCurrentUnderline: isCurrentPage,
     labelColor: isCurrentPage ? '#F3F7FB' : '#D5DDE8',
-    focusPillBackgroundColor: isFocused ? '#FFFFFF33' : '#00000000',
-    focusPillBorderColor: isFocused ? '#FFFFFFCC' : '#00000000',
-    focusPillBorderWidth: isFocused ? 2 : 0
+    backgroundColor: isEmphasized ? 'rgba(255, 255, 255, 0.22)' :
+      isCurrentPage ? 'rgba(255, 255, 255, 0.12)' : '#00000000',
+    focusPillBackgroundColor: '#00000000',
+    focusPillBorderColor: '#00000000',
+    focusPillBorderWidth: 0,
+    focusBorderWidth: 0,
+    scale: isEmphasized ? EPISODE_TAB_SCALE_FOCUSED : 1,
+    horizontalPadding: EPISODE_PAGE_TAB_HORIZONTAL_PADDING,
+    verticalPadding: EPISODE_PAGE_TAB_VERTICAL_PADDING,
+    borderRadius: EPISODE_PAGE_TAB_RADIUS,
+    fontSize: EPISODE_PAGE_TAB_FONT_SIZE,
+    shadowRadius: isFocused ? 8 : 0,
+    shadowColor: isFocused ? '#264C77A8' : '#00000000'
   }
   return styleState
 }
@@ -154,14 +227,23 @@ export struct EpisodeListPanel {
 
   @State private currentPage: number = 0
   @State private focusedCardIndex: number = 0
+  @State private hoveredCardIndex: number = -1
   @State private isPageBarFocused: boolean = false
   @State private pageBarFocusedIndex: number = 0
+  @State private hoveredPageBarIndex: number = -1
+  @State private waveFrameIndex: number = 0
+  private waveTimerId: number | undefined = undefined
 
   aboutToAppear(): void {
     const currentIdx = this.context.currentIndex
     this.currentPage = getEpisodePageIndex(currentIdx, this.context.items.length)
     this.focusedCardIndex = getEpisodeFocusIndex(currentIdx, this.context.items.length)
     this.pageBarFocusedIndex = this.currentPage
+    this.startWaveAnimation()
+  }
+
+  aboutToDisappear(): void {
+    this.stopWaveAnimation()
   }
 
   // ── 数据辅助方法 ───────────────────────────────────────────────────────────
@@ -210,75 +292,125 @@ export struct EpisodeListPanel {
   }
 
   private getCardStyleState(item: PlaybackContextItem, index: number): EpisodeCardStyleState {
-    return getEpisodeCardStyleState(this.focusedCardIndex === index && !this.isPageBarFocused, this.isCurrentItem(item))
+    return getEpisodeCardStyleState(
+      this.focusedCardIndex === index && !this.isPageBarFocused,
+      this.isCurrentItem(item),
+      this.hoveredCardIndex === index
+    )
   }
 
   private getPageTabStyleState(pageIdx: number): EpisodePageTabStyleState {
-    return getEpisodePageTabStyleState(this.isPageBarFocused && this.pageBarFocusedIndex === pageIdx, this.currentPage === pageIdx)
+    return getEpisodePageTabStyleState(
+      this.isPageBarFocused && this.pageBarFocusedIndex === pageIdx,
+      this.currentPage === pageIdx,
+      this.hoveredPageBarIndex === pageIdx
+    )
+  }
+
+  private startWaveAnimation(): void {
+    if (this.waveTimerId !== undefined) {
+      return
+    }
+    this.waveTimerId = setInterval(() => {
+      this.waveFrameIndex = (this.waveFrameIndex + 1) % EPISODE_WAVE_FRAMES.length
+    }, 240)
+  }
+
+  private stopWaveAnimation(): void {
+    if (this.waveTimerId === undefined) {
+      return
+    }
+    clearInterval(this.waveTimerId)
+    this.waveTimerId = undefined
+  }
+
+  private getWaveBarHeights(): number[] {
+    return EPISODE_WAVE_FRAMES[this.waveFrameIndex % EPISODE_WAVE_FRAMES.length]
   }
 
   // ── 卡片 Builder ──────────────────────────────────────────────────────────
 
   @Builder
+  private PlayingWaveIcon() {
+    Row({ space: 3 }) {
+      ForEach(this.getWaveBarHeights(), (barHeight: number, index: number) => {
+        Row()
+          .width(3)
+          .height(barHeight)
+          .borderRadius(2)
+          .backgroundColor('#A9F4FF')
+      }, (barHeight: number, index: number): string => index.toString())
+    }
+    .height(16)
+    .alignItems(VerticalAlign.Bottom)
+    .justifyContent(FlexAlign.Center)
+  }
+
+  @Builder
   EpisodeCard(item: PlaybackContextItem, index: number) {
-    Column({ space: 8 }) {
+    Row({ space: this.getCardStyleState(item, index).contentGap }) {
       Stack({ alignContent: Alignment.Center }) {
         Image(item.thumbnailUrl ? item.thumbnailUrl : $r('app.media.empty_folder'))
-          .width('100%')
-          .height('100%')
+          .width(this.getCardStyleState(item, index).thumbnailWidth)
+          .height(this.getCardStyleState(item, index).thumbnailHeight)
           .objectFit(ImageFit.Cover)
+      }
+      .width(this.getCardStyleState(item, index).thumbnailWidth)
+      .height(this.getCardStyleState(item, index).thumbnailHeight)
+      .borderRadius(this.getCardStyleState(item, index).thumbnailRadius)
+      .clip(true)
+      .shadow({
+        radius: this.isCurrentItem(item) ? 4 : 0,
+        color: this.isCurrentItem(item) ? '#2CA9F4FF' : '#00000000',
+        offsetX: 0,
+        offsetY: 2
+      })
 
-        if (this.getCardStyleState(item, index).showCurrentOutline && this.getCardStyleState(item, index).showFocusOutline) {
-          Row()
-            .width(this.getCardStyleState(item, index).layoutWidth - this.getCardStyleState(item, index).currentInnerOutlineInset * 2)
-            .height(this.getCardStyleState(item, index).layoutHeight - this.getCardStyleState(item, index).currentInnerOutlineInset * 2)
-            .borderRadius(this.getCardStyleState(item, index).borderRadius - this.getCardStyleState(item, index).currentInnerOutlineInset / 2)
-            .border({
-              width: this.getCardStyleState(item, index).currentOutlineWidth,
-              color: this.getCardStyleState(item, index).currentOutlineColor,
-              style: BorderStyle.Solid
-            })
+      Row({ space: 6 }) {
+        Text('第' + (item.episodeNumber ?? (item.index + 1)).toString() + '集')
+          .fontSize(this.getCardStyleState(item, index).labelFontSize)
+          .fontWeight(this.isCurrentItem(item) ? FontWeight.Medium : FontWeight.Regular)
+          .fontColor(this.getCardStyleState(item, index).labelColor)
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+
+        if (this.getCardStyleState(item, index).showWaveIcon) {
+          this.PlayingWaveIcon()
         }
       }
-      .width(this.getCardStyleState(item, index).layoutWidth)
-      .height(this.getCardStyleState(item, index).layoutHeight)
-      .borderRadius(this.getCardStyleState(item, index).borderRadius)
-      .border({
-        width: this.getCardStyleState(item, index).showFocusOutline
-          ? this.getCardStyleState(item, index).focusOutlineWidth
-          : this.getCardStyleState(item, index).currentOutlineWidth,
-        color: this.getCardStyleState(item, index).showFocusOutline
-          ? this.getCardStyleState(item, index).focusOutlineColor
-          : this.getCardStyleState(item, index).currentOutlineColor,
-        style: BorderStyle.Solid
-      })
-      .clip(true)
-      .scale({ x: this.getCardStyleState(item, index).scale, y: this.getCardStyleState(item, index).scale })
-      .shadow({
-        radius: this.getCardStyleState(item, index).shadowRadius,
-        color: this.getCardStyleState(item, index).shadowColor,
-        offsetX: 0,
-        offsetY: 8
-      })
-      .focusable(true)
-      .onFocus(() => {
-        this.focusedCardIndex = index
-        this.isPageBarFocused = false
-      })
-      .onClick(() => {
-        this.onSelect(item)
-      })
-
-      // 集名
-      Text('第' + (item.episodeNumber ?? (item.index + 1)).toString() + '集')
-        .fontSize(22)
-        .fontColor('#F0F4F9')
-        .textAlign(TextAlign.Center)
-        .width(this.getCardStyleState(item, index).layoutWidth)
-        .maxLines(1)
-        .textOverflow({ overflow: TextOverflow.Ellipsis })
+      .layoutWeight(1)
+      .justifyContent(FlexAlign.Start)
+      .alignItems(VerticalAlign.Center)
     }
-    .alignItems(HorizontalAlign.Center)
+    .width(this.getCardStyleState(item, index).layoutWidth)
+    .height(this.getCardStyleState(item, index).layoutHeight)
+    .padding({
+      left: this.getCardStyleState(item, index).horizontalPadding,
+      right: this.getCardStyleState(item, index).rightPadding,
+      top: this.getCardStyleState(item, index).verticalPadding,
+      bottom: this.getCardStyleState(item, index).verticalPadding
+    })
+    .borderRadius(this.getCardStyleState(item, index).borderRadius)
+    .backgroundColor(this.getCardStyleState(item, index).backgroundColor)
+    .scale({ x: this.getCardStyleState(item, index).scale, y: this.getCardStyleState(item, index).scale })
+    .shadow({
+      radius: this.getCardStyleState(item, index).shadowRadius,
+      color: this.getCardStyleState(item, index).shadowColor,
+      offsetX: 0,
+      offsetY: 6
+    })
+    .focusable(true)
+    .onFocus(() => {
+      this.focusedCardIndex = index
+      this.isPageBarFocused = false
+    })
+    .onHover((isHover: boolean) => {
+      this.hoveredCardIndex = isHover ? index : -1
+    })
+    .onClick(() => {
+      this.onSelect(item)
+    })
+    .alignItems(VerticalAlign.Center)
   }
 
   // ── build ─────────────────────────────────────────────────────────────────
@@ -294,7 +426,7 @@ export struct EpisodeListPanel {
         .alignSelf(ItemAlign.Start)
 
       // 集数卡片横向列表
-      List({ space: 48 }) {
+      List({ space: 18 }) {
         ForEach(
           this.getPageItems(),
           (item: PlaybackContextItem, index: number) => {
@@ -308,7 +440,7 @@ export struct EpisodeListPanel {
       .listDirection(Axis.Horizontal)
       .scrollBar(BarState.Off)
       .width('100%')
-      .height(200)
+      .height(92)
       .onKeyEvent((event: KeyEvent) => {
         if (event.type !== KeyType.Down) {
           return
@@ -332,44 +464,61 @@ export struct EpisodeListPanel {
 
       // 分页范围条（多页时才显示）
       if (this.getTotalPages() > 1) {
-        Row({ space: 58 }) {
+        Row({ space: 12 }) {
           ForEach(
             this.buildPageRange(),
             (pageIdx: number) => {
               Stack() {
-                if (this.getPageTabStyleState(pageIdx).showFocusPill) {
+                if (this.getPageTabStyleState(pageIdx).showFocusBackground) {
                   Row()
-                    .width(76)
-                    .height(34)
-                    .borderRadius(18)
-                    .backgroundColor(this.getPageTabStyleState(pageIdx).focusPillBackgroundColor)
-                    .border({
-                      width: this.getPageTabStyleState(pageIdx).focusPillBorderWidth,
-                      color: this.getPageTabStyleState(pageIdx).focusPillBorderColor,
-                      style: BorderStyle.Solid
+                    .padding({
+                      left: this.getPageTabStyleState(pageIdx).horizontalPadding,
+                      right: this.getPageTabStyleState(pageIdx).horizontalPadding,
+                      top: this.getPageTabStyleState(pageIdx).verticalPadding,
+                      bottom: this.getPageTabStyleState(pageIdx).verticalPadding
                     })
+                    .borderRadius(this.getPageTabStyleState(pageIdx).borderRadius)
+                    .backgroundColor(this.getPageTabStyleState(pageIdx).backgroundColor)
                 }
 
                 // 分页标签 + 激活下划线
                 Column({ space: 6 }) {
                   Text(this.getPageLabel(pageIdx))
-                    .fontSize(22)
+                    .fontSize(this.getPageTabStyleState(pageIdx).fontSize)
                     .fontColor(this.getPageTabStyleState(pageIdx).labelColor)
                     .fontWeight(FontWeight.Bold)
+                    .padding({
+                      left: this.getPageTabStyleState(pageIdx).horizontalPadding,
+                      right: this.getPageTabStyleState(pageIdx).horizontalPadding,
+                      top: this.getPageTabStyleState(pageIdx).verticalPadding,
+                      bottom: this.getPageTabStyleState(pageIdx).verticalPadding
+                    })
+                    .backgroundColor(this.getPageTabStyleState(pageIdx).backgroundColor)
+                    .borderRadius(this.getPageTabStyleState(pageIdx).borderRadius)
 
                   if (this.getPageTabStyleState(pageIdx).showCurrentUnderline) {
                     Row()
-                      .width(84)
+                      .width(38)
                       .height(3)
                       .backgroundColor('#F5F8FC')
                       .borderRadius(2)
                   }
                 }
               }
+              .scale({ x: this.getPageTabStyleState(pageIdx).scale, y: this.getPageTabStyleState(pageIdx).scale })
+              .shadow({
+                radius: this.getPageTabStyleState(pageIdx).shadowRadius,
+                color: this.getPageTabStyleState(pageIdx).shadowColor,
+                offsetX: 0,
+                offsetY: 6
+              })
               .focusable(true)
               .onFocus(() => {
                 this.isPageBarFocused = true
                 this.pageBarFocusedIndex = pageIdx
+              })
+              .onHover((isHover: boolean) => {
+                this.hoveredPageBarIndex = isHover ? pageIdx : -1
               })
               .onBlur(() => {
                 this.isPageBarFocused = false
@@ -395,7 +544,7 @@ export struct EpisodeListPanel {
             (pageIdx: number) => pageIdx.toString()
           )
         }
-        .margin({ top: 32 })
+        .margin({ top: 18 })
         .alignSelf(ItemAlign.Start)
       }
     }

--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -1,34 +1,78 @@
 import { PlaybackContextItem, MediaLibraryContext } from './PlaybackContext'
 import { KeyCode } from '@kit.InputKit'
 
-// ── LazyForEach DataSource ──────────────────────────────────────────────────
+const FIRST_PAGE_SIZE: number = 6
 
-class EpisodeDataSource implements IDataSource {
-  private dataArray: PlaybackContextItem[] = []
-  private listeners: DataChangeListener[] = []
+export interface EpisodePageRange {
+  pageIndex: number
+  startIndex: number
+  endIndexExclusive: number
+  label: string
+}
 
-  constructor(items: PlaybackContextItem[]) {
-    this.dataArray = items
+export function buildEpisodePageRanges(totalCount: number): EpisodePageRange[] {
+  const result: EpisodePageRange[] = []
+  if (totalCount <= 0) {
+    return result
   }
 
-  totalCount(): number {
-    return this.dataArray.length
+  const firstPageEnd = Math.min(FIRST_PAGE_SIZE, totalCount)
+  const firstRange: EpisodePageRange = {
+    pageIndex: 0,
+    startIndex: 0,
+    endIndexExclusive: firstPageEnd,
+    label: `1-${firstPageEnd}`
+  }
+  result.push(firstRange)
+
+  if (totalCount > FIRST_PAGE_SIZE) {
+    const secondRange: EpisodePageRange = {
+      pageIndex: 1,
+      startIndex: FIRST_PAGE_SIZE,
+      endIndexExclusive: totalCount,
+      label: `${FIRST_PAGE_SIZE + 1}-${totalCount}`
+    }
+    result.push(secondRange)
   }
 
-  getData(index: number): Object {
-    return this.dataArray[index]
-  }
+  return result
+}
 
-  registerDataChangeListener(listener: DataChangeListener): void {
-    this.listeners.push(listener)
+export function getEpisodePageItems(items: PlaybackContextItem[], page: number): PlaybackContextItem[] {
+  const ranges = buildEpisodePageRanges(items.length)
+  if (page < 0 || page >= ranges.length) {
+    return []
   }
+  const range = ranges[page]
+  return items.slice(range.startIndex, range.endIndexExclusive)
+}
 
-  unregisterDataChangeListener(listener: DataChangeListener): void {
-    const pos = this.listeners.indexOf(listener)
-    if (pos >= 0) {
-      this.listeners.splice(pos, 1)
+export function getEpisodeItemRenderKey(item: PlaybackContextItem): string {
+  if (item.videoPath.length > 0) {
+    return item.videoPath
+  }
+  return item.index.toString()
+}
+
+function getEpisodePageIndex(currentIndex: number, totalCount: number): number {
+  const ranges = buildEpisodePageRanges(totalCount)
+  for (let i = 0; i < ranges.length; i++) {
+    const range = ranges[i]
+    if (currentIndex >= range.startIndex && currentIndex < range.endIndexExclusive) {
+      return range.pageIndex
     }
   }
+  return 0
+}
+
+function getEpisodeFocusIndex(currentIndex: number, totalCount: number): number {
+  const ranges = buildEpisodePageRanges(totalCount)
+  const pageIndex = getEpisodePageIndex(currentIndex, totalCount)
+  if (pageIndex < 0 || pageIndex >= ranges.length) {
+    return 0
+  }
+  const range = ranges[pageIndex]
+  return currentIndex - range.startIndex
 }
 
 // ── EpisodeListPanel ────────────────────────────────────────────────────────
@@ -42,32 +86,26 @@ export struct EpisodeListPanel {
   @State private focusedCardIndex: number = 0
   @State private isPageBarFocused: boolean = false
   @State private pageBarFocusedIndex: number = 0
-  @State private dataSource: EpisodeDataSource = new EpisodeDataSource([])
-
-  private readonly PAGE_SIZE: number = 6
 
   aboutToAppear(): void {
-    // 定位到当前播放集所在分页
     const currentIdx = this.context.currentIndex
-    this.currentPage = Math.floor(currentIdx / this.PAGE_SIZE)
-    this.focusedCardIndex = currentIdx % this.PAGE_SIZE
-    this.dataSource = new EpisodeDataSource(this.getPageItems())
+    this.currentPage = getEpisodePageIndex(currentIdx, this.context.items.length)
+    this.focusedCardIndex = getEpisodeFocusIndex(currentIdx, this.context.items.length)
+    this.pageBarFocusedIndex = this.currentPage
   }
 
   // ── 数据辅助方法 ───────────────────────────────────────────────────────────
 
+  private getPageRanges(): EpisodePageRange[] {
+    return buildEpisodePageRanges(this.context.items.length)
+  }
+
   private getTotalPages(): number {
-    return Math.max(1, Math.ceil(this.context.items.length / this.PAGE_SIZE))
+    return Math.max(1, this.getPageRanges().length)
   }
 
   private getPageItems(): PlaybackContextItem[] {
-    const start = this.currentPage * this.PAGE_SIZE
-    const end = Math.min(start + this.PAGE_SIZE, this.context.items.length)
-    const result: PlaybackContextItem[] = []
-    for (let i = start; i < end; i++) {
-      result.push(this.context.items[i])
-    }
-    return result
+    return getEpisodePageItems(this.context.items, this.currentPage)
   }
 
   private goToPage(page: number): void {
@@ -77,13 +115,15 @@ export struct EpisodeListPanel {
     }
     this.currentPage = page
     this.focusedCardIndex = 0
-    this.dataSource = new EpisodeDataSource(this.getPageItems())
+    this.pageBarFocusedIndex = page
   }
 
   private getPageLabel(page: number): string {
-    const start = page * this.PAGE_SIZE + 1
-    const end = Math.min((page + 1) * this.PAGE_SIZE, this.context.items.length)
-    return `${start}-${end}`
+    const ranges = this.getPageRanges()
+    if (page < 0 || page >= ranges.length) {
+      return ''
+    }
+    return ranges[page].label
   }
 
   private isCurrentItem(item: PlaybackContextItem): boolean {
@@ -91,7 +131,7 @@ export struct EpisodeListPanel {
   }
 
   private buildPageRange(): number[] {
-    const total = this.getTotalPages()
+    const total = this.getPageRanges().length
     const result: number[] = []
     for (let i = 0; i < total; i++) {
       result.push(i)
@@ -168,16 +208,16 @@ export struct EpisodeListPanel {
         .margin({ bottom: 32 })
         .alignSelf(ItemAlign.Start)
 
-      // 集数卡片横向列表（LazyForEach + 遥控器键盘处理）
+      // 集数卡片横向列表
       List({ space: 48 }) {
-        LazyForEach(
-          this.dataSource,
-          (item: Object, index: number) => {
+        ForEach(
+          this.getPageItems(),
+          (item: PlaybackContextItem, index: number) => {
             ListItem() {
-              this.EpisodeCard(item as PlaybackContextItem, index)
+              this.EpisodeCard(item, index)
             }
           },
-          (item: Object, index: number) => index.toString()
+          (item: PlaybackContextItem): string => getEpisodeItemRenderKey(item)
         )
       }
       .listDirection(Axis.Horizontal)
@@ -258,11 +298,9 @@ export struct EpisodeListPanel {
                 } else if (event.keyCode === KeyCode.KEYCODE_DPAD_UP) {
                   this.isPageBarFocused = false
                 } else if (event.keyCode === KeyCode.KEYCODE_DPAD_LEFT && this.pageBarFocusedIndex > 0) {
-                  this.pageBarFocusedIndex = this.pageBarFocusedIndex - 1
-                  this.goToPage(this.pageBarFocusedIndex)
+                  this.goToPage(pageIdx - 1)
                 } else if (event.keyCode === KeyCode.KEYCODE_DPAD_RIGHT && this.pageBarFocusedIndex < this.getTotalPages() - 1) {
-                  this.pageBarFocusedIndex = this.pageBarFocusedIndex + 1
-                  this.goToPage(this.pageBarFocusedIndex)
+                  this.goToPage(pageIdx + 1)
                 }
               })
             },

--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -90,23 +90,6 @@ export struct EpisodeListPanel {
     return item.index === this.context.currentIndex
   }
 
-  /**
-   * 计算卡片宽度：
-   * - 当前播放集：210vp（高亮缩窄）
-   * - 最后一张且下一页存在（edgeCard）：168vp（截断暗示更多内容）
-   * - 普通集：256vp
-   */
-  private getCardWidth(item: PlaybackContextItem, index: number): number {
-    const pageItems = this.getPageItems()
-    if (index === pageItems.length - 1 && this.currentPage < this.getTotalPages() - 1) {
-      return 168
-    }
-    if (this.isCurrentItem(item)) {
-      return 210
-    }
-    return 256
-  }
-
   private buildPageRange(): number[] {
     const total = this.getTotalPages()
     const result: number[] = []
@@ -124,31 +107,33 @@ export struct EpisodeListPanel {
 
   @Builder
   EpisodeCard(item: PlaybackContextItem, index: number) {
-    Stack({ alignContent: Alignment.BottomEnd }) {
-      // 卡片主体
-      Column() {
-        Text(`第${item.index + 1}集`)
-          .height(28)
-          .fontSize(24)
-          .fontWeight(FontWeight.Bold)
-          .fontColor('#F0F4F9')
-          .textAlign(TextAlign.Center)
+    Column({ space: 8 }) {
+      // 海报卡片主体
+      Stack({ alignContent: Alignment.BottomEnd }) {
+        Image(item.posterPath ? item.posterPath : $r('app.media.empty_folder'))
           .width('100%')
+          .height('100%')
+          .objectFit(ImageFit.Cover)
+
+        // 焦点环：叠加在右下角，仅当前焦点卡片显示
+        if (this.isFocusRingVisible(index)) {
+          Ellipse()
+            .width(42)
+            .height(42)
+            .stroke('#FFFFFF')
+            .strokeWidth(5)
+            .fill(Color.Transparent)
+            .margin({ right: 6, bottom: 6 })
+        }
       }
-      .width(this.getCardWidth(item, index))
-      .height(136)
+      .width(220)
+      .height(140)
       .borderRadius(26)
-      .backgroundColor(
-        this.isCurrentItem(item)
-          ? 'rgba(169, 244, 255, 0.15)'
-          : 'rgba(255, 255, 255, 0.1)'
-      )
       .border(
         this.isCurrentItem(item)
           ? { width: 4, color: '#A9F4FF', style: BorderStyle.Solid }
           : { width: 0, color: Color.Transparent, style: BorderStyle.Solid }
       )
-      .justifyContent(FlexAlign.Center)
       .clip(true)
       .focusable(true)
       .onFocus(() => {
@@ -159,17 +144,14 @@ export struct EpisodeListPanel {
         this.onSelect(item)
       })
 
-      // 焦点环：叠加在右下角，仅当前焦点卡片显示
-      if (this.isFocusRingVisible(index)) {
-        Ellipse()
-          .width(42)
-          .height(42)
-          .stroke('#FFFFFF')
-          .strokeWidth(5)
-          .fill(Color.Transparent)
-          .margin({ right: 6, bottom: 6 })
-      }
+      // 集名
+      Text(item.title)
+        .fontSize(22)
+        .fontColor('#F0F4F9')
+        .textAlign(TextAlign.Center)
+        .width(220)
     }
+    .alignItems(HorizontalAlign.Center)
   }
 
   // ── build ─────────────────────────────────────────────────────────────────
@@ -199,7 +181,7 @@ export struct EpisodeListPanel {
       .listDirection(Axis.Horizontal)
       .scrollBar(BarState.Off)
       .width('100%')
-      .height(160)
+      .height(200)
       .onKeyEvent((event: KeyEvent) => {
         if (event.type !== KeyType.Down) {
           return
@@ -265,33 +247,31 @@ export struct EpisodeListPanel {
               .onClick(() => {
                 this.goToPage(pageIdx)
               })
+              .onKeyEvent((event: KeyEvent) => {
+                if (event.type !== KeyType.Down) {
+                  return
+                }
+                if (event.keyCode === KeyCode.KEYCODE_ENTER || event.keyCode === KeyCode.KEYCODE_DPAD_CENTER) {
+                  this.goToPage(pageIdx)
+                } else if (event.keyCode === KeyCode.KEYCODE_DPAD_UP) {
+                  this.isPageBarFocused = false
+                } else if (event.keyCode === KeyCode.KEYCODE_DPAD_LEFT && this.pageBarFocusedIndex > 0) {
+                  this.pageBarFocusedIndex = this.pageBarFocusedIndex - 1
+                  this.goToPage(this.pageBarFocusedIndex)
+                } else if (event.keyCode === KeyCode.KEYCODE_DPAD_RIGHT && this.pageBarFocusedIndex < this.getTotalPages() - 1) {
+                  this.pageBarFocusedIndex = this.pageBarFocusedIndex + 1
+                  this.goToPage(this.pageBarFocusedIndex)
+                }
+              })
             },
             (pageIdx: number) => pageIdx.toString()
           )
         }
         .margin({ top: 32 })
         .alignSelf(ItemAlign.Start)
-        .onKeyEvent((event: KeyEvent) => {
-          if (event.type !== KeyType.Down) {
-            return
-          }
-          if (event.keyCode === KeyCode.KEYCODE_DPAD_UP) {
-            // 向上回到卡片区
-            this.isPageBarFocused = false
-          } else if (event.keyCode === KeyCode.KEYCODE_DPAD_LEFT && this.pageBarFocusedIndex > 0) {
-            this.pageBarFocusedIndex = this.pageBarFocusedIndex - 1
-            this.goToPage(this.pageBarFocusedIndex)
-          } else if (
-            event.keyCode === KeyCode.KEYCODE_DPAD_RIGHT &&
-            this.pageBarFocusedIndex < this.getTotalPages() - 1
-          ) {
-            this.pageBarFocusedIndex = this.pageBarFocusedIndex + 1
-            this.goToPage(this.pageBarFocusedIndex)
-          }
-        })
       }
     }
-    .backgroundColor('#0B1020')
+    .backgroundColor(Color.Transparent)
     .width('100%')
     .padding({ top: 40, bottom: 40, left: 84 })
     .alignItems(HorizontalAlign.Start)

--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -110,7 +110,7 @@ export struct EpisodeListPanel {
     Column({ space: 8 }) {
       // 海报卡片主体
       Stack({ alignContent: Alignment.BottomEnd }) {
-        Image(item.posterPath ? item.posterPath : $r('app.media.empty_folder'))
+        Image(item.thumbnailUrl ? item.thumbnailUrl : $r('app.media.empty_folder'))
           .width('100%')
           .height('100%')
           .objectFit(ImageFit.Cover)

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -1,12 +1,19 @@
 import { FileSourceDatabase } from '../../../db/files/FileSourceDatabase';
-import { MediaItem } from '../../../db/models/MediaEntity';
+import { MediaItem, TvEpisodeEntity } from '../../../db/models/MediaEntity';
+
+function tmdbImageUrl(path: string | undefined, width: string): string {
+  if (path === undefined || path.length === 0) {
+    return '';
+  }
+  return `https://image.tmdb.org/t/p/${width}${path}`;
+}
 
 // 播放上下文条目接口
 export interface PlaybackContextItem {
   videoPath: string;
   title: string;
   index: number;
-  posterPath?: string;      // 集的封面图本地路径（可选）
+  thumbnailUrl?: string;    // 集缩略图 URL（优先 stillUrl/stillPath）
   episodeNumber?: number;   // 集号（如 1, 2, 3...）
 }
 
@@ -53,18 +60,21 @@ export class MediaLibraryContext extends PlaybackContext {
   static buildItems(
     allItems: MediaItem[],
     seasonNumber: number,
-    currentVideoPath: string
+    currentVideoPath: string,
+    episodeEntities: TvEpisodeEntity[] = []
   ): BuildItemsResult {
     const seasonItems = allItems.filter(item => item.seasonNumber === seasonNumber);
+    const episodeEntityByNumber = MediaLibraryContext.buildEpisodeEntityByNumber(episodeEntities);
 
     const mapped: PlaybackContextItem[] = [];
     for (let i = 0; i < seasonItems.length; i++) {
       const ep = seasonItems[i];
+      const episodeEntity = MediaLibraryContext.findEpisodeEntity(ep, i, episodeEntities, episodeEntityByNumber);
       const item: PlaybackContextItem = {
         videoPath: ep.filePath,
         title: ep.title ?? ep.fileName,
         index: i,
-        posterPath: ep.posterLocalPath ?? undefined,
+        thumbnailUrl: MediaLibraryContext.getEpisodeThumbnailUrl(episodeEntity),
         episodeNumber: ep.episodeNumber ?? undefined,
       };
       mapped.push(item);
@@ -94,7 +104,8 @@ export class MediaLibraryContext extends PlaybackContext {
     currentVideoPath: string
   ): Promise<MediaLibraryContext> {
     const allItems = await db.getMediaItemsByTvSeriesId(seriesId);
-    const buildResult = MediaLibraryContext.buildItems(allItems, seasonNumber, currentVideoPath);
+    const episodeEntities = await db.getEpisodesBySeriesAndSeason(seriesId, seasonNumber);
+    const buildResult = MediaLibraryContext.buildItems(allItems, seasonNumber, currentVideoPath, episodeEntities);
 
     const ctx = new MediaLibraryContext();
     ctx.seriesId = seriesId;
@@ -103,6 +114,46 @@ export class MediaLibraryContext extends PlaybackContext {
     ctx.items = buildResult.items;
     ctx.currentIndex = buildResult.currentIndex;
     return ctx;
+  }
+
+  private static buildEpisodeEntityByNumber(episodeEntities: TvEpisodeEntity[]): Map<number, TvEpisodeEntity> {
+    const result = new Map<number, TvEpisodeEntity>();
+    for (let i = 0; i < episodeEntities.length; i++) {
+      const entity = episodeEntities[i];
+      result.set(entity.episodeNumber, entity);
+    }
+    return result;
+  }
+
+  private static findEpisodeEntity(
+    item: MediaItem,
+    index: number,
+    episodeEntities: TvEpisodeEntity[],
+    episodeEntityByNumber: Map<number, TvEpisodeEntity>
+  ): TvEpisodeEntity | undefined {
+    if (item.episodeNumber !== undefined) {
+      const matchedEntity = episodeEntityByNumber.get(item.episodeNumber);
+      if (matchedEntity !== undefined) {
+        return matchedEntity;
+      }
+    }
+    if (index >= 0 && index < episodeEntities.length) {
+      return episodeEntities[index];
+    }
+    return undefined;
+  }
+
+  private static getEpisodeThumbnailUrl(entity: TvEpisodeEntity | undefined): string | undefined {
+    if (entity === undefined) {
+      return undefined;
+    }
+    if (entity.stillUrl !== undefined && entity.stillUrl.length > 0) {
+      return entity.stillUrl;
+    }
+    if (entity.stillPath !== undefined && entity.stillPath.length > 0) {
+      return tmdbImageUrl(entity.stillPath, 'w342');
+    }
+    return undefined;
   }
 
   jumpTo(index: number): PlaybackContextItem | null {

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -6,7 +6,8 @@ export interface PlaybackContextItem {
   videoPath: string;
   title: string;
   index: number;
-  posterPath?: string;  // 集的封面图本地路径（可选）
+  posterPath?: string;      // 集的封面图本地路径（可选）
+  episodeNumber?: number;   // 集号（如 1, 2, 3...）
 }
 
 // 播放上下文抽象基类
@@ -64,6 +65,7 @@ export class MediaLibraryContext extends PlaybackContext {
         title: ep.title ?? ep.fileName,
         index: i,
         posterPath: ep.posterLocalPath ?? undefined,
+        episodeNumber: ep.episodeNumber ?? undefined,
       };
       mapped.push(item);
     }

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -1,0 +1,27 @@
+// 播放上下文条目接口
+export interface PlaybackContextItem {
+  videoPath: string;
+  title: string;
+  index: number;
+}
+
+// 播放上下文抽象基类
+@ObservedV2
+export abstract class PlaybackContext {
+  abstract readonly contextType: string;
+
+  @Trace currentIndex: number = 0;
+  @Trace items: PlaybackContextItem[] = [];
+
+  get hasNext(): boolean {
+    return this.currentIndex < this.items.length - 1;
+  }
+
+  get hasPrev(): boolean {
+    return this.currentIndex > 0;
+  }
+
+  abstract jumpToNext(): PlaybackContextItem | null;
+  abstract jumpToPrev(): PlaybackContextItem | null;
+  abstract jumpTo(index: number): PlaybackContextItem | null;
+}

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -1,3 +1,6 @@
+import { FileSourceDatabase } from '../../../db/files/FileSourceDatabase';
+import { MediaItem } from '../../../db/models/MediaEntity';
+
 // 播放上下文条目接口
 export interface PlaybackContextItem {
   videoPath: string;
@@ -24,4 +27,97 @@ export abstract class PlaybackContext {
   abstract jumpToNext(): PlaybackContextItem | null;
   abstract jumpToPrev(): PlaybackContextItem | null;
   abstract jumpTo(index: number): PlaybackContextItem | null;
+}
+
+// 媒体库播放上下文：基于剧集数据库加载当季集列表
+@ObservedV2
+export class MediaLibraryContext extends PlaybackContext {
+  readonly contextType: string = 'media_library';
+
+  @Trace seriesId: number = 0;
+  @Trace seasonNumber: number = 0;
+  @Trace episodes: MediaItem[] = [];
+
+  /**
+   * 工厂方法：查询数据库获取当季所有剧集并定位 currentIndex。
+   * 使用 getMediaItemsByTvSeriesId 获取全季数据，按 seasonNumber 过滤，
+   * 以 filePath 映射为 PlaybackContextItem。
+   */
+  static async build(
+    db: FileSourceDatabase,
+    seriesId: number,
+    seasonNumber: number,
+    currentVideoPath: string
+  ): Promise<MediaLibraryContext> {
+    const allItems = await db.getMediaItemsByTvSeriesId(seriesId);
+    const seasonItems = allItems.filter(item => item.seasonNumber === seasonNumber);
+
+    const ctx = new MediaLibraryContext();
+    ctx.seriesId = seriesId;
+    ctx.seasonNumber = seasonNumber;
+    ctx.episodes = seasonItems;
+
+    const mapped: PlaybackContextItem[] = [];
+    for (let i = 0; i < seasonItems.length; i++) {
+      const ep = seasonItems[i];
+      const item: PlaybackContextItem = {
+        videoPath: ep.filePath,
+        title: ep.title ?? ep.fileName,
+        index: i
+      };
+      mapped.push(item);
+    }
+    ctx.items = mapped;
+
+    // 定位当前集
+    let foundIndex = 0;
+    for (let i = 0; i < mapped.length; i++) {
+      if (mapped[i].videoPath === currentVideoPath) {
+        foundIndex = i;
+        break;
+      }
+    }
+    ctx.currentIndex = foundIndex;
+    return ctx;
+  }
+
+  jumpTo(index: number): PlaybackContextItem | null {
+    if (index < 0 || index >= this.items.length) {
+      return null;
+    }
+    this.currentIndex = index;
+    return this.items[index];
+  }
+
+  jumpToNext(): PlaybackContextItem | null {
+    if (!this.hasNext) {
+      return null;
+    }
+    return this.jumpTo(this.currentIndex + 1);
+  }
+
+  jumpToPrev(): PlaybackContextItem | null {
+    if (!this.hasPrev) {
+      return null;
+    }
+    return this.jumpTo(this.currentIndex - 1);
+  }
+}
+
+// 文件浏览器播放上下文：骨架实现，jumpTo 系列均返回 null（待后续 Phase 实现）
+@ObservedV2
+export class FileExplorerContext extends PlaybackContext {
+  readonly contextType: string = 'file_explorer';
+
+  jumpTo(_index: number): PlaybackContextItem | null {
+    return null;
+  }
+
+  jumpToNext(): PlaybackContextItem | null {
+    return null;
+  }
+
+  jumpToPrev(): PlaybackContextItem | null {
+    return null;
+  }
 }

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -6,6 +6,7 @@ export interface PlaybackContextItem {
   videoPath: string;
   title: string;
   index: number;
+  posterPath?: string;  // 集的封面图本地路径（可选）
 }
 
 // 播放上下文抽象基类
@@ -61,7 +62,8 @@ export class MediaLibraryContext extends PlaybackContext {
       const item: PlaybackContextItem = {
         videoPath: ep.filePath,
         title: ep.title ?? ep.fileName,
-        index: i
+        index: i,
+        posterPath: ep.posterLocalPath ?? undefined,
       };
       mapped.push(item);
     }

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -29,6 +29,12 @@ export abstract class PlaybackContext {
   abstract jumpTo(index: number): PlaybackContextItem | null;
 }
 
+// buildItems 辅助方法返回类型（不依赖 DB，可在单测中直接调用）
+export interface BuildItemsResult {
+  items: PlaybackContextItem[];
+  currentIndex: number;
+}
+
 // 媒体库播放上下文：基于剧集数据库加载当季集列表
 @ObservedV2
 export class MediaLibraryContext extends PlaybackContext {
@@ -37,6 +43,40 @@ export class MediaLibraryContext extends PlaybackContext {
   @Trace seriesId: number = 0;
   @Trace seasonNumber: number = 0;
   @Trace episodes: MediaItem[] = [];
+
+  /**
+   * 纯函数辅助方法：从所有剧集中按 seasonNumber 过滤并定位 currentIndex。
+   * 不依赖 DB，可在单测中直接调用。
+   */
+  static buildItems(
+    allItems: MediaItem[],
+    seasonNumber: number,
+    currentVideoPath: string
+  ): BuildItemsResult {
+    const seasonItems = allItems.filter(item => item.seasonNumber === seasonNumber);
+
+    const mapped: PlaybackContextItem[] = [];
+    for (let i = 0; i < seasonItems.length; i++) {
+      const ep = seasonItems[i];
+      const item: PlaybackContextItem = {
+        videoPath: ep.filePath,
+        title: ep.title ?? ep.fileName,
+        index: i
+      };
+      mapped.push(item);
+    }
+
+    let foundIndex = 0;
+    for (let i = 0; i < mapped.length; i++) {
+      if (mapped[i].videoPath === currentVideoPath) {
+        foundIndex = i;
+        break;
+      }
+    }
+
+    const result: BuildItemsResult = { items: mapped, currentIndex: foundIndex };
+    return result;
+  }
 
   /**
    * 工厂方法：查询数据库获取当季所有剧集并定位 currentIndex。
@@ -50,34 +90,14 @@ export class MediaLibraryContext extends PlaybackContext {
     currentVideoPath: string
   ): Promise<MediaLibraryContext> {
     const allItems = await db.getMediaItemsByTvSeriesId(seriesId);
-    const seasonItems = allItems.filter(item => item.seasonNumber === seasonNumber);
+    const buildResult = MediaLibraryContext.buildItems(allItems, seasonNumber, currentVideoPath);
 
     const ctx = new MediaLibraryContext();
     ctx.seriesId = seriesId;
     ctx.seasonNumber = seasonNumber;
-    ctx.episodes = seasonItems;
-
-    const mapped: PlaybackContextItem[] = [];
-    for (let i = 0; i < seasonItems.length; i++) {
-      const ep = seasonItems[i];
-      const item: PlaybackContextItem = {
-        videoPath: ep.filePath,
-        title: ep.title ?? ep.fileName,
-        index: i
-      };
-      mapped.push(item);
-    }
-    ctx.items = mapped;
-
-    // 定位当前集
-    let foundIndex = 0;
-    for (let i = 0; i < mapped.length; i++) {
-      if (mapped[i].videoPath === currentVideoPath) {
-        foundIndex = i;
-        break;
-      }
-    }
-    ctx.currentIndex = foundIndex;
+    ctx.episodes = allItems.filter(item => item.seasonNumber === seasonNumber);
+    ctx.items = buildResult.items;
+    ctx.currentIndex = buildResult.currentIndex;
     return ctx;
   }
 

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -591,6 +591,67 @@ interface SpeedOption {
   speed: number;
 }
 
+const PLAYER_SETTINGS_CHIP_HEIGHT: number = 68
+const PLAYER_SETTINGS_CHIP_RADIUS: number = 22
+const PLAYER_SETTINGS_CHIP_FONT_SIZE: number = 18
+const PLAYER_SETTINGS_CHIP_HORIZONTAL_PADDING: number = 18
+const PLAYER_SETTINGS_CHIP_VERTICAL_PADDING: number = 10
+const PLAYER_SETTINGS_CHIP_GAP: number = 10
+const PLAYER_SETTINGS_CHIP_SCALE_FOCUSED: number = 1.04
+
+export interface PlayerSettingsChipStyleState {
+  isFocused: boolean
+  isHovered: boolean
+  isSelected: boolean
+  showFocusOutline: boolean
+  showSelectedOutline: boolean
+  showWaveIcon: boolean
+  scale: number
+  shadowRadius: number
+  shadowColor: string
+  backgroundColor: string
+  labelColor: string
+  focusBorderWidth: number
+  selectedBorderWidth: number
+  height: number
+  borderRadius: number
+  labelFontSize: number
+  horizontalPadding: number
+  verticalPadding: number
+  groupGap: number
+}
+
+export function getPlayerSettingsChipStyleState(
+  isFocused: boolean,
+  isSelected: boolean,
+  isHovered: boolean = false
+): PlayerSettingsChipStyleState {
+  const isEmphasized = isFocused || isHovered
+  const styleState: PlayerSettingsChipStyleState = {
+    isFocused,
+    isHovered,
+    isSelected,
+    showFocusOutline: false,
+    showSelectedOutline: false,
+    showWaveIcon: false,
+    scale: isEmphasized ? PLAYER_SETTINGS_CHIP_SCALE_FOCUSED : 1,
+    shadowRadius: isEmphasized ? 12 : 0,
+    shadowColor: isEmphasized ? '#386EA8E0' : '#00000000',
+    backgroundColor: isSelected ? 'rgba(255, 255, 255, 0.28)' :
+      isEmphasized ? 'rgba(255, 255, 255, 0.22)' : 'rgba(255, 255, 255, 0.12)',
+    labelColor: isSelected ? '#F9FCFF' : isEmphasized ? '#F3F7FF' : '#E8EDF5',
+    focusBorderWidth: 0,
+    selectedBorderWidth: 0,
+    height: PLAYER_SETTINGS_CHIP_HEIGHT,
+    borderRadius: PLAYER_SETTINGS_CHIP_RADIUS,
+    labelFontSize: PLAYER_SETTINGS_CHIP_FONT_SIZE,
+    horizontalPadding: PLAYER_SETTINGS_CHIP_HORIZONTAL_PADDING,
+    verticalPadding: PLAYER_SETTINGS_CHIP_VERTICAL_PADDING,
+    groupGap: PLAYER_SETTINGS_CHIP_GAP
+  }
+  return styleState
+}
+
 @CustomDialog
 export struct PlayerSettingsDialog {
   controller: CustomDialogController
@@ -600,6 +661,8 @@ export struct PlayerSettingsDialog {
   @State private currentAspectRatioMode: AspectRatioMode = AspectRatioMode.FIT
   @State private arFocusedIndex: number = -1
   @State private speedFocusedIndex: number = -1
+  @State private arHoveredIndex: number = -1
+  @State private speedHoveredIndex: number = -1
   private readonly aspectRatioOptions: AspectRatioOption[] = [
     { label: '适应', mode: AspectRatioMode.FIT },
     { label: '填充', mode: AspectRatioMode.FILL },
@@ -622,6 +685,8 @@ export struct PlayerSettingsDialog {
     this.currentAspectRatioMode = this.videoController.aspectRatioMode;
     this.arFocusedIndex = -1;
     this.speedFocusedIndex = -1;
+    this.arHoveredIndex = -1;
+    this.speedHoveredIndex = -1;
     // 从控制器同步当前播放速率，找到匹配的 index（默认回退到 1.0x = index 2）
     const currentSpeed = this.videoController.playbackSpeed;
     let matchIdx = 2;
@@ -637,6 +702,8 @@ export struct PlayerSettingsDialog {
   aboutToDisappear(): void {
     this.arFocusedIndex = -1;
     this.speedFocusedIndex = -1;
+    this.arHoveredIndex = -1;
+    this.speedHoveredIndex = -1;
   }
 
   /** 当 playbackContext 是媒体库上下文时返回，否则返回 undefined */
@@ -658,6 +725,41 @@ export struct PlayerSettingsDialog {
       .borderRadius("50%")
       .border({ width: selected ? 2 : 1, color: selected ? '#fffefe' : '#45ffffff' })
       .shadow({ radius: selected ? 8 : 0, color: selected ? '#33597FB8' : '#00ffffff' })
+  }
+
+  @Builder
+  private SelectionOptionChip(label: string, styleState: PlayerSettingsChipStyleState) {
+    Row() {
+      Text(label)
+        .fontSize(styleState.labelFontSize)
+        .fontColor(styleState.labelColor)
+        .fontWeight(styleState.isSelected ? FontWeight.Medium : FontWeight.Regular)
+        .maxLines(1)
+    }
+    .height(styleState.height)
+    .padding({ left: styleState.horizontalPadding, right: styleState.horizontalPadding })
+    .justifyContent(FlexAlign.Center)
+    .backgroundColor(styleState.backgroundColor)
+    .borderRadius(styleState.borderRadius)
+    .shadow({ radius: styleState.shadowRadius, color: styleState.shadowColor })
+    .scale({ x: styleState.scale, y: styleState.scale })
+    .animation({ duration: 180, curve: Curve.EaseInOut })
+  }
+
+  private getSpeedChipStyleState(idx: number): PlayerSettingsChipStyleState {
+    return getPlayerSettingsChipStyleState(
+      this.speedFocusedIndex === idx,
+      this.selectedPlaybackRateIndex === idx,
+      this.speedHoveredIndex === idx
+    )
+  }
+
+  private getAspectRatioChipStyleState(idx: number): PlayerSettingsChipStyleState {
+    return getPlayerSettingsChipStyleState(
+      this.arFocusedIndex === idx,
+      this.currentAspectRatioMode === this.aspectRatioOptions[idx].mode,
+      this.arHoveredIndex === idx
+    )
   }
 
   build() {
@@ -689,33 +791,16 @@ export struct PlayerSettingsDialog {
                 .fontWeight(FontWeight.Medium)
                 .alignSelf(ItemAlign.Start)
 
-              Row({ space: 12 }) {
+              Row({ space: PLAYER_SETTINGS_CHIP_GAP }) {
                 ForEach(this.speedOptions, (opt: SpeedOption, idx: number) => {
                   Row() {
-                    Text(opt.label)
-                      .fontSize(26)
-                      .fontColor(this.selectedPlaybackRateIndex === idx ? '#F3F7FF' : '#D7DCE7')
-                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                      .backgroundColor(this.selectedPlaybackRateIndex === idx
-                        ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                      .borderRadius("50%")
-                      .border({
-                        width: this.selectedPlaybackRateIndex === idx ? 2 : 1,
-                        color: this.selectedPlaybackRateIndex === idx ? '#fffefe' : '#45ffffff'
-                      })
-                      .shadow({
-                        radius: this.selectedPlaybackRateIndex === idx ? 8 : 0,
-                        color: this.selectedPlaybackRateIndex === idx ? '#33597FB8' : '#00ffffff'
-                      })
+                    this.SelectionOptionChip(opt.label, this.getSpeedChipStyleState(idx))
                   }
                   .focusable(true)
                   .onFocus(() => { this.speedFocusedIndex = idx })
                   .onBlur(() => { this.speedFocusedIndex = -1 })
-                  .borderRadius(99)
-                  .padding(this.speedFocusedIndex === idx ? 2 : 0)
-                  .border({
-                    width: this.speedFocusedIndex === idx ? 2 : 0,
-                    color: this.speedFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
+                  .onHover((isHover: boolean) => {
+                    this.speedHoveredIndex = isHover ? idx : -1
                   })
                   .onClick(() => {
                     this.selectedPlaybackRateIndex = idx
@@ -735,33 +820,16 @@ export struct PlayerSettingsDialog {
                 .fontWeight(FontWeight.Medium)
                 .alignSelf(ItemAlign.Start)
 
-              Row({ space: 12 }) {
+              Row({ space: PLAYER_SETTINGS_CHIP_GAP }) {
                 ForEach(this.aspectRatioOptions, (opt: AspectRatioOption, idx: number) => {
                   Row() {
-                    Text(opt.label)
-                      .fontSize(26)
-                      .fontColor(this.currentAspectRatioMode === opt.mode ? '#F3F7FF' : '#D7DCE7')
-                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                      .backgroundColor(this.currentAspectRatioMode === opt.mode
-                        ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                      .borderRadius("50%")
-                      .border({
-                        width: this.currentAspectRatioMode === opt.mode ? 2 : 1,
-                        color: this.currentAspectRatioMode === opt.mode ? '#fffefe' : '#45ffffff'
-                      })
-                      .shadow({
-                        radius: this.currentAspectRatioMode === opt.mode ? 8 : 0,
-                        color: this.currentAspectRatioMode === opt.mode ? '#33597FB8' : '#00ffffff'
-                      })
+                    this.SelectionOptionChip(opt.label, this.getAspectRatioChipStyleState(idx))
                   }
                   .focusable(true)
                   .onFocus(() => { this.arFocusedIndex = idx })
                   .onBlur(() => { this.arFocusedIndex = -1 })
-                  .borderRadius(99)
-                  .padding(this.arFocusedIndex === idx ? 2 : 0)
-                  .border({
-                    width: this.arFocusedIndex === idx ? 2 : 0,
-                    color: this.arFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
+                  .onHover((isHover: boolean) => {
+                    this.arHoveredIndex = isHover ? idx : -1
                   })
                   .onClick(() => {
                     this.currentAspectRatioMode = opt.mode

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -868,7 +868,7 @@ export struct PlayerSettingsDialog {
       .scrollBar(BarState.Off)
       .width('100%')
       .height('55%')
-      .backgroundColor('rgba(9,14,25,0.92)')
+      .backgroundColor(Color.Transparent)
       .borderRadius({ topLeft: 24, topRight: 24 })
       .nestedScroll({ scrollForward: NestedScrollMode.SELF_ONLY, scrollBackward: NestedScrollMode.SELF_ONLY })
     }

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -615,7 +615,6 @@ export struct PlayerSettingsDialog {
   ]
   @State private aiEnhanceOn: boolean = true
   @State private aiEnhanceQuality: VpeQualityLevel = 'medium'
-  @State private selectedTabIndex: number = 0
 
   aboutToAppear(): void {
     this.aiEnhanceOn = this.videoController.aiEnhanceEnabled;
@@ -638,7 +637,6 @@ export struct PlayerSettingsDialog {
   aboutToDisappear(): void {
     this.arFocusedIndex = -1;
     this.speedFocusedIndex = -1;
-    this.selectedTabIndex = 0;
   }
 
   /** 当 playbackContext 是媒体库上下文时返回，否则返回 undefined */
@@ -669,236 +667,210 @@ export struct PlayerSettingsDialog {
         .height('100%')
         .backgroundColor(Color.Transparent)
 
-      Column() {
-        // ── Tab 切换栏（仅 media_library 上下文时显示）──────────────────────
-        if (this.getMediaLibraryContext() !== undefined) {
-          Row({ space: 8 }) {
-            Text('选集')
-              .fontSize(28)
-              .fontColor(this.selectedTabIndex === 0 ? '#F3F7FF' : '#D7DCE7')
-              .padding({ left: 24, right: 24, top: 10, bottom: 10 })
-              .backgroundColor(this.selectedTabIndex === 0 ? 'rgba(255,255,255,0.3)' : Color.Transparent)
-              .borderRadius(20)
-              .focusable(true)
-              .onClick(() => { this.selectedTabIndex = 0 })
-
-            Text('更多设置')
-              .fontSize(28)
-              .fontColor(this.selectedTabIndex === 1 ? '#F3F7FF' : '#D7DCE7')
-              .padding({ left: 24, right: 24, top: 10, bottom: 10 })
-              .backgroundColor(this.selectedTabIndex === 1 ? 'rgba(255,255,255,0.3)' : Color.Transparent)
-              .borderRadius(20)
-              .focusable(true)
-              .onClick(() => { this.selectedTabIndex = 1 })
+      Scroll() {
+        Column({ space: 0 }) {
+          // ── 选集区域（仅 MediaLibraryContext 时显示）────────────────────────
+          if (this.getMediaLibraryContext() !== undefined) {
+            EpisodeListPanel({
+              context: this.getMediaLibraryContext() as MediaLibraryContext,
+              onSelect: (item: PlaybackContextItem) => {
+                this.videoController.playbackContext?.jumpTo(item.index)
+                this.controller.close()
+              }
+            })
           }
-          .padding({ left: 26, top: 16, bottom: 8 })
-          .width('100%')
-          .backgroundColor('#090E1922')
-        }
 
-        // ── 内容区 ──────────────────────────────────────────────────────────
-        if (this.getMediaLibraryContext() !== undefined && this.selectedTabIndex === 0) {
-          // 选集面板
-          EpisodeListPanel({
-            context: this.getMediaLibraryContext() as MediaLibraryContext,
-            onSelect: (item: PlaybackContextItem) => {
-              this.videoController.playbackContext?.jumpTo(item.index)
-              this.controller.close()
-            }
-          })
-        } else {
-          // 原有设置内容（无 playbackContext 或切到"更多设置"时保持不变）
-          Scroll() {
-            Column({ space: 28 }) {
-              Column({ space: 12 }) {
-                Text('倍速播放')
-                  .fontSize(32)
-                  .fontColor('#EFF2FB')
-                  .fontWeight(FontWeight.Medium)
-                  .alignSelf(ItemAlign.Start)
+          // ── 倍速播放 & 其他设置 ─────────────────────────────────────────────
+          Column({ space: 28 }) {
+            Column({ space: 12 }) {
+              Text('倍速播放')
+                .fontSize(32)
+                .fontColor('#EFF2FB')
+                .fontWeight(FontWeight.Medium)
+                .alignSelf(ItemAlign.Start)
 
-                Row({ space: 12 }) {
-                  ForEach(this.speedOptions, (opt: SpeedOption, idx: number) => {
-                    Row() {
-                      Text(opt.label)
-                        .fontSize(26)
-                        .fontColor(this.selectedPlaybackRateIndex === idx ? '#F3F7FF' : '#D7DCE7')
-                        .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                        .backgroundColor(this.selectedPlaybackRateIndex === idx
-                          ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                        .borderRadius("50%")
-                        .border({
-                          width: this.selectedPlaybackRateIndex === idx ? 2 : 1,
-                          color: this.selectedPlaybackRateIndex === idx ? '#fffefe' : '#45ffffff'
-                        })
-                        .shadow({
-                          radius: this.selectedPlaybackRateIndex === idx ? 8 : 0,
-                          color: this.selectedPlaybackRateIndex === idx ? '#33597FB8' : '#00ffffff'
-                        })
-                    }
-                    .focusable(true)
-                    .onFocus(() => { this.speedFocusedIndex = idx })
-                    .onBlur(() => { this.speedFocusedIndex = -1 })
-                    .borderRadius(99)
-                    .padding(this.speedFocusedIndex === idx ? 2 : 0)
-                    .border({
-                      width: this.speedFocusedIndex === idx ? 2 : 0,
-                      color: this.speedFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
-                    })
-                    .onClick(() => {
-                      this.selectedPlaybackRateIndex = idx
-                      this.videoController.setPlaybackSpeed(opt.speed)
-                    })
-                  }, (opt: SpeedOption) => opt.speed.toString())
-                }
-                .justifyContent(FlexAlign.Start)
-                .width('100%')
-              }
-
-
-              Column({ space: 12 }) {
-                Text('画面比例')
-                  .fontSize(32)
-                  .fontColor('#EFF2FB')
-                  .fontWeight(FontWeight.Medium)
-                  .alignSelf(ItemAlign.Start)
-
-                Row({ space: 12 }) {
-                  ForEach(this.aspectRatioOptions, (opt: AspectRatioOption, idx: number) => {
-                    Row() {
-                      Text(opt.label)
-                        .fontSize(26)
-                        .fontColor(this.currentAspectRatioMode === opt.mode ? '#F3F7FF' : '#D7DCE7')
-                        .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                        .backgroundColor(this.currentAspectRatioMode === opt.mode
-                          ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                        .borderRadius("50%")
-                        .border({
-                          width: this.currentAspectRatioMode === opt.mode ? 2 : 1,
-                          color: this.currentAspectRatioMode === opt.mode ? '#fffefe' : '#45ffffff'
-                        })
-                        .shadow({
-                          radius: this.currentAspectRatioMode === opt.mode ? 8 : 0,
-                          color: this.currentAspectRatioMode === opt.mode ? '#33597FB8' : '#00ffffff'
-                        })
-                    }
-                    .focusable(true)
-                    .onFocus(() => { this.arFocusedIndex = idx })
-                    .onBlur(() => { this.arFocusedIndex = -1 })
-                    .borderRadius(99)
-                    .padding(this.arFocusedIndex === idx ? 2 : 0)
-                    .border({
-                      width: this.arFocusedIndex === idx ? 2 : 0,
-                      color: this.arFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
-                    })
-                    .onClick(() => {
-                      this.currentAspectRatioMode = opt.mode
-                      this.videoController.setAspectRatioMode(opt.mode)
-                    })
-                  }, (opt: AspectRatioOption) => opt.mode.toString())
-                }
-                .justifyContent(FlexAlign.Start)
-                .width('100%')
-              }
-
-              Column({ space: 12 }) {
-                Text('字幕管理')
-                  .fontSize(32)
-                  .fontColor('#EFF2FB')
-                  .fontWeight(FontWeight.Medium)
-                  .alignSelf(ItemAlign.Start)
-
-                Row() {
-                  this.SettingsChip('选择字幕', this.videoController.activeSubtitleIndex >= 0)
-                }
-                .onClick(() => {
-                  this.onOpenSubtitleSelector()
-                })
-              }
-
-              if (canIUse('SystemCapability.Multimedia.VideoProcessingEngine') && this.videoController.backend === 'avplayer') {
-                Column({ space: 12 }) {
-                  Text('画质增强')
-                    .fontSize(32)
-                    .fontColor('#EFF2FB')
-                    .fontWeight(FontWeight.Medium)
-                    .alignSelf(ItemAlign.Start)
-
-                  Row({ space: 12 }) {
-                    // 直接内联 Text + onClick，绕过 @CustomDialog @Builder 参数不刷新问题
-                    Text('关闭')
+              Row({ space: 12 }) {
+                ForEach(this.speedOptions, (opt: SpeedOption, idx: number) => {
+                  Row() {
+                    Text(opt.label)
                       .fontSize(26)
-                      .fontColor(!this.aiEnhanceOn ? '#F3F7FF' : '#D7DCE7')
+                      .fontColor(this.selectedPlaybackRateIndex === idx ? '#F3F7FF' : '#D7DCE7')
                       .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                      .backgroundColor(!this.aiEnhanceOn ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                      .borderRadius(99)
-                      .border({ width: !this.aiEnhanceOn ? 2 : 1, color: !this.aiEnhanceOn ? '#fffefe' : '#45ffffff' })
-                      .onClick(() => {
-                        hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击关闭');
-                        this.aiEnhanceOn = false;
-                        this.videoController.disableAiEnhance();
+                      .backgroundColor(this.selectedPlaybackRateIndex === idx
+                        ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                      .borderRadius("50%")
+                      .border({
+                        width: this.selectedPlaybackRateIndex === idx ? 2 : 1,
+                        color: this.selectedPlaybackRateIndex === idx ? '#fffefe' : '#45ffffff'
                       })
-
-                    Text('低')
-                      .fontSize(26)
-                      .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#F3F7FF' : '#D7DCE7')
-                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                      .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                      .borderRadius(99)
-                      .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#fffefe' : '#45ffffff' })
-                      .onClick(() => {
-                        hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击低');
-                        this.aiEnhanceOn = true;
-                        this.aiEnhanceQuality = 'low';
-                        this.videoController.setAiEnhance('low');
-                      })
-
-                    Text('中')
-                      .fontSize(26)
-                      .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#F3F7FF' : '#D7DCE7')
-                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                      .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                      .borderRadius(99)
-                      .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#fffefe' : '#45ffffff' })
-                      .onClick(() => {
-                        hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击中');
-                        this.aiEnhanceOn = true;
-                        this.aiEnhanceQuality = 'medium';
-                        this.videoController.setAiEnhance('medium');
-                      })
-
-                    Text('高')
-                      .fontSize(26)
-                      .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#F3F7FF' : '#D7DCE7')
-                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                      .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                      .borderRadius(99)
-                      .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#fffefe' : '#45ffffff' })
-                      .onClick(() => {
-                        hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击高');
-                        this.aiEnhanceOn = true;
-                        this.aiEnhanceQuality = 'high';
-                        this.videoController.setAiEnhance('high');
+                      .shadow({
+                        radius: this.selectedPlaybackRateIndex === idx ? 8 : 0,
+                        color: this.selectedPlaybackRateIndex === idx ? '#33597FB8' : '#00ffffff'
                       })
                   }
-                  .justifyContent(FlexAlign.Start)
-                  .width('100%')
+                  .focusable(true)
+                  .onFocus(() => { this.speedFocusedIndex = idx })
+                  .onBlur(() => { this.speedFocusedIndex = -1 })
+                  .borderRadius(99)
+                  .padding(this.speedFocusedIndex === idx ? 2 : 0)
+                  .border({
+                    width: this.speedFocusedIndex === idx ? 2 : 0,
+                    color: this.speedFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
+                  })
+                  .onClick(() => {
+                    this.selectedPlaybackRateIndex = idx
+                    this.videoController.setPlaybackSpeed(opt.speed)
+                  })
+                }, (opt: SpeedOption) => opt.speed.toString())
+              }
+              .justifyContent(FlexAlign.Start)
+              .width('100%')
+            }
+
+
+            Column({ space: 12 }) {
+              Text('画面比例')
+                .fontSize(32)
+                .fontColor('#EFF2FB')
+                .fontWeight(FontWeight.Medium)
+                .alignSelf(ItemAlign.Start)
+
+              Row({ space: 12 }) {
+                ForEach(this.aspectRatioOptions, (opt: AspectRatioOption, idx: number) => {
+                  Row() {
+                    Text(opt.label)
+                      .fontSize(26)
+                      .fontColor(this.currentAspectRatioMode === opt.mode ? '#F3F7FF' : '#D7DCE7')
+                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                      .backgroundColor(this.currentAspectRatioMode === opt.mode
+                        ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                      .borderRadius("50%")
+                      .border({
+                        width: this.currentAspectRatioMode === opt.mode ? 2 : 1,
+                        color: this.currentAspectRatioMode === opt.mode ? '#fffefe' : '#45ffffff'
+                      })
+                      .shadow({
+                        radius: this.currentAspectRatioMode === opt.mode ? 8 : 0,
+                        color: this.currentAspectRatioMode === opt.mode ? '#33597FB8' : '#00ffffff'
+                      })
+                  }
+                  .focusable(true)
+                  .onFocus(() => { this.arFocusedIndex = idx })
+                  .onBlur(() => { this.arFocusedIndex = -1 })
+                  .borderRadius(99)
+                  .padding(this.arFocusedIndex === idx ? 2 : 0)
+                  .border({
+                    width: this.arFocusedIndex === idx ? 2 : 0,
+                    color: this.arFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
+                  })
+                  .onClick(() => {
+                    this.currentAspectRatioMode = opt.mode
+                    this.videoController.setAspectRatioMode(opt.mode)
+                  })
+                }, (opt: AspectRatioOption) => opt.mode.toString())
+              }
+              .justifyContent(FlexAlign.Start)
+              .width('100%')
+            }
+
+            Column({ space: 12 }) {
+              Text('字幕管理')
+                .fontSize(32)
+                .fontColor('#EFF2FB')
+                .fontWeight(FontWeight.Medium)
+                .alignSelf(ItemAlign.Start)
+
+              Row() {
+                this.SettingsChip('选择字幕', this.videoController.activeSubtitleIndex >= 0)
+              }
+              .onClick(() => {
+                this.onOpenSubtitleSelector()
+              })
+            }
+
+            if (canIUse('SystemCapability.Multimedia.VideoProcessingEngine') && this.videoController.backend === 'avplayer') {
+              Column({ space: 12 }) {
+                Text('画质增强')
+                  .fontSize(32)
+                  .fontColor('#EFF2FB')
+                  .fontWeight(FontWeight.Medium)
+                  .alignSelf(ItemAlign.Start)
+
+                Row({ space: 12 }) {
+                  // 直接内联 Text + onClick，绕过 @CustomDialog @Builder 参数不刷新问题
+                  Text('关闭')
+                    .fontSize(26)
+                    .fontColor(!this.aiEnhanceOn ? '#F3F7FF' : '#D7DCE7')
+                    .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                    .backgroundColor(!this.aiEnhanceOn ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                    .borderRadius(99)
+                    .border({ width: !this.aiEnhanceOn ? 2 : 1, color: !this.aiEnhanceOn ? '#fffefe' : '#45ffffff' })
+                    .onClick(() => {
+                      hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击关闭');
+                      this.aiEnhanceOn = false;
+                      this.videoController.disableAiEnhance();
+                    })
+
+                  Text('低')
+                    .fontSize(26)
+                    .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#F3F7FF' : '#D7DCE7')
+                    .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                    .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                    .borderRadius(99)
+                    .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#fffefe' : '#45ffffff' })
+                    .onClick(() => {
+                      hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击低');
+                      this.aiEnhanceOn = true;
+                      this.aiEnhanceQuality = 'low';
+                      this.videoController.setAiEnhance('low');
+                    })
+
+                  Text('中')
+                    .fontSize(26)
+                    .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#F3F7FF' : '#D7DCE7')
+                    .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                    .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                    .borderRadius(99)
+                    .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#fffefe' : '#45ffffff' })
+                    .onClick(() => {
+                      hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击中');
+                      this.aiEnhanceOn = true;
+                      this.aiEnhanceQuality = 'medium';
+                      this.videoController.setAiEnhance('medium');
+                    })
+
+                  Text('高')
+                    .fontSize(26)
+                    .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#F3F7FF' : '#D7DCE7')
+                    .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                    .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                    .borderRadius(99)
+                    .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#fffefe' : '#45ffffff' })
+                    .onClick(() => {
+                      hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击高');
+                      this.aiEnhanceOn = true;
+                      this.aiEnhanceQuality = 'high';
+                      this.videoController.setAiEnhance('high');
+                    })
                 }
+                .justifyContent(FlexAlign.Start)
+                .width('100%')
               }
             }
-            .padding({ left: 26, right: 26, top: 18, bottom: 28 })
-            .alignItems(HorizontalAlign.Start)
-            .width('100%')
           }
-          .scrollBar(BarState.Off)
+          .padding({ left: 26, right: 26, top: 18, bottom: 28 })
+          .alignItems(HorizontalAlign.Start)
           .width('100%')
-          .height('50%')
-          .backgroundColor('#090E1922')
-          .nestedScroll({ scrollForward: NestedScrollMode.SELF_ONLY, scrollBackward: NestedScrollMode.SELF_ONLY })
         }
+        .alignItems(HorizontalAlign.Start)
+        .width('100%')
       }
+      .scrollBar(BarState.Off)
       .width('100%')
-      .height('100%')
+      .height('55%')
+      .backgroundColor('rgba(9,14,25,0.92)')
+      .borderRadius({ topLeft: 24, topRight: 24 })
+      .nestedScroll({ scrollForward: NestedScrollMode.SELF_ONLY, scrollBackward: NestedScrollMode.SELF_ONLY })
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -4,6 +4,8 @@ import { VpeQualityLevel } from "../../../utils/VpeEnhancerUtil"
 import { hilog } from "@kit.PerformanceAnalysisKit"
 import { LengthMetrics } from "@kit.ArkUI"
 import { media } from "@kit.MediaKit"
+import { EpisodeListPanel } from './EpisodeListPanel'
+import { PlaybackContextItem, MediaLibraryContext } from './PlaybackContext'
 
 @ComponentV2
 struct VideoControls {
@@ -613,6 +615,7 @@ export struct PlayerSettingsDialog {
   ]
   @State private aiEnhanceOn: boolean = true
   @State private aiEnhanceQuality: VpeQualityLevel = 'medium'
+  @State private selectedTabIndex: number = 0
 
   aboutToAppear(): void {
     this.aiEnhanceOn = this.videoController.aiEnhanceEnabled;
@@ -635,6 +638,16 @@ export struct PlayerSettingsDialog {
   aboutToDisappear(): void {
     this.arFocusedIndex = -1;
     this.speedFocusedIndex = -1;
+    this.selectedTabIndex = 0;
+  }
+
+  /** 当 playbackContext 是媒体库上下文时返回，否则返回 undefined */
+  private getMediaLibraryContext(): MediaLibraryContext | undefined {
+    const ctx = this.videoController.playbackContext
+    if (ctx !== undefined && ctx.contextType === 'media_library') {
+      return ctx as MediaLibraryContext
+    }
+    return undefined
   }
 
   @Builder
@@ -656,193 +669,236 @@ export struct PlayerSettingsDialog {
         .height('100%')
         .backgroundColor(Color.Transparent)
 
-      Scroll() {
-        Column({ space: 28 }) {
-          Column({ space: 12 }) {
-            Text('倍速播放')
-              .fontSize(32)
-              .fontColor('#EFF2FB')
-              .fontWeight(FontWeight.Medium)
-              .alignSelf(ItemAlign.Start)
+      Column() {
+        // ── Tab 切换栏（仅 media_library 上下文时显示）──────────────────────
+        if (this.getMediaLibraryContext() !== undefined) {
+          Row({ space: 8 }) {
+            Text('选集')
+              .fontSize(28)
+              .fontColor(this.selectedTabIndex === 0 ? '#F3F7FF' : '#D7DCE7')
+              .padding({ left: 24, right: 24, top: 10, bottom: 10 })
+              .backgroundColor(this.selectedTabIndex === 0 ? 'rgba(255,255,255,0.3)' : Color.Transparent)
+              .borderRadius(20)
+              .focusable(true)
+              .onClick(() => { this.selectedTabIndex = 0 })
 
-            Row({ space: 12 }) {
-              ForEach(this.speedOptions, (opt: SpeedOption, idx: number) => {
-                Row() {
-                  Text(opt.label)
-                    .fontSize(26)
-                    .fontColor(this.selectedPlaybackRateIndex === idx ? '#F3F7FF' : '#D7DCE7')
-                    .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                    .backgroundColor(this.selectedPlaybackRateIndex === idx
-                      ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                    .borderRadius("50%")
-                    .border({
-                      width: this.selectedPlaybackRateIndex === idx ? 2 : 1,
-                      color: this.selectedPlaybackRateIndex === idx ? '#fffefe' : '#45ffffff'
-                    })
-                    .shadow({
-                      radius: this.selectedPlaybackRateIndex === idx ? 8 : 0,
-                      color: this.selectedPlaybackRateIndex === idx ? '#33597FB8' : '#00ffffff'
-                    })
-                }
-                .focusable(true)
-                .onFocus(() => { this.speedFocusedIndex = idx })
-                .onBlur(() => { this.speedFocusedIndex = -1 })
-                .borderRadius(99)
-                .padding(this.speedFocusedIndex === idx ? 2 : 0)
-                .border({
-                  width: this.speedFocusedIndex === idx ? 2 : 0,
-                  color: this.speedFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
-                })
-                .onClick(() => {
-                  this.selectedPlaybackRateIndex = idx
-                  this.videoController.setPlaybackSpeed(opt.speed)
-                })
-              }, (opt: SpeedOption) => opt.speed.toString())
-            }
-            .justifyContent(FlexAlign.Start)
-            .width('100%')
+            Text('更多设置')
+              .fontSize(28)
+              .fontColor(this.selectedTabIndex === 1 ? '#F3F7FF' : '#D7DCE7')
+              .padding({ left: 24, right: 24, top: 10, bottom: 10 })
+              .backgroundColor(this.selectedTabIndex === 1 ? 'rgba(255,255,255,0.3)' : Color.Transparent)
+              .borderRadius(20)
+              .focusable(true)
+              .onClick(() => { this.selectedTabIndex = 1 })
           }
-
-
-          Column({ space: 12 }) {
-            Text('画面比例')
-              .fontSize(32)
-              .fontColor('#EFF2FB')
-              .fontWeight(FontWeight.Medium)
-              .alignSelf(ItemAlign.Start)
-
-            Row({ space: 12 }) {
-              ForEach(this.aspectRatioOptions, (opt: AspectRatioOption, idx: number) => {
-                Row() {
-                  Text(opt.label)
-                    .fontSize(26)
-                    .fontColor(this.currentAspectRatioMode === opt.mode ? '#F3F7FF' : '#D7DCE7')
-                    .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                    .backgroundColor(this.currentAspectRatioMode === opt.mode
-                      ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                    .borderRadius("50%")
-                    .border({
-                      width: this.currentAspectRatioMode === opt.mode ? 2 : 1,
-                      color: this.currentAspectRatioMode === opt.mode ? '#fffefe' : '#45ffffff'
-                    })
-                    .shadow({
-                      radius: this.currentAspectRatioMode === opt.mode ? 8 : 0,
-                      color: this.currentAspectRatioMode === opt.mode ? '#33597FB8' : '#00ffffff'
-                    })
-                }
-                .focusable(true)
-                .onFocus(() => { this.arFocusedIndex = idx })
-                .onBlur(() => { this.arFocusedIndex = -1 })
-                .borderRadius(99)
-                .padding(this.arFocusedIndex === idx ? 2 : 0)
-                .border({
-                  width: this.arFocusedIndex === idx ? 2 : 0,
-                  color: this.arFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
-                })
-                .onClick(() => {
-                  this.currentAspectRatioMode = opt.mode
-                  this.videoController.setAspectRatioMode(opt.mode)
-                })
-              }, (opt: AspectRatioOption) => opt.mode.toString())
-            }
-            .justifyContent(FlexAlign.Start)
-            .width('100%')
-          }
-
-          Column({ space: 12 }) {
-            Text('字幕管理')
-              .fontSize(32)
-              .fontColor('#EFF2FB')
-              .fontWeight(FontWeight.Medium)
-              .alignSelf(ItemAlign.Start)
-
-            Row() {
-              this.SettingsChip('选择字幕', this.videoController.activeSubtitleIndex >= 0)
-            }
-            .onClick(() => {
-              this.onOpenSubtitleSelector()
-            })
-          }
-
-          if (canIUse('SystemCapability.Multimedia.VideoProcessingEngine') && this.videoController.backend === 'avplayer') {
-            Column({ space: 12 }) {
-              Text('画质增强')
-                .fontSize(32)
-                .fontColor('#EFF2FB')
-                .fontWeight(FontWeight.Medium)
-                .alignSelf(ItemAlign.Start)
-
-              Row({ space: 12 }) {
-                // 直接内联 Text + onClick，绕过 @CustomDialog @Builder 参数不刷新问题
-                Text('关闭')
-                  .fontSize(26)
-                  .fontColor(!this.aiEnhanceOn ? '#F3F7FF' : '#D7DCE7')
-                  .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                  .backgroundColor(!this.aiEnhanceOn ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                  .borderRadius(99)
-                  .border({ width: !this.aiEnhanceOn ? 2 : 1, color: !this.aiEnhanceOn ? '#fffefe' : '#45ffffff' })
-                  .onClick(() => {
-                    hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击关闭');
-                    this.aiEnhanceOn = false;
-                    this.videoController.disableAiEnhance();
-                  })
-
-                Text('低')
-                  .fontSize(26)
-                  .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#F3F7FF' : '#D7DCE7')
-                  .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                  .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                  .borderRadius(99)
-                  .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#fffefe' : '#45ffffff' })
-                  .onClick(() => {
-                    hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击低');
-                    this.aiEnhanceOn = true;
-                    this.aiEnhanceQuality = 'low';
-                    this.videoController.setAiEnhance('low');
-                  })
-
-                Text('中')
-                  .fontSize(26)
-                  .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#F3F7FF' : '#D7DCE7')
-                  .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                  .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                  .borderRadius(99)
-                  .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#fffefe' : '#45ffffff' })
-                  .onClick(() => {
-                    hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击中');
-                    this.aiEnhanceOn = true;
-                    this.aiEnhanceQuality = 'medium';
-                    this.videoController.setAiEnhance('medium');
-                  })
-
-                Text('高')
-                  .fontSize(26)
-                  .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#F3F7FF' : '#D7DCE7')
-                  .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                  .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                  .borderRadius(99)
-                  .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#fffefe' : '#45ffffff' })
-                  .onClick(() => {
-                    hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击高');
-                    this.aiEnhanceOn = true;
-                    this.aiEnhanceQuality = 'high';
-                    this.videoController.setAiEnhance('high');
-                  })
-              }
-              .justifyContent(FlexAlign.Start)
-              .width('100%')
-            }
-          }
+          .padding({ left: 26, top: 16, bottom: 8 })
+          .width('100%')
+          .backgroundColor('#090E1922')
         }
-        .padding({ left: 26, right: 26, top: 18, bottom: 28 })
-        .alignItems(HorizontalAlign.Start)
-        .width('100%')
+
+        // ── 内容区 ──────────────────────────────────────────────────────────
+        if (this.getMediaLibraryContext() !== undefined && this.selectedTabIndex === 0) {
+          // 选集面板
+          EpisodeListPanel({
+            context: this.getMediaLibraryContext() as MediaLibraryContext,
+            onSelect: (item: PlaybackContextItem) => {
+              this.videoController.playbackContext?.jumpTo(item.index)
+              this.controller.close()
+            }
+          })
+        } else {
+          // 原有设置内容（无 playbackContext 或切到"更多设置"时保持不变）
+          Scroll() {
+            Column({ space: 28 }) {
+              Column({ space: 12 }) {
+                Text('倍速播放')
+                  .fontSize(32)
+                  .fontColor('#EFF2FB')
+                  .fontWeight(FontWeight.Medium)
+                  .alignSelf(ItemAlign.Start)
+
+                Row({ space: 12 }) {
+                  ForEach(this.speedOptions, (opt: SpeedOption, idx: number) => {
+                    Row() {
+                      Text(opt.label)
+                        .fontSize(26)
+                        .fontColor(this.selectedPlaybackRateIndex === idx ? '#F3F7FF' : '#D7DCE7')
+                        .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                        .backgroundColor(this.selectedPlaybackRateIndex === idx
+                          ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                        .borderRadius("50%")
+                        .border({
+                          width: this.selectedPlaybackRateIndex === idx ? 2 : 1,
+                          color: this.selectedPlaybackRateIndex === idx ? '#fffefe' : '#45ffffff'
+                        })
+                        .shadow({
+                          radius: this.selectedPlaybackRateIndex === idx ? 8 : 0,
+                          color: this.selectedPlaybackRateIndex === idx ? '#33597FB8' : '#00ffffff'
+                        })
+                    }
+                    .focusable(true)
+                    .onFocus(() => { this.speedFocusedIndex = idx })
+                    .onBlur(() => { this.speedFocusedIndex = -1 })
+                    .borderRadius(99)
+                    .padding(this.speedFocusedIndex === idx ? 2 : 0)
+                    .border({
+                      width: this.speedFocusedIndex === idx ? 2 : 0,
+                      color: this.speedFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
+                    })
+                    .onClick(() => {
+                      this.selectedPlaybackRateIndex = idx
+                      this.videoController.setPlaybackSpeed(opt.speed)
+                    })
+                  }, (opt: SpeedOption) => opt.speed.toString())
+                }
+                .justifyContent(FlexAlign.Start)
+                .width('100%')
+              }
+
+
+              Column({ space: 12 }) {
+                Text('画面比例')
+                  .fontSize(32)
+                  .fontColor('#EFF2FB')
+                  .fontWeight(FontWeight.Medium)
+                  .alignSelf(ItemAlign.Start)
+
+                Row({ space: 12 }) {
+                  ForEach(this.aspectRatioOptions, (opt: AspectRatioOption, idx: number) => {
+                    Row() {
+                      Text(opt.label)
+                        .fontSize(26)
+                        .fontColor(this.currentAspectRatioMode === opt.mode ? '#F3F7FF' : '#D7DCE7')
+                        .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                        .backgroundColor(this.currentAspectRatioMode === opt.mode
+                          ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                        .borderRadius("50%")
+                        .border({
+                          width: this.currentAspectRatioMode === opt.mode ? 2 : 1,
+                          color: this.currentAspectRatioMode === opt.mode ? '#fffefe' : '#45ffffff'
+                        })
+                        .shadow({
+                          radius: this.currentAspectRatioMode === opt.mode ? 8 : 0,
+                          color: this.currentAspectRatioMode === opt.mode ? '#33597FB8' : '#00ffffff'
+                        })
+                    }
+                    .focusable(true)
+                    .onFocus(() => { this.arFocusedIndex = idx })
+                    .onBlur(() => { this.arFocusedIndex = -1 })
+                    .borderRadius(99)
+                    .padding(this.arFocusedIndex === idx ? 2 : 0)
+                    .border({
+                      width: this.arFocusedIndex === idx ? 2 : 0,
+                      color: this.arFocusedIndex === idx ? '#4D9FFF' : Color.Transparent
+                    })
+                    .onClick(() => {
+                      this.currentAspectRatioMode = opt.mode
+                      this.videoController.setAspectRatioMode(opt.mode)
+                    })
+                  }, (opt: AspectRatioOption) => opt.mode.toString())
+                }
+                .justifyContent(FlexAlign.Start)
+                .width('100%')
+              }
+
+              Column({ space: 12 }) {
+                Text('字幕管理')
+                  .fontSize(32)
+                  .fontColor('#EFF2FB')
+                  .fontWeight(FontWeight.Medium)
+                  .alignSelf(ItemAlign.Start)
+
+                Row() {
+                  this.SettingsChip('选择字幕', this.videoController.activeSubtitleIndex >= 0)
+                }
+                .onClick(() => {
+                  this.onOpenSubtitleSelector()
+                })
+              }
+
+              if (canIUse('SystemCapability.Multimedia.VideoProcessingEngine') && this.videoController.backend === 'avplayer') {
+                Column({ space: 12 }) {
+                  Text('画质增强')
+                    .fontSize(32)
+                    .fontColor('#EFF2FB')
+                    .fontWeight(FontWeight.Medium)
+                    .alignSelf(ItemAlign.Start)
+
+                  Row({ space: 12 }) {
+                    // 直接内联 Text + onClick，绕过 @CustomDialog @Builder 参数不刷新问题
+                    Text('关闭')
+                      .fontSize(26)
+                      .fontColor(!this.aiEnhanceOn ? '#F3F7FF' : '#D7DCE7')
+                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                      .backgroundColor(!this.aiEnhanceOn ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                      .borderRadius(99)
+                      .border({ width: !this.aiEnhanceOn ? 2 : 1, color: !this.aiEnhanceOn ? '#fffefe' : '#45ffffff' })
+                      .onClick(() => {
+                        hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击关闭');
+                        this.aiEnhanceOn = false;
+                        this.videoController.disableAiEnhance();
+                      })
+
+                    Text('低')
+                      .fontSize(26)
+                      .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#F3F7FF' : '#D7DCE7')
+                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                      .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                      .borderRadius(99)
+                      .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#fffefe' : '#45ffffff' })
+                      .onClick(() => {
+                        hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击低');
+                        this.aiEnhanceOn = true;
+                        this.aiEnhanceQuality = 'low';
+                        this.videoController.setAiEnhance('low');
+                      })
+
+                    Text('中')
+                      .fontSize(26)
+                      .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#F3F7FF' : '#D7DCE7')
+                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                      .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                      .borderRadius(99)
+                      .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#fffefe' : '#45ffffff' })
+                      .onClick(() => {
+                        hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击中');
+                        this.aiEnhanceOn = true;
+                        this.aiEnhanceQuality = 'medium';
+                        this.videoController.setAiEnhance('medium');
+                      })
+
+                    Text('高')
+                      .fontSize(26)
+                      .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#F3F7FF' : '#D7DCE7')
+                      .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+                      .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                      .borderRadius(99)
+                      .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#fffefe' : '#45ffffff' })
+                      .onClick(() => {
+                        hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击高');
+                        this.aiEnhanceOn = true;
+                        this.aiEnhanceQuality = 'high';
+                        this.videoController.setAiEnhance('high');
+                      })
+                  }
+                  .justifyContent(FlexAlign.Start)
+                  .width('100%')
+                }
+              }
+            }
+            .padding({ left: 26, right: 26, top: 18, bottom: 28 })
+            .alignItems(HorizontalAlign.Start)
+            .width('100%')
+          }
+          .scrollBar(BarState.Off)
+          .width('100%')
+          .height('50%')
+          .backgroundColor('#090E1922')
+          .nestedScroll({ scrollForward: NestedScrollMode.SELF_ONLY, scrollBackward: NestedScrollMode.SELF_ONLY })
+        }
       }
-      .scrollBar(BarState.Off)
       .width('100%')
-      .height('50%')
-      .backgroundColor('#090E1922')
-      .nestedScroll({ scrollForward: NestedScrollMode.SELF_ONLY, scrollBackward: NestedScrollMode.SELF_ONLY })
+      .height('100%')
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -23,6 +23,7 @@ import {
 import { SmbAvSubtitleBridgeAdapter } from "./SmbSubtitleBridgeAdapter";
 import { VpeEnhancerUtil, VpeQualityLevel } from "../../../utils/VpeEnhancerUtil";
 import { ParsedSubtitle } from "./SubtitleRenderer";
+import { PlaybackContext } from "./PlaybackContext";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
 
@@ -221,6 +222,8 @@ export class VideoPlayerController {
 
   /** 播放进度上下文（由调用方在 initPlayer 前设置） */
   progressContext: PlayProgressEntity | null = null;
+  /** 播放上下文（当季集列表 + 当前集索引），供连播/上下集跳转使用；文件浏览器入口不传时为 undefined */
+  playbackContext: PlaybackContext | undefined = undefined;
   /** 10s 防抖进度写入定时器 */
   private progressTimer?: number;
   /** 播放会话编号：每次 initPlayer 自增，用于忽略旧实例回调 */

--- a/entry/src/main/ets/components/media/ContinueWatchCard.ets
+++ b/entry/src/main/ets/components/media/ContinueWatchCard.ets
@@ -16,6 +16,7 @@
 import { ContinueWatchingItem } from '../../db/models/MediaEntity';
 import { PlayerPageParam, PlayerPage } from '../../pages/player/index';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
+import { MediaLibraryContext } from '../core/player/PlaybackContext';
 import { FileSourceType, FileSourceTypeLabels, SMBSourceConfig } from '../../db/models/FileSourceEntity';
 import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient';
 import promptAction from '@ohos.promptAction';
@@ -187,6 +188,20 @@ export struct ContinueWatchCard {
         seasonNumber: this.item.seasonNumber,
         episodeNumber: this.item.episodeNumber
       };
+      if (this.item.kind === 'series' && this.item.tvSeriesId > 0 && this.item.seasonNumber > 0) {
+        try {
+          const playbackCtx = await MediaLibraryContext.build(
+            db,
+            this.item.tvSeriesId,
+            this.item.seasonNumber,
+            this.item.filePath
+          );
+          param.playbackContext = playbackCtx;
+        } catch (e) {
+          // 构建失败不阻断播放，playbackContext 保持 undefined
+          console.warn('[ContinueWatchCard] 构建 playbackContext 失败');
+        }
+      }
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
     } catch (e) {
       console.error('[ContinueWatchCard] buildAndPlay 失败', JSON.stringify(e));

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -2555,7 +2555,6 @@ export class FileSourceDatabase {
     if (this.rdbStore === null) { return []; }
     let tvRs: relationalStore.ResultSet | null = null;
     let movieRs: relationalStore.ResultSet | null = null;
-    let unscrapedRs: relationalStore.ResultSet | null = null;
     try {
       // ── 电视剧（按剧+季分组）──────────────────────────────────
       const tvSql = `
@@ -2664,58 +2663,15 @@ export class FileSourceDatabase {
       }
       movieRs.close(); movieRs = null;
 
-      // ── 未刮削视频（兜底：新增目录扫描后未配置 TMDB Key 或刮削失败的文件） ──
-      // 这类文件存在于 videos 表但无 scrape_info 记录，通过 scanned_at 排序保证新扫描文件出现在最前
-      const unscrapedSql = `
-        SELECT v.id AS vid, v.source_id, v.directory_path, v.file_path, v.file_name,
-               v.file_size, v.duration_ms, v.width, v.height, v.video_codec,
-               v.audio_tracks_json, v.scanned_at
-        FROM ${FileSourceDatabase.TABLE_VIDEOS} v
-        WHERE NOT EXISTS (
-          SELECT 1 FROM ${FileSourceDatabase.TABLE_SCRAPE_INFO} si WHERE si.video_id = v.id
-        )
-        ORDER BY v.scanned_at DESC
-        LIMIT ?
-      `;
-      unscrapedRs = await this.rdbStore.querySql(unscrapedSql, [limit]);
-      const unscrapedItems: MediaListItem[] = [];
-      while (unscrapedRs.goToNextRow()) {
-        const strU = (col: string): string | undefined => {
-          const i = unscrapedRs!.getColumnIndex(col);
-          return unscrapedRs!.isColumnNull(i) ? undefined : unscrapedRs!.getString(i);
-        };
-        const numU = (col: string): number | undefined => {
-          const i = unscrapedRs!.getColumnIndex(col);
-          return unscrapedRs!.isColumnNull(i) ? undefined : unscrapedRs!.getLong(i);
-        };
-        const uScannedAt = unscrapedRs.getLong(unscrapedRs.getColumnIndex('scanned_at'));
-        const uMediaItem: MediaItem = {
-          id: unscrapedRs.getLong(unscrapedRs.getColumnIndex('vid')),
-          sourceId: unscrapedRs.getLong(unscrapedRs.getColumnIndex('source_id')),
-          directoryPath: strU('directory_path') ?? '',
-          filePath: strU('file_path') ?? '',
-          fileName: strU('file_name') ?? '',
-          fileSize: numU('file_size'),
-          durationMs: numU('duration_ms'),
-          width: numU('width'),
-          height: numU('height'),
-          videoCodec: strU('video_codec'),
-          audioTracksJson: strU('audio_tracks_json'),
-          scannedAt: uScannedAt,
-        };
-        const uListItem: MediaListItem = { kind: 'video', video: uMediaItem, sortTs: uScannedAt };
-        unscrapedItems.push(uListItem);
-      }
-      unscrapedRs.close(); unscrapedRs = null;
-
       // ── 合并，按 sortTs 倒序，取前 limit 条 ──────────────────
+      // 注意：仅保留有 scrape_info 记录的条目（tvSql/movieSql 均通过 scrape_info JOIN 过滤）
+      // 有 scrape_info 但 poster 为空的记录仍会出现，由 UI 层用 title 兜底展示
       const combined: MediaListItem[] = [];
       for (const it of tvItems) { combined.push(it); }
       for (const it of movieItems) { combined.push(it); }
-      for (const it of unscrapedItems) { combined.push(it); }
       combined.sort((a: MediaListItem, b: MediaListItem) => b.sortTs - a.sortTs);
       const result = combined.slice(0, limit);
-      console.info(`[DB][getRecentlyAddedList] TV季=${tvItems.length} 电影=${movieItems.length} 未刮削=${unscrapedItems.length} 合并后=${result.length}`);
+      console.info(`[DB][getRecentlyAddedList] TV季=${tvItems.length} 电影=${movieItems.length} 合并后=${result.length}`);
       return result;
     } catch (e) {
       console.error('[DB][getRecentlyAddedList] 查询失败', JSON.stringify(e));
@@ -2723,7 +2679,6 @@ export class FileSourceDatabase {
     } finally {
       try { tvRs?.close(); } catch { }
       try { movieRs?.close(); } catch { }
-      try { unscrapedRs?.close(); } catch { }
     }
   }
 

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -991,7 +991,8 @@ export struct SeasonDetailPage {
       // 构建播放上下文：查询当季集列表并定位当前集，供播放器内连播使用
       const seriesDbId = this.seriesEntity?.id ?? 0;
       let playbackContext: MediaLibraryContext | undefined = undefined;
-      if (seriesDbId > 0) {
+      // episodeSeason=0 表示 seasonNumber 缺失，跳过无意义的 DB 查询
+      if (seriesDbId > 0 && episodeSeason > 0) {
         try {
           playbackContext = await MediaLibraryContext.build(db, seriesDbId, episodeSeason, episode.filePath);
         } catch (e) {

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -13,6 +13,7 @@ import { FfprobeUtil, FfprobeTrack } from '../../utils/FfprobeUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
 import { emitter } from "@kit.BasicServicesKit"
 import { PlayerEvents } from '../../components/core/player/Constants'
+import { MediaLibraryContext } from '../../components/core/player/PlaybackContext'
 
 // ─────────────────────────────────────────────
 // 工具函数
@@ -986,6 +987,18 @@ export struct SeasonDetailPage {
       const mKey = (seriesProviderId.length > 0 && episodeNum > 0)
         ? MediaProgressStore.episodeKey(seriesProviderId, episodeSeason, episodeNum)
         : undefined;
+
+      // 构建播放上下文：查询当季集列表并定位当前集，供播放器内连播使用
+      const seriesDbId = this.seriesEntity?.id ?? 0;
+      let playbackContext: MediaLibraryContext | undefined = undefined;
+      if (seriesDbId > 0) {
+        try {
+          playbackContext = await MediaLibraryContext.build(db, seriesDbId, episodeSeason, episode.filePath);
+        } catch (e) {
+          console.warn('[SeasonDetailPage] MediaLibraryContext.build 失败，跳过: ' + JSON.stringify(e));
+        }
+      }
+
       const param: PlayerPageParam = {
         // getFullUrl() 已编码，传给播放页时保持原值，避免二次编码。
         url: fullUrl,
@@ -999,7 +1012,8 @@ export struct SeasonDetailPage {
         presetAudioTracks: presetAudioTracks.length > 0 ? presetAudioTracks : undefined,
         presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined,
         mediaKey: mKey,
-        startPositionMs: startPositionMs > 0 ? startPositionMs : undefined
+        startPositionMs: startPositionMs > 0 ? startPositionMs : undefined,
+        playbackContext
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param, (popInfo: PopInfo) => {
         if (popInfo.result !== null && popInfo.result !== undefined) {

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -796,7 +796,8 @@ export struct SeriesDetailPage {
       const seriesDbId = this.seriesEntity?.id ?? 0;
       const episodeSeasonNum = episode.seasonNumber ?? 0;
       let playbackContext: MediaLibraryContext | undefined = undefined;
-      if (seriesDbId > 0) {
+      // episodeSeasonNum=0 表示 seasonNumber 缺失，跳过无意义的 DB 查询
+      if (seriesDbId > 0 && episodeSeasonNum > 0) {
         try {
           playbackContext = await MediaLibraryContext.build(db, seriesDbId, episodeSeasonNum, episode.filePath);
         } catch (e) {

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -16,6 +16,7 @@ import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/pla
 import { CastDetailPage, CastDetailPageParam } from './CastDetailPage'
 import { emitter } from "@kit.BasicServicesKit"
 import { PlayerEvents } from '../../components/core/player/Constants'
+import { MediaLibraryContext } from '../../components/core/player/PlaybackContext'
 
 // ─────────────────────────────────────────────
 // TMDB 图片 URL 工具
@@ -790,6 +791,19 @@ export struct SeriesDetailPage {
       }
 
       const episodeName = await this.resolveEpisodeName(db, episode);
+
+      // 构建播放上下文：查询当季集列表并定位当前集，供播放器内连播使用
+      const seriesDbId = this.seriesEntity?.id ?? 0;
+      const episodeSeasonNum = episode.seasonNumber ?? 0;
+      let playbackContext: MediaLibraryContext | undefined = undefined;
+      if (seriesDbId > 0) {
+        try {
+          playbackContext = await MediaLibraryContext.build(db, seriesDbId, episodeSeasonNum, episode.filePath);
+        } catch (e) {
+          console.warn('[SeriesDetailPage] MediaLibraryContext.build 失败，跳过: ' + JSON.stringify(e));
+        }
+      }
+
       const param: PlayerPageParam = {
         // getFullUrl() 已编码，传给播放页时保持原值，避免二次编码。
         url: fullUrl,
@@ -802,7 +816,8 @@ export struct SeriesDetailPage {
         episodeNumber: episode.episodeNumber ?? 0,
         presetAudioTracks: presetAudioTracks.length > 0 ? presetAudioTracks : undefined,
         presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined,
-        mediaKey: mediaKey
+        mediaKey: mediaKey,
+        playbackContext
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param, (popInfo: PopInfo) => {
         if (popInfo.result !== null && popInfo.result !== undefined) {

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -6,6 +6,7 @@ import {
   type PlayerBackend,
   type UnsupportedFormatFallback
 } from "../../components/core/player/VideoPlayerController";
+import { PlaybackContext } from "../../components/core/player/PlaybackContext";
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { PlayProgressEntity } from "../../db/models/MediaEntity";
 import { MediaProgressStore } from "../../db/MediaProgressStore";
@@ -49,6 +50,11 @@ export interface PlayerPageParam {
    * 若未设置或为 0，则回退到 media_progress 同季同集匹配 seek 逻辑。
    */
   startPositionMs?: number;
+  /**
+   * 播放上下文（可选）。携带当季集列表及当前集索引，供播放器内连播/上下集跳转使用。
+   * 由 SeasonDetailPage / SeriesDetailPage 在 playEpisode() 中构建并传入。
+   */
+  playbackContext?: PlaybackContext;
 }
 
 @ComponentV2
@@ -391,6 +397,11 @@ export struct PlayerPage {
               }).catch(() => {});
             });
           }
+        }
+
+        // 播放上下文：有则传递给播放器控制器，供后续连播/跳集逻辑使用
+        if (pageParam.playbackContext !== undefined) {
+          this.videoPlayerController.playbackContext = pageParam.playbackContext;
         }
       }
     })

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -399,10 +399,8 @@ export struct PlayerPage {
           }
         }
 
-        // 播放上下文：有则传递给播放器控制器，供后续连播/跳集逻辑使用
-        if (pageParam.playbackContext !== undefined) {
-          this.videoPlayerController.playbackContext = pageParam.playbackContext;
-        }
+        // 播放上下文：始终更新，无值时显式置 undefined，避免同一实例复用时旧值残留
+        this.videoPlayerController.playbackContext = pageParam.playbackContext;
       }
     })
     .onBackPressed(() => {

--- a/entry/src/test/EpisodeListPanel.test.ets
+++ b/entry/src/test/EpisodeListPanel.test.ets
@@ -64,38 +64,73 @@ export default function EpisodeListPanelTest() {
   })
 
   describe('EpisodeListPanel style states', () => {
-    it('聚焦卡片时不再显示右下角圆圈，改为整卡焦点态', 0, () => {
+    it('聚焦卡片时使用整项 scale 提亮，不再依赖边框语义', 0, () => {
       const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(true, false)
 
       expect(styleState.showLegacyFocusRing).assertFalse()
-      expect(styleState.showFocusOutline).assertTrue()
+      expect(styleState.showFocusOutline).assertFalse()
       expect(styleState.showCurrentOutline).assertFalse()
-      expect(styleState.scale).assertEqual(1.03)
+      expect(styleState.scale).assertEqual(1.04)
+      expect(styleState.focusBorderWidth).assertEqual(0)
+      expect(styleState.currentBorderWidth).assertEqual(0)
     })
 
-    it('当前播放项与聚焦项叠加时保留双重语义', 0, () => {
+    it('hover 卡片时也沿用同一套放大语义', 0, () => {
+      const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(false, false, true)
+
+      expect(styleState.scale).assertEqual(1.04)
+      expect(styleState.focusBorderWidth).assertEqual(0)
+      expect(styleState.currentBorderWidth).assertEqual(0)
+    })
+
+    it('当前播放项与聚焦项叠加时保留波形图与放大效果', 0, () => {
       const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(true, true)
 
       expect(styleState.showLegacyFocusRing).assertFalse()
-      expect(styleState.showFocusOutline).assertTrue()
-      expect(styleState.showCurrentOutline).assertTrue()
-      expect(styleState.scale).assertEqual(1.03)
+      expect(styleState.showFocusOutline).assertFalse()
+      expect(styleState.showCurrentOutline).assertFalse()
+      expect(styleState.showWaveIcon).assertTrue()
+      expect(styleState.waveBarCount).assertEqual(3)
+      expect(styleState.scale).assertEqual(1.04)
     })
 
-    it('聚焦样式保持卡片默认布局 footprint，不依赖更大包裹层', 0, () => {
-      const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(true, false)
+    it('选集项收敛为紧凑 chip 尺寸与字号', 0, () => {
+      const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(false, false)
 
-      expect(styleState.layoutWidth).assertEqual(220)
-      expect(styleState.layoutHeight).assertEqual(140)
+      expect(styleState.layoutWidth).assertEqual(184)
+      expect(styleState.layoutHeight).assertEqual(68)
+      expect(styleState.borderRadius).assertEqual(22)
+      expect(styleState.thumbnailWidth).assertEqual(64)
+      expect(styleState.thumbnailHeight).assertEqual(40)
+      expect(styleState.labelFontSize).assertEqual(18)
+      expect(styleState.contentGap).assertEqual(10)
+      expect(styleState.horizontalPadding).assertEqual(8)
+      expect(styleState.rightPadding).assertEqual(12)
+      expect(styleState.verticalPadding).assertEqual(10)
     })
 
-    it('分页 tab 的聚焦态与当前页态可以并存', 0, () => {
+    it('分页 tab 改为无边框 chip 风格，当前页与聚焦态仍可区分', 0, () => {
       const styleState: EpisodePageTabStyleState = getEpisodePageTabStyleState(true, true)
 
-      expect(styleState.showFocusPill).assertTrue()
+      expect(styleState.showFocusPill).assertFalse()
+      expect(styleState.showFocusBackground).assertTrue()
       expect(styleState.showCurrentUnderline).assertTrue()
       expect(styleState.isCurrentPage).assertTrue()
       expect(styleState.isFocused).assertTrue()
+      expect(styleState.focusBorderWidth).assertEqual(0)
+      expect(styleState.scale).assertEqual(1.04)
+      expect(styleState.borderRadius).assertEqual(20)
+      expect(styleState.fontSize).assertEqual(18)
+      expect(styleState.horizontalPadding).assertEqual(16)
+      expect(styleState.verticalPadding).assertEqual(8)
+    })
+
+    it('分页 tab 在 hover 时同样使用 scale 而不是边框', 0, () => {
+      const styleState: EpisodePageTabStyleState = getEpisodePageTabStyleState(false, false, true)
+
+      expect(styleState.showFocusBackground).assertTrue()
+      expect(styleState.focusBorderWidth).assertEqual(0)
+      expect(styleState.scale).assertEqual(1.04)
     })
   })
 }

--- a/entry/src/test/EpisodeListPanel.test.ets
+++ b/entry/src/test/EpisodeListPanel.test.ets
@@ -2,7 +2,11 @@ import { describe, it, expect } from '@ohos/hypium'
 import {
   buildEpisodePageRanges,
   getEpisodePageItems,
-  getEpisodeItemRenderKey
+  getEpisodeItemRenderKey,
+  getEpisodeCardStyleState,
+  getEpisodePageTabStyleState,
+  EpisodeCardStyleState,
+  EpisodePageTabStyleState
 } from '../main/ets/components/core/player/EpisodeListPanel'
 import { PlaybackContextItem } from '../main/ets/components/core/player/PlaybackContext'
 
@@ -56,6 +60,35 @@ export default function EpisodeListPanelTest() {
 
       expect(ranges.length).assertEqual(1)
       expect(ranges[0].label).assertEqual('1-6')
+    })
+  })
+
+  describe('EpisodeListPanel style states', () => {
+    it('聚焦卡片时不再显示右下角圆圈，改为整卡焦点态', 0, () => {
+      const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(true, false)
+
+      expect(styleState.showLegacyFocusRing).assertFalse()
+      expect(styleState.showFocusOutline).assertTrue()
+      expect(styleState.showCurrentOutline).assertFalse()
+      expect(styleState.scale).assertEqual(1.03)
+    })
+
+    it('当前播放项与聚焦项叠加时保留双重语义', 0, () => {
+      const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(true, true)
+
+      expect(styleState.showLegacyFocusRing).assertFalse()
+      expect(styleState.showFocusOutline).assertTrue()
+      expect(styleState.showCurrentOutline).assertTrue()
+      expect(styleState.scale).assertEqual(1.03)
+    })
+
+    it('分页 tab 的聚焦态与当前页态可以并存', 0, () => {
+      const styleState: EpisodePageTabStyleState = getEpisodePageTabStyleState(true, true)
+
+      expect(styleState.showFocusPill).assertTrue()
+      expect(styleState.showCurrentUnderline).assertTrue()
+      expect(styleState.isCurrentPage).assertTrue()
+      expect(styleState.isFocused).assertTrue()
     })
   })
 }

--- a/entry/src/test/EpisodeListPanel.test.ets
+++ b/entry/src/test/EpisodeListPanel.test.ets
@@ -82,6 +82,13 @@ export default function EpisodeListPanelTest() {
       expect(styleState.scale).assertEqual(1.03)
     })
 
+    it('聚焦样式保持卡片默认布局 footprint，不依赖更大包裹层', 0, () => {
+      const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(true, false)
+
+      expect(styleState.layoutWidth).assertEqual(220)
+      expect(styleState.layoutHeight).assertEqual(140)
+    })
+
     it('分页 tab 的聚焦态与当前页态可以并存', 0, () => {
       const styleState: EpisodePageTabStyleState = getEpisodePageTabStyleState(true, true)
 

--- a/entry/src/test/EpisodeListPanel.test.ets
+++ b/entry/src/test/EpisodeListPanel.test.ets
@@ -3,8 +3,10 @@ import {
   buildEpisodePageRanges,
   getEpisodePageItems,
   getEpisodeItemRenderKey,
+  getEpisodeSectionTitleStyleState,
   getEpisodeCardStyleState,
   getEpisodePageTabStyleState,
+  EpisodeSectionTitleStyleState,
   EpisodeCardStyleState,
   EpisodePageTabStyleState
 } from '../main/ets/components/core/player/EpisodeListPanel'
@@ -64,6 +66,14 @@ export default function EpisodeListPanelTest() {
   })
 
   describe('EpisodeListPanel style states', () => {
+    it('选集标题收敛为与下方设置分组一致的 section title 节奏', 0, () => {
+      const titleStyleState: EpisodeSectionTitleStyleState = getEpisodeSectionTitleStyleState()
+
+      expect(titleStyleState.fontSize).assertEqual(32)
+      expect(titleStyleState.leftMargin).assertEqual(0)
+      expect(titleStyleState.bottomMargin).assertEqual(12)
+    })
+
     it('聚焦卡片时使用整项 scale 提亮，不再依赖边框语义', 0, () => {
       const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(true, false)
 
@@ -94,19 +104,28 @@ export default function EpisodeListPanelTest() {
       expect(styleState.scale).assertEqual(1.04)
     })
 
-    it('选集项收敛为紧凑 chip 尺寸与字号', 0, () => {
+    it('选集项恢复为上图下字布局，并回到更易读的中号卡片尺寸', 0, () => {
       const styleState: EpisodeCardStyleState = getEpisodeCardStyleState(false, false)
 
-      expect(styleState.layoutWidth).assertEqual(184)
-      expect(styleState.layoutHeight).assertEqual(68)
-      expect(styleState.borderRadius).assertEqual(22)
-      expect(styleState.thumbnailWidth).assertEqual(64)
-      expect(styleState.thumbnailHeight).assertEqual(40)
-      expect(styleState.labelFontSize).assertEqual(18)
+      expect(styleState.useVerticalLayout).assertTrue()
+      expect(styleState.layoutWidth).assertEqual(200)
+      expect(styleState.layoutHeight).assertEqual(130)
+      expect(styleState.borderRadius).assertEqual(20)
+      expect(styleState.thumbnailWidth).assertEqual(184)
+      expect(styleState.thumbnailHeight).assertEqual(84)
+      expect(styleState.labelFontSize).assertEqual(20)
       expect(styleState.contentGap).assertEqual(10)
       expect(styleState.horizontalPadding).assertEqual(8)
-      expect(styleState.rightPadding).assertEqual(12)
-      expect(styleState.verticalPadding).assertEqual(10)
+      expect(styleState.rightPadding).assertEqual(8)
+      expect(styleState.verticalPadding).assertEqual(8)
+      expect(styleState.layoutWidth > 184).assertTrue()
+      expect(styleState.layoutWidth < 220).assertTrue()
+      expect(styleState.layoutHeight > 68).assertTrue()
+      expect(styleState.layoutHeight < 140).assertTrue()
+      expect(styleState.thumbnailWidth > 64).assertTrue()
+      expect(styleState.thumbnailHeight > 40).assertTrue()
+      expect(styleState.labelFontSize > 18).assertTrue()
+      expect(styleState.labelFontSize < 22).assertTrue()
     })
 
     it('分页 tab 改为无边框 chip 风格，当前页与聚焦态仍可区分', 0, () => {

--- a/entry/src/test/EpisodeListPanel.test.ets
+++ b/entry/src/test/EpisodeListPanel.test.ets
@@ -1,0 +1,61 @@
+import { describe, it, expect } from '@ohos/hypium'
+import {
+  buildEpisodePageRanges,
+  getEpisodePageItems,
+  getEpisodeItemRenderKey
+} from '../main/ets/components/core/player/EpisodeListPanel'
+import { PlaybackContextItem } from '../main/ets/components/core/player/PlaybackContext'
+
+interface EpisodePageRangeExpectation {
+  label: string
+}
+
+function makeItems(count: number): PlaybackContextItem[] {
+  const result: PlaybackContextItem[] = []
+  for (let i = 0; i < count; i++) {
+    const item: PlaybackContextItem = {
+      videoPath: `/episode-${i + 1}.mp4`,
+      title: `Episode ${i + 1}`,
+      index: i,
+      episodeNumber: i + 1
+    }
+    result.push(item)
+  }
+  return result
+}
+
+export default function EpisodeListPanelTest() {
+  describe('EpisodeListPanel pagination', () => {
+    it('切换到第二组选集后返回 7 到最后一集', 0, () => {
+      const items: PlaybackContextItem[] = makeItems(15)
+
+      const ranges: EpisodePageRangeExpectation[] = buildEpisodePageRanges(items.length)
+      const secondPageItems: PlaybackContextItem[] = getEpisodePageItems(items, 1)
+
+      expect(ranges.length).assertEqual(2)
+      expect(ranges[1].label).assertEqual('7-15')
+      expect(secondPageItems.length).assertEqual(9)
+      expect(secondPageItems[0].episodeNumber).assertEqual(7)
+      expect(secondPageItems[8].episodeNumber).assertEqual(15)
+    })
+
+    it('分页切换后渲染 key 使用全局唯一值，不复用第一页索引', 0, () => {
+      const items: PlaybackContextItem[] = makeItems(15)
+
+      const firstPageItems: PlaybackContextItem[] = getEpisodePageItems(items, 0)
+      const secondPageItems: PlaybackContextItem[] = getEpisodePageItems(items, 1)
+      const firstPageKeys: string[] = firstPageItems.map((item: PlaybackContextItem): string => getEpisodeItemRenderKey(item))
+      const secondPageFirstKey: string = getEpisodeItemRenderKey(secondPageItems[0])
+
+      expect(firstPageKeys.indexOf(secondPageFirstKey)).assertEqual(-1)
+      expect(secondPageFirstKey).assertEqual('/episode-7.mp4')
+    })
+
+    it('总集数不超过 6 时不生成第二组', 0, () => {
+      const ranges: EpisodePageRangeExpectation[] = buildEpisodePageRanges(6)
+
+      expect(ranges.length).assertEqual(1)
+      expect(ranges[0].label).assertEqual('1-6')
+    })
+  })
+}

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -1,4 +1,5 @@
 import timeUtilTest from './TimeUtil.test';
+import playbackContextTest from './ets/PlaybackContextTest';
 import settingsControllerTest from './SettingsController.test';
 import validationUtilTest from './ValidationUtil.test';
 import scrapeClientTest from './ScrapeClient.test';
@@ -14,6 +15,7 @@ import videoScannerTest from './VideoScanner.test';
 
 export default function testsuite() {
   timeUtilTest();
+  playbackContextTest();
   settingsControllerTest();
   validationUtilTest();
   scrapeClientTest();

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -9,6 +9,7 @@ import ijkSubtitleBridgeTest from './IjkSubtitleBridge.test';
 import subtitleBridgeAdapterTest from './SubtitleBridgeAdapter.test';
 import webDAVClientUtilsTest from './WebDAVClientUtils.test';
 import episodeListPanelTest from './EpisodeListPanel.test';
+import videoControlsTest from './VideoControls.test';
 // 需要真实 Context 和 .so 的集成测试放在 UnitTestBuild 侧（entry 模块本身，包含 native .so）
 // ohosTest(entry_test HAP) 不包含 .so，不能 import VideoScannerUtil / WebDAVClient
 import fileSourceDatabaseTest from './FileSourceDatabase.test';
@@ -26,6 +27,7 @@ export default function testsuite() {
   subtitleBridgeAdapterTest();
   webDAVClientUtilsTest();
   episodeListPanelTest();
+  videoControlsTest();
   // 集成测试：需要设备上的真实 Context（由 TestAbility.onCreate 设置到 globalThis）
   fileSourceDatabaseTest();
   videoScannerTest();

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -8,6 +8,7 @@ import videoDataTest from './VideoData.test';
 import ijkSubtitleBridgeTest from './IjkSubtitleBridge.test';
 import subtitleBridgeAdapterTest from './SubtitleBridgeAdapter.test';
 import webDAVClientUtilsTest from './WebDAVClientUtils.test';
+import episodeListPanelTest from './EpisodeListPanel.test';
 // 需要真实 Context 和 .so 的集成测试放在 UnitTestBuild 侧（entry 模块本身，包含 native .so）
 // ohosTest(entry_test HAP) 不包含 .so，不能 import VideoScannerUtil / WebDAVClient
 import fileSourceDatabaseTest from './FileSourceDatabase.test';
@@ -24,6 +25,7 @@ export default function testsuite() {
   ijkSubtitleBridgeTest();
   subtitleBridgeAdapterTest();
   webDAVClientUtilsTest();
+  episodeListPanelTest();
   // 集成测试：需要设备上的真实 Context（由 TestAbility.onCreate 设置到 globalThis）
   fileSourceDatabaseTest();
   videoScannerTest();

--- a/entry/src/test/VideoControls.test.ets
+++ b/entry/src/test/VideoControls.test.ets
@@ -1,0 +1,49 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { getEpisodeCardStyleState } from '../main/ets/components/core/player/EpisodeListPanel'
+import { PlayerSettingsChipStyleState, getPlayerSettingsChipStyleState } from '../main/ets/components/core/player/VideoControls'
+
+export default function videoControlsTest() {
+  describe('VideoControls player settings chip styles', () => {
+    it('倍速与画面比例项不再使用边框与描边语义，也不显示波形图', 0, () => {
+      const styleState: PlayerSettingsChipStyleState = getPlayerSettingsChipStyleState(true, false)
+
+      expect(styleState.showFocusOutline).assertFalse()
+      expect(styleState.showSelectedOutline).assertFalse()
+      expect(styleState.focusBorderWidth).assertEqual(0)
+      expect(styleState.selectedBorderWidth).assertEqual(0)
+      expect(styleState.showWaveIcon).assertFalse()
+    })
+
+    it('聚焦态改为使用 scale、背景与阴影提亮', 0, () => {
+      const styleState: PlayerSettingsChipStyleState = getPlayerSettingsChipStyleState(true, false)
+
+      expect(styleState.scale).assertEqual(1.04)
+      expect(styleState.shadowRadius).assertEqual(12)
+      expect(styleState.backgroundColor).assertEqual('rgba(255, 255, 255, 0.22)')
+      expect(styleState.focusBorderWidth).assertEqual(0)
+    })
+
+    it('倍速与画面比例项收敛到与选集 chip 一致的高度、字号、圆角与间距', 0, () => {
+      const chipStyleState: PlayerSettingsChipStyleState = getPlayerSettingsChipStyleState(false, false)
+      const episodeStyleState = getEpisodeCardStyleState(false, false)
+
+      expect(chipStyleState.height).assertEqual(episodeStyleState.layoutHeight)
+      expect(chipStyleState.borderRadius).assertEqual(episodeStyleState.borderRadius)
+      expect(chipStyleState.labelFontSize).assertEqual(episodeStyleState.labelFontSize)
+      expect(chipStyleState.groupGap).assertEqual(episodeStyleState.contentGap)
+    })
+
+    it('当前值与聚焦态仍可区分，叠加时保留当前值表达', 0, () => {
+      const selectedState: PlayerSettingsChipStyleState = getPlayerSettingsChipStyleState(false, true)
+      const focusedState: PlayerSettingsChipStyleState = getPlayerSettingsChipStyleState(true, false)
+      const focusedSelectedState: PlayerSettingsChipStyleState = getPlayerSettingsChipStyleState(true, true)
+
+      expect(selectedState.backgroundColor).assertEqual('rgba(255, 255, 255, 0.28)')
+      expect(selectedState.scale).assertEqual(1)
+      expect(focusedState.backgroundColor).assertEqual('rgba(255, 255, 255, 0.22)')
+      expect(focusedState.scale).assertEqual(1.04)
+      expect(focusedSelectedState.backgroundColor).assertEqual(selectedState.backgroundColor)
+      expect(focusedSelectedState.scale).assertEqual(focusedState.scale)
+    })
+  })
+}

--- a/entry/src/test/VideoControls.test.ets
+++ b/entry/src/test/VideoControls.test.ets
@@ -1,5 +1,4 @@
 import { describe, it, expect } from '@ohos/hypium'
-import { getEpisodeCardStyleState } from '../main/ets/components/core/player/EpisodeListPanel'
 import { PlayerSettingsChipStyleState, getPlayerSettingsChipStyleState } from '../main/ets/components/core/player/VideoControls'
 
 export default function videoControlsTest() {
@@ -25,12 +24,11 @@ export default function videoControlsTest() {
 
     it('倍速与画面比例项收敛到与选集 chip 一致的高度、字号、圆角与间距', 0, () => {
       const chipStyleState: PlayerSettingsChipStyleState = getPlayerSettingsChipStyleState(false, false)
-      const episodeStyleState = getEpisodeCardStyleState(false, false)
 
-      expect(chipStyleState.height).assertEqual(episodeStyleState.layoutHeight)
-      expect(chipStyleState.borderRadius).assertEqual(episodeStyleState.borderRadius)
-      expect(chipStyleState.labelFontSize).assertEqual(episodeStyleState.labelFontSize)
-      expect(chipStyleState.groupGap).assertEqual(episodeStyleState.contentGap)
+      expect(chipStyleState.height).assertEqual(68)
+      expect(chipStyleState.borderRadius).assertEqual(22)
+      expect(chipStyleState.labelFontSize).assertEqual(18)
+      expect(chipStyleState.groupGap).assertEqual(10)
     })
 
     it('当前值与聚焦态仍可区分，叠加时保留当前值表达', 0, () => {

--- a/entry/src/test/ets/PlaybackContextTest.ets
+++ b/entry/src/test/ets/PlaybackContextTest.ets
@@ -1,8 +1,9 @@
 import { describe, it, expect } from '@ohos/hypium';
 import {
   PlaybackContext, PlaybackContextItem,
-  MediaLibraryContext, FileExplorerContext
+  MediaLibraryContext, FileExplorerContext, BuildItemsResult
 } from '../../main/ets/components/core/player/PlaybackContext';
+import { MediaItem } from '../../main/ets/db/models/MediaEntity';
 
 // 用于测试的具体实现类（不测试具体播放逻辑，只验证基类导航方法）
 class TestPlaybackContext extends PlaybackContext {
@@ -100,7 +101,7 @@ export default function PlaybackContextTest() {
   // ─────────────────────────────────────────────
   describe('MediaLibraryContextTest', () => {
 
-    it('工厂方法从 DB 加载当前季剧集', 0, () => {
+    it('MediaLibraryContext 实例化与导航', 0, () => {
       // 用直接构造模拟 build() 产出，验证 currentIndex 定位逻辑
       const ctx = new MediaLibraryContext();
       ctx.items = makeItems(4);
@@ -161,6 +162,72 @@ export default function PlaybackContextTest() {
       const result = ctx.jumpToNext();
       expect(result === null).assertTrue();
       expect(ctx.currentIndex).assertEqual(ctx.items.length - 1);
+    });
+
+    // ── buildItems 辅助方法测试（不依赖 DB）──
+    it('buildItems 按 seasonNumber 过滤并定位 currentIndex', 0, () => {
+      const fakeItems: MediaItem[] = [
+        {
+          id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep1.mkv', fileName: 'ep1.mkv', seasonNumber: 1, title: 'EP1'
+        },
+        {
+          id: 2, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep2.mkv', fileName: 'ep2.mkv', seasonNumber: 1, title: 'EP2'
+        },
+        {
+          id: 3, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/s2ep1.mkv', fileName: 's2ep1.mkv', seasonNumber: 2, title: 'S2EP1'
+        },
+      ];
+      const result: BuildItemsResult = MediaLibraryContext.buildItems(fakeItems, 1, '/ep2.mkv');
+      // 只保留 season=1 的 2 集
+      expect(result.items.length).assertEqual(2);
+      // currentVideoPath='/ep2.mkv' 对应 index=1
+      expect(result.currentIndex).assertEqual(1);
+      expect(result.items[0].videoPath).assertEqual('/ep1.mkv');
+      expect(result.items[1].videoPath).assertEqual('/ep2.mkv');
+    });
+
+    it('buildItems currentVideoPath 不存在时 currentIndex 默认为 0', 0, () => {
+      const fakeItems: MediaItem[] = [
+        {
+          id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep1.mkv', fileName: 'ep1.mkv', seasonNumber: 1
+        },
+        {
+          id: 2, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep2.mkv', fileName: 'ep2.mkv', seasonNumber: 1
+        },
+      ];
+      const result: BuildItemsResult = MediaLibraryContext.buildItems(fakeItems, 1, '/not-exist.mkv');
+      expect(result.items.length).assertEqual(2);
+      expect(result.currentIndex).assertEqual(0);
+    });
+
+    it('buildItems season 不存在时返回空列表', 0, () => {
+      const fakeItems: MediaItem[] = [
+        {
+          id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep1.mkv', fileName: 'ep1.mkv', seasonNumber: 1
+        },
+      ];
+      const result: BuildItemsResult = MediaLibraryContext.buildItems(fakeItems, 99, '/ep1.mkv');
+      expect(result.items.length).assertEqual(0);
+      expect(result.currentIndex).assertEqual(0);
+    });
+
+    it('buildItems title 为 undefined 时回退到 fileName', 0, () => {
+      const fakeItems: MediaItem[] = [
+        {
+          id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep1.mkv', fileName: 'ep1.mkv', seasonNumber: 1
+          // title 未设置
+        },
+      ];
+      const result: BuildItemsResult = MediaLibraryContext.buildItems(fakeItems, 1, '/ep1.mkv');
+      expect(result.items.length).assertEqual(1);
+      expect(result.items[0].title).assertEqual('ep1.mkv');
     });
 
   });

--- a/entry/src/test/ets/PlaybackContextTest.ets
+++ b/entry/src/test/ets/PlaybackContextTest.ets
@@ -1,0 +1,93 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { PlaybackContext, PlaybackContextItem } from '../../main/ets/components/core/player/PlaybackContext';
+
+// 用于测试的具体实现类（不测试具体播放逻辑，只验证基类导航方法）
+class TestPlaybackContext extends PlaybackContext {
+  readonly contextType: string = 'test';
+
+  jumpToNext(): PlaybackContextItem | null {
+    if (!this.hasNext) {
+      return null;
+    }
+    this.currentIndex = this.currentIndex + 1;
+    return this.items[this.currentIndex];
+  }
+
+  jumpToPrev(): PlaybackContextItem | null {
+    if (!this.hasPrev) {
+      return null;
+    }
+    this.currentIndex = this.currentIndex - 1;
+    return this.items[this.currentIndex];
+  }
+
+  jumpTo(index: number): PlaybackContextItem | null {
+    if (index < 0 || index >= this.items.length) {
+      return null;
+    }
+    this.currentIndex = index;
+    return this.items[this.currentIndex];
+  }
+}
+
+function makeItems(count: number): PlaybackContextItem[] {
+  const result: PlaybackContextItem[] = [];
+  for (let i = 0; i < count; i++) {
+    const item: PlaybackContextItem = { videoPath: `path_${i}`, title: `title_${i}`, index: i };
+    result.push(item);
+  }
+  return result;
+}
+
+export default function PlaybackContextTest() {
+  describe('PlaybackContext', () => {
+
+    it('hasNext 在末尾集返回 false', 0, () => {
+      const ctx = new TestPlaybackContext();
+      ctx.items = makeItems(3);
+      ctx.currentIndex = 2; // 末尾集 index = length - 1
+      expect(ctx.hasNext).assertFalse();
+    });
+
+    it('hasNext 在非末尾集返回 true', 0, () => {
+      const ctx = new TestPlaybackContext();
+      ctx.items = makeItems(3);
+      ctx.currentIndex = 0;
+      expect(ctx.hasNext).assertTrue();
+    });
+
+    it('hasPrev 在第一集返回 false', 0, () => {
+      const ctx = new TestPlaybackContext();
+      ctx.items = makeItems(3);
+      ctx.currentIndex = 0;
+      expect(ctx.hasPrev).assertFalse();
+    });
+
+    it('hasPrev 在非第一集返回 true', 0, () => {
+      const ctx = new TestPlaybackContext();
+      ctx.items = makeItems(3);
+      ctx.currentIndex = 1;
+      expect(ctx.hasPrev).assertTrue();
+    });
+
+    it('空列表处理', 0, () => {
+      const ctx = new TestPlaybackContext();
+      ctx.items = [];
+      expect(ctx.hasNext).assertFalse();
+      expect(ctx.hasPrev).assertFalse();
+    });
+
+    it('jumpTo 越界返回 null', 0, () => {
+      const ctx = new TestPlaybackContext();
+      ctx.items = makeItems(3);
+      ctx.currentIndex = 1;
+      const r1 = ctx.jumpTo(-1);
+      expect(r1 === null).assertTrue();
+      expect(ctx.currentIndex).assertEqual(1);
+      const r2 = ctx.jumpTo(3); // items.length = 3，越界
+      expect(r2 === null).assertTrue();
+      expect(ctx.currentIndex).assertEqual(1);
+    });
+
+  });
+}

--- a/entry/src/test/ets/PlaybackContextTest.ets
+++ b/entry/src/test/ets/PlaybackContextTest.ets
@@ -1,5 +1,8 @@
 import { describe, it, expect } from '@ohos/hypium';
-import { PlaybackContext, PlaybackContextItem } from '../../main/ets/components/core/player/PlaybackContext';
+import {
+  PlaybackContext, PlaybackContextItem,
+  MediaLibraryContext, FileExplorerContext
+} from '../../main/ets/components/core/player/PlaybackContext';
 
 // 用于测试的具体实现类（不测试具体播放逻辑，只验证基类导航方法）
 class TestPlaybackContext extends PlaybackContext {
@@ -87,6 +90,96 @@ export default function PlaybackContextTest() {
       const r2 = ctx.jumpTo(3); // items.length = 3，越界
       expect(r2 === null).assertTrue();
       expect(ctx.currentIndex).assertEqual(1);
+    });
+
+  });
+
+  // ─────────────────────────────────────────────
+  // MediaLibraryContext 测试套件
+  // 不依赖真实 DB：直接构造实例并赋值 items，验证导航行为
+  // ─────────────────────────────────────────────
+  describe('MediaLibraryContextTest', () => {
+
+    it('工厂方法从 DB 加载当前季剧集', 0, () => {
+      // 用直接构造模拟 build() 产出，验证 currentIndex 定位逻辑
+      const ctx = new MediaLibraryContext();
+      ctx.items = makeItems(4);
+      ctx.seriesId = 1;
+      ctx.seasonNumber = 1;
+      ctx.currentIndex = 2; // 模拟 currentVideoPath 对应 index=2
+      expect(ctx !== null).assertTrue();
+      expect(ctx.currentIndex).assertEqual(2);
+      expect(ctx.items.length).assertEqual(4);
+    });
+
+    it('jumpTo 切换到指定集', 0, () => {
+      const ctx = new MediaLibraryContext();
+      ctx.items = makeItems(4);
+      ctx.currentIndex = 0;
+      const result = ctx.jumpTo(2);
+      expect(ctx.currentIndex).assertEqual(2);
+      expect(result !== null).assertTrue();
+      if (result !== null) {
+        expect(result.videoPath).assertEqual('path_2');
+      }
+    });
+
+    it('jumpTo 越界返回 null', 0, () => {
+      const ctx = new MediaLibraryContext();
+      ctx.items = makeItems(3);
+      ctx.currentIndex = 1;
+      const r1 = ctx.jumpTo(-1);
+      expect(r1 === null).assertTrue();
+      expect(ctx.currentIndex).assertEqual(1);
+      const r2 = ctx.jumpTo(ctx.items.length);
+      expect(r2 === null).assertTrue();
+      expect(ctx.currentIndex).assertEqual(1);
+    });
+
+    it('jumpToNext 跳转到下一集', 0, () => {
+      const ctx = new MediaLibraryContext();
+      ctx.items = makeItems(4);
+      ctx.currentIndex = 1;
+      const result = ctx.jumpToNext();
+      expect(ctx.currentIndex).assertEqual(2);
+      expect(result !== null).assertTrue();
+    });
+
+    it('jumpToPrev 跳转到上一集', 0, () => {
+      const ctx = new MediaLibraryContext();
+      ctx.items = makeItems(4);
+      ctx.currentIndex = 2;
+      const result = ctx.jumpToPrev();
+      expect(ctx.currentIndex).assertEqual(1);
+      expect(result !== null).assertTrue();
+    });
+
+    it('jumpToNext 在末尾集返回 null', 0, () => {
+      const ctx = new MediaLibraryContext();
+      ctx.items = makeItems(4);
+      ctx.currentIndex = ctx.items.length - 1; // 末尾
+      const result = ctx.jumpToNext();
+      expect(result === null).assertTrue();
+      expect(ctx.currentIndex).assertEqual(ctx.items.length - 1);
+    });
+
+  });
+
+  // ─────────────────────────────────────────────
+  // FileExplorerContext 骨架测试套件
+  // ─────────────────────────────────────────────
+  describe('FileExplorerContextTest', () => {
+
+    it('jumpTo 始终返回 null', 0, () => {
+      const ctx = new FileExplorerContext();
+      ctx.items = makeItems(3);
+      const result = ctx.jumpTo(0);
+      expect(result === null).assertTrue();
+    });
+
+    it('contextType 为 file_explorer', 0, () => {
+      const ctx = new FileExplorerContext();
+      expect(ctx.contextType).assertEqual('file_explorer');
     });
 
   });

--- a/entry/src/test/ets/PlaybackContextTest.ets
+++ b/entry/src/test/ets/PlaybackContextTest.ets
@@ -3,7 +3,7 @@ import {
   PlaybackContext, PlaybackContextItem,
   MediaLibraryContext, FileExplorerContext, BuildItemsResult
 } from '../../main/ets/components/core/player/PlaybackContext';
-import { MediaItem } from '../../main/ets/db/models/MediaEntity';
+import { MediaItem, TvEpisodeEntity } from '../../main/ets/db/models/MediaEntity';
 
 // 用于测试的具体实现类（不测试具体播放逻辑，只验证基类导航方法）
 class TestPlaybackContext extends PlaybackContext {
@@ -41,6 +41,10 @@ function makeItems(count: number): PlaybackContextItem[] {
     result.push(item);
   }
   return result;
+}
+
+interface PlaybackContextItemWithThumbnail extends PlaybackContextItem {
+  thumbnailUrl?: string;
 }
 
 export default function PlaybackContextTest() {
@@ -228,6 +232,49 @@ export default function PlaybackContextTest() {
       const result: BuildItemsResult = MediaLibraryContext.buildItems(fakeItems, 1, '/ep1.mkv');
       expect(result.items.length).assertEqual(1);
       expect(result.items[0].title).assertEqual('ep1.mkv');
+    });
+
+    it('buildItems 优先使用剧集 stillUrl 填充缩略图字段且不再依赖 posterLocalPath', 0, () => {
+      const fakeItems: MediaItem[] = [
+        {
+          id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep1.mkv', fileName: 'ep1.mkv', seasonNumber: 1, episodeNumber: 1,
+          title: 'EP1', posterLocalPath: '/series-poster.jpg'
+        },
+      ];
+      const episodeEntities: TvEpisodeEntity[] = [
+        {
+          seriesId: 1, provider: 'tmdb', providerId: 'ep1',
+          seasonNumber: 1, episodeNumber: 1, scrapedAt: 0,
+          stillUrl: 'https://image.tmdb.org/t/p/w342/still-ep1.jpg'
+        },
+      ];
+      const result = MediaLibraryContext.buildItems(fakeItems, 1, '/ep1.mkv', episodeEntities);
+      const firstItem = result.items[0] as PlaybackContextItemWithThumbnail;
+
+      expect(firstItem.thumbnailUrl).assertEqual('https://image.tmdb.org/t/p/w342/still-ep1.jpg');
+      expect(JSON.stringify(firstItem).indexOf('posterPath')).assertEqual(-1);
+    });
+
+    it('buildItems 在 stillUrl 缺失时使用 stillPath 生成与季详情页一致的缩略图 URL', 0, () => {
+      const fakeItems: MediaItem[] = [
+        {
+          id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep1.mkv', fileName: 'ep1.mkv', seasonNumber: 1, episodeNumber: 1,
+          title: 'EP1'
+        },
+      ];
+      const episodeEntities: TvEpisodeEntity[] = [
+        {
+          seriesId: 1, provider: 'tmdb', providerId: 'ep1',
+          seasonNumber: 1, episodeNumber: 1, scrapedAt: 0,
+          stillPath: '/still-ep1.jpg'
+        },
+      ];
+      const result = MediaLibraryContext.buildItems(fakeItems, 1, '/ep1.mkv', episodeEntities);
+      const firstItem = result.items[0] as PlaybackContextItemWithThumbnail;
+
+      expect(firstItem.thumbnailUrl).assertEqual('https://image.tmdb.org/t/p/w342/still-ep1.jpg');
     });
 
   });


### PR DESCRIPTION
## 功能说明

实现 Issue #119 剧集播放列表功能，包含以下核心模块：

### PlaybackContext 抽象类体系（Phase 1-3）
- 新增 `PlaybackContext.ets`：`@ObservedV2 abstract class PlaybackContext`，支持 `currentIndex`、`items`、`hasNext`/`hasPrev` 响应式字段
- 实现 `MediaLibraryContext`：从本地数据库加载当季剧集，支持 `jumpTo/jumpToNext/jumpToPrev`
- 实现 `FileExplorerContext` 骨架：预留扩展点，jumpTo 系列返回 null
- TDD 覆盖：16 个单测用例，100% 通过

### 播放器集成（Phase 4-5）
- `PlayerPageParam` 新增可选字段 `playbackContext?: PlaybackContext`
- `VideoPlayerController` 新增 `playbackContext` 字段（向后兼容，不影响现有播放逻辑）
- `SeasonDetailPage` / `SeriesDetailPage` 的 `playEpisode()` 改为 async，进播放器前构建 `MediaLibraryContext`

### EpisodeListPanel UI 组件（Phase 6）
- 新建 `EpisodeListPanel.ets`，严格按 Pencil 设计规范实现
- `LazyForEach` 渲染，支持大列表性能
- 三态卡片：当前集（210vp，`#A9F4FF` 描边）/ 普通集（256vp）/ edgeCard（168vp 截断）
- 分页条：每页 6 集，激活/非激活颜色，下划线
- pagerPill 胶囊（焦点在分页条时显示）
- 焦点环（42×42vp 椭圆，white stroke 5vp）
- TV 遥控器完整键盘处理（左右翻页、上下导航区域切换）

### PlayerSettingsDialog 集成（Phase 7）
- `MediaLibraryContext` 下显示选集Tab，`onSelect` 调用 `jumpTo` 更新 currentIndex
- 无 playbackContext 时原有设置（倍速/画面比例/字幕/画质增强）完全不变

### 媒体库过滤策略（Phase 8）
- 删除 `getRecentlyAddedList()` 中的 `unscrapedSql` UNION 查询
- 只有有 `scrape_info` 的媒体才出现在海报墙，无海报用标题兜底

## 测试

- 单元测试：142 个用例全部通过
- assembleHap / UnitTestBuild：BUILD SUCCESSFUL

## 关联 Issue

Closes #119
Related: #121 #122 #123 #124

## 已知后续事项

- `jumpTo` 更新 currentIndex 后，实际 URL 切换需在 VideoPlayer.ets 监听 currentIndex 变化后触发（将在后续 Issue 联调）
- `EpisodeListPanel` 分页逻辑（纯函数）建议后续补充单测

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paginated episode selection panel with per-card focus, keyboard/DPAD navigation, and integration in player settings to jump to episodes.
  * Player now accepts an optional playback context enabling continuous up-next / previous-episode navigation.

* **Improvements**
  * Recently added list excludes unscraped items for cleaner results.
  * Player settings layout adjusted to surface episode list when available.

* **Tests**
  * New tests covering playback-context building and navigation, including boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->