### PR TITLE
文档: 补充 OpenSpec 本地保留规则

### DIFF
--- a/.github/instructions/githubWorkflow.instructions.md
+++ b/.github/instructions/githubWorkflow.instructions.md
@@ -22,6 +22,13 @@ description: "GitHub 工作流指令。用于 git add、git commit、git push、
 - 创建 PR 时优先分 3 步执行：先 `git push`，再准备标题/正文，最后 `gh pr create`
 - 若 PR 正文较长，优先使用 `gh pr create --body-file <file>`，不要内联超长正文
 
+## OpenSpec 本地保留规则
+
+- `openspec/` 目录仅保留在本地工作区，禁止纳入 Git 跟踪，禁止提交或推送到远端
+- `.gitignore` 中必须保留 `/openspec` 规则，禁止删除、放宽或绕过该忽略项
+- 若 `git ls-files -- openspec` 输出非空，说明 `openspec/` 已重新进入跟踪集合；立即执行 `git rm --cached -r -- openspec` 清理 index，并保留本地文件
+- 仓库已配置 `OpenSpec Guard CI` 作为防回归门禁；处理 PR 或 GitHub Actions 时以该检查为准，失败时先清理 tracked `openspec/`，再继续后续操作
+
 ## 命令行稳定性
 
 - 默认 shell 为 zsh 时，命令中的 `?`、`*`、`[`、`]` 等字符可能触发 glob 展开；包含这类字符的参数必须安全引用


### PR DESCRIPTION
## 变更说明
- 在 `.github/instructions/githubWorkflow.instructions.md` 中新增 `OpenSpec 本地保留规则`。
- 明确 `openspec/` 仅本地保留，不应被 Git 跟踪或推送到远端。
- 明确当 `openspec/` 重新进入跟踪集合时，应执行 `git rm --cached -r -- openspec` 清理 index，同时保留本地文件。
- 明确 `OpenSpec Guard CI` 是用于防止 `openspec/` 被重新纳入版本控制的防回归门禁。

## 备注
- 本次为文档规则补充任务，不涉及代码实现、构建链路或功能行为变更。