### PR TITLE
新增: 完成剧集自动下一集与本地季集匹配

### DIFF
--- a/entry/src/main/ets/components/core/player/EpisodeAutoplayPreferences.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeAutoplayPreferences.ets
@@ -1,0 +1,55 @@
+import { AppPreferences, PrefKey } from '../../../utils/AppPreferences'
+
+export interface EpisodeAutoplaySettings {
+  enabled: boolean;
+  countdownSeconds: number;
+}
+
+export const DEFAULT_EPISODE_AUTOPLAY_ENABLED: boolean = true
+export const DEFAULT_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS: number = 8
+const MIN_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS: number = 3
+const MAX_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS: number = 10
+
+export function normalizeEpisodeAutoplayCountdownSeconds(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS
+  }
+  const roundedValue = Math.round(value)
+  if (roundedValue < MIN_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS) {
+    return MIN_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS
+  }
+  if (roundedValue > MAX_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS) {
+    return MAX_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS
+  }
+  return roundedValue
+}
+
+export async function loadEpisodeAutoplaySettings(): Promise<EpisodeAutoplaySettings> {
+  const enabledValue = await AppPreferences.getNumber(
+    PrefKey.PLAYER_EPISODE_AUTOPLAY_ENABLED,
+    DEFAULT_EPISODE_AUTOPLAY_ENABLED ? 1 : 0
+  )
+  const countdownValue = await AppPreferences.getNumber(
+    PrefKey.PLAYER_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS,
+    DEFAULT_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS
+  )
+  const settings: EpisodeAutoplaySettings = {
+    enabled: enabledValue !== 0,
+    countdownSeconds: normalizeEpisodeAutoplayCountdownSeconds(countdownValue)
+  }
+  return settings
+}
+
+export async function saveEpisodeAutoplayEnabled(enabled: boolean): Promise<void> {
+  await AppPreferences.set(
+    PrefKey.PLAYER_EPISODE_AUTOPLAY_ENABLED,
+    enabled ? 1 : 0
+  )
+}
+
+export async function saveEpisodeAutoplayCountdownSeconds(countdownSeconds: number): Promise<void> {
+  await AppPreferences.set(
+    PrefKey.PLAYER_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS,
+    normalizeEpisodeAutoplayCountdownSeconds(countdownSeconds)
+  )
+}

--- a/entry/src/main/ets/components/core/player/EpisodeGroupMatcher.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeGroupMatcher.ets
@@ -1,0 +1,159 @@
+import { MediaItem, TvEpisodeEntity } from '../../../db/models/MediaEntity'
+
+function tmdbStillImageUrl(path: string | undefined, width: string): string {
+  if (path === undefined || path.length === 0) {
+    return ''
+  }
+  return `https://image.tmdb.org/t/p/${width}${path}`
+}
+
+export interface EpisodeGroupMatchItem {
+  videoPath: string
+  title: string
+  index: number
+  thumbnailUrl?: string
+  episodeNumber?: number
+  seasonNumber?: number
+  sourceId?: number
+  videoId?: number
+  durationMs?: number
+}
+
+export interface EpisodeGroupMatchResult {
+  mediaItems: MediaItem[]
+  items: EpisodeGroupMatchItem[]
+}
+
+export class EpisodeGroupMatcher {
+  private readonly seasonCache: Map<string, EpisodeGroupMatchResult> = new Map<string, EpisodeGroupMatchResult>()
+
+  async matchSeasonEpisodes(
+    seriesId: number,
+    seasonNumber: number,
+    loadMediaItems: () => Promise<MediaItem[]>,
+    loadEpisodeEntities: () => Promise<TvEpisodeEntity[]>
+  ): Promise<EpisodeGroupMatchResult> {
+    const cacheKey = this.buildCacheKey(seriesId, seasonNumber)
+    const cached = this.seasonCache.get(cacheKey)
+    if (cached !== undefined) {
+      return cached
+    }
+
+    const allItems = await loadMediaItems()
+    const seasonItems = this.filterSeasonItems(allItems, seasonNumber)
+    const episodeEntities = await loadEpisodeEntities()
+    const episodeEntityByNumber = this.buildEpisodeEntityByNumber(episodeEntities)
+
+    const playbackItems: EpisodeGroupMatchItem[] = []
+    for (let i = 0; i < seasonItems.length; i++) {
+      const mediaItem = seasonItems[i]
+      const episodeEntity = this.findEpisodeEntity(mediaItem, i, episodeEntities, episodeEntityByNumber)
+      const playbackItem: EpisodeGroupMatchItem = {
+        videoPath: mediaItem.filePath,
+        title: this.getEpisodeDisplayTitle(mediaItem, episodeEntity),
+        index: i,
+        thumbnailUrl: this.getEpisodeThumbnailUrl(episodeEntity),
+        episodeNumber: mediaItem.episodeNumber ?? undefined,
+        seasonNumber: mediaItem.seasonNumber ?? undefined,
+        sourceId: mediaItem.sourceId,
+        videoId: mediaItem.id,
+        durationMs: mediaItem.durationMs ?? undefined
+      }
+      playbackItems.push(playbackItem)
+    }
+
+    const result: EpisodeGroupMatchResult = {
+      mediaItems: seasonItems,
+      items: playbackItems
+    }
+    this.seasonCache.set(cacheKey, result)
+    return result
+  }
+
+  clearCache(): void {
+    this.seasonCache.clear()
+  }
+
+  private buildCacheKey(seriesId: number, seasonNumber: number): string {
+    return `${seriesId}:${seasonNumber}`
+  }
+
+  private filterSeasonItems(allItems: MediaItem[], seasonNumber: number): MediaItem[] {
+    const seasonItems: MediaItem[] = []
+    for (let i = 0; i < allItems.length; i++) {
+      const item = allItems[i]
+      if (item.seasonNumber === seasonNumber) {
+        seasonItems.push(item)
+      }
+    }
+    seasonItems.sort((a: MediaItem, b: MediaItem): number => {
+      const aEpisode = a.episodeNumber ?? Number.MAX_SAFE_INTEGER
+      const bEpisode = b.episodeNumber ?? Number.MAX_SAFE_INTEGER
+      if (aEpisode !== bEpisode) {
+        return aEpisode - bEpisode
+      }
+      return a.filePath.localeCompare(b.filePath)
+    })
+    return seasonItems
+  }
+
+  private buildEpisodeEntityByNumber(episodeEntities: TvEpisodeEntity[]): Map<number, TvEpisodeEntity> {
+    const result = new Map<number, TvEpisodeEntity>()
+    for (let i = 0; i < episodeEntities.length; i++) {
+      const entity = episodeEntities[i]
+      result.set(entity.episodeNumber, entity)
+    }
+    return result
+  }
+
+  private findEpisodeEntity(
+    mediaItem: MediaItem,
+    index: number,
+    episodeEntities: TvEpisodeEntity[],
+    episodeEntityByNumber: Map<number, TvEpisodeEntity>
+  ): TvEpisodeEntity | undefined {
+    if (mediaItem.episodeNumber !== undefined) {
+      const matchedEntity = episodeEntityByNumber.get(mediaItem.episodeNumber)
+      if (matchedEntity !== undefined) {
+        return matchedEntity
+      }
+    }
+    if (index >= 0 && index < episodeEntities.length) {
+      return episodeEntities[index]
+    }
+    return undefined
+  }
+
+  private getEpisodeDisplayTitle(mediaItem: MediaItem, episodeEntity: TvEpisodeEntity | undefined): string {
+    const entityTitle = (episodeEntity?.title ?? '').trim()
+    if (entityTitle.length > 0) {
+      return entityTitle
+    }
+    const episodeNumber = mediaItem.episodeNumber ?? 0
+    if (episodeNumber > 0) {
+      return `第${episodeNumber}集`
+    }
+    const title = (mediaItem.title ?? '').trim()
+    if (title.length > 0) {
+      return title
+    }
+    const fileName = (mediaItem.fileName ?? '').trim()
+    if (fileName.length > 0) {
+      return fileName
+    }
+    return '未知集名'
+  }
+
+  private getEpisodeThumbnailUrl(episodeEntity: TvEpisodeEntity | undefined): string | undefined {
+    if (episodeEntity === undefined) {
+      return undefined
+    }
+    if (episodeEntity.stillUrl !== undefined && episodeEntity.stillUrl.length > 0) {
+      return episodeEntity.stillUrl
+    }
+    if (episodeEntity.stillPath !== undefined && episodeEntity.stillPath.length > 0) {
+      return tmdbStillImageUrl(episodeEntity.stillPath, 'w342')
+    }
+    return undefined
+  }
+}

--- a/entry/src/main/ets/components/core/player/EpisodeGroupMatcher.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeGroupMatcher.ets
@@ -117,6 +117,7 @@ export class EpisodeGroupMatcher {
       if (matchedEntity !== undefined) {
         return matchedEntity
       }
+      return undefined
     }
     if (index >= 0 && index < episodeEntities.length) {
       return episodeEntities[index]

--- a/entry/src/main/ets/components/core/player/EpisodePlaybackManager.ets
+++ b/entry/src/main/ets/components/core/player/EpisodePlaybackManager.ets
@@ -1,0 +1,115 @@
+import { MediaLibraryContext, PlaybackContext, PlaybackContextItem } from './PlaybackContext'
+import {
+  DEFAULT_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS,
+  DEFAULT_EPISODE_AUTOPLAY_ENABLED,
+  normalizeEpisodeAutoplayCountdownSeconds
+} from './EpisodeAutoplayPreferences'
+
+export interface EpisodePlaybackManagerState {
+  visible: boolean;
+  remainingSeconds: number;
+  nextItem: PlaybackContextItem | null;
+  shouldPlayNext: boolean;
+}
+
+function buildIdleEpisodePlaybackManagerState(): EpisodePlaybackManagerState {
+  const state: EpisodePlaybackManagerState = {
+    visible: false,
+    remainingSeconds: 0,
+    nextItem: null,
+    shouldPlayNext: false
+  }
+  return state
+}
+
+export class EpisodePlaybackManager {
+  private autoplayEnabled: boolean = DEFAULT_EPISODE_AUTOPLAY_ENABLED
+  private countdownSeconds: number = DEFAULT_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS
+  private activeEpisodeKey: string = ''
+  private suppressedEpisodeKey: string = ''
+
+  updateSettings(enabled: boolean, countdownSeconds: number): void {
+    this.autoplayEnabled = enabled
+    this.countdownSeconds = normalizeEpisodeAutoplayCountdownSeconds(countdownSeconds)
+  }
+
+  clear(): void {
+    this.activeEpisodeKey = ''
+    this.suppressedEpisodeKey = ''
+  }
+
+  cancelCurrentEpisode(): void {
+    if (this.activeEpisodeKey.length > 0) {
+      this.suppressedEpisodeKey = this.activeEpisodeKey
+    }
+  }
+
+  markAutoplayFailed(): void {
+    this.cancelCurrentEpisode()
+  }
+
+  sync(playbackContext: PlaybackContext | undefined, currentTimeMs: number, durationMs: number): EpisodePlaybackManagerState {
+    const mediaLibraryContext = this.getMediaLibraryContext(playbackContext)
+    const currentEpisodeKey = this.getCurrentEpisodeKey(mediaLibraryContext)
+    if (currentEpisodeKey !== this.activeEpisodeKey) {
+      this.activeEpisodeKey = currentEpisodeKey
+      this.suppressedEpisodeKey = ''
+    }
+    if (!this.autoplayEnabled || mediaLibraryContext === undefined || durationMs <= 0 || currentEpisodeKey.length === 0) {
+      return buildIdleEpisodePlaybackManagerState()
+    }
+    const nextItem = this.getNextItem(mediaLibraryContext)
+    if (nextItem === null || this.suppressedEpisodeKey === currentEpisodeKey) {
+      return buildIdleEpisodePlaybackManagerState()
+    }
+    const remainingMs = durationMs - Math.max(currentTimeMs, 0)
+    if (remainingMs > this.countdownSeconds * 1000) {
+      return buildIdleEpisodePlaybackManagerState()
+    }
+    if (remainingMs <= 0) {
+      const state: EpisodePlaybackManagerState = {
+        visible: false,
+        remainingSeconds: 0,
+        nextItem,
+        shouldPlayNext: true
+      }
+      return state
+    }
+    const state: EpisodePlaybackManagerState = {
+      visible: true,
+      remainingSeconds: Math.ceil(remainingMs / 1000),
+      nextItem,
+      shouldPlayNext: false
+    }
+    return state
+  }
+
+  private getMediaLibraryContext(playbackContext: PlaybackContext | undefined): MediaLibraryContext | undefined {
+    if (playbackContext === undefined || playbackContext.contextType !== 'media_library') {
+      return undefined
+    }
+    return playbackContext as MediaLibraryContext
+  }
+
+  private getCurrentEpisodeKey(playbackContext: MediaLibraryContext | undefined): string {
+    if (playbackContext === undefined) {
+      return ''
+    }
+    if (playbackContext.currentIndex < 0 || playbackContext.currentIndex >= playbackContext.items.length) {
+      return ''
+    }
+    const currentItem = playbackContext.items[playbackContext.currentIndex]
+    return currentItem.videoPath
+  }
+
+  private getNextItem(playbackContext: MediaLibraryContext): PlaybackContextItem | null {
+    if (!playbackContext.hasNext) {
+      return null
+    }
+    const nextIndex = playbackContext.currentIndex + 1
+    if (nextIndex < 0 || nextIndex >= playbackContext.items.length) {
+      return null
+    }
+    return playbackContext.items[nextIndex]
+  }
+}

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -49,11 +49,14 @@ export interface BuildItemsResult {
   currentIndex: number;
 }
 
+export function createMediaLibraryEpisodeGroupMatcher(): EpisodeGroupMatcher {
+  return new EpisodeGroupMatcher();
+}
+
 // 媒体库播放上下文：基于剧集数据库加载当季集列表
 @ObservedV2
 export class MediaLibraryContext extends PlaybackContext {
   readonly contextType: string = 'media_library';
-  private static readonly episodeGroupMatcher: EpisodeGroupMatcher = new EpisodeGroupMatcher();
 
   @Trace seriesId: number = 0;
   @Trace seasonNumber: number = 0;
@@ -122,7 +125,8 @@ export class MediaLibraryContext extends PlaybackContext {
     seasonNumber: number,
     currentVideoPath: string
   ): Promise<MediaLibraryContext> {
-    const matchResult = await MediaLibraryContext.episodeGroupMatcher.matchSeasonEpisodes(
+    const episodeGroupMatcher = createMediaLibraryEpisodeGroupMatcher();
+    const matchResult = await episodeGroupMatcher.matchSeasonEpisodes(
       seriesId,
       seasonNumber,
       (): Promise<MediaItem[]> => db.getMediaItemsByTvSeriesId(seriesId),
@@ -192,6 +196,7 @@ export class MediaLibraryContext extends PlaybackContext {
       if (matchedEntity !== undefined) {
         return matchedEntity;
       }
+      return undefined;
     }
     if (index >= 0 && index < episodeEntities.length) {
       return episodeEntities[index];

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -1,5 +1,6 @@
 import { FileSourceDatabase } from '../../../db/files/FileSourceDatabase';
 import { MediaItem, TvEpisodeEntity } from '../../../db/models/MediaEntity';
+import { EpisodeGroupMatcher, EpisodeGroupMatchResult, EpisodeGroupMatchItem } from './EpisodeGroupMatcher';
 
 function tmdbImageUrl(path: string | undefined, width: string): string {
   if (path === undefined || path.length === 0) {
@@ -52,6 +53,7 @@ export interface BuildItemsResult {
 @ObservedV2
 export class MediaLibraryContext extends PlaybackContext {
   readonly contextType: string = 'media_library';
+  private static readonly episodeGroupMatcher: EpisodeGroupMatcher = new EpisodeGroupMatcher();
 
   @Trace seriesId: number = 0;
   @Trace seasonNumber: number = 0;
@@ -68,6 +70,14 @@ export class MediaLibraryContext extends PlaybackContext {
     episodeEntities: TvEpisodeEntity[] = []
   ): BuildItemsResult {
     const seasonItems = allItems.filter(item => item.seasonNumber === seasonNumber);
+    seasonItems.sort((a: MediaItem, b: MediaItem): number => {
+      const aEpisode = a.episodeNumber ?? Number.MAX_SAFE_INTEGER;
+      const bEpisode = b.episodeNumber ?? Number.MAX_SAFE_INTEGER;
+      if (aEpisode !== bEpisode) {
+        return aEpisode - bEpisode;
+      }
+      return a.filePath.localeCompare(b.filePath);
+    });
     const episodeEntityByNumber = MediaLibraryContext.buildEpisodeEntityByNumber(episodeEntities);
 
     const mapped: PlaybackContextItem[] = [];
@@ -112,17 +122,54 @@ export class MediaLibraryContext extends PlaybackContext {
     seasonNumber: number,
     currentVideoPath: string
   ): Promise<MediaLibraryContext> {
-    const allItems = await db.getMediaItemsByTvSeriesId(seriesId);
-    const episodeEntities = await db.getEpisodesBySeriesAndSeason(seriesId, seasonNumber);
-    const buildResult = MediaLibraryContext.buildItems(allItems, seasonNumber, currentVideoPath, episodeEntities);
+    const matchResult = await MediaLibraryContext.episodeGroupMatcher.matchSeasonEpisodes(
+      seriesId,
+      seasonNumber,
+      (): Promise<MediaItem[]> => db.getMediaItemsByTvSeriesId(seriesId),
+      (): Promise<TvEpisodeEntity[]> => db.getEpisodesBySeriesAndSeason(seriesId, seasonNumber)
+    );
+    const buildResult = MediaLibraryContext.buildItemsFromMatchResult(matchResult, currentVideoPath);
 
     const ctx = new MediaLibraryContext();
     ctx.seriesId = seriesId;
     ctx.seasonNumber = seasonNumber;
-    ctx.episodes = allItems.filter(item => item.seasonNumber === seasonNumber);
+    ctx.episodes = matchResult.mediaItems;
     ctx.items = buildResult.items;
     ctx.currentIndex = buildResult.currentIndex;
     return ctx;
+  }
+
+  private static buildItemsFromMatchResult(
+    matchResult: EpisodeGroupMatchResult,
+    currentVideoPath: string
+  ): BuildItemsResult {
+    const mapped: PlaybackContextItem[] = [];
+    for (let i = 0; i < matchResult.items.length; i++) {
+      const matchItem: EpisodeGroupMatchItem = matchResult.items[i];
+      const item: PlaybackContextItem = {
+        videoPath: matchItem.videoPath,
+        title: matchItem.title,
+        index: matchItem.index,
+        thumbnailUrl: matchItem.thumbnailUrl,
+        episodeNumber: matchItem.episodeNumber,
+        seasonNumber: matchItem.seasonNumber,
+        sourceId: matchItem.sourceId,
+        videoId: matchItem.videoId,
+        durationMs: matchItem.durationMs,
+      };
+      mapped.push(item);
+    }
+
+    let foundIndex = 0;
+    for (let i = 0; i < mapped.length; i++) {
+      if (mapped[i].videoPath === currentVideoPath) {
+        foundIndex = i;
+        break;
+      }
+    }
+
+    const result: BuildItemsResult = { items: mapped, currentIndex: foundIndex };
+    return result;
   }
 
   private static buildEpisodeEntityByNumber(episodeEntities: TvEpisodeEntity[]): Map<number, TvEpisodeEntity> {

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -6,6 +6,11 @@ import { LengthMetrics } from "@kit.ArkUI"
 import { media } from "@kit.MediaKit"
 import { EpisodeListPanel } from './EpisodeListPanel'
 import { PlaybackContextItem, MediaLibraryContext } from './PlaybackContext'
+import {
+  loadEpisodeAutoplaySettings,
+  saveEpisodeAutoplayCountdownSeconds,
+  saveEpisodeAutoplayEnabled
+} from './EpisodeAutoplayPreferences'
 
 @ComponentV2
 struct VideoControls {
@@ -679,6 +684,14 @@ export struct PlayerSettingsDialog {
   ]
   @State private aiEnhanceOn: boolean = true
   @State private aiEnhanceQuality: VpeQualityLevel = 'medium'
+  @State private autoplayEnabled: boolean = true
+  @State private autoplayCountdownSeconds: number = 8
+  @State private autoplayToggleFocusedIndex: number = -1
+  @State private autoplayCountdownFocusedIndex: number = -1
+  @State private autoplayToggleHoveredIndex: number = -1
+  @State private autoplayCountdownHoveredIndex: number = -1
+  private readonly autoplayToggleOptions: Array<boolean> = [true, false]
+  private readonly autoplayCountdownOptions: Array<number> = [3, 5, 8, 10]
 
   aboutToAppear(): void {
     this.aiEnhanceOn = this.videoController.aiEnhanceEnabled;
@@ -688,6 +701,10 @@ export struct PlayerSettingsDialog {
     this.speedFocusedIndex = -1;
     this.arHoveredIndex = -1;
     this.speedHoveredIndex = -1;
+    this.autoplayToggleFocusedIndex = -1;
+    this.autoplayCountdownFocusedIndex = -1;
+    this.autoplayToggleHoveredIndex = -1;
+    this.autoplayCountdownHoveredIndex = -1;
     // 从控制器同步当前播放速率，找到匹配的 index（默认回退到 1.0x = index 2）
     const currentSpeed = this.videoController.playbackSpeed;
     let matchIdx = 2;
@@ -698,6 +715,14 @@ export struct PlayerSettingsDialog {
       }
     }
     this.selectedPlaybackRateIndex = matchIdx;
+    this.autoplayEnabled = this.videoController.episodeAutoplayEnabled;
+    this.autoplayCountdownSeconds = this.videoController.episodeAutoplayCountdownSeconds;
+    loadEpisodeAutoplaySettings().then((settings) => {
+      this.autoplayEnabled = settings.enabled;
+      this.autoplayCountdownSeconds = settings.countdownSeconds;
+      this.videoController.episodeAutoplayEnabled = settings.enabled;
+      this.videoController.episodeAutoplayCountdownSeconds = settings.countdownSeconds;
+    }).catch(() => {})
   }
 
   aboutToDisappear(): void {
@@ -705,6 +730,10 @@ export struct PlayerSettingsDialog {
     this.speedFocusedIndex = -1;
     this.arHoveredIndex = -1;
     this.speedHoveredIndex = -1;
+    this.autoplayToggleFocusedIndex = -1;
+    this.autoplayCountdownFocusedIndex = -1;
+    this.autoplayToggleHoveredIndex = -1;
+    this.autoplayCountdownHoveredIndex = -1;
   }
 
   /** 当 playbackContext 是媒体库上下文时返回，否则返回 undefined */
@@ -761,6 +790,34 @@ export struct PlayerSettingsDialog {
       this.currentAspectRatioMode === this.aspectRatioOptions[idx].mode,
       this.arHoveredIndex === idx
     )
+  }
+
+  private getAutoplayToggleChipStyleState(idx: number): PlayerSettingsChipStyleState {
+    return getPlayerSettingsChipStyleState(
+      this.autoplayToggleFocusedIndex === idx,
+      this.autoplayEnabled === this.autoplayToggleOptions[idx],
+      this.autoplayToggleHoveredIndex === idx
+    )
+  }
+
+  private getAutoplayCountdownChipStyleState(idx: number): PlayerSettingsChipStyleState {
+    return getPlayerSettingsChipStyleState(
+      this.autoplayCountdownFocusedIndex === idx,
+      this.autoplayCountdownSeconds === this.autoplayCountdownOptions[idx],
+      this.autoplayCountdownHoveredIndex === idx
+    )
+  }
+
+  private updateEpisodeAutoplayEnabled(enabled: boolean): void {
+    this.autoplayEnabled = enabled
+    this.videoController.episodeAutoplayEnabled = enabled
+    saveEpisodeAutoplayEnabled(enabled).catch(() => {})
+  }
+
+  private updateEpisodeAutoplayCountdownSeconds(seconds: number): void {
+    this.autoplayCountdownSeconds = seconds
+    this.videoController.episodeAutoplayCountdownSeconds = seconds
+    saveEpisodeAutoplayCountdownSeconds(seconds).catch(() => {})
   }
 
   build() {
@@ -858,6 +915,62 @@ export struct PlayerSettingsDialog {
               .onClick(() => {
                 this.onOpenSubtitleSelector()
               })
+            }
+
+            if (this.getMediaLibraryContext() !== undefined) {
+              Column({ space: 12 }) {
+                Text('自动下一集')
+                  .fontSize(32)
+                  .fontColor('#EFF2FB')
+                  .fontWeight(FontWeight.Medium)
+                  .alignSelf(ItemAlign.Start)
+
+                Row({ space: PLAYER_SETTINGS_CHIP_GAP }) {
+                  ForEach(this.autoplayToggleOptions, (enabled: boolean, idx: number) => {
+                    Row() {
+                      this.SelectionOptionChip(enabled ? '开启' : '关闭', this.getAutoplayToggleChipStyleState(idx))
+                    }
+                    .focusable(true)
+                    .onFocus(() => { this.autoplayToggleFocusedIndex = idx })
+                    .onBlur(() => { this.autoplayToggleFocusedIndex = -1 })
+                    .onHover((isHover: boolean) => {
+                      this.autoplayToggleHoveredIndex = isHover ? idx : -1
+                    })
+                    .onClick(() => {
+                      this.updateEpisodeAutoplayEnabled(enabled)
+                    })
+                  }, (enabled: boolean) => enabled ? 'enabled' : 'disabled')
+                }
+                .justifyContent(FlexAlign.Start)
+                .width('100%')
+              }
+
+              Column({ space: 12 }) {
+                Text('倒计时秒数')
+                  .fontSize(32)
+                  .fontColor('#EFF2FB')
+                  .fontWeight(FontWeight.Medium)
+                  .alignSelf(ItemAlign.Start)
+
+                Row({ space: PLAYER_SETTINGS_CHIP_GAP }) {
+                  ForEach(this.autoplayCountdownOptions, (seconds: number, idx: number) => {
+                    Row() {
+                      this.SelectionOptionChip(`${seconds}s`, this.getAutoplayCountdownChipStyleState(idx))
+                    }
+                    .focusable(true)
+                    .onFocus(() => { this.autoplayCountdownFocusedIndex = idx })
+                    .onBlur(() => { this.autoplayCountdownFocusedIndex = -1 })
+                    .onHover((isHover: boolean) => {
+                      this.autoplayCountdownHoveredIndex = isHover ? idx : -1
+                    })
+                    .onClick(() => {
+                      this.updateEpisodeAutoplayCountdownSeconds(seconds)
+                    })
+                  }, (seconds: number) => seconds.toString())
+                }
+                .justifyContent(FlexAlign.Start)
+                .width('100%')
+              }
             }
 
             if (canIUse('SystemCapability.Multimedia.VideoProcessingEngine') && this.videoController.backend === 'avplayer') {

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -657,6 +657,14 @@ export function getPlayerSettingsChipStyleState(
   return styleState
 }
 
+export function shouldApplyEpisodeAutoplaySettingsLoad(
+  requestToken: number,
+  currentToken: number,
+  isDirty: boolean
+): boolean {
+  return requestToken === currentToken && !isDirty
+}
+
 @CustomDialog
 export struct PlayerSettingsDialog {
   controller: CustomDialogController
@@ -692,6 +700,8 @@ export struct PlayerSettingsDialog {
   @State private autoplayCountdownHoveredIndex: number = -1
   private readonly autoplayToggleOptions: Array<boolean> = [true, false]
   private readonly autoplayCountdownOptions: Array<number> = [3, 5, 8, 10]
+  private autoplaySettingsLoadToken: number = 0
+  private autoplaySettingsDirty: boolean = false
 
   aboutToAppear(): void {
     this.aiEnhanceOn = this.videoController.aiEnhanceEnabled;
@@ -717,7 +727,17 @@ export struct PlayerSettingsDialog {
     this.selectedPlaybackRateIndex = matchIdx;
     this.autoplayEnabled = this.videoController.episodeAutoplayEnabled;
     this.autoplayCountdownSeconds = this.videoController.episodeAutoplayCountdownSeconds;
+    this.autoplaySettingsDirty = false
+    this.autoplaySettingsLoadToken += 1
+    const currentLoadToken = this.autoplaySettingsLoadToken
     loadEpisodeAutoplaySettings().then((settings) => {
+      if (!shouldApplyEpisodeAutoplaySettingsLoad(
+        currentLoadToken,
+        this.autoplaySettingsLoadToken,
+        this.autoplaySettingsDirty
+      )) {
+        return
+      }
       this.autoplayEnabled = settings.enabled;
       this.autoplayCountdownSeconds = settings.countdownSeconds;
       this.videoController.episodeAutoplayEnabled = settings.enabled;
@@ -809,12 +829,14 @@ export struct PlayerSettingsDialog {
   }
 
   private updateEpisodeAutoplayEnabled(enabled: boolean): void {
+    this.autoplaySettingsDirty = true
     this.autoplayEnabled = enabled
     this.videoController.episodeAutoplayEnabled = enabled
     saveEpisodeAutoplayEnabled(enabled).catch(() => {})
   }
 
   private updateEpisodeAutoplayCountdownSeconds(seconds: number): void {
+    this.autoplaySettingsDirty = true
     this.autoplayCountdownSeconds = seconds
     this.videoController.episodeAutoplayCountdownSeconds = seconds
     saveEpisodeAutoplayCountdownSeconds(seconds).catch(() => {})

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -24,6 +24,10 @@ import { SmbAvSubtitleBridgeAdapter } from "./SmbSubtitleBridgeAdapter";
 import { VpeEnhancerUtil, VpeQualityLevel } from "../../../utils/VpeEnhancerUtil";
 import { ParsedSubtitle } from "./SubtitleRenderer";
 import { PlaybackContext } from "./PlaybackContext";
+import {
+  DEFAULT_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS,
+  DEFAULT_EPISODE_AUTOPLAY_ENABLED
+} from "./EpisodeAutoplayPreferences";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
 
@@ -235,6 +239,10 @@ export class VideoPlayerController {
   progressContext: PlayProgressEntity | null = null;
   /** 播放上下文（当季集列表 + 当前集索引），供连播/上下集跳转使用；文件浏览器入口不传时为 undefined */
   playbackContext: PlaybackContext | undefined = undefined;
+  /** 是否自动播放下一集 */
+  @Trace episodeAutoplayEnabled: boolean = DEFAULT_EPISODE_AUTOPLAY_ENABLED;
+  /** 自动播放下一集前的倒计时秒数 */
+  @Trace episodeAutoplayCountdownSeconds: number = DEFAULT_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS;
   /** 10s 防抖进度写入定时器 */
   private progressTimer?: number;
   /** 播放会话编号：每次 initPlayer 自增，用于忽略旧实例回调 */

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -514,9 +514,7 @@ export struct PlayerPage {
     if (this.episodePlaybackManager !== undefined) {
       this.episodePlaybackManager.cancelCurrentEpisode();
     }
-    this.showEpisodeAutoplayOverlay = false;
-    this.episodeAutoplayRemainingSeconds = 0;
-    this.episodeAutoplayNextTitle = '';
+    this.hideEpisodeAutoplayOverlay();
     const playbackContext = this.videoPlayerController.playbackContext;
     if (playbackContext !== undefined && playbackContext.contextType === 'media_library') {
       const mediaLibraryContext = playbackContext as MediaLibraryContext;

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -17,6 +17,8 @@ import { SubtitleSegment } from "../../components/core/player/SubtitleRenderer";
 import { WebDAVClient, WebDAVConfig } from "../../lib/WebDAVClient";
 import { FileSourceType, SMBSourceConfig, WebDAVSourceConfig } from "../../db/models/FileSourceEntity";
 import { FfprobeUtil, FfprobeTrack } from "../../utils/FfprobeUtil";
+import { EpisodePlaybackManager, EpisodePlaybackManagerState } from "../../components/core/player/EpisodePlaybackManager";
+import { loadEpisodeAutoplaySettings } from "../../components/core/player/EpisodeAutoplayPreferences";
 
 export interface PlayerPageParam {
   fileUrl?: string;
@@ -160,6 +162,7 @@ export struct PlayerPage {
   private currentPageParam?: PlayerPageParam
   private pageParamToken: number = 0
   private episodeSwitching: boolean = false
+  private readonly episodePlaybackManager = new EpisodePlaybackManager()
   @Local isBackPressedOnce: boolean = false
   /** 续播提示弹窗 */
   @Local showResumeDialog: boolean = false
@@ -174,8 +177,13 @@ export struct PlayerPage {
   private currentMediaEpisode: number = 0;
   /** media_progress 周期写入定时器 ID，-1 表示未启动 */
   private mediaProgressTimerId: number = -1;
+  /** 自动下一集轮询定时器 ID，-1 表示未启动 */
+  private episodeAutoplayTimerId: number = -1;
   /** 文件不存在时待 pop 的 videoId（-1 表示无） */
   private fileNotFoundVideoId: number = -1;
+  @Local showEpisodeAutoplayOverlay: boolean = false
+  @Local episodeAutoplayRemainingSeconds: number = 0
+  @Local episodeAutoplayNextTitle: string = ''
 
   /** 合并字幕行中各 Segment 的文本 */
   private mergeSubtitleLineText(line: SubtitleSegment[]): string {
@@ -335,6 +343,8 @@ export struct PlayerPage {
     this.currentMediaEpisode = pageParam.episodeNumber ?? 0;
     this.showResumeDialog = false;
     this.pendingSeekMs = -1;
+    this.hideEpisodeAutoplayOverlay();
+    this.episodePlaybackManager.clear();
     if (pageParam.videoId !== undefined && pageParam.videoId > 0) {
       this.videoPlayerController.progressContext = this.buildProgressContext(pageParam);
       this.registerPreparedResume(pageParam, token);
@@ -471,6 +481,12 @@ export struct PlayerPage {
     if (currentParam === undefined || this.episodeSwitching) {
       return false;
     }
+    if (this.episodePlaybackManager !== undefined) {
+      this.episodePlaybackManager.cancelCurrentEpisode();
+    }
+    this.showEpisodeAutoplayOverlay = false;
+    this.episodeAutoplayRemainingSeconds = 0;
+    this.episodeAutoplayNextTitle = '';
     const playbackContext = this.videoPlayerController.playbackContext;
     if (playbackContext !== undefined && playbackContext.contextType === 'media_library') {
       const mediaLibraryContext = playbackContext as MediaLibraryContext;
@@ -528,6 +544,116 @@ export struct PlayerPage {
         this.pageParamToken = previousPageParamToken;
       }
       this.episodeSwitching = false;
+    }
+  }
+
+  private hideEpisodeAutoplayOverlay(): void {
+    this.showEpisodeAutoplayOverlay = false
+    this.episodeAutoplayRemainingSeconds = 0
+    this.episodeAutoplayNextTitle = ''
+  }
+
+  private applyEpisodeAutoplayOverlayState(state: EpisodePlaybackManagerState): void {
+    if (!state.visible || state.nextItem === null) {
+      this.hideEpisodeAutoplayOverlay()
+      return
+    }
+    this.showEpisodeAutoplayOverlay = true
+    this.episodeAutoplayRemainingSeconds = state.remainingSeconds
+    this.episodeAutoplayNextTitle = state.nextItem.title
+  }
+
+  private cancelEpisodeAutoplayCountdown(): boolean {
+    if (!this.showEpisodeAutoplayOverlay) {
+      return false
+    }
+    this.episodePlaybackManager.cancelCurrentEpisode()
+    this.hideEpisodeAutoplayOverlay()
+    return true
+  }
+
+  private loadEpisodeAutoplayPreferences(): void {
+    loadEpisodeAutoplaySettings().then((settings) => {
+      this.videoPlayerController.episodeAutoplayEnabled = settings.enabled
+      this.videoPlayerController.episodeAutoplayCountdownSeconds = settings.countdownSeconds
+    }).catch(() => {})
+  }
+
+  private showEpisodeAutoplayFailureToast(): void {
+    try {
+      this.getUIContext().getPromptAction().showToast({ message: '自动播放下一集失败' })
+    } catch (_) {}
+  }
+
+  private triggerEpisodeAutoplay(nextItem: PlaybackContextItem): void {
+    if (this.episodeSwitching) {
+      return
+    }
+    this.handleEpisodeSelect(nextItem).then((didSwitch: boolean) => {
+      if (!didSwitch) {
+        this.episodePlaybackManager.markAutoplayFailed()
+        this.hideEpisodeAutoplayOverlay()
+        this.showEpisodeAutoplayFailureToast()
+      }
+    }).catch(() => {
+      this.episodePlaybackManager.markAutoplayFailed()
+      this.hideEpisodeAutoplayOverlay()
+      this.showEpisodeAutoplayFailureToast()
+    })
+  }
+
+  private syncEpisodeAutoplayState(): void {
+    this.episodePlaybackManager.updateSettings(
+      this.videoPlayerController.episodeAutoplayEnabled,
+      this.videoPlayerController.episodeAutoplayCountdownSeconds
+    )
+    const state = this.episodePlaybackManager.sync(
+      this.videoPlayerController.playbackContext,
+      this.videoPlayerController.currentTime,
+      this.videoPlayerController.duration
+    )
+    this.applyEpisodeAutoplayOverlayState(state)
+    if (state.shouldPlayNext && state.nextItem !== null) {
+      this.triggerEpisodeAutoplay(state.nextItem)
+    }
+  }
+
+  @Builder
+  private EpisodeAutoplayOverlay() {
+    if (this.showEpisodeAutoplayOverlay) {
+      Row({ space: 18 }) {
+        Column({ space: 4 }) {
+          Text(`即将播放下一集 · ${this.episodeAutoplayRemainingSeconds}s`)
+            .fontSize(24)
+            .fontColor(Color.White)
+            .fontWeight(FontWeight.Medium)
+          Text(this.episodeAutoplayNextTitle.length > 0 ? this.episodeAutoplayNextTitle : '下一集')
+            .fontSize(18)
+            .fontColor('#D7DCE7')
+            .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
+        }
+        .alignItems(HorizontalAlign.Start)
+
+        Button('取消')
+          .fontSize(16)
+          .fontColor(Color.White)
+          .backgroundColor('rgba(255, 255, 255, 0.18)')
+          .borderRadius(20)
+          .padding({ left: 18, right: 18, top: 10, bottom: 10 })
+          .onClick(() => {
+            this.cancelEpisodeAutoplayCountdown()
+          })
+      }
+      .padding({ left: 22, right: 22, top: 18, bottom: 18 })
+      .backgroundColor('rgba(0, 0, 0, 0.78)')
+      .borderRadius(20)
+      .shadow({ radius: 12, color: '#55000000', offsetX: 0, offsetY: 4 })
+      .alignRules({
+        bottom: { anchor: '__container__', align: VerticalAlign.Bottom },
+        middle: { anchor: '__container__', align: HorizontalAlign.Center }
+      })
+      .margin({ bottom: 160 })
     }
   }
 
@@ -662,6 +788,7 @@ export struct PlayerPage {
         }
 
         this.ResumeDialog()
+        this.EpisodeAutoplayOverlay()
 
         Text(this.getBackendDebugText())
           .fontSize(12)
@@ -718,13 +845,20 @@ export struct PlayerPage {
           }
         }
       }, 10000);
+      this.episodeAutoplayTimerId = setInterval(() => {
+        this.syncEpisodeAutoplayState()
+      }, 500);
 
       let pageParam = context.pathInfo.param as PlayerPageParam
       if (pageParam) {
         this.applyPlayerPageParam(pageParam);
       }
+      this.loadEpisodeAutoplayPreferences();
     })
     .onBackPressed(() => {
+      if (this.cancelEpisodeAutoplayCountdown()) {
+        return true
+      }
       if (this.isBackPressedOnce) {
         return false
       } else {
@@ -744,6 +878,10 @@ export struct PlayerPage {
     if (this.mediaProgressTimerId >= 0) {
       clearInterval(this.mediaProgressTimerId);
       this.mediaProgressTimerId = -1;
+    }
+    if (this.episodeAutoplayTimerId >= 0) {
+      clearInterval(this.episodeAutoplayTimerId);
+      this.episodeAutoplayTimerId = -1;
     }
     // 媒体级进度：完播则清除，否则保存当前位置；结束后通知继续播放栏刷新
     if (this.currentMediaKey.length > 0) {

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -8,7 +8,7 @@ import {
 } from "../../components/core/player/VideoPlayerController";
 import { PlaybackContext, PlaybackContextItem, MediaLibraryContext } from "../../components/core/player/PlaybackContext";
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
-import { PlayProgressEntity } from "../../db/models/MediaEntity";
+import { PlayProgressEntity, MediaProgressEntry } from "../../db/models/MediaEntity";
 import { MediaProgressStore } from "../../db/MediaProgressStore";
 import { millisecondsToTime } from "../../utils/TimeUtil";
 import { PlayerEvents } from "../../components/core/player/Constants";
@@ -69,6 +69,35 @@ export interface ResolvedEpisodePlaybackSource {
   presetAudioTracks?: PresetAudioTrack[];
   presetSubtitleTracks?: PresetSubtitleTrack[];
   startPositionMs?: number;
+}
+
+export type MediaProgressResumeActionType = 'seek' | 'play' | 'clear_and_play';
+
+export interface MediaProgressResumeAction {
+  action: MediaProgressResumeActionType;
+  positionMs?: number;
+}
+
+export function resolveMediaProgressResumeAction(
+  saved: MediaProgressEntry | null,
+  currentDurationMs: number,
+  currentSeason: number,
+  currentEpisode: number
+): MediaProgressResumeAction {
+  if (saved === null || saved.positionMs <= 0) {
+    return { action: 'play' };
+  }
+  if (saved.seasonNumber !== currentSeason || saved.episodeNumber !== currentEpisode) {
+    return { action: 'play' };
+  }
+  const effectiveDurationMs = currentDurationMs > 0 ? currentDurationMs : saved.durationMs;
+  if (MediaProgressStore.isNearEnd(saved.positionMs, effectiveDurationMs)) {
+    return { action: 'clear_and_play' };
+  }
+  return {
+    action: 'seek',
+    positionMs: saved.positionMs
+  };
 }
 
 function buildPlayerEpisodeCode(seasonNumber: number, episodeNumber: number): string {
@@ -269,19 +298,20 @@ export struct PlayerPage {
         return;
       }
       MediaProgressStore.get(mediaKey).then((saved) => {
-        if (saved !== null && saved.positionMs > 0
-            && saved.seasonNumber === this.currentMediaSeason
-            && saved.episodeNumber === this.currentMediaEpisode) {
-          const dur = this.videoPlayerController.duration;
-          const isNearEnd = MediaProgressStore.isNearEnd(saved.positionMs, dur > 0 ? dur : saved.durationMs);
-          if (!isNearEnd) {
-            this.videoPlayerController.seek(saved.positionMs).catch(() => {});
-          } else {
-            MediaProgressStore.clear(mediaKey).catch(() => {});
-          }
-        } else {
-          this.videoPlayerController.play().catch(() => {});
+        const resumeAction = resolveMediaProgressResumeAction(
+          saved,
+          this.videoPlayerController.duration,
+          this.currentMediaSeason,
+          this.currentMediaEpisode
+        );
+        if (resumeAction.action === 'seek' && resumeAction.positionMs !== undefined && resumeAction.positionMs > 0) {
+          this.videoPlayerController.seek(resumeAction.positionMs).catch(() => {});
+          return;
         }
+        if (resumeAction.action === 'clear_and_play') {
+          MediaProgressStore.clear(mediaKey).catch(() => {});
+        }
+        this.videoPlayerController.play().catch(() => {});
       }).catch(() => {
         this.videoPlayerController.play().catch(() => {});
       });

--- a/entry/src/main/ets/utils/AppPreferences.ets
+++ b/entry/src/main/ets/utils/AppPreferences.ets
@@ -18,6 +18,10 @@ export class PrefKey {
   static readonly SCRAPE_PROVIDER_ORDER = 'scrape_provider_order';
   /** 播放器诊断面包屑（用于无 faultlog 场景定位最后阶段） */
   static readonly PLAYER_LAST_BREADCRUMB = 'player_last_breadcrumb';
+  /** 剧集播放结束前是否自动切到下一集（1=开启，0=关闭） */
+  static readonly PLAYER_EPISODE_AUTOPLAY_ENABLED = 'player_episode_autoplay_enabled';
+  /** 自动切到下一集前的倒计时秒数 */
+  static readonly PLAYER_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS = 'player_episode_autoplay_countdown_seconds';
 }
 
 // ─────────────────────────────────────────────
@@ -99,4 +103,3 @@ export class AppPreferences {
     }
   }
 }
-

--- a/entry/src/test/EpisodeGroupMatcher.test.ets
+++ b/entry/src/test/EpisodeGroupMatcher.test.ets
@@ -1,0 +1,190 @@
+import { describe, it, expect } from '@ohos/hypium'
+import {
+  EpisodeGroupMatcher,
+  EpisodeGroupMatchResult
+} from '../main/ets/components/core/player/EpisodeGroupMatcher'
+import { MediaItem, TvEpisodeEntity } from '../main/ets/db/models/MediaEntity'
+
+class FakeEpisodeGroupMatcherDatabase {
+  mediaItemsCalls: number = 0
+  episodeEntitiesCalls: number = 0
+  private readonly mediaItems: MediaItem[]
+  private readonly episodeEntities: TvEpisodeEntity[]
+
+  constructor(mediaItems: MediaItem[], episodeEntities: TvEpisodeEntity[]) {
+    this.mediaItems = mediaItems
+    this.episodeEntities = episodeEntities
+  }
+
+  async getMediaItemsByTvSeriesId(_seriesId: number): Promise<MediaItem[]> {
+    this.mediaItemsCalls += 1
+    return this.mediaItems
+  }
+
+  async getEpisodesBySeriesAndSeason(_seriesId: number, _seasonNumber: number): Promise<TvEpisodeEntity[]> {
+    this.episodeEntitiesCalls += 1
+    return this.episodeEntities
+  }
+}
+
+export default function episodeGroupMatcherTest() {
+  describe('EpisodeGroupMatcher', () => {
+    it('matchSeasonEpisodes 会按当前季过滤并按集号升序返回可播放条目', 0, async () => {
+      const matcher = new EpisodeGroupMatcher()
+      const db = new FakeEpisodeGroupMatcherDatabase(
+        [
+          {
+            id: 2, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/s1e2.mkv', fileName: 's1e2.mkv', seasonNumber: 1, episodeNumber: 2,
+            title: '剧级标题'
+          },
+          {
+            id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/s1e1.mkv', fileName: 's1e1.mkv', seasonNumber: 1, episodeNumber: 1,
+            title: '剧级标题'
+          },
+          {
+            id: 3, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/s2e1.mkv', fileName: 's2e1.mkv', seasonNumber: 2, episodeNumber: 1,
+            title: '第二季'
+          }
+        ],
+        [
+          {
+            seriesId: 7, provider: 'tmdb', providerId: 'ep-1', seasonNumber: 1, episodeNumber: 1,
+            title: '第一集', stillUrl: 'https://image.tmdb.org/t/p/w342/ep1.jpg', scrapedAt: 0
+          },
+          {
+            seriesId: 7, provider: 'tmdb', providerId: 'ep-2', seasonNumber: 1, episodeNumber: 2,
+            title: '第二集', scrapedAt: 0
+          }
+        ]
+      )
+
+      const result: EpisodeGroupMatchResult = await matcher.matchSeasonEpisodes(
+        7,
+        1,
+        (): Promise<MediaItem[]> => db.getMediaItemsByTvSeriesId(7),
+        (): Promise<TvEpisodeEntity[]> => db.getEpisodesBySeriesAndSeason(7, 1)
+      )
+
+      expect(result.items.length).assertEqual(2)
+      expect(result.items[0].videoPath).assertEqual('/s1e1.mkv')
+      expect(result.items[0].title).assertEqual('第一集')
+      expect(result.items[0].thumbnailUrl).assertEqual('https://image.tmdb.org/t/p/w342/ep1.jpg')
+      expect(result.items[1].videoPath).assertEqual('/s1e2.mkv')
+      expect(result.items[1].title).assertEqual('第二集')
+    })
+
+    it('matchSeasonEpisodes 在集元数据缺失时回退到文件名或第X集', 0, async () => {
+      const matcher = new EpisodeGroupMatcher()
+      const db = new FakeEpisodeGroupMatcherDatabase(
+        [
+          {
+            id: 5, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/s1e5.mkv', fileName: 's1e5.mkv', seasonNumber: 1, episodeNumber: 5,
+            title: '整剧标题'
+          },
+          {
+            id: 6, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/special.mkv', fileName: 'special.mkv', seasonNumber: 1,
+            title: ''
+          }
+        ],
+        []
+      )
+
+      const result: EpisodeGroupMatchResult = await matcher.matchSeasonEpisodes(
+        7,
+        1,
+        (): Promise<MediaItem[]> => db.getMediaItemsByTvSeriesId(7),
+        (): Promise<TvEpisodeEntity[]> => db.getEpisodesBySeriesAndSeason(7, 1)
+      )
+
+      expect(result.items.length).assertEqual(2)
+      expect(result.items[0].title).assertEqual('第5集')
+      expect(result.items[1].title).assertEqual('special.mkv')
+    })
+
+    it('matchSeasonEpisodes 在本地缺少部分剧集时返回可播放子集且保持升序', 0, async () => {
+      const matcher = new EpisodeGroupMatcher()
+      const db = new FakeEpisodeGroupMatcherDatabase(
+        [
+          {
+            id: 13, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/s1e3.mkv', fileName: 's1e3.mkv', seasonNumber: 1, episodeNumber: 3,
+            title: '整剧标题'
+          },
+          {
+            id: 11, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/s1e1.mkv', fileName: 's1e1.mkv', seasonNumber: 1, episodeNumber: 1,
+            title: '整剧标题'
+          }
+        ],
+        [
+          {
+            seriesId: 7, provider: 'tmdb', providerId: 'ep-1', seasonNumber: 1, episodeNumber: 1,
+            title: '第一集', scrapedAt: 0
+          },
+          {
+            seriesId: 7, provider: 'tmdb', providerId: 'ep-2', seasonNumber: 1, episodeNumber: 2,
+            title: '第二集', scrapedAt: 0
+          },
+          {
+            seriesId: 7, provider: 'tmdb', providerId: 'ep-3', seasonNumber: 1, episodeNumber: 3,
+            title: '第三集', scrapedAt: 0
+          }
+        ]
+      )
+
+      const result: EpisodeGroupMatchResult = await matcher.matchSeasonEpisodes(
+        7,
+        1,
+        (): Promise<MediaItem[]> => db.getMediaItemsByTvSeriesId(7),
+        (): Promise<TvEpisodeEntity[]> => db.getEpisodesBySeriesAndSeason(7, 1)
+      )
+
+      expect(result.items.length).assertEqual(2)
+      expect(result.items[0].videoPath).assertEqual('/s1e1.mkv')
+      expect(result.items[0].title).assertEqual('第一集')
+      expect(result.items[1].videoPath).assertEqual('/s1e3.mkv')
+      expect(result.items[1].title).assertEqual('第三集')
+    })
+
+    it('matchSeasonEpisodes 在同一 matcher 会话内命中 series+season 缓存', 0, async () => {
+      const matcher = new EpisodeGroupMatcher()
+      const db = new FakeEpisodeGroupMatcherDatabase(
+        [
+          {
+            id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/s1e1.mkv', fileName: 's1e1.mkv', seasonNumber: 1, episodeNumber: 1
+          }
+        ],
+        [
+          {
+            seriesId: 7, provider: 'tmdb', providerId: 'ep-1', seasonNumber: 1, episodeNumber: 1,
+            title: '第一集', scrapedAt: 0
+          }
+        ]
+      )
+
+      const first: EpisodeGroupMatchResult = await matcher.matchSeasonEpisodes(
+        7,
+        1,
+        (): Promise<MediaItem[]> => db.getMediaItemsByTvSeriesId(7),
+        (): Promise<TvEpisodeEntity[]> => db.getEpisodesBySeriesAndSeason(7, 1)
+      )
+      const second: EpisodeGroupMatchResult = await matcher.matchSeasonEpisodes(
+        7,
+        1,
+        (): Promise<MediaItem[]> => db.getMediaItemsByTvSeriesId(7),
+        (): Promise<TvEpisodeEntity[]> => db.getEpisodesBySeriesAndSeason(7, 1)
+      )
+
+      expect(first.items.length).assertEqual(1)
+      expect(second.items.length).assertEqual(1)
+      expect(db.mediaItemsCalls).assertEqual(1)
+      expect(db.episodeEntitiesCalls).assertEqual(1)
+    })
+  })
+}

--- a/entry/src/test/EpisodeGroupMatcher.test.ets
+++ b/entry/src/test/EpisodeGroupMatcher.test.ets
@@ -186,5 +186,47 @@ export default function episodeGroupMatcherTest() {
       expect(db.mediaItemsCalls).assertEqual(1)
       expect(db.episodeEntitiesCalls).assertEqual(1)
     })
+
+    it('matchSeasonEpisodes 在已知 episodeNumber 未命中元数据时不会按索引错配到其他集', 0, async () => {
+      const matcher = new EpisodeGroupMatcher()
+      const db = new FakeEpisodeGroupMatcherDatabase(
+        [
+          {
+            id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/s1e1.mkv', fileName: 's1e1.mkv', seasonNumber: 1, episodeNumber: 1
+          },
+          {
+            id: 3, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+            filePath: '/s1e3.mkv', fileName: 's1e3.mkv', seasonNumber: 1, episodeNumber: 3
+          }
+        ],
+        [
+          {
+            seriesId: 7, provider: 'tmdb', providerId: 'ep-1', seasonNumber: 1, episodeNumber: 1,
+            title: '第一集', scrapedAt: 0
+          },
+          {
+            seriesId: 7, provider: 'tmdb', providerId: 'ep-2', seasonNumber: 1, episodeNumber: 2,
+            title: '第二集', scrapedAt: 0, stillUrl: 'https://image.tmdb.org/t/p/w342/ep2.jpg'
+          },
+          {
+            seriesId: 7, provider: 'tmdb', providerId: 'ep-4', seasonNumber: 1, episodeNumber: 4,
+            title: '第四集', scrapedAt: 0
+          }
+        ]
+      )
+
+      const result: EpisodeGroupMatchResult = await matcher.matchSeasonEpisodes(
+        7,
+        1,
+        (): Promise<MediaItem[]> => db.getMediaItemsByTvSeriesId(7),
+        (): Promise<TvEpisodeEntity[]> => db.getEpisodesBySeriesAndSeason(7, 1)
+      )
+
+      expect(result.items.length).assertEqual(2)
+      expect(result.items[0].title).assertEqual('第一集')
+      expect(result.items[1].title).assertEqual('第3集')
+      expect(result.items[1].thumbnailUrl === undefined).assertTrue()
+    })
   })
 }

--- a/entry/src/test/EpisodePlaybackManager.test.ets
+++ b/entry/src/test/EpisodePlaybackManager.test.ets
@@ -1,0 +1,106 @@
+import { describe, it, expect } from '@ohos/hypium'
+import {
+  EpisodePlaybackManager,
+  EpisodePlaybackManagerState
+} from '../main/ets/components/core/player/EpisodePlaybackManager'
+import { FileExplorerContext, MediaLibraryContext, PlaybackContextItem } from '../main/ets/components/core/player/PlaybackContext'
+
+function buildEpisodeItem(index: number): PlaybackContextItem {
+  return {
+    index,
+    title: `第${index + 1}集`,
+    videoPath: `/series/s01e0${index + 1}.mkv`,
+    videoId: 101 + index,
+    sourceId: 201 + index,
+    seasonNumber: 1,
+    episodeNumber: index + 1,
+    durationMs: 1800000
+  }
+}
+
+function buildMediaLibraryContext(currentIndex: number = 0): MediaLibraryContext {
+  const context = new MediaLibraryContext()
+  context.items = [buildEpisodeItem(0), buildEpisodeItem(1), buildEpisodeItem(2)]
+  context.currentIndex = currentIndex
+  return context
+}
+
+export default function episodePlaybackManagerTest() {
+  describe('EpisodePlaybackManager', () => {
+    it('启用自动下一集时会在接近结束时展示倒计时并触发下一集', 0, () => {
+      const manager: EpisodePlaybackManager = new EpisodePlaybackManager()
+      const context = buildMediaLibraryContext(0)
+
+      manager.updateSettings(true, 8)
+      const countdownState: EpisodePlaybackManagerState = manager.sync(context, 1793000, 1800000)
+      expect(countdownState.visible).assertTrue()
+      expect(countdownState.remainingSeconds).assertEqual(7)
+      expect(countdownState.nextItem?.videoPath ?? '').assertEqual('/series/s01e02.mkv')
+
+      const autoplayState: EpisodePlaybackManagerState = manager.sync(context, 1800000, 1800000)
+      expect(autoplayState.shouldPlayNext).assertTrue()
+      expect(autoplayState.nextItem?.videoPath ?? '').assertEqual('/series/s01e02.mkv')
+    })
+
+    it('关闭自动下一集后即使接近结束也不展示倒计时', 0, () => {
+      const manager: EpisodePlaybackManager = new EpisodePlaybackManager()
+      const context = buildMediaLibraryContext(0)
+
+      manager.updateSettings(false, 8)
+      const state: EpisodePlaybackManagerState = manager.sync(context, 1795000, 1800000)
+
+      expect(state.visible).assertFalse()
+      expect(state.shouldPlayNext).assertFalse()
+      expect(state.nextItem === null).assertTrue()
+    })
+
+    it('用户取消后当前集不再自动切换，直到当前播放项发生变化', 0, () => {
+      const manager: EpisodePlaybackManager = new EpisodePlaybackManager()
+      const context = buildMediaLibraryContext(0)
+
+      manager.updateSettings(true, 8)
+      manager.sync(context, 1794000, 1800000)
+      manager.cancelCurrentEpisode()
+
+      const cancelledState: EpisodePlaybackManagerState = manager.sync(context, 1800000, 1800000)
+      expect(cancelledState.shouldPlayNext).assertFalse()
+      expect(cancelledState.visible).assertFalse()
+
+      context.jumpTo(1)
+      const resumedState: EpisodePlaybackManagerState = manager.sync(context, 1799000, 1800000)
+      expect(resumedState.visible).assertTrue()
+      expect(resumedState.nextItem?.videoPath ?? '').assertEqual('/series/s01e03.mkv')
+    })
+
+    it('非媒体库上下文或无下一集时安全降级', 0, () => {
+      const manager: EpisodePlaybackManager = new EpisodePlaybackManager()
+      const fileExplorerContext = new FileExplorerContext()
+      fileExplorerContext.items = [buildEpisodeItem(0), buildEpisodeItem(1)]
+      fileExplorerContext.currentIndex = 0
+
+      manager.updateSettings(true, 8)
+      const fileExplorerState: EpisodePlaybackManagerState = manager.sync(fileExplorerContext, 1795000, 1800000)
+      expect(fileExplorerState.visible).assertFalse()
+      expect(fileExplorerState.shouldPlayNext).assertFalse()
+
+      const mediaContext = buildMediaLibraryContext(2)
+      const lastEpisodeState: EpisodePlaybackManagerState = manager.sync(mediaContext, 1795000, 1800000)
+      expect(lastEpisodeState.visible).assertFalse()
+      expect(lastEpisodeState.shouldPlayNext).assertFalse()
+    })
+
+    it('自动切换失败后当前集保持降级停用，不会重复重试', 0, () => {
+      const manager: EpisodePlaybackManager = new EpisodePlaybackManager()
+      const context = buildMediaLibraryContext(0)
+
+      manager.updateSettings(true, 8)
+      const initialState: EpisodePlaybackManagerState = manager.sync(context, 1800000, 1800000)
+      expect(initialState.shouldPlayNext).assertTrue()
+
+      manager.markAutoplayFailed()
+      const failedState: EpisodePlaybackManagerState = manager.sync(context, 1800000, 1800000)
+      expect(failedState.shouldPlayNext).assertFalse()
+      expect(failedState.visible).assertFalse()
+    })
+  })
+}

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -10,6 +10,8 @@ import ijkSubtitleBridgeTest from './IjkSubtitleBridge.test';
 import subtitleBridgeAdapterTest from './SubtitleBridgeAdapter.test';
 import webDAVClientUtilsTest from './WebDAVClientUtils.test';
 import episodeListPanelTest from './EpisodeListPanel.test';
+import episodeGroupMatcherTest from './EpisodeGroupMatcher.test';
+import episodePlaybackManagerTest from './EpisodePlaybackManager.test';
 import videoControlsTest from './VideoControls.test';
 import playerPageTest from './PlayerPage.test';
 import videoPlayerControllerTest from './VideoPlayerController.test';
@@ -31,6 +33,8 @@ export default function testsuite() {
   subtitleBridgeAdapterTest();
   webDAVClientUtilsTest();
   episodeListPanelTest();
+  episodeGroupMatcherTest();
+  episodePlaybackManagerTest();
   videoControlsTest();
   playerPageTest();
   videoPlayerControllerTest();

--- a/entry/src/test/PlayerPage.test.ets
+++ b/entry/src/test/PlayerPage.test.ets
@@ -23,12 +23,16 @@ interface PlayerPageAccessor {
   persistCurrentPlaybackState(): void
   resolveEpisodePlaybackSource(item: PlaybackContextItem): Promise<ResolvedEpisodePlaybackSource | null>
   handleEpisodeSelect(item: PlaybackContextItem): Promise<boolean>
+  hideEpisodeAutoplayOverlay(): void
   resumePlaybackForParam(pageParam: PlayerPageParam): void
   currentMediaKey: string
   currentMediaSeason: number
   currentMediaEpisode: number
   currentPageParam?: PlayerPageParam
   episodeSwitching: boolean
+  showEpisodeAutoplayOverlay?: boolean
+  episodeAutoplayRemainingSeconds?: number
+  episodeAutoplayNextTitle?: string
   showResumeDialog: boolean
   pendingSeekMs: number
   videoData?: PlayerPageVideoDataAccessor
@@ -208,6 +212,9 @@ class PreparedResumeListenerPage {
 class EpisodeSwitchTokenPage {
   currentPageParam?: PlayerPageParam
   episodeSwitching: boolean = false
+  showEpisodeAutoplayOverlay: boolean = false
+  episodeAutoplayRemainingSeconds: number = 0
+  episodeAutoplayNextTitle: string = ''
   showResumeDialog: boolean = false
   pendingSeekMs: number = -1
   currentMediaKey: string = ''
@@ -230,6 +237,12 @@ class EpisodeSwitchTokenPage {
 
   handleEpisodeSelect(item: PlaybackContextItem): Promise<boolean> {
     return this.handleEpisodeSelectImpl(item)
+  }
+
+  hideEpisodeAutoplayOverlay(): void {
+    this.showEpisodeAutoplayOverlay = false
+    this.episodeAutoplayRemainingSeconds = 0
+    this.episodeAutoplayNextTitle = ''
   }
 
   persistCurrentPlaybackState(): void {
@@ -273,11 +286,15 @@ class EpisodeSwitchTokenPage {
 class TestEpisodeSwitchPage {
   currentPageParam?: PlayerPageParam
   episodeSwitching: boolean = false
+  showEpisodeAutoplayOverlay: boolean = false
+  episodeAutoplayRemainingSeconds: number = 0
+  episodeAutoplayNextTitle: string = ''
   showResumeDialog: boolean = false
   pendingSeekMs: number = -1
   currentMediaKey: string = ''
   currentMediaSeason: number = 0
   currentMediaEpisode: number = 0
+  pageParamToken: number = 0
   videoData?: PlayerPageVideoDataAccessor
   videoPlayerController: PlayerPageControllerPlaybackAccessor
   private readonly handleEpisodeSelectImpl: (item: PlaybackContextItem) => Promise<boolean>
@@ -293,6 +310,12 @@ class TestEpisodeSwitchPage {
 
   handleEpisodeSelect(item: PlaybackContextItem): Promise<boolean> {
     return this.handleEpisodeSelectImpl(item)
+  }
+
+  hideEpisodeAutoplayOverlay(): void {
+    this.showEpisodeAutoplayOverlay = false
+    this.episodeAutoplayRemainingSeconds = 0
+    this.episodeAutoplayNextTitle = ''
   }
 
   persistCurrentPlaybackState(): void {

--- a/entry/src/test/PlayerPage.test.ets
+++ b/entry/src/test/PlayerPage.test.ets
@@ -2,9 +2,11 @@ import { describe, it, expect } from '@ohos/hypium'
 import {
   buildMediaLibraryEpisodeSwitchParam,
   commitMediaLibraryEpisodeSwitch,
+  MediaProgressResumeAction,
   PlayerPage,
   PlayerPageParam,
-  ResolvedEpisodePlaybackSource
+  ResolvedEpisodePlaybackSource,
+  resolveMediaProgressResumeAction
 } from '../main/ets/pages/player/index'
 import {
   MediaLibraryContext,
@@ -12,7 +14,7 @@ import {
   PlaybackContext,
   PlaybackContextItem
 } from '../main/ets/components/core/player/PlaybackContext'
-import { MediaItem, TvEpisodeEntity } from '../main/ets/db/models/MediaEntity'
+import { MediaItem, TvEpisodeEntity, MediaProgressEntry } from '../main/ets/db/models/MediaEntity'
 import { PlayerEvents } from '../main/ets/components/core/player/Constants'
 import { emitter } from '@kit.BasicServicesKit'
 
@@ -163,7 +165,10 @@ class CountingEpisodeSwitchController extends TestPlayerPageController implement
 }
 
 class PreparedResumeIsolationController extends TestPlayerPageController implements PlayerPageControllerPlaybackAccessor {
+  playCalls: number = 0
+
   play(): Promise<void> {
+    this.playCalls += 1
     return Promise.resolve()
   }
 }
@@ -750,6 +755,27 @@ export default function playerPageTest() {
       emitter.emit(PlayerEvents.PREPARED)
       expect(page.resumeCalls.length).assertEqual(0)
       emitter.off(PlayerEvents.PREPARED.eventId)
+    })
+
+    it('媒体级进度接近完播时会改为清理进度后继续播放', 0, () => {
+      const mediaKey = 'media_progress_episode_tmdb_tmdb-9527_s1_e7'
+      const nearEndEntry: MediaProgressEntry = {
+        mediaKey,
+        positionMs: 1720000,
+        durationMs: 1800000,
+        lastPlayedAt: 1,
+        seasonNumber: 1,
+        episodeNumber: 7
+      }
+      const action: MediaProgressResumeAction = resolveMediaProgressResumeAction(
+        nearEndEntry,
+        1800000,
+        1,
+        7
+      )
+
+      expect(action.action).assertEqual('clear_and_play')
+      expect(action.positionMs ?? 0).assertEqual(0)
     })
 
     it('handleEpisodeSelect 会在解析新播放源前推进 pageParamToken', 0, async () => {

--- a/entry/src/test/VideoControls.test.ets
+++ b/entry/src/test/VideoControls.test.ets
@@ -1,5 +1,9 @@
 import { describe, it, expect } from '@ohos/hypium'
-import { PlayerSettingsChipStyleState, getPlayerSettingsChipStyleState } from '../main/ets/components/core/player/VideoControls'
+import {
+  PlayerSettingsChipStyleState,
+  getPlayerSettingsChipStyleState,
+  shouldApplyEpisodeAutoplaySettingsLoad
+} from '../main/ets/components/core/player/VideoControls'
 
 export default function videoControlsTest() {
   describe('VideoControls player settings chip styles', () => {
@@ -42,6 +46,17 @@ export default function videoControlsTest() {
       expect(focusedState.scale).assertEqual(1.04)
       expect(focusedSelectedState.backgroundColor).assertEqual(selectedState.backgroundColor)
       expect(focusedSelectedState.scale).assertEqual(focusedState.scale)
+    })
+  })
+
+  describe('VideoControls autoplay settings load guard', () => {
+    it('用户已修改设置后不再应用旧的异步加载结果', 0, () => {
+      expect(shouldApplyEpisodeAutoplaySettingsLoad(1, 1, true)).assertFalse()
+    })
+
+    it('弹窗重新打开后只接受最新一次加载结果', 0, () => {
+      expect(shouldApplyEpisodeAutoplaySettingsLoad(1, 2, false)).assertFalse()
+      expect(shouldApplyEpisodeAutoplaySettingsLoad(2, 2, false)).assertTrue()
     })
   })
 }

--- a/entry/src/test/ets/PlaybackContextTest.ets
+++ b/entry/src/test/ets/PlaybackContextTest.ets
@@ -193,6 +193,31 @@ export default function PlaybackContextTest() {
       expect(result.items[1].videoPath).assertEqual('/ep2.mkv');
     });
 
+    it('buildItems 会将当前季的可播放条目按集号升序排列', 0, () => {
+      const fakeItems: MediaItem[] = [
+        {
+          id: 2, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep2.mkv', fileName: 'ep2.mkv', seasonNumber: 1, episodeNumber: 2, title: 'EP2'
+        },
+        {
+          id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/ep1.mkv', fileName: 'ep1.mkv', seasonNumber: 1, episodeNumber: 1, title: 'EP1'
+        },
+        {
+          id: 3, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/special.mkv', fileName: 'special.mkv', seasonNumber: 1, title: 'SPECIAL'
+        }
+      ];
+
+      const result: BuildItemsResult = MediaLibraryContext.buildItems(fakeItems, 1, '/ep2.mkv');
+
+      expect(result.items.length).assertEqual(3);
+      expect(result.items[0].videoPath).assertEqual('/ep1.mkv');
+      expect(result.items[1].videoPath).assertEqual('/ep2.mkv');
+      expect(result.items[2].videoPath).assertEqual('/special.mkv');
+      expect(result.currentIndex).assertEqual(1);
+    });
+
     it('buildItems currentVideoPath 不存在时 currentIndex 默认为 0', 0, () => {
       const fakeItems: MediaItem[] = [
         {

--- a/entry/src/test/ets/PlaybackContextTest.ets
+++ b/entry/src/test/ets/PlaybackContextTest.ets
@@ -1,7 +1,8 @@
 import { describe, it, expect } from '@ohos/hypium';
 import {
   PlaybackContext, PlaybackContextItem,
-  MediaLibraryContext, FileExplorerContext, BuildItemsResult
+  MediaLibraryContext, FileExplorerContext, BuildItemsResult,
+  createMediaLibraryEpisodeGroupMatcher
 } from '../../main/ets/components/core/player/PlaybackContext';
 import { MediaItem, TvEpisodeEntity } from '../../main/ets/db/models/MediaEntity';
 
@@ -355,6 +356,48 @@ export default function PlaybackContextTest() {
       const result = MediaLibraryContext.buildItems(fakeItems, 1, '/s1e7.mkv');
       expect(result.items.length).assertEqual(1);
       expect(result.items[0].title).assertEqual('第7集');
+    });
+
+    it('buildItems 在已知 episodeNumber 未命中元数据时不会按索引错配到其他集', 0, () => {
+      const fakeItems: MediaItem[] = [
+        {
+          id: 1, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/s1e1.mkv', fileName: 's1e1.mkv', seasonNumber: 1, episodeNumber: 1
+        },
+        {
+          id: 3, sourceId: 1, directoryPath: '/tv', scannedAt: 0,
+          filePath: '/s1e3.mkv', fileName: 's1e3.mkv', seasonNumber: 1, episodeNumber: 3
+        }
+      ];
+      const episodeEntities: TvEpisodeEntity[] = [
+        {
+          seriesId: 7, provider: 'tmdb', providerId: 'ep-1',
+          seasonNumber: 1, episodeNumber: 1, scrapedAt: 0, title: '第一集'
+        },
+        {
+          seriesId: 7, provider: 'tmdb', providerId: 'ep-2',
+          seasonNumber: 1, episodeNumber: 2, scrapedAt: 0, title: '第二集',
+          stillUrl: 'https://image.tmdb.org/t/p/w342/ep2.jpg'
+        },
+        {
+          seriesId: 7, provider: 'tmdb', providerId: 'ep-4',
+          seasonNumber: 1, episodeNumber: 4, scrapedAt: 0, title: '第四集'
+        }
+      ];
+
+      const result = MediaLibraryContext.buildItems(fakeItems, 1, '/s1e3.mkv', episodeEntities);
+      const thirdItem = result.items[1] as PlaybackContextItemWithThumbnail;
+
+      expect(result.items.length).assertEqual(2);
+      expect(thirdItem.title).assertEqual('第3集');
+      expect(thirdItem.thumbnailUrl === undefined).assertTrue();
+    });
+
+    it('createMediaLibraryEpisodeGroupMatcher 每次都返回新实例以避免跨 build 复用旧缓存', 0, () => {
+      const first = createMediaLibraryEpisodeGroupMatcher();
+      const second = createMediaLibraryEpisodeGroupMatcher();
+
+      expect(first === second).assertFalse();
     });
 
   });


### PR DESCRIPTION
## 关联 Issue

Closes #122
Closes #123

## 变更概览

本 PR 完成 `complete-episode-autoplay-flow` 变更提案，补齐媒体库场景下“本地季集识别 → 切集 → 自动下一集”的连续播放闭环。

## 主要改动

1. 新增 `EpisodeGroupMatcher`，基于本地 `tv_episodes`、`scrape_info` 与 `videos` 匹配当前季可播放剧集列表，并补充缓存与缺失数据降级。
2. 调整 `MediaLibraryContext` / `PlaybackContext` 构建逻辑，统一复用本地季集匹配结果，保证排序、索引回退和缺集场景稳定。
3. 新增 `EpisodePlaybackManager`、自动下一集倒计时浮层、返回键取消、失败抑制与播放器设置项，完成 #123 的交互链路。
4. 修复切回已接近完播旧剧集时首次停留黑屏的问题，近完播进度会在清理后继续自动播放。

## 验证

- 本地单测通过（含 `EpisodeGroupMatcher`、`EpisodePlaybackManager`、`PlaybackContext`、`PlayerPage` 回归）
- 真机覆盖安装验证通过，确认不会卸载或清空数据库
- 重点回归通过：
  - 自动下一集与倒计时取消
  - 正向/反向切集
  - 从第 8 集切回第 7 集首次不再黑屏

## 影响范围

- `entry/src/main/ets/components/core/player/`
- `entry/src/main/ets/pages/player/index.ets`
- `entry/src/test/`
- `openspec/changes/complete-episode-autoplay-flow/tasks.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Episode autoplay with automatic next-episode playback after a configurable countdown
  * Autoplay controls in player settings to enable/disable and set countdown seconds
  * Countdown overlay with cancel option and automatic triggering of the next episode

* **Bug Fixes**
  * Improved media-progress resume behavior for more accurate resume actions

* **Tests**
  * Added tests covering episode grouping/matching, autoplay manager, and resume behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->