### PR TITLE
重构: 统一 WebDAV 与 SMB 文件浏览基线

### DIFF
--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -4449,6 +4449,120 @@ static void CompleteSmbReadTextFile(napi_env env, napi_status /*status*/, void *
     delete ctx;
 }
 
+struct SmbDownloadFileContext {
+    napi_async_work work = nullptr;
+    napi_deferred deferred = nullptr;
+    std::string url;
+    std::string outputPath;
+    int32_t timeoutSeconds = 15;
+    std::string errorMessage;
+};
+
+static void ExecuteSmbDownloadFile(napi_env /*env*/, void *data) {
+    auto *ctx = static_cast<SmbDownloadFileContext *>(data);
+    SmbUrlComponents comps = ParseSmbUrl(ctx->url);
+    if (!comps.valid) {
+        ctx->errorMessage = "smbDownloadFile: invalid SMB URL";
+        return;
+    }
+
+    OH_LOG_Print(LOG_APP, LOG_INFO, 0x0000, "SMBClient",
+                 "smbDownloadFile: host=%{public}s share=%{public}s path=%{public}s output=%{public}s",
+                 comps.host.c_str(), comps.share.c_str(), comps.subPath.c_str(), ctx->outputPath.c_str());
+
+    struct smb2_context *smb2 = smb2_init_context();
+    if (!smb2) {
+        ctx->errorMessage = "smb2_init_context failed (out of memory)";
+        return;
+    }
+    if (!comps.user.empty())     smb2_set_user(smb2, comps.user.c_str());
+    if (!comps.password.empty()) smb2_set_password(smb2, comps.password.c_str());
+    smb2_set_timeout(smb2, ctx->timeoutSeconds);
+
+    int ret = smb2_connect_share(smb2, comps.host.c_str(), comps.share.c_str(),
+                                 comps.user.empty() ? nullptr : comps.user.c_str());
+    if (ret < 0) {
+        const char *errStr = smb2_get_error(smb2);
+        ctx->errorMessage = (errStr && errStr[0]) ? errStr : "SMB connection failed";
+        smb2_destroy_context(smb2);
+        return;
+    }
+
+    struct smb2fh *fh = smb2_open(smb2, comps.subPath.c_str(), O_RDONLY);
+    if (!fh) {
+        const char *errStr = smb2_get_error(smb2);
+        ctx->errorMessage = (errStr && errStr[0]) ? errStr : "smb2_open failed";
+        smb2_disconnect_share(smb2);
+        smb2_destroy_context(smb2);
+        return;
+    }
+
+    FILE *outputFile = std::fopen(ctx->outputPath.c_str(), "wb");
+    if (!outputFile) {
+        ctx->errorMessage = "smbDownloadFile: failed to open output file";
+        smb2_close(smb2, fh);
+        smb2_disconnect_share(smb2);
+        smb2_destroy_context(smb2);
+        return;
+    }
+
+    const size_t kBufSize = 65536;
+    std::vector<uint8_t> buf(kBufSize);
+    int32_t bytesRead = 0;
+    while ((bytesRead = smb2_read(smb2, fh, buf.data(), kBufSize)) > 0) {
+        size_t bytesWritten = std::fwrite(buf.data(), 1, static_cast<size_t>(bytesRead), outputFile);
+        if (bytesWritten != static_cast<size_t>(bytesRead)) {
+            ctx->errorMessage = "smbDownloadFile: failed to write output file";
+            break;
+        }
+    }
+    if (bytesRead < 0 && ctx->errorMessage.empty()) {
+        const char *errStr = smb2_get_error(smb2);
+        ctx->errorMessage = (errStr && errStr[0]) ? errStr : "smb2_read failed";
+    }
+
+    std::fclose(outputFile);
+    smb2_close(smb2, fh);
+    smb2_disconnect_share(smb2);
+    smb2_destroy_context(smb2);
+
+    if (!ctx->errorMessage.empty()) {
+        std::remove(ctx->outputPath.c_str());
+        return;
+    }
+}
+
+static void CompleteSmbDownloadFile(napi_env env, napi_status /*status*/, void *data) {
+    auto *ctx = static_cast<SmbDownloadFileContext *>(data);
+    if (!ctx->errorMessage.empty()) {
+        napi_value errMsg = nullptr;
+        napi_create_string_utf8(env, ctx->errorMessage.c_str(), NAPI_AUTO_LENGTH, &errMsg);
+        napi_value errObj = nullptr;
+        if (napi_create_error(env, nullptr, errMsg, &errObj) == napi_ok) {
+            napi_reject_deferred(env, ctx->deferred, errObj);
+        } else {
+            napi_reject_deferred(env, ctx->deferred, errMsg);
+        }
+    } else {
+        napi_value outputPathVal = nullptr;
+        if (napi_create_string_utf8(env, ctx->outputPath.c_str(), NAPI_AUTO_LENGTH, &outputPathVal) == napi_ok) {
+            napi_resolve_deferred(env, ctx->deferred, outputPathVal);
+        } else {
+            napi_value errMsg = nullptr;
+            napi_create_string_utf8(env, "NAPI internal error: failed to create output path string",
+                                    NAPI_AUTO_LENGTH, &errMsg);
+            napi_value errObj = nullptr;
+            if (napi_create_error(env, nullptr, errMsg, &errObj) == napi_ok) {
+                napi_reject_deferred(env, ctx->deferred, errObj);
+            } else {
+                napi_reject_deferred(env, ctx->deferred, errMsg);
+            }
+        }
+    }
+    if (ctx->work) napi_delete_async_work(env, ctx->work);
+    delete ctx;
+}
+
 #endif // VIDALL_HAS_LIBSMB2
 
 /**
@@ -5125,6 +5239,85 @@ static napi_value SmbReadTextFile(napi_env env, napi_callback_info info) {
     return promise;
 }
 
+static napi_value SmbDownloadFile(napi_env env, napi_callback_info info) {
+    size_t argc = 3;
+    napi_value args[3] = { nullptr, nullptr, nullptr };
+    if (napi_get_cb_info(env, info, &argc, args, nullptr, nullptr) != napi_ok) {
+        ThrowTypeError(env, "smbDownloadFile failed to read args");
+        return nullptr;
+    }
+    if (argc < 2) {
+        ThrowTypeError(env, "smbDownloadFile requires (url, outputPath)");
+        return nullptr;
+    }
+
+    std::string url;
+    std::string outputPath;
+    if (!ReadUtf8String(env, args[0], url)) {
+        ThrowTypeError(env, "smbDownloadFile url must be string");
+        return nullptr;
+    }
+    if (!ReadUtf8String(env, args[1], outputPath)) {
+        ThrowTypeError(env, "smbDownloadFile outputPath must be string");
+        return nullptr;
+    }
+
+    int32_t timeoutSeconds = 15;
+    if (argc >= 3 && args[2] != nullptr) {
+        int64_t ts = 0;
+        if (napi_get_value_int64(env, args[2], &ts) == napi_ok && ts > 0 && ts <= 300) {
+            timeoutSeconds = static_cast<int32_t>(ts);
+        }
+    }
+
+    napi_deferred deferred = nullptr;
+    napi_value promise = nullptr;
+    if (napi_create_promise(env, &deferred, &promise) != napi_ok) {
+        ThrowTypeError(env, "smbDownloadFile failed to create promise");
+        return nullptr;
+    }
+
+#if VIDALL_HAS_LIBSMB2
+    {
+        auto *ctx = new SmbDownloadFileContext();
+        ctx->deferred = deferred;
+        ctx->url = url;
+        ctx->outputPath = outputPath;
+        ctx->timeoutSeconds = timeoutSeconds;
+
+        napi_value resourceName = nullptr;
+        if (napi_create_string_utf8(env, "smbDownloadFileAsync", NAPI_AUTO_LENGTH, &resourceName) != napi_ok) {
+            delete ctx;
+            ThrowTypeError(env, "smbDownloadFile failed to create resource name");
+            return nullptr;
+        }
+        if (napi_create_async_work(env, nullptr, resourceName,
+                                   ExecuteSmbDownloadFile, CompleteSmbDownloadFile,
+                                   ctx, &ctx->work) != napi_ok) {
+            delete ctx;
+            ThrowTypeError(env, "smbDownloadFile failed to create async work");
+            return nullptr;
+        }
+        if (napi_queue_async_work(env, ctx->work) != napi_ok) {
+            napi_delete_async_work(env, ctx->work);
+            delete ctx;
+            ThrowTypeError(env, "smbDownloadFile failed to queue async work");
+            return nullptr;
+        }
+    }
+#else
+    {
+        napi_value errorMsg = nullptr;
+        napi_create_string_utf8(env,
+            "SMB protocol not available: libsmb2 not compiled (VIDALL_HAS_LIBSMB2=0)",
+            NAPI_AUTO_LENGTH, &errorMsg);
+        napi_reject_deferred(env, deferred, errorMsg);
+    }
+#endif
+
+    return promise;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     { "createPlayer", nullptr, CreatePlayer, nullptr, nullptr, nullptr, napi_default, nullptr },
@@ -5159,7 +5352,8 @@ static napi_value Init(napi_env env, napi_value exports) {
     { "smbListDirectory",  nullptr, SmbListDirectory,  nullptr, nullptr, nullptr, napi_default, nullptr },
     { "smbListShares",     nullptr, SmbListShares,     nullptr, nullptr, nullptr, napi_default, nullptr },
     { "smbDiscoverHosts",  nullptr, SmbDiscoverHosts,  nullptr, nullptr, nullptr, napi_default, nullptr },
-    { "smbReadTextFile",   nullptr, SmbReadTextFile,   nullptr, nullptr, nullptr, napi_default, nullptr }
+    { "smbReadTextFile",   nullptr, SmbReadTextFile,   nullptr, nullptr, nullptr, napi_default, nullptr },
+    { "smbDownloadFile",   nullptr, SmbDownloadFile,   nullptr, nullptr, nullptr, napi_default, nullptr }
   };
   if (napi_define_properties(env, exports, sizeof(descriptors) / sizeof(descriptors[0]), descriptors) != napi_ok) {
     ThrowTypeError(env, "failed to define native module properties");

--- a/entry/src/main/ets/components/core/file/FileExplorer.ets
+++ b/entry/src/main/ets/components/core/file/FileExplorer.ets
@@ -1,20 +1,11 @@
-import { WebDAVResource } from "../../../lib/WebDAVClient";
-import { FileExplorerController } from "./FileExplorerController";
+import { FileExplorerController, FileExplorerPathItem, FileExplorerResource } from "./FileExplorerController";
 
 /**
  * 文件点击事件数据
  */
 export interface FileClickEvent {
-  resource: WebDAVResource;
+  resource: FileExplorerResource;
   fullPath: string;
-}
-
-/**
- * 路径导航项
- */
-interface PathItem {
-  name: string;
-  path: string;
 }
 
 interface ColorsInterface {
@@ -33,7 +24,19 @@ interface ColorsInterface {
 @ComponentV2
 export struct FileExplorer {
   @Param @Require controller: FileExplorerController
+  @Param isLoading: boolean = false
+  @Param errorMessage: string = ''
+  @Param emptyText: string = '此文件夹为空'
+  @Param showDetailColumns: boolean = true
+  @Param disableResourceClick: (resource: FileExplorerResource) => boolean = () => false
+  @Param resourceSecondaryText: (resource: FileExplorerResource) => string = () => ''
+  @Param showResourceSelection: (resource: FileExplorerResource) => boolean = () => false
+  @Param isResourceSelected: (resource: FileExplorerResource) => boolean = () => false
+  @Param onResourceSelectionToggle: (resource: FileExplorerResource) => void = () => {}
   @Event onFileClick: (event: FileClickEvent) => void = () => {};
+  @BuilderParam extraTopBuilder?: () => void
+  @BuilderParam extraBottomBuilder?: () => void
+  @BuilderParam overlayBuilder?: () => void
 
   // 深色主题颜色定义
   private readonly COLORS: ColorsInterface = {
@@ -48,36 +51,6 @@ export struct FileExplorer {
     hover: '#3A3A3C',               // 悬停色
     button: '#48484A'               // 按钮色
   };
-
-  /**
-   * 获取路径导航项
-   */
-  @Computed
-  get pathItems(): PathItem[] {
-    const items: PathItem[] = [];
-
-    items.push({
-      name: '根目录',
-      path: '/'
-    });
-
-    if (this.controller.currentPath === '/') {
-      return items;
-    }
-
-    const parts = this.controller.currentPath.split('/').filter(p => p.length > 0);
-    let accumulatedPath = '';
-
-    for (let i = 0; i < parts.length; i++) {
-      accumulatedPath += '/' + parts[i];
-      items.push({
-        name: decodeURIComponent(parts[i]),
-        path: accumulatedPath
-      });
-    }
-
-    return items;
-  }
 
   private changeSortField(field: 'name' | 'size' | 'date'): void {
     if (this.controller.sortField === field) {
@@ -95,23 +68,17 @@ export struct FileExplorer {
     return this.controller.sortAscending ? '↑' : '↓';
   }
 
-  private handleResourceClick(resource: WebDAVResource): void {
-    if (resource.isCollection) {
-      let newPath = this.controller.currentPath;
-      if (!newPath.endsWith('/')) {
-        newPath += '/';
-      }
-      newPath += resource.displayName;
+  private handleResourceClick(resource: FileExplorerResource): void {
+    if (this.disableResourceClick(resource)) {
+      return;
+    }
 
-      this.controller.onFolderChange(newPath);
+    if (resource.isDirectory) {
+      this.controller.onFolderChange(resource.path);
     } else {
-      const fullPath = this.controller.currentPath.endsWith('/')
-        ? this.controller.currentPath + resource.displayName
-        : this.controller.currentPath + '/' + resource.displayName;
-
       this.onFileClick({
         resource: resource,
-        fullPath: fullPath
+        fullPath: resource.path
       });
     }
   }
@@ -131,29 +98,24 @@ export struct FileExplorer {
     return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
   }
 
-  private formatDate(dateStr?: string): string {
-    if (!dateStr) return '-';
+  private formatDate(dateMs?: number): string {
+    if (dateMs === undefined) return '-';
+    const date = new Date(dateMs);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
 
-    try {
-      const date = new Date(dateStr);
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      const hours = String(date.getHours()).padStart(2, '0');
-      const minutes = String(date.getMinutes()).padStart(2, '0');
-
-      return `${year}-${month}-${day} ${hours}:${minutes}`;
-    } catch (error) {
-      return dateStr;
-    }
+    return `${year}-${month}-${day} ${hours}:${minutes}`;
   }
 
-  private getFileIcon(resource: WebDAVResource): string {
-    if (resource.isCollection) {
+  private getFileIcon(resource: FileExplorerResource): string {
+    if (resource.isDirectory) {
       return '📁';
     }
 
-    const fileName = resource.displayName.toLowerCase();
+    const fileName = resource.name.toLowerCase();
 
     if (fileName.endsWith('.jpg') || fileName.endsWith('.jpeg') ||
     fileName.endsWith('.png') || fileName.endsWith('.gif') ||
@@ -193,210 +155,275 @@ export struct FileExplorer {
     return '📄';
   }
 
+  private getResourceSecondaryText(resource: FileExplorerResource): string {
+    return this.resourceSecondaryText(resource);
+  }
+
   build() {
-    Column() {
-      // 顶部工具栏
-      Row() {
-        Button('返回')
-          .fontSize(16)
-          .height(40)
-          .backgroundColor(this.COLORS.button)
-          .fontColor(this.COLORS.accent)
-          .onClick(() => {
-            this.controller.handleBack();
-          })
-          .margin({ right: 10 })
-
-        Button(this.controller.showHiddenFiles ? '隐藏隐藏文件' : '显示隐藏文件')
-          .fontSize(16)
-          .height(40)
-          .backgroundColor(this.COLORS.button)
-          .fontColor(this.controller.showHiddenFiles ? this.COLORS.accent : this.COLORS.secondaryText)
-          .onClick(() => {
-            this.controller.showHiddenFiles = !this.controller.showHiddenFiles;
-          })
-          .margin({ right: 10 })
-
-        Text(`文件：${this.controller.sortedResources.length}`)
-          .fontSize(14)
-          .fontColor(this.COLORS.tertiaryText)
-      }
-      .width('100%')
-      .padding({ left: 16, right: 16, top: 12, bottom: 12 })
-      .backgroundColor(this.COLORS.surface)
-
-      // 路径导航
-      Scroll() {
+    Stack() {
+      Column() {
+        // 顶部工具栏
         Row() {
-          ForEach(this.pathItems, (item: PathItem, index: number) => {
+          Button('返回')
+            .fontSize(16)
+            .height(40)
+            .backgroundColor(this.COLORS.button)
+            .fontColor(this.COLORS.accent)
+            .onClick(() => {
+              this.controller.handleBack();
+            })
+            .margin({ right: 10 })
+
+          Button(this.controller.showHiddenFiles ? '隐藏隐藏文件' : '显示隐藏文件')
+            .fontSize(16)
+            .height(40)
+            .backgroundColor(this.COLORS.button)
+            .fontColor(this.controller.showHiddenFiles ? this.COLORS.accent : this.COLORS.secondaryText)
+            .onClick(() => {
+              this.controller.showHiddenFiles = !this.controller.showHiddenFiles;
+            })
+            .margin({ right: 10 })
+
+          Text(`文件：${this.controller.sortedResources.length}`)
+            .fontSize(14)
+            .fontColor(this.COLORS.tertiaryText)
+            .layoutWeight(1)
+
+          if (this.isLoading) {
+            LoadingProgress()
+              .width(24)
+              .height(24)
+              .color(this.COLORS.accent)
+          }
+        }
+        .width('100%')
+        .padding({ left: 16, right: 16, top: 12, bottom: 12 })
+        .backgroundColor(this.COLORS.surface)
+
+        // 路径导航
+        Scroll() {
+          Row() {
+            ForEach(this.controller.pathItems, (item: FileExplorerPathItem, index: number) => {
+              Row() {
+                Text(item.name)
+                  .fontSize(14)
+                  .fontColor(index === this.controller.pathItems.length - 1
+                    ? this.COLORS.primaryText
+                    : this.COLORS.accent)
+                  .fontWeight(index === this.controller.pathItems.length - 1
+                    ? FontWeight.Bold
+                    : FontWeight.Normal)
+                  .onClick(() => {
+                    if (index !== this.controller.pathItems.length - 1) {
+                      this.handlePathClick(item.path);
+                    }
+                  })
+
+                if (index < this.controller.pathItems.length - 1) {
+                  Text(' / ')
+                    .fontSize(14)
+                    .fontColor(this.COLORS.tertiaryText)
+                    .margin({ left: 4, right: 4 })
+                }
+              }
+            }, (item: FileExplorerPathItem) => item.path)
+          }
+          .padding({ left: 16, right: 16 })
+        }
+        .scrollable(ScrollDirection.Horizontal)
+        .scrollBar(BarState.Off)
+        .width('100%')
+        .height(40)
+        .backgroundColor(this.COLORS.surfaceVariant)
+
+        Divider()
+          .color(this.COLORS.divider)
+
+        if (this.extraTopBuilder) {
+          this.extraTopBuilder()
+        }
+
+        // 排序栏
+        if (this.showDetailColumns) {
+          Row() {
             Row() {
-              Text(item.name)
-                .fontSize(14)
-                .fontColor(index === this.pathItems.length - 1
-                  ? this.COLORS.primaryText
-                  : this.COLORS.accent)
-                .fontWeight(index === this.pathItems.length - 1
-                  ? FontWeight.Bold
+              Text('名称 ' + this.getSortIcon('name'))
+                .fontSize(13)
+                .fontColor(this.controller.sortField === 'name'
+                  ? this.COLORS.accent
+                  : this.COLORS.tertiaryText)
+                .fontWeight(this.controller.sortField === 'name'
+                  ? FontWeight.Medium
                   : FontWeight.Normal)
                 .onClick(() => {
-                  if (index !== this.pathItems.length - 1) {
-                    this.handlePathClick(item.path);
-                  }
+                  this.changeSortField('name');
                 })
-
-              if (index < this.pathItems.length - 1) {
-                Text(' / ')
-                  .fontSize(14)
-                  .fontColor(this.COLORS.tertiaryText)
-                  .margin({ left: 4, right: 4 })
-              }
             }
-          }, (item: PathItem) => item.path)
+            .layoutWeight(3)
+
+            Row() {
+              Text('大小 ' + this.getSortIcon('size'))
+                .fontSize(13)
+                .fontColor(this.controller.sortField === 'size'
+                  ? this.COLORS.accent
+                  : this.COLORS.tertiaryText)
+                .fontWeight(this.controller.sortField === 'size'
+                  ? FontWeight.Medium
+                  : FontWeight.Normal)
+                .onClick(() => {
+                  this.changeSortField('size');
+                })
+            }
+            .layoutWeight(2)
+            .justifyContent(FlexAlign.End)
+
+            Row() {
+              Text('修改日期 ' + this.getSortIcon('date'))
+                .fontSize(13)
+                .fontColor(this.controller.sortField === 'date'
+                  ? this.COLORS.accent
+                  : this.COLORS.tertiaryText)
+                .fontWeight(this.controller.sortField === 'date'
+                  ? FontWeight.Medium
+                  : FontWeight.Normal)
+                .onClick(() => {
+                  this.changeSortField('date');
+                })
+            }
+            .layoutWeight(2)
+            .justifyContent(FlexAlign.End)
+          }
+          .width('100%')
+          .padding({ left: 16, right: 16, top: 8, bottom: 8 })
+          .backgroundColor(this.COLORS.surface)
+
+          Divider()
+            .color(this.COLORS.divider)
         }
-        .padding({ left: 16, right: 16 })
-      }
-      .scrollable(ScrollDirection.Horizontal)
-      .scrollBar(BarState.Off)
-      .width('100%')
-      .height(40)
-      .backgroundColor(this.COLORS.surfaceVariant)
 
-      Divider()
-        .color(this.COLORS.divider)
-
-      // 排序栏
-      Row() {
-        Row() {
-          Text('名称 ' + this.getSortIcon('name'))
-            .fontSize(13)
-            .fontColor(this.controller.sortField === 'name'
-              ? this.COLORS.accent
-              : this.COLORS.tertiaryText)
-            .fontWeight(this.controller.sortField === 'name'
-              ? FontWeight.Medium
-              : FontWeight.Normal)
-            .onClick(() => {
-              this.changeSortField('name');
-            })
+        if (this.errorMessage.length > 0) {
+          Row() {
+            Text('⚠️  ' + this.errorMessage)
+              .fontSize(14)
+              .fontColor('#FF6B6B')
+              .padding({ left: 16, right: 16, top: 8, bottom: 8 })
+          }
+          .width('100%')
+          .backgroundColor(this.COLORS.surface)
         }
-        .layoutWeight(3)
 
-        Row() {
-          Text('大小 ' + this.getSortIcon('size'))
-            .fontSize(13)
-            .fontColor(this.controller.sortField === 'size'
-              ? this.COLORS.accent
-              : this.COLORS.tertiaryText)
-            .fontWeight(this.controller.sortField === 'size'
-              ? FontWeight.Medium
-              : FontWeight.Normal)
-            .onClick(() => {
-              this.changeSortField('size');
-            })
-        }
-        .layoutWeight(2)
-        .justifyContent(FlexAlign.End)
+        // 文件列表
+        if (this.controller.sortedResources.length === 0 && !this.isLoading) {
+          Column() {
+            Text('📂')
+              .fontSize(48)
+              .margin({ bottom: 12 })
 
-        Row() {
-          Text('修改日期 ' + this.getSortIcon('date'))
-            .fontSize(13)
-            .fontColor(this.controller.sortField === 'date'
-              ? this.COLORS.accent
-              : this.COLORS.tertiaryText)
-            .fontWeight(this.controller.sortField === 'date'
-              ? FontWeight.Medium
-              : FontWeight.Normal)
-            .onClick(() => {
-              this.changeSortField('date');
-            })
-        }
-        .layoutWeight(2)
-        .justifyContent(FlexAlign.End)
-      }
-      .width('100%')
-      .padding({ left: 16, right: 16, top: 8, bottom: 8 })
-      .backgroundColor(this.COLORS.surface)
+            Text(this.emptyText)
+              .fontSize(16)
+              .fontColor(this.COLORS.tertiaryText)
+          }
+          .width('100%')
+          .layoutWeight(1)
+          .justifyContent(FlexAlign.Center)
+          .backgroundColor(this.COLORS.background)
+        } else {
+          List({ space: 0 }) {
+            ForEach(this.controller.sortedResources, (resource: FileExplorerResource, index: number) => {
+              ListItem() {
+                Row() {
+                  // 图标和名称
+                  Row({ space: 12 }) {
+                    Text(this.getFileIcon(resource))
+                      .fontSize($r('app.float.font_h6_title_large'))
 
-      Divider()
-        .color(this.COLORS.divider)
+                    Column() {
+                      Text(resource.name)
+                        .fontSize($r('app.float.font_h7_title_small'))
+                        .maxLines(1)
+                        .textOverflow({ overflow: TextOverflow.MARQUEE })
+                        .fontColor(resource.isDirectory
+                          ? this.COLORS.accent
+                          : this.COLORS.primaryText)
+                        .width('100%')
 
-      // 文件列表
-      if (this.controller.sortedResources.length === 0) {
-        Column() {
-          Text('📂')
-            .fontSize(48)
-            .margin({ bottom: 12 })
-
-          Text('此文件夹为空')
-            .fontSize(16)
-            .fontColor(this.COLORS.tertiaryText)
-        }
-        .width('100%')
-        .layoutWeight(1)
-        .justifyContent(FlexAlign.Center)
-        .backgroundColor(this.COLORS.background)
-      } else {
-        List({ space: 0 }) {
-          ForEach(this.controller.sortedResources, (resource: WebDAVResource, index: number) => {
-            ListItem() {
-              Row() {
-                // 图标和名称
-                Row({ space: 12 }) {
-                  Text(this.getFileIcon(resource))
-                    .fontSize($r('app.float.font_h6_title_large'))
-
-                  Column() {
-                    Text(resource.displayName)
-                      .fontSize($r('app.float.font_h7_title_small'))
-                      .maxLines(1)
-                      .textOverflow({ overflow: TextOverflow.MARQUEE })
-                      .fontColor(resource.isCollection
-                        ? this.COLORS.accent
-                        : this.COLORS.primaryText)
-                      .width('100%')
+                      if (this.getResourceSecondaryText(resource).length > 0) {
+                        Text(this.getResourceSecondaryText(resource))
+                          .fontSize(12)
+                          .fontColor(this.COLORS.tertiaryText)
+                          .maxLines(1)
+                          .textOverflow({ overflow: TextOverflow.Ellipsis })
+                          .width('100%')
+                          .margin({ top: 4 })
+                      }
+                    }
+                    .alignItems(HorizontalAlign.Start)
+                    .layoutWeight(1)
                   }
-                  .alignItems(HorizontalAlign.Start)
-                  .layoutWeight(1)
+                  .layoutWeight(this.showDetailColumns ? 3 : 1)
+                  .alignItems(VerticalAlign.Center)
+
+                  if (this.showDetailColumns) {
+                    // 文件大小
+                    Text(resource.isDirectory ? '-' : this.formatFileSize(resource.size))
+                      .fontSize($r('app.float.font_subtitle_1'))
+                      .fontColor(this.COLORS.tertiaryText)
+                      .layoutWeight(2)
+                      .textAlign(TextAlign.End)
+                      .maxLines(1)
+
+                    // 修改日期
+                    Text(this.formatDate(resource.lastModifiedMs))
+                      .fontSize(13)
+                      .fontColor(this.COLORS.tertiaryText)
+                      .layoutWeight(2)
+                      .textAlign(TextAlign.End)
+                      .maxLines(1)
+                  }
+
+                  if (this.showResourceSelection(resource)) {
+                    Checkbox()
+                      .select(this.isResourceSelected(resource))
+                      .selectedColor(this.COLORS.accent)
+                      .margin({ left: 12 })
+                      .onChange(() => {
+                        this.onResourceSelectionToggle(resource)
+                      })
+                  }
                 }
-                .layoutWeight(3)
-                .alignItems(VerticalAlign.Center)
-
-                // 文件大小
-                Text(resource.isCollection ? '-' : this.formatFileSize(resource.size))
-                  .fontSize($r('app.float.font_subtitle_1'))
-                  .fontColor(this.COLORS.tertiaryText)
-                  .layoutWeight(2)
-                  .textAlign(TextAlign.End)
-                  .maxLines(1)
-
-                // 修改日期
-                Text(this.formatDate(resource.lastModified))
-                  .fontSize(13)
-                  .fontColor(this.COLORS.tertiaryText)
-                  .layoutWeight(2)
-                  .textAlign(TextAlign.End)
-                  .maxLines(1)
+                .width('100%')
+                .padding({ left: 16, right: 16, top: 12, bottom: 12 })
+                .backgroundColor(index % 2 === 0
+                  ? this.COLORS.background
+                  : this.COLORS.surface)
+                .opacity(this.disableResourceClick(resource) ? 0.5 : 1)
               }
-              .width('100%')
-              .padding({ left: 16, right: 16, top: 12, bottom: 12 })
-              .backgroundColor(index % 2 === 0
-                ? this.COLORS.background
-                : this.COLORS.surface)
-            }
-            .onClick(() => {
-              this.handleResourceClick(resource);
-            })
-          }, (resource: WebDAVResource) => resource.href)
+              .onClick(() => {
+                this.handleResourceClick(resource);
+              })
+            }, (resource: FileExplorerResource) => resource.key)
+          }
+          .width('100%')
+          .layoutWeight(1)
+          .backgroundColor(this.COLORS.background)
+          .divider({
+            strokeWidth: 0.5,
+            color: this.COLORS.divider,
+            startMargin: 16,
+            endMargin: 16
+          })
         }
-        .width('100%')
-        .layoutWeight(1)
-        .backgroundColor(this.COLORS.background)
-        .divider({
-          strokeWidth: 0.5,
-          color: this.COLORS.divider,
-          startMargin: 16,
-          endMargin: 16
-        })
+
+        if (this.extraBottomBuilder) {
+          this.extraBottomBuilder()
+        }
+      }
+      .width('100%')
+      .height('100%')
+      .backgroundColor(this.COLORS.background)
+
+      if (this.overlayBuilder) {
+        this.overlayBuilder()
       }
     }
     .width('100%')

--- a/entry/src/main/ets/components/core/file/FileExplorerAdapter.ets
+++ b/entry/src/main/ets/components/core/file/FileExplorerAdapter.ets
@@ -1,0 +1,71 @@
+import { WebDAVResource } from "../../../lib/WebDAVClient";
+import { SmbListDirectoryResult } from "../../../lib/SMBClient";
+import {
+  createFileExplorerResourceFromSmb,
+  createFileExplorerResourceFromWebDav,
+  FileExplorerAdapter,
+  FileExplorerLoadResult,
+  FileExplorerResource
+} from "./FileExplorerController";
+
+export type WebDavListDirectory = (path: string) => Promise<WebDAVResource[]>;
+
+export type SmbListDirectory = (path: string) => Promise<SmbListDirectoryResult>;
+
+function buildLoadResult(resources: FileExplorerResource[], errorMessage?: string): FileExplorerLoadResult {
+  const result: FileExplorerLoadResult = {
+    resources: resources,
+    errorMessage: errorMessage
+  };
+  return result;
+}
+
+function getErrorMessage(error: Error): string {
+  if (error.message.length > 0) {
+    return error.message;
+  }
+  return '加载目录失败';
+}
+
+export class WebDavFileExplorerAdapter implements FileExplorerAdapter {
+  private readonly listDirectory: WebDavListDirectory;
+
+  constructor(listDirectory: WebDavListDirectory) {
+    this.listDirectory = listDirectory;
+  }
+
+  async list(path: string): Promise<FileExplorerLoadResult> {
+    try {
+      const rawResources = await this.listDirectory(path);
+      const mappedResources = rawResources
+        .filter((resource: WebDAVResource, index: number) => index > 0)
+        .map((resource: WebDAVResource) => createFileExplorerResourceFromWebDav(path, resource));
+      return buildLoadResult(mappedResources);
+    } catch (error) {
+      const typedError = error as Error;
+      return buildLoadResult([], getErrorMessage(typedError));
+    }
+  }
+}
+
+export class SmbFileExplorerAdapter implements FileExplorerAdapter {
+  private readonly listDirectory: SmbListDirectory;
+
+  constructor(listDirectory: SmbListDirectory) {
+    this.listDirectory = listDirectory;
+  }
+
+  async list(path: string): Promise<FileExplorerLoadResult> {
+    try {
+      const result = await this.listDirectory(path);
+      if (result.error !== undefined && result.error.length > 0) {
+        return buildLoadResult([], result.error);
+      }
+      const mappedResources = result.files.map(createFileExplorerResourceFromSmb);
+      return buildLoadResult(mappedResources);
+    } catch (error) {
+      const typedError = error as Error;
+      return buildLoadResult([], getErrorMessage(typedError));
+    }
+  }
+}

--- a/entry/src/main/ets/components/core/file/FileExplorerAdapter.ets
+++ b/entry/src/main/ets/components/core/file/FileExplorerAdapter.ets
@@ -12,6 +12,12 @@ export type WebDavListDirectory = (path: string) => Promise<WebDAVResource[]>;
 
 export type SmbListDirectory = (path: string) => Promise<SmbListDirectoryResult>;
 
+export interface FileExplorerErrorMessageCarrier {
+  message: string;
+}
+
+export type FileExplorerErrorValue = Error | string | FileExplorerErrorMessageCarrier | Object | undefined | null;
+
 function buildLoadResult(resources: FileExplorerResource[], errorMessage?: string): FileExplorerLoadResult {
   const result: FileExplorerLoadResult = {
     resources: resources,
@@ -20,9 +26,30 @@ function buildLoadResult(resources: FileExplorerResource[], errorMessage?: strin
   return result;
 }
 
-function getErrorMessage(error: Error): string {
-  if (error.message.length > 0) {
+function isFileExplorerErrorMessageCarrier(error: FileExplorerErrorValue): boolean {
+  if (error === undefined || error === null || typeof error === 'string' || error instanceof Error) {
+    return false;
+  }
+  const carrier = error as FileExplorerErrorMessageCarrier;
+  return carrier.message !== undefined && carrier.message.length > 0;
+}
+
+export function getFileExplorerErrorMessage(error: FileExplorerErrorValue): string {
+  if (typeof error === 'string' && error.length > 0) {
+    return error;
+  }
+  if (error instanceof Error && error.message.length > 0) {
     return error.message;
+  }
+  if (isFileExplorerErrorMessageCarrier(error)) {
+    const carrier = error as FileExplorerErrorMessageCarrier;
+    return carrier.message;
+  }
+  if (error !== undefined && error !== null) {
+    const fallbackMessage = String(error);
+    if (fallbackMessage.length > 0 && fallbackMessage !== '[object Object]') {
+      return fallbackMessage;
+    }
   }
   return '加载目录失败';
 }
@@ -42,8 +69,8 @@ export class WebDavFileExplorerAdapter implements FileExplorerAdapter {
         .map((resource: WebDAVResource) => createFileExplorerResourceFromWebDav(path, resource));
       return buildLoadResult(mappedResources);
     } catch (error) {
-      const typedError = error as Error;
-      return buildLoadResult([], getErrorMessage(typedError));
+      const typedError = error as FileExplorerErrorValue;
+      return buildLoadResult([], getFileExplorerErrorMessage(typedError));
     }
   }
 }
@@ -64,8 +91,8 @@ export class SmbFileExplorerAdapter implements FileExplorerAdapter {
       const mappedResources = result.files.map(createFileExplorerResourceFromSmb);
       return buildLoadResult(mappedResources);
     } catch (error) {
-      const typedError = error as Error;
-      return buildLoadResult([], getErrorMessage(typedError));
+      const typedError = error as FileExplorerErrorValue;
+      return buildLoadResult([], getFileExplorerErrorMessage(typedError));
     }
   }
 }

--- a/entry/src/main/ets/components/core/file/FileExplorerController.ets
+++ b/entry/src/main/ets/components/core/file/FileExplorerController.ets
@@ -141,6 +141,13 @@ function joinFileExplorerPath(parentPath: string, childName: string): string {
   return parentPath.endsWith('/') ? parentPath + childName : parentPath + '/' + childName;
 }
 
+function isFileExplorerPathInRoot(currentPath: string, rootPath: string): boolean {
+  if (rootPath === '/') {
+    return currentPath.startsWith('/');
+  }
+  return currentPath === rootPath || currentPath.startsWith(rootPath + '/');
+}
+
 function normalizeWebDavLastModified(lastModified?: string): number | undefined {
   if (lastModified === undefined || lastModified.length === 0) {
     return undefined;
@@ -248,7 +255,7 @@ export class FileExplorerController {
       return items;
     }
 
-    const relativePath = this.currentPath.startsWith(this.rootPath)
+    const relativePath = isFileExplorerPathInRoot(this.currentPath, this.rootPath)
       ? this.currentPath.substring(this.rootPath.length)
       : this.currentPath;
     const parts = relativePath.split('/').filter(p => p.length > 0);
@@ -314,7 +321,7 @@ export class FileExplorerController {
     if (parentPath.length < this.rootPath.length) {
       return this.rootPath
     }
-    return parentPath.startsWith(this.rootPath) ? parentPath : this.rootPath
+    return isFileExplorerPathInRoot(parentPath, this.rootPath) ? parentPath : this.rootPath
   }
 
   handleBack(): void {

--- a/entry/src/main/ets/components/core/file/FileExplorerController.ets
+++ b/entry/src/main/ets/components/core/file/FileExplorerController.ets
@@ -1,8 +1,192 @@
 import { WebDAVResource } from "../../../lib/WebDAVClient";
+import { SmbFileInfo } from "../../../lib/SMBClient";
+
+export type FileExplorerSortField = 'name' | 'size' | 'date'
+
+export interface FileExplorerResource {
+  key: string;
+  name: string;
+  path: string;
+  isDirectory: boolean;
+  size?: number;
+  lastModifiedMs?: number;
+  isHidden: boolean;
+  sourceType: 'webdav' | 'smb';
+}
+
+export interface FileExplorerLoadResult {
+  resources: FileExplorerResource[];
+  errorMessage?: string;
+}
+
+export interface FileExplorerAdapter {
+  list(path: string): Promise<FileExplorerLoadResult>;
+}
+
+function getChineseDigitValue(char: string): number {
+  switch (char) {
+    case '零':
+      return 0;
+    case '一':
+      return 1;
+    case '二':
+      return 2;
+    case '两':
+      return 2;
+    case '三':
+      return 3;
+    case '四':
+      return 4;
+    case '五':
+      return 5;
+    case '六':
+      return 6;
+    case '七':
+      return 7;
+    case '八':
+      return 8;
+    case '九':
+      return 9;
+    default:
+      return -1;
+  }
+}
+
+function getChineseUnitValue(char: string): number {
+  switch (char) {
+    case '十':
+      return 10;
+    case '百':
+      return 100;
+    case '千':
+      return 1000;
+    case '万':
+      return 10000;
+    default:
+      return 0;
+  }
+}
+
+function parseChineseOrdinalNumber(rawValue: string): number | undefined {
+  if (/^\d+$/.test(rawValue)) {
+    return parseInt(rawValue, 10);
+  }
+
+  let total = 0;
+  let current = 0;
+  let hasValue = false;
+  for (let i = 0; i < rawValue.length; i++) {
+    const char = rawValue[i];
+    const digitValue = getChineseDigitValue(char);
+    if (digitValue >= 0) {
+      current = digitValue;
+      hasValue = true;
+      continue;
+    }
+
+    const unitValue = getChineseUnitValue(char);
+    if (unitValue > 0) {
+      const baseValue = current === 0 ? 1 : current;
+      total += baseValue * unitValue;
+      current = 0;
+      hasValue = true;
+      continue;
+    }
+
+    return undefined;
+  }
+
+  if (!hasValue) {
+    return undefined;
+  }
+
+  return total + current;
+}
+
+function padNaturalNumber(value: number): string {
+  return value.toString().padStart(8, '0');
+}
+
+function normalizeChineseOrdinalName(name: string): string {
+  return name.replace(/第([零一二两三四五六七八九十百千万\d]+)(季|集|章|部|卷|话|回)/g, (_match: string, rawValue: string, suffix: string): string => {
+    const parsed = parseChineseOrdinalNumber(rawValue);
+    if (parsed === undefined) {
+      return `第${rawValue}${suffix}`;
+    }
+    return `第${padNaturalNumber(parsed)}${suffix}`;
+  });
+}
+
+function normalizeArabicNumberName(name: string): string {
+  return name.replace(/\d+/g, (rawValue: string): string => {
+    return padNaturalNumber(parseInt(rawValue, 10));
+  });
+}
+
+function normalizeFileExplorerSortName(name: string): string {
+  const normalizedChinese = normalizeChineseOrdinalName(name);
+  return normalizeArabicNumberName(normalizedChinese);
+}
+
+export function compareFileExplorerNames(a: string, b: string): number {
+  const normalizedA = normalizeFileExplorerSortName(a);
+  const normalizedB = normalizeFileExplorerSortName(b);
+  return normalizedA.localeCompare(normalizedB);
+}
+
+function joinFileExplorerPath(parentPath: string, childName: string): string {
+  if (parentPath === '/') {
+    return '/' + childName;
+  }
+  return parentPath.endsWith('/') ? parentPath + childName : parentPath + '/' + childName;
+}
+
+function normalizeWebDavLastModified(lastModified?: string): number | undefined {
+  if (lastModified === undefined || lastModified.length === 0) {
+    return undefined;
+  }
+  const timestamp = Date.parse(lastModified);
+  if (Number.isNaN(timestamp)) {
+    return undefined;
+  }
+  return timestamp;
+}
+
+export function createFileExplorerResourceFromWebDav(
+  currentPath: string,
+  resource: WebDAVResource
+): FileExplorerResource {
+  const mappedResource: FileExplorerResource = {
+    key: resource.href,
+    name: resource.displayName,
+    path: joinFileExplorerPath(currentPath, resource.displayName),
+    isDirectory: resource.isCollection,
+    size: resource.size,
+    lastModifiedMs: normalizeWebDavLastModified(resource.lastModified),
+    isHidden: resource.displayName.startsWith('.'),
+    sourceType: 'webdav'
+  };
+  return mappedResource;
+}
+
+export function createFileExplorerResourceFromSmb(file: SmbFileInfo): FileExplorerResource {
+  const mappedResource: FileExplorerResource = {
+    key: file.path,
+    name: file.name,
+    path: file.path,
+    isDirectory: file.isDirectory,
+    size: file.size,
+    lastModifiedMs: file.lastModifiedMs,
+    isHidden: file.name.startsWith('.'),
+    sourceType: 'smb'
+  };
+  return mappedResource;
+}
 
 export interface FileExplorerControllerParam {
-  resources: WebDAVResource[];
+  resources: FileExplorerResource[];
   currentPath: string;
+  rootPath?: string;
   onFolderChange?: (path: string) => void
   onBack?: () => boolean
 }
@@ -10,17 +194,28 @@ export interface FileExplorerControllerParam {
 /**
  * 路径导航项
  */
-interface PathItem {
+export interface FileExplorerPathItem {
   name: string;
   path: string;
 }
 
+function normalizeFileExplorerRootPath(path: string): string {
+  if (path.length === 0 || path === '/') {
+    return '/';
+  }
+  if (!path.startsWith('/')) {
+    return '/' + path;
+  }
+  return path.endsWith('/') ? path.substring(0, path.length - 1) : path;
+}
+
 @ObservedV2
 export class FileExplorerController {
-  @Trace resources: WebDAVResource[] = [];
+  @Trace resources: FileExplorerResource[] = [];
   @Trace currentPath: string = '/';
+  @Trace rootPath: string = '/';
 
-  @Trace sortField: 'name' | 'size' | 'date' = 'name';
+  @Trace sortField: FileExplorerSortField = 'name';
   @Trace sortAscending: boolean = true;
   @Trace showHiddenFiles: boolean = false;
   onFolderChange: (path: string) => void = () => {}
@@ -32,6 +227,7 @@ export class FileExplorerController {
   constructor(params: FileExplorerControllerParam) {
     this.resources = params.resources
     this.currentPath = params.currentPath
+    this.rootPath = normalizeFileExplorerRootPath(params.rootPath ?? '/')
     this.onFolderChange = params.onFolderChange || this.onFolderChange
     this.onBack = params.onBack || this.onBack
   }
@@ -40,20 +236,23 @@ export class FileExplorerController {
    * 获取路径导航项
    */
   @Computed
-  get pathItems(): PathItem[] {
-    const items: PathItem[] = [];
+  get pathItems(): FileExplorerPathItem[] {
+    const items: FileExplorerPathItem[] = [];
 
     items.push({
       name: '根目录',
-      path: '/'
+      path: this.rootPath
     });
 
-    if (this.currentPath === '/') {
+    if (this.currentPath === this.rootPath) {
       return items;
     }
 
-    const parts = this.currentPath.split('/').filter(p => p.length > 0);
-    let accumulatedPath = '';
+    const relativePath = this.currentPath.startsWith(this.rootPath)
+      ? this.currentPath.substring(this.rootPath.length)
+      : this.currentPath;
+    const parts = relativePath.split('/').filter(p => p.length > 0);
+    let accumulatedPath = this.rootPath === '/' ? '' : this.rootPath;
 
     for (let i = 0; i < parts.length; i++) {
       accumulatedPath += '/' + parts[i];
@@ -70,34 +269,31 @@ export class FileExplorerController {
    * 获取排序后的资源列表
    */
   @Computed
-  get sortedResources(): WebDAVResource[] {
+  get sortedResources(): FileExplorerResource[] {
     // 先过滤隐藏文件
     let filtered = this.resources;
     if (!this.showHiddenFiles) {
-      filtered = this.resources.filter(resource => {
-        // 过滤掉以.开头的隐藏文件和文件夹
-        return !resource.displayName.startsWith('.');
-      });
+      filtered = this.resources.filter((resource: FileExplorerResource) => !resource.isHidden);
     }
 
     const sorted = filtered.slice();
 
-    sorted.sort((a, b) => {
-      if (a.isCollection && !b.isCollection) return -1;
-      if (!a.isCollection && b.isCollection) return 1;
+    sorted.sort((a: FileExplorerResource, b: FileExplorerResource) => {
+      if (a.isDirectory && !b.isDirectory) return -1;
+      if (!a.isDirectory && b.isDirectory) return 1;
 
       let compareResult = 0;
 
       if (this.sortField === 'name') {
-        compareResult = a.displayName.localeCompare(b.displayName);
+        compareResult = compareFileExplorerNames(a.name, b.name);
       } else if (this.sortField === 'size') {
         const sizeA = a.size || 0;
         const sizeB = b.size || 0;
         compareResult = sizeA - sizeB;
       } else if (this.sortField === 'date') {
-        const dateA = a.lastModified || '';
-        const dateB = b.lastModified || '';
-        compareResult = dateA.localeCompare(dateB);
+        const dateA = a.lastModifiedMs || 0;
+        const dateB = b.lastModifiedMs || 0;
+        compareResult = dateA - dateB;
       }
 
       return this.sortAscending ? compareResult : -compareResult;
@@ -108,18 +304,24 @@ export class FileExplorerController {
 
   @Computed
   get parentPath() {
+    if (this.currentPath === this.rootPath) {
+      return this.rootPath
+    }
     const lastSlashIndex = this.currentPath.lastIndexOf('/');
     const parentPath = lastSlashIndex > 0
       ? this.currentPath.substring(0, lastSlashIndex)
-      : '/';
-    return parentPath
+      : this.rootPath;
+    if (parentPath.length < this.rootPath.length) {
+      return this.rootPath
+    }
+    return parentPath.startsWith(this.rootPath) ? parentPath : this.rootPath
   }
 
   handleBack(): void {
-    if (this.currentPath === '/') {
+    if (this.currentPath === this.rootPath) {
       const handled = this.onBack();
       if (!handled) {
-        console.info('Already at root directory');
+        console.info('Already at explorer root directory');
       }
       return;
     }

--- a/entry/src/main/ets/components/core/file/ImagePreviewSessionController.ets
+++ b/entry/src/main/ets/components/core/file/ImagePreviewSessionController.ets
@@ -1,0 +1,28 @@
+export interface DialogHandle {
+  open(): void;
+  close(): void;
+}
+
+export class ImagePreviewSessionController {
+  private activeDialog?: DialogHandle;
+
+  openDialog(dialog: DialogHandle): void {
+    this.closeActiveDialog();
+    this.activeDialog = dialog;
+    dialog.open();
+  }
+
+  closeActiveDialog(): boolean {
+    if (this.activeDialog === undefined) {
+      return false;
+    }
+    const dialog = this.activeDialog;
+    this.activeDialog = undefined;
+    dialog.close();
+    return true;
+  }
+
+  handleBack(): boolean {
+    return this.closeActiveDialog();
+  }
+}

--- a/entry/src/main/ets/lib/SMBClient.ets
+++ b/entry/src/main/ets/lib/SMBClient.ets
@@ -62,6 +62,7 @@ interface SmbNapiBridge {
   smbListShares: (host: string, port: number, username: string, password: string, domain: string, timeoutMs: number) => Promise<Record<string, Object>>;
   smbDiscoverHosts: (subnetPrefix: string, startOctet: number, endOctet: number, port: number, timeoutMs: number) => Promise<Record<string, Object>>;
   smbReadTextFile: (url: string, maxSizeBytes: number, timeoutSeconds?: number) => Promise<string>;
+  smbDownloadFile: (url: string, outputPath: string, timeoutSeconds?: number) => Promise<string>;
 }
 
 interface SmbNapiBridgeModule {
@@ -413,6 +414,18 @@ export class SMBClient {
     } catch (e) {
       const err = e as import('@kit.BasicServicesKit').BusinessError;
       throw new Error(err.message ?? '读取文件失败');
+    }
+  }
+
+  async downloadFileToLocal(filePath: string, outputPath: string): Promise<string> {
+    console.info(`[SMBClient] downloadFileToLocal: ${this.host}/${this.shareName}${filePath}`);
+    const url: string = this.buildSmbUrl(filePath);
+    try {
+      const savedPath: string = await getModule().smbDownloadFile(url, outputPath, 15);
+      return savedPath;
+    } catch (e) {
+      const err = e as import('@kit.BasicServicesKit').BusinessError;
+      throw new Error(err.message ?? '下载文件失败');
     }
   }
 

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -1,6 +1,10 @@
-import { BusinessError } from '@kit.BasicServicesKit'
+import { common } from '@kit.AbilityKit'
+import { FileExplorer } from '../../components/core/file/FileExplorer'
+import { SmbFileExplorerAdapter } from '../../components/core/file/FileExplorerAdapter'
+import { FileExplorerController } from '../../components/core/file/FileExplorerController'
+import { ImagePreviewDialog } from '../../components/core/file/ImagePreview'
 import { SMBSourceConfig } from '../../db/models/FileSourceEntity'
-import { SMBClient, SmbFileInfo } from '../../lib/SMBClient'
+import { SMBClient, SmbFileInfo, SmbListDirectoryResult } from '../../lib/SMBClient'
 import { PlayerPage, PlayerPageParam } from '../player'
 import { FfprobeUtil } from '../../utils/FfprobeUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
@@ -51,6 +55,7 @@ const DEFAULT_SMB_CONFIG: SMBSourceConfig = {
 export struct SmbFileExplorerPage {
   static PAGE_NAME = 'smbFileExplorerPage'
 
+  @Local private imagePath: string = ''
   @Local private files: SmbFileInfo[] = []
   @Local private currentPath: string = '/'
   @Local private isLoading: boolean = false
@@ -65,6 +70,21 @@ export struct SmbFileExplorerPage {
 
   private config: SMBSourceConfig = DEFAULT_SMB_CONFIG
   private client: SMBClient = SMBClient.fromSourceConfig(DEFAULT_SMB_CONFIG)
+  private fileExplorerAdapter: SmbFileExplorerAdapter = new SmbFileExplorerAdapter(
+    (path: string): Promise<SmbListDirectoryResult> => this.client.listDirectory(path)
+  )
+  private fileExplorerController: FileExplorerController = new FileExplorerController({
+    resources: [],
+    currentPath: '/',
+    rootPath: '/',
+    onFolderChange: (path: string): void => {
+      this.loadDirectory(path)
+    },
+    onBack: (): boolean => {
+      this.pageStack.pop(true)
+      return true
+    }
+  })
 
   private readonly COLORS: ColorsInterface = {
     background: '#000000',
@@ -139,24 +159,17 @@ export struct SmbFileExplorerPage {
 
   private loadDirectory(path: string): void {
     console.info('[SmbExplorer] loadDirectory path=' + path)
-    // 避免重复 push 同一路径（面包屑点击 / navigateUp 已截断后再调用时）
-    if (this.pathHistory.length === 0 || this.pathHistory[this.pathHistory.length - 1] !== path) {
-      this.pathHistory.push(path)
-    }
     this.isLoading = true
     this.errorMessage = ''
-    this.client.listDirectory(path).then((result) => {
+    this.fileExplorerAdapter.list(path).then((result) => {
       this.isLoading = false
-      if (result.error) {
-        console.error('[SmbExplorer] listDirectory error path=' + path + ' err=' + result.error)
-        this.errorMessage = result.error
-      } else {
-        console.info('[SmbExplorer] listDirectory ok path=' + path + ' count=' + result.files.length.toString())
-      }
-      this.files = result.files
+      this.errorMessage = result.errorMessage ?? ''
+      this.fileExplorerController.resources = result.resources
+      this.fileExplorerController.currentPath = path
       this.currentPath = path
     }).catch(() => {
       this.isLoading = false
+      this.fileExplorerController.resources = []
       this.errorMessage = '加载目录失败'
       console.error('[SmbExplorer] listDirectory catch path=' + path)
     })
@@ -194,7 +207,30 @@ export struct SmbFileExplorerPage {
       this.loadDirectory(file.path)
     } else if (this.isVideoFile(file.name)) {
       this.playVideo(file)
+    } else if (this.isImageFile(file.name)) {
+      this.previewImage(file.path, file.name)
     }
+  }
+
+  private previewImage(filePath: string, displayName: string): void {
+    const context = this.getUIContext().getHostContext() as common.UIAbilityContext
+    const tempPath = context.tempDir + '/' + displayName
+    this.client.downloadFileToLocal(filePath, tempPath).then((savedPath: string) => {
+      this.imagePath = 'file://' + savedPath
+      const dialogController: CustomDialogController = new CustomDialogController({
+        builder: ImagePreviewDialog({
+          imageSrc: this.imagePath
+        }),
+        width: '100%',
+        height: '100%',
+        maskColor: Color.Transparent,
+        cornerRadius: 0,
+        customStyle: true,
+      })
+      dialogController.open()
+    }).catch(() => {
+      console.error('[SmbExplorer] 图片预览失败')
+    })
   }
 
   private async playVideo(file: SmbFileInfo): Promise<void> {
@@ -330,218 +366,45 @@ export struct SmbFileExplorerPage {
 
   build() {
     NavDestination() {
-      Column() {
-        // ── 工具栏（返回 / 隐藏文件 / 文件计数 / 加载指示）────────────────────
-        Row() {
-          Button('返回')
-            .fontSize(16)
-            .height(40)
-            .backgroundColor(this.COLORS.button)
-            .fontColor(this.COLORS.accent)
-            .onClick(() => { this.navigateUp() })
-            .margin({ right: 10 })
-
-          Button(this.showHiddenFiles ? '隐藏隐藏文件' : '显示隐藏文件')
-            .fontSize(16)
-            .height(40)
-            .backgroundColor(this.COLORS.button)
-            .fontColor(this.showHiddenFiles ? this.COLORS.accent : this.COLORS.secondaryText)
-            .onClick(() => { this.showHiddenFiles = !this.showHiddenFiles })
-            .margin({ right: 10 })
-
-          Text('文件：' + this.sortedFiles.length.toString())
-            .fontSize(14)
-            .fontColor(this.COLORS.tertiaryText)
-            .layoutWeight(1)
-
-          if (this.isLoading) {
-            LoadingProgress()
-              .width(24)
-              .height(24)
-              .color(this.COLORS.accent)
+      FileExplorer({
+        controller: this.fileExplorerController,
+        isLoading: this.isLoading,
+        errorMessage: this.errorMessage,
+        onFileClick: (event) => {
+          if (this.isVideoFile(event.resource.name)) {
+            const fileInfo: SmbFileInfo = {
+              name: event.resource.name,
+              path: event.resource.path,
+              isDirectory: false,
+              size: event.resource.size ?? 0,
+              lastModifiedMs: event.resource.lastModifiedMs ?? 0
+            }
+            this.playVideo(fileInfo)
+          } else if (this.isImageFile(event.resource.name)) {
+            this.previewImage(event.resource.path, event.resource.name)
           }
         }
-        .width('100%')
-        .padding({ left: 16, right: 16, top: 12, bottom: 12 })
-        .backgroundColor(this.COLORS.surface)
-
-        // ── 路径面包屑 ────────────────────────────────────────────────────────
-        Scroll() {
-          Row() {
-            ForEach(this.pathItems, (item: PathItem, index: number) => {
-              Row() {
-                Text(item.name)
-                  .fontSize(14)
-                  .fontColor(index === this.pathItems.length - 1
-                    ? this.COLORS.primaryText
-                    : this.COLORS.accent)
-                  .fontWeight(index === this.pathItems.length - 1
-                    ? FontWeight.Bold
-                    : FontWeight.Normal)
-                  .onClick(() => {
-                    if (index !== this.pathItems.length - 1) {
-                      this.navigateToBreadcrumb(item.path)
-                    }
-                  })
-
-                if (index < this.pathItems.length - 1) {
-                  Text(' / ')
-                    .fontSize(14)
-                    .fontColor(this.COLORS.tertiaryText)
-                    .margin({ left: 4, right: 4 })
-                }
-              }
-            }, (item: PathItem) => item.path)
-          }
-          .padding({ left: 16, right: 16 })
-        }
-        .scrollable(ScrollDirection.Horizontal)
-        .scrollBar(BarState.Off)
-        .width('100%')
-        .height(40)
-        .backgroundColor(this.COLORS.surfaceVariant)
-
-        Divider()
-          .color(this.COLORS.divider)
-
-        // ── 排序栏头（可点击切换排序字段和升降序）──────────────────────────────
-        Row() {
-          Text('名称 ' + this.getSortIcon('name'))
-            .fontSize(13)
-            .fontColor(this.sortField === 'name' ? this.COLORS.accent : this.COLORS.tertiaryText)
-            .fontWeight(this.sortField === 'name' ? FontWeight.Medium : FontWeight.Normal)
-            .layoutWeight(3)
-            .onClick(() => { this.changeSortField('name') })
-
-          Text('大小 ' + this.getSortIcon('size'))
-            .fontSize(13)
-            .fontColor(this.sortField === 'size' ? this.COLORS.accent : this.COLORS.tertiaryText)
-            .fontWeight(this.sortField === 'size' ? FontWeight.Medium : FontWeight.Normal)
-            .layoutWeight(2)
-            .textAlign(TextAlign.End)
-            .onClick(() => { this.changeSortField('size') })
-
-          Text('修改日期 ' + this.getSortIcon('date'))
-            .fontSize(13)
-            .fontColor(this.sortField === 'date' ? this.COLORS.accent : this.COLORS.tertiaryText)
-            .fontWeight(this.sortField === 'date' ? FontWeight.Medium : FontWeight.Normal)
-            .layoutWeight(2)
-            .textAlign(TextAlign.End)
-            .onClick(() => { this.changeSortField('date') })
-        }
-        .width('100%')
-        .padding({ left: 16, right: 16, top: 8, bottom: 8 })
-        .backgroundColor(this.COLORS.surface)
-
-        Divider()
-          .color(this.COLORS.divider)
-
-        // ── 错误提示 ──────────────────────────────────────────────────────────
-        if (this.errorMessage.length > 0) {
-          Row() {
-            Text('⚠️  ' + this.errorMessage)
-              .fontSize(14)
-              .fontColor('#FF6B6B')
-              .padding({ left: 16, right: 16, top: 8, bottom: 8 })
-          }
-          .width('100%')
-          .backgroundColor(this.COLORS.surface)
-        }
-
-        // ── 文件列表 ──────────────────────────────────────────────────────────
-        if (this.sortedFiles.length === 0 && !this.isLoading) {
-          Column() {
-            Text('📂')
-              .fontSize(48)
-              .margin({ bottom: 12 })
-
-            Text('此文件夹为空')
-              .fontSize(16)
-              .fontColor(this.COLORS.tertiaryText)
-          }
-          .width('100%')
-          .layoutWeight(1)
-          .justifyContent(FlexAlign.Center)
-          .backgroundColor(this.COLORS.background)
-        } else {
-          List({ space: 0 }) {
-            ForEach(this.sortedFiles, (file: SmbFileInfo, index: number) => {
-              ListItem() {
-                Row() {
-                  // 图标 + 文件名
-                  Row({ space: 12 }) {
-                    Text(this.getFileIcon(file))
-                      .fontSize($r('app.float.font_h6_title_large'))
-
-                    Column() {
-                      Text(file.name)
-                        .fontSize($r('app.float.font_h7_title_small'))
-                        .maxLines(1)
-                        .textOverflow({ overflow: TextOverflow.MARQUEE })
-                        .fontColor(file.isDirectory
-                          ? this.COLORS.accent
-                          : this.COLORS.primaryText)
-                        .width('100%')
-                    }
-                    .alignItems(HorizontalAlign.Start)
-                    .layoutWeight(1)
-                  }
-                  .layoutWeight(3)
-                  .alignItems(VerticalAlign.Center)
-
-                  // 大小
-                  Text(file.isDirectory ? '-' : this.formatFileSize(file.size))
-                    .fontSize(13)
-                    .fontColor(this.COLORS.tertiaryText)
-                    .layoutWeight(2)
-                    .textAlign(TextAlign.End)
-                    .maxLines(1)
-
-                  // 修改日期
-                  Text(this.formatDate(file.lastModifiedMs))
-                    .fontSize(13)
-                    .fontColor(this.COLORS.tertiaryText)
-                    .layoutWeight(2)
-                    .textAlign(TextAlign.End)
-                    .maxLines(1)
-                }
-                .width('100%')
-                .padding({ left: 16, right: 16, top: 12, bottom: 12 })
-                .backgroundColor(index % 2 === 0
-                  ? this.COLORS.background
-                  : this.COLORS.surface)
-              }
-              .onClick(() => {
-                this.handleFileClick(file)
-              })
-            }, (file: SmbFileInfo) => file.path)
-          }
-          .width('100%')
-          .layoutWeight(1)
-          .backgroundColor(this.COLORS.background)
-          .divider({
-            strokeWidth: 0.5,
-            color: this.COLORS.divider,
-            startMargin: 16,
-            endMargin: 16
-          })
-        }
-      }
-      .width('100%')
-      .height('100%')
-      .backgroundColor(this.COLORS.background)
+      })
     }
     .onReady((context) => {
       const param = context.pathInfo.param as SmbFileExplorerPageParam
       this.config = param.config
       this.client = SMBClient.fromSourceConfig(param.config)
+      this.fileExplorerAdapter = new SmbFileExplorerAdapter(
+        (path: string): Promise<SmbListDirectoryResult> => this.client.listDirectory(path)
+      )
       const startPath = param.initialPath ?? '/'
-      // 以 startPath 为历史栈起点，确保首次点返回键直接关闭弹窗
-      this.pathHistory = [startPath]
+      this.fileExplorerController.rootPath = startPath
+      this.fileExplorerController.currentPath = startPath
       this.loadDirectory(startPath)
     })
     .onBackPressed(() => {
-      return this.handleBack()
+      if (this.imagePath.length > 0) {
+        this.imagePath = ''
+        return true
+      }
+      this.fileExplorerController.handleBack()
+      return true
     })
     .mode(NavDestinationMode.DIALOG)
     .hideTitleBar(true)

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -3,6 +3,7 @@ import { FileExplorer } from '../../components/core/file/FileExplorer'
 import { SmbFileExplorerAdapter } from '../../components/core/file/FileExplorerAdapter'
 import { FileExplorerController } from '../../components/core/file/FileExplorerController'
 import { ImagePreviewDialog } from '../../components/core/file/ImagePreview'
+import { DialogHandle, ImagePreviewSessionController } from '../../components/core/file/ImagePreviewSessionController'
 import { SMBSourceConfig } from '../../db/models/FileSourceEntity'
 import { SMBClient, SmbFileInfo, SmbListDirectoryResult } from '../../lib/SMBClient'
 import { PlayerPage, PlayerPageParam } from '../player'
@@ -70,6 +71,7 @@ export struct SmbFileExplorerPage {
 
   private config: SMBSourceConfig = DEFAULT_SMB_CONFIG
   private client: SMBClient = SMBClient.fromSourceConfig(DEFAULT_SMB_CONFIG)
+  private imagePreviewSessionController: ImagePreviewSessionController = new ImagePreviewSessionController()
   private fileExplorerAdapter: SmbFileExplorerAdapter = new SmbFileExplorerAdapter(
     (path: string): Promise<SmbListDirectoryResult> => this.client.listDirectory(path)
   )
@@ -216,6 +218,7 @@ export struct SmbFileExplorerPage {
     const context = this.getUIContext().getHostContext() as common.UIAbilityContext
     const tempPath = context.tempDir + '/' + displayName
     this.client.downloadFileToLocal(filePath, tempPath).then((savedPath: string) => {
+      this.closeImagePreview()
       this.imagePath = 'file://' + savedPath
       const dialogController: CustomDialogController = new CustomDialogController({
         builder: ImagePreviewDialog({
@@ -227,10 +230,18 @@ export struct SmbFileExplorerPage {
         cornerRadius: 0,
         customStyle: true,
       })
-      dialogController.open()
+      this.imagePreviewSessionController.openDialog(dialogController as DialogHandle)
     }).catch(() => {
       console.error('[SmbExplorer] 图片预览失败')
     })
+  }
+
+  private closeImagePreview(): boolean {
+    const handled = this.imagePreviewSessionController.closeActiveDialog()
+    if (handled) {
+      this.imagePath = ''
+    }
+    return handled
   }
 
   private async playVideo(file: SmbFileInfo): Promise<void> {
@@ -399,7 +410,7 @@ export struct SmbFileExplorerPage {
       this.loadDirectory(startPath)
     })
     .onBackPressed(() => {
-      if (this.imagePath.length > 0) {
+      if (this.imagePreviewSessionController.handleBack()) {
         this.imagePath = ''
         return true
       }
@@ -408,5 +419,9 @@ export struct SmbFileExplorerPage {
     })
     .mode(NavDestinationMode.DIALOG)
     .hideTitleBar(true)
+  }
+
+  aboutToDisappear(): void {
+    this.closeImagePreview()
   }
 }

--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -1,4 +1,5 @@
 import { IBestToast } from "@ibestservices/ibest-ui";
+import { WebDavFileExplorerAdapter } from "../../components/core/file/FileExplorerAdapter";
 import { FileExplorer } from "../../components/core/file/FileExplorer";
 import { FileExplorerController } from "../../components/core/file/FileExplorerController";
 import { WebDAVClient, WebDAVConfig, WebDAVResource } from "../../lib/WebDAVClient";
@@ -40,7 +41,12 @@ const config: WebDAVConfig = {
 export struct FileExplorerPage {
   static PAGE_NAME = "fileExplorerPage"
   client: WebDAVClient = new WebDAVClient(config)
+  private fileExplorerAdapter: WebDavFileExplorerAdapter = new WebDavFileExplorerAdapter(
+    (path: string): Promise<WebDAVResource[]> => this.client.listDirectory(path)
+  )
   @Local imagePath: string = ''
+  @Local isLoading: boolean = false
+  @Local errorMessage: string = ''
   @Local showMissingDirDialog: boolean = false
   @Local isCleaningUp: boolean = false
   private cachedDirId: number = 0
@@ -64,10 +70,12 @@ export struct FileExplorerPage {
       Stack() {
         FileExplorer({
           controller: this.fileExplorerController,
+          isLoading: this.isLoading,
+          errorMessage: this.errorMessage,
           onFileClick: event => {
-            const displayName = event.resource.displayName
+            const displayName = event.resource.name
             if (this.isVideoFile(displayName)) {
-              this.playVideo(event.fullPath, event.resource.displayName)
+              this.playVideo(event.fullPath, displayName)
             }
             if (this.isImageFile(displayName)) {
               this.previewImage(event.fullPath, displayName)
@@ -140,6 +148,9 @@ export struct FileExplorerPage {
         return
       }
       this.client = new WebDAVClient(param.config)
+      this.fileExplorerAdapter = new WebDavFileExplorerAdapter(
+        (path: string): Promise<WebDAVResource[]> => this.client.listDirectory(path)
+      )
       this.cachedDirId = param.dirId ?? 0
       this.cachedSourceId = param.sourceId ?? 0
       this.cachedDirectoryPath = param.directoryPath ?? ''
@@ -372,10 +383,17 @@ export struct FileExplorerPage {
   }
 
   private changePath(newPath: string = '/') {
-    this.client.listDirectory(encodeURIComponent(newPath)).then(files => {
-      files.shift()
+    this.isLoading = true
+    this.errorMessage = ''
+    this.fileExplorerAdapter.list(newPath).then((result) => {
       this.fileExplorerController.currentPath = newPath
-      this.fileExplorerController.resources = files
+      this.fileExplorerController.resources = result.resources
+      this.errorMessage = result.errorMessage ?? ''
+      this.isLoading = false
+    }).catch(() => {
+      this.fileExplorerController.resources = []
+      this.isLoading = false
+      this.errorMessage = '加载目录失败'
     })
   }
 

--- a/entry/src/test/FileExplorerAdapter.test.ets
+++ b/entry/src/test/FileExplorerAdapter.test.ets
@@ -3,6 +3,7 @@ import { WebDAVResource } from '../main/ets/lib/WebDAVClient'
 import { SmbFileInfo, SmbListDirectoryResult } from '../main/ets/lib/SMBClient'
 import { FileExplorerLoadResult } from '../main/ets/components/core/file/FileExplorerController'
 import {
+  getFileExplorerErrorMessage,
   SmbFileExplorerAdapter,
   WebDavFileExplorerAdapter
 } from '../main/ets/components/core/file/FileExplorerAdapter'
@@ -29,6 +30,10 @@ class FakeSmbClient {
   async listDirectory(_path: string): Promise<SmbListDirectoryResult> {
     return this.result
   }
+}
+
+interface MessageOnlyError {
+  message: string
 }
 
 function makeWebDavResource(name: string, href: string, isCollection: boolean): WebDAVResource {
@@ -81,6 +86,13 @@ export default function fileExplorerAdapterTest() {
 
       expect(result.resources.length).assertEqual(0)
       expect(result.errorMessage).assertEqual('连接失败')
+    })
+
+    it('getFileExplorerErrorMessage 会兼容 message 对象与字符串输入', 0, () => {
+      const messageOnlyError: MessageOnlyError = { message: '服务端拒绝访问' }
+
+      expect(getFileExplorerErrorMessage(messageOnlyError)).assertEqual('服务端拒绝访问')
+      expect(getFileExplorerErrorMessage('连接中断')).assertEqual('连接中断')
     })
   })
 }

--- a/entry/src/test/FileExplorerAdapter.test.ets
+++ b/entry/src/test/FileExplorerAdapter.test.ets
@@ -1,0 +1,86 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { WebDAVResource } from '../main/ets/lib/WebDAVClient'
+import { SmbFileInfo, SmbListDirectoryResult } from '../main/ets/lib/SMBClient'
+import { FileExplorerLoadResult } from '../main/ets/components/core/file/FileExplorerController'
+import {
+  SmbFileExplorerAdapter,
+  WebDavFileExplorerAdapter
+} from '../main/ets/components/core/file/FileExplorerAdapter'
+
+class FakeWebDavClient {
+  private readonly resources: WebDAVResource[]
+
+  constructor(resources: WebDAVResource[]) {
+    this.resources = resources
+  }
+
+  async listDirectory(_path: string): Promise<WebDAVResource[]> {
+    return this.resources
+  }
+}
+
+class FakeSmbClient {
+  private readonly result: SmbListDirectoryResult
+
+  constructor(result: SmbListDirectoryResult) {
+    this.result = result
+  }
+
+  async listDirectory(_path: string): Promise<SmbListDirectoryResult> {
+    return this.result
+  }
+}
+
+function makeWebDavResource(name: string, href: string, isCollection: boolean): WebDAVResource {
+  const resource: WebDAVResource = {
+    href: href,
+    displayName: name,
+    isCollection: isCollection
+  }
+  return resource
+}
+
+function makeSmbFile(name: string, path: string, isDirectory: boolean): SmbFileInfo {
+  const file: SmbFileInfo = {
+    name: name,
+    path: path,
+    isDirectory: isDirectory,
+    size: isDirectory ? 0 : 128,
+    lastModifiedMs: 1
+  }
+  return file
+}
+
+export default function fileExplorerAdapterTest() {
+  describe('FileExplorerAdapter', () => {
+    it('WebDavFileExplorerAdapter 会过滤当前目录自身并映射为统一资源', 0, async () => {
+      const client = new FakeWebDavClient([
+        makeWebDavResource('当前目录', '/dav/root', true),
+        makeWebDavResource('Movies', '/dav/root/Movies', true),
+        makeWebDavResource('cover.jpg', '/dav/root/cover.jpg', false)
+      ])
+      const adapter = new WebDavFileExplorerAdapter(client.listDirectory.bind(client))
+
+      const result: FileExplorerLoadResult = await adapter.list('/root')
+
+      expect(result.resources.length).assertEqual(2)
+      expect(result.resources[0].name).assertEqual('Movies')
+      expect(result.resources[0].path).assertEqual('/root/Movies')
+      expect(result.resources[1].name).assertEqual('cover.jpg')
+      expect(result.errorMessage === undefined).assertTrue()
+    })
+
+    it('SmbFileExplorerAdapter 会把客户端错误转成统一错误消息', 0, async () => {
+      const client = new FakeSmbClient({
+        files: [makeSmbFile('cover.jpg', '/share/cover.jpg', false)],
+        error: '连接失败'
+      })
+      const adapter = new SmbFileExplorerAdapter(client.listDirectory.bind(client))
+
+      const result: FileExplorerLoadResult = await adapter.list('/share')
+
+      expect(result.resources.length).assertEqual(0)
+      expect(result.errorMessage).assertEqual('连接失败')
+    })
+  })
+}

--- a/entry/src/test/FileExplorerController.test.ets
+++ b/entry/src/test/FileExplorerController.test.ets
@@ -179,5 +179,20 @@ export default function fileExplorerControllerTest() {
       expect(controller.pathItems[0].path).assertEqual('/share/library')
       expect(controller.pathItems[1].path).assertEqual('/share/library/season1')
     })
+
+    it('rootPath 仅在完整路径段匹配时才视为当前根目录前缀', 0, () => {
+      const resources: FileExplorerResource[] = []
+      const params: FileExplorerControllerParam = {
+        resources: resources,
+        currentPath: '/share/library2',
+        rootPath: '/share/library'
+      }
+      const controller = new FileExplorerController(params)
+
+      expect(controller.pathItems.length).assertEqual(2)
+      expect(controller.pathItems[0].path).assertEqual('/share/library')
+      expect(controller.pathItems[1].name).assertEqual('library2')
+      expect(controller.pathItems[1].path).assertEqual('/share/library2')
+    })
   })
 }

--- a/entry/src/test/FileExplorerController.test.ets
+++ b/entry/src/test/FileExplorerController.test.ets
@@ -1,0 +1,183 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { WebDAVResource } from '../main/ets/lib/WebDAVClient'
+import { SmbFileInfo } from '../main/ets/lib/SMBClient'
+import {
+  compareFileExplorerNames,
+  FileExplorerController,
+  FileExplorerControllerParam,
+  FileExplorerResource,
+  createFileExplorerResourceFromSmb,
+  createFileExplorerResourceFromWebDav
+} from '../main/ets/components/core/file/FileExplorerController'
+
+function makeWebDavResource(name: string, isCollection: boolean, lastModified?: string): WebDAVResource {
+  const resource: WebDAVResource = {
+    href: '/root/' + name,
+    displayName: name,
+    isCollection: isCollection,
+    lastModified: lastModified,
+    size: isCollection ? undefined : 128
+  }
+  return resource
+}
+
+function makeSmbFileInfo(name: string, path: string, isDirectory: boolean, lastModifiedMs: number): SmbFileInfo {
+  const file: SmbFileInfo = {
+    name: name,
+    path: path,
+    isDirectory: isDirectory,
+    size: isDirectory ? 0 : 256,
+    lastModifiedMs: lastModifiedMs
+  }
+  return file
+}
+
+export default function fileExplorerControllerTest() {
+  describe('FileExplorerResource mapping', () => {
+    it('会把 WebDAV 资源转换为统一模型并解析隐藏标记与完整路径', 0, () => {
+      const resource: FileExplorerResource = createFileExplorerResourceFromWebDav(
+        '/影视',
+        makeWebDavResource('.cover.jpg', false, 'Wed, 26 Apr 2026 10:30:00 GMT')
+      )
+
+      expect(resource.name).assertEqual('.cover.jpg')
+      expect(resource.path).assertEqual('/影视/.cover.jpg')
+      expect(resource.isDirectory).assertFalse()
+      expect(resource.isHidden).assertTrue()
+      expect(resource.lastModifiedMs !== undefined).assertTrue()
+    })
+
+    it('会把 SMB 资源转换为统一模型并保留毫秒时间戳', 0, () => {
+      const resource: FileExplorerResource = createFileExplorerResourceFromSmb(
+        makeSmbFileInfo('Episode01.mkv', '/share/TV/Episode01.mkv', false, 1714000000123)
+      )
+
+      expect(resource.name).assertEqual('Episode01.mkv')
+      expect(resource.path).assertEqual('/share/TV/Episode01.mkv')
+      expect(resource.isDirectory).assertFalse()
+      expect(resource.isHidden).assertFalse()
+      expect(resource.lastModifiedMs).assertEqual(1714000000123)
+    })
+  })
+
+  describe('FileExplorerController unified resources', () => {
+    it('会按统一模型过滤隐藏文件并保持目录优先排序', 0, () => {
+      const controller = new FileExplorerController({
+        resources: [
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('video.mkv', '/share/video.mkv', false, 10)),
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('.hidden', '/share/.hidden', false, 11)),
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('Season 1', '/share/Season 1', true, 9))
+        ],
+        currentPath: '/'
+      })
+
+      expect(controller.sortedResources.length).assertEqual(2)
+      expect(controller.sortedResources[0].name).assertEqual('Season 1')
+      expect(controller.sortedResources[1].name).assertEqual('video.mkv')
+
+      controller.showHiddenFiles = true
+      expect(controller.sortedResources.length).assertEqual(3)
+    })
+
+    it('按名称排序时会把中文季序号按自然顺序排列', 0, () => {
+      const names: string[] = ['第一季', '第七季', '第三季', '第二季', '第五季', '第六季', '第四季']
+      names.sort((a: string, b: string): number => compareFileExplorerNames(a, b))
+      expect(names[0]).assertEqual('第一季')
+      expect(names[1]).assertEqual('第二季')
+      expect(names[2]).assertEqual('第三季')
+      expect(names[3]).assertEqual('第四季')
+      expect(names[4]).assertEqual('第五季')
+      expect(names[5]).assertEqual('第六季')
+      expect(names[6]).assertEqual('第七季')
+
+      const controller = new FileExplorerController({
+        resources: [
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('第五季', '/share/第五季', true, 5)),
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('第四季', '/share/第四季', true, 4)),
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('第七季', '/share/第七季', true, 7)),
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('第三季', '/share/第三季', true, 3)),
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('第一季', '/share/第一季', true, 1)),
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('第二季', '/share/第二季', true, 2)),
+          createFileExplorerResourceFromSmb(makeSmbFileInfo('第六季', '/share/第六季', true, 6))
+        ],
+        currentPath: '/'
+      })
+
+      expect(controller.sortedResources[0].name).assertEqual('第一季')
+      expect(controller.sortedResources[1].name).assertEqual('第二季')
+      expect(controller.sortedResources[2].name).assertEqual('第三季')
+      expect(controller.sortedResources[3].name).assertEqual('第四季')
+      expect(controller.sortedResources[4].name).assertEqual('第五季')
+      expect(controller.sortedResources[5].name).assertEqual('第六季')
+      expect(controller.sortedResources[6].name).assertEqual('第七季')
+    })
+
+    it('handleBack 在非根目录时回到上一级，在根目录时交给外层处理', 0, () => {
+      const folderChanges: string[] = []
+      let backCalls = 0
+      const controller = new FileExplorerController({
+        resources: [],
+        currentPath: '/电影/华语',
+        onFolderChange: (path: string): void => {
+          folderChanges.push(path)
+        },
+        onBack: (): boolean => {
+          backCalls += 1
+          return true
+        }
+      })
+
+      controller.handleBack()
+      expect(folderChanges.length).assertEqual(1)
+      expect(folderChanges[0]).assertEqual('/电影')
+      expect(backCalls).assertEqual(0)
+
+      controller.currentPath = '/'
+      controller.handleBack()
+      expect(backCalls).assertEqual(1)
+    })
+
+    it('配置了 rootPath 时回退到文件源根目录就交给外层关闭', 0, () => {
+      const folderChanges: string[] = []
+      let backCalls = 0
+      const resources: FileExplorerResource[] = []
+      const params: FileExplorerControllerParam = {
+        resources: resources,
+        currentPath: '/share/library/season1',
+        rootPath: '/share/library',
+        onFolderChange: (path: string): void => {
+          folderChanges.push(path)
+        },
+        onBack: (): boolean => {
+          backCalls += 1
+          return true
+        }
+      }
+      const controller = new FileExplorerController(params)
+
+      controller.handleBack()
+      expect(folderChanges.length).assertEqual(1)
+      expect(folderChanges[0]).assertEqual('/share/library')
+      expect(backCalls).assertEqual(0)
+
+      controller.currentPath = '/share/library'
+      controller.handleBack()
+      expect(backCalls).assertEqual(1)
+    })
+
+    it('配置了 rootPath 时面包屑根项使用文件源根目录', 0, () => {
+      const resources: FileExplorerResource[] = []
+      const params: FileExplorerControllerParam = {
+        resources: resources,
+        currentPath: '/share/library/season1',
+        rootPath: '/share/library'
+      }
+      const controller = new FileExplorerController(params)
+
+      expect(controller.pathItems.length).assertEqual(2)
+      expect(controller.pathItems[0].name).assertEqual('根目录')
+      expect(controller.pathItems[0].path).assertEqual('/share/library')
+      expect(controller.pathItems[1].path).assertEqual('/share/library/season1')
+    })
+  })
+}

--- a/entry/src/test/ImagePreviewSessionController.test.ets
+++ b/entry/src/test/ImagePreviewSessionController.test.ets
@@ -1,0 +1,43 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { DialogHandle, ImagePreviewSessionController } from '../main/ets/components/core/file/ImagePreviewSessionController'
+
+class FakeDialogHandle implements DialogHandle {
+  openCount: number = 0
+  closeCount: number = 0
+
+  open(): void {
+    this.openCount += 1
+  }
+
+  close(): void {
+    this.closeCount += 1
+  }
+}
+
+export default function imagePreviewSessionControllerTest() {
+  describe('ImagePreviewSessionController', () => {
+    it('打开新预览前会先关闭旧弹窗', 0, () => {
+      const controller = new ImagePreviewSessionController()
+      const firstDialog = new FakeDialogHandle()
+      const secondDialog = new FakeDialogHandle()
+
+      controller.openDialog(firstDialog)
+      controller.openDialog(secondDialog)
+
+      expect(firstDialog.openCount).assertEqual(1)
+      expect(firstDialog.closeCount).assertEqual(1)
+      expect(secondDialog.openCount).assertEqual(1)
+      expect(secondDialog.closeCount).assertEqual(0)
+    })
+
+    it('handleBack 会关闭当前预览并返回已消费', 0, () => {
+      const controller = new ImagePreviewSessionController()
+      const dialog = new FakeDialogHandle()
+
+      controller.openDialog(dialog)
+      expect(controller.handleBack()).assertTrue()
+      expect(dialog.closeCount).assertEqual(1)
+      expect(controller.handleBack()).assertFalse()
+    })
+  })
+}

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -15,6 +15,8 @@ import episodePlaybackManagerTest from './EpisodePlaybackManager.test';
 import videoControlsTest from './VideoControls.test';
 import playerPageTest from './PlayerPage.test';
 import videoPlayerControllerTest from './VideoPlayerController.test';
+import fileExplorerControllerTest from './FileExplorerController.test';
+import fileExplorerAdapterTest from './FileExplorerAdapter.test';
 // 需要真实 Context 和 .so 的集成测试放在 UnitTestBuild 侧（entry 模块本身，包含 native .so）
 // ohosTest(entry_test HAP) 不包含 .so，不能 import VideoScannerUtil / WebDAVClient
 import fileSourceDatabaseTest from './FileSourceDatabase.test';
@@ -38,6 +40,8 @@ export default function testsuite() {
   videoControlsTest();
   playerPageTest();
   videoPlayerControllerTest();
+  fileExplorerControllerTest();
+  fileExplorerAdapterTest();
   fileSourceDatabaseTest();
   videoScannerTest();
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -17,6 +17,7 @@ import playerPageTest from './PlayerPage.test';
 import videoPlayerControllerTest from './VideoPlayerController.test';
 import fileExplorerControllerTest from './FileExplorerController.test';
 import fileExplorerAdapterTest from './FileExplorerAdapter.test';
+import imagePreviewSessionControllerTest from './ImagePreviewSessionController.test';
 // 需要真实 Context 和 .so 的集成测试放在 UnitTestBuild 侧（entry 模块本身，包含 native .so）
 // ohosTest(entry_test HAP) 不包含 .so，不能 import VideoScannerUtil / WebDAVClient
 import fileSourceDatabaseTest from './FileSourceDatabase.test';
@@ -42,6 +43,7 @@ export default function testsuite() {
   videoPlayerControllerTest();
   fileExplorerControllerTest();
   fileExplorerAdapterTest();
+  imagePreviewSessionControllerTest();
   fileSourceDatabaseTest();
   videoScannerTest();
 }


### PR DESCRIPTION
## Summary
- 统一 WebDAV 与 SMB 文件浏览基线，抽取通用 `FileExplorer`、`FileExplorerController` 和协议适配器
- 为 SMB 文件浏览补齐图片预览、本地临时文件下载，以及以配置根目录为边界的返回/面包屑行为
- 补充文件浏览 controller / adapter 回归测试，并修正中文季序号自然排序与图片预览标题一致性

## Test Plan
- [x] `hvigorw.js --mode module -p module=entry@default -p product=default -p isLocalTest=true -p unitTestMode=true -p buildRoot=.test -p scope=fileExplorerControllerTest test --analyze=normal --parallel --incremental --no-daemon`
- [x] `hvigorw.js --mode module -p module=entry@default -p product=default assembleHap --analyze=normal --parallel --incremental --daemon`
- [x] 真机覆盖安装回归：WebDAV 文件浏览 / 图片预览 / 中文排序
- [x] 真机覆盖安装回归：SMB 浏览 / 播放 / 图片预览 / 返回到文件源根目录即关闭

Closes #73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SMB file download support for streaming remote files to local storage
  * Unified file explorer with both WebDAV and SMB backends
  * Improved navigation, root-clamping, natural name sorting, and hidden-file handling
  * Configurable loading / error / empty states and optional per-item selection checkboxes
  * Image preview with single-active preview lifecycle management

* **Tests**
  * Added tests covering adapters, controller behavior, and image preview session handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->