### PR TITLE
新增 OpenSpec Guard CI 工作流

### DIFF
--- a/.github/workflows/openspec-guard.yml
+++ b/.github/workflows/openspec-guard.yml
@@ -1,0 +1,26 @@
+name: OpenSpec Guard CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  openspec-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Guard openspec tracking
+        shell: bash
+        run: |
+          tracked="$(git ls-files -- openspec)"
+          if [ -n "$tracked" ]; then
+            echo "$tracked"
+            exit 1
+          else
+            echo "No tracked openspec files detected."
+          fi

--- a/.github/workflows/openspec-guard.yml
+++ b/.github/workflows/openspec-guard.yml
@@ -11,9 +11,11 @@ permissions:
 
 jobs:
   openspec-guard:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Guard openspec tracking
         shell: bash
         run: |

--- a/.github/workflows/openspec-guard.yml
+++ b/.github/workflows/openspec-guard.yml
@@ -17,10 +17,17 @@ jobs:
       - name: Guard openspec tracking
         shell: bash
         run: |
-          tracked="$(git ls-files -- openspec)"
-          if [ -n "$tracked" ]; then
-            echo "$tracked"
+          set -euo pipefail
+
+          tracked_files="$(git --no-pager ls-files -- openspec)"
+          if [ -n "$tracked_files" ]; then
+            echo "::error title=OpenSpec Guard Failed::检测到 openspec 目录下存在被 Git 跟踪的文件。请执行 git rm --cached -r -- openspec，并保留 .gitignore 中的 /openspec 规则。"
+            echo "OpenSpec Guard Failed"
+            echo "Tracked openspec files:"
+            printf "%s\n" "$tracked_files"
+            echo "Fix: git rm --cached -r -- openspec"
+            echo "Reminder: 保留 .gitignore 中的 /openspec 规则"
             exit 1
-          else
-            echo "No tracked openspec files detected."
           fi
+
+          echo "OpenSpec Guard passed: openspec 目录仍为未跟踪状态。"


### PR DESCRIPTION
## 变更说明
- 新增独立 workflow `.github/workflows/openspec-guard.yml`
- 以 `git ls-files -- openspec` 作为唯一 guard 判定
- 当 tracked files 非空时直接失败，并给出修复命令
- 已完成本地正常场景与异常场景验证

## 说明
- 本次 PR 不调整 `pull_request` 触发范围设计，保持与已确认方案一致
- 待在本 PR 页面补齐真实 `OpenSpec Guard CI` 运行结果证据

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI validation that prevents committed files in the /openspec directory from being merged. It warns and fails the check if tracked files are detected, showing how to untrack them and reminding to keep /openspec ignored; passes when no tracked files exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->