### PR TITLE
feat: close out #29 subtitle language preference integration

### DIFF
--- a/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
@@ -9,6 +9,11 @@ import { VideoData } from './VideoData';
 import { VideoDataType } from './Constants';
 import { IPlayer, SubtitleInfo, TrackInfo } from './IPlayer';
 import { AssFileParser, SrtEntry, SrtParser } from './SubtitleRenderer';
+import {
+  findPreferredSubtitleTrackIndex,
+  loadSubtitleLanguagePreference,
+  SubtitleTrackLanguageCandidate
+} from '../../../subtitle/SubtitleLanguagePreference';
 
 const TAG = '[SubtitleBridgeAdapter]';
 const MAX_SUBTITLE_PROBE_CANDIDATES = 12;
@@ -443,21 +448,21 @@ export class BaseSubtitleBridgeAdapter implements ISubtitleBridgeAdapter {
     this.allSubtitleTracks = mergedItems;
 
     if (this.allSubtitleTracks.length > 0) {
-      const preferredIndex = this.findPreferredTrackIndex();
-      // 不 await：auto-select 的轨道切换可能包含长时间异步操作（如 SMB 内嵌字幕 30s 提取）
-      // fire-and-forget，初始化立即完成，字幕在提取完成后自动开始渲染
-      this.switchTrack(preferredIndex).catch(() => {
-        hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-          `[字幕指标] 自动选轨异常，降级无字幕`);
-      });
-      const selected = this.allSubtitleTracks[preferredIndex];
-      if (selected) {
+      const preferredIndex = await this.findPreferredTrackIndex();
+      if (preferredIndex >= 0) {
+        // 不 await：auto-select 的轨道切换可能包含长时间异步操作（如 SMB 内嵌字幕 30s 提取）
+        // fire-and-forget，初始化立即完成，字幕在提取完成后自动开始渲染
+        this.switchTrack(preferredIndex).catch(() => {
+          hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+            `[字幕指标] 自动选轨异常，降级无字幕`);
+        });
+        const selected = this.allSubtitleTracks[preferredIndex];
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
           `[字幕指标] 初始化完成: 内嵌=${internalItems.length} 外置=${externalItems.length}` +
           ` 自动选中[${preferredIndex}]=${selected.displayName}(${selected.kind})`);
       } else {
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-          `[字幕指标] 初始化完成: 内嵌=${internalItems.length} 外置=${externalItems.length} 轨道索引越界`);
+          `[字幕指标] 初始化完成: 内嵌=${internalItems.length} 外置=${externalItems.length} 无偏好匹配，保持关闭字幕`);
       }
     } else {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
@@ -465,21 +470,37 @@ export class BaseSubtitleBridgeAdapter implements ISubtitleBridgeAdapter {
     }
   }
 
-  /** 默认优先选择第一条内嵌字幕，没有内嵌字幕再选第一条外置字幕 */
-  protected findPreferredTrackIndex(): number {
-    // 先找内嵌字幕
-    for (let i = 0; i < this.allSubtitleTracks.length; i++) {
-      if (this.allSubtitleTracks[i].kind === 'internal') {
-        return i;
+  protected async findPreferredTrackIndex(): Promise<number> {
+    const preference = await loadSubtitleLanguagePreference()
+    const trackCandidates: SubtitleTrackLanguageCandidate[] = []
+    for (let index = 0; index < this.allSubtitleTracks.length; index++) {
+      const item = this.allSubtitleTracks[index]
+      const candidate: SubtitleTrackLanguageCandidate = {
+        displayName: item.displayName
+      }
+      if (item.kind === 'internal') {
+        const language = this.findInternalTrackLanguage(item.internalIndex)
+        if (language !== undefined && language.length > 0) {
+          candidate.language = language
+        }
+      }
+      trackCandidates.push(candidate)
+    }
+
+    return findPreferredSubtitleTrackIndex(trackCandidates, preference)
+  }
+
+  private findInternalTrackLanguage(trackIndex: number | undefined): string | undefined {
+    if (trackIndex === undefined) {
+      return undefined
+    }
+    for (let index = 0; index < this.subtitleTracks.length; index++) {
+      const track = this.subtitleTracks[index]
+      if (track.trackIndex === trackIndex) {
+        return track.language
       }
     }
-    // 没有内嵌字幕则找外置字幕
-    for (let i = 0; i < this.allSubtitleTracks.length; i++) {
-      if (this.allSubtitleTracks[i].kind === 'external') {
-        return i;
-      }
-    }
-    return 0;
+    return undefined
   }
 
   onTimeUpdate(currentTimeMs: number): void {

--- a/entry/src/main/ets/pages/settings/Index.ets
+++ b/entry/src/main/ets/pages/settings/Index.ets
@@ -37,7 +37,7 @@ export struct SettingsPage {
 
   build() {
     NavDestination() {
-      RelativeContainer() {
+      Row() {
         Scroll() {
           Column() {
             if (this.controller.type === SettingType.HOME) {
@@ -76,10 +76,6 @@ export struct SettingsPage {
         .scrollBar(BarState.Off)
         .width("35%")
         .height("100%")
-        .alignRules({
-          top: { anchor: '__container__', align: VerticalAlign.Top },
-          left: { anchor: '__container__', align: HorizontalAlign.Start }
-        })
         .translate({
           x: this.menuVisible ? 0 : -400
         })
@@ -87,13 +83,18 @@ export struct SettingsPage {
           duration: 300,
           curve: Curve.EaseOut
         })
+
+        Column() {
+        }
+        .layoutWeight(1)
+        .height("100%")
+        .onClick(() => {
+          this.pageStack.pop(true)
+        })
       }
       .width("100%")
       .height("100%")
       .padding(20)
-      .onClick(() => {
-        this.pageStack.pop(true)
-      })
       .backgroundColor('#88000000')
     }
     .onReady((context) => {

--- a/entry/src/main/ets/pages/settings/Index.ets
+++ b/entry/src/main/ets/pages/settings/Index.ets
@@ -7,6 +7,7 @@ import { WebDAVConfigBuilder } from "./builders/WebDAVConfigBuilder"
 import { SMBConfigBuilder } from "./builders/SMBConfigBuilder"
 import { DirectorySelectorBuilder } from "./builders/DirectorySelectorBuilder"
 import { SmbDirectorySelectorBuilder } from "./builders/SmbDirectorySelectorBuilder"
+import { SubtitleLanguagePreferenceBuilder } from "./builders/SubtitleLanguagePreferenceBuilder"
 import { SettingsController } from "./SettingsController"
 import SettingType from "./SettingType"
 
@@ -65,6 +66,9 @@ export struct SettingsPage {
             }
             if (this.controller.type === SettingType.RESOURCE_LIBRARY) {
               ResourceLibrarySettingBuilder()
+            }
+            if (this.controller.type === SettingType.SUBTITLE_LANGUAGE_PREFERENCE) {
+              SubtitleLanguagePreferenceBuilder()
             }
           }
         }

--- a/entry/src/main/ets/pages/settings/SettingContainer.ets
+++ b/entry/src/main/ets/pages/settings/SettingContainer.ets
@@ -26,13 +26,6 @@ export struct SettingContainer {
       .backgroundColor("#222222")
     }
     .id("menuContainer")
-    .onClick((event) => {
-      try {
-        event.preventDefault()
-      } catch (error) {
-        // TODO: Implement error handling.
-      }
-    })
     .backgroundColor("#222222")
     .width("100%")
     .height("100%")

--- a/entry/src/main/ets/pages/settings/SettingType.ets
+++ b/entry/src/main/ets/pages/settings/SettingType.ets
@@ -8,4 +8,5 @@ export default class SettingType {
   static SMB_CONFIG = "smbConfig" // SMB 配置
   static DIRECTORY_SELECTOR = "directorySelector" // WebDAV 文件夹选择器
   static SMB_DIRECTORY_SELECTOR = "smbDirectorySelector" // SMB 文件夹选择器
+  static SUBTITLE_LANGUAGE_PREFERENCE = "subtitleLanguagePreference" // 字幕语言偏好
 }

--- a/entry/src/main/ets/pages/settings/builders/HomeSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/HomeSettingBuilder.ets
@@ -8,6 +8,7 @@ import {
   DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
   loadSubtitleLanguagePreference
 } from "../../../subtitle/SubtitleLanguagePreference";
+import { buildSubtitleLanguagePreferenceEntryModel } from "./HomeSettingBuilderModel";
 
 @Builder
 function vipTitleBuilder() {
@@ -92,14 +93,11 @@ struct HomeSettingBuilderComponent {
       SettingListItemGroup({
         title: "字幕"
       }) {
-        SettingListItem({
-          title: "字幕语言偏好",
-          value: this.isSubtitleLanguageSummaryLoaded ? this.subtitleLanguageSummary : '正在加载…',
-          isLink: true,
-          onItemClick: () => {
-            this.controller.pushType(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
-          }
-        })
+        SettingListItem(buildSubtitleLanguagePreferenceEntryModel(
+          this.controller,
+          this.subtitleLanguageSummary,
+          this.isSubtitleLanguageSummaryLoaded
+        ))
       }
 
       SettingListItemGroup({

--- a/entry/src/main/ets/pages/settings/builders/HomeSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/HomeSettingBuilder.ets
@@ -3,6 +3,11 @@ import { SettingListItemGroup } from "../SettingListItemGroup";
 import { SettingContainer } from "../SettingContainer";
 import { SettingsController } from "../SettingsController";
 import SettingType from "../SettingType";
+import {
+  buildSubtitleLanguagePreferenceSummary,
+  DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
+  loadSubtitleLanguagePreference
+} from "../../../subtitle/SubtitleLanguagePreference";
 
 @Builder
 function vipTitleBuilder() {
@@ -23,6 +28,20 @@ function vipTitleBuilder() {
 @ComponentV2
 struct HomeSettingBuilderComponent {
   @Consumer('settingsController') controller: SettingsController = new SettingsController()
+  @Local subtitleLanguageSummary: string = buildSubtitleLanguagePreferenceSummary(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE)
+
+  aboutToAppear(): void {
+    this.loadSubtitlePreference()
+  }
+
+  private async loadSubtitlePreference(): Promise<void> {
+    try {
+      const preference = await loadSubtitleLanguagePreference()
+      this.subtitleLanguageSummary = buildSubtitleLanguagePreferenceSummary(preference)
+    } catch {
+      this.subtitleLanguageSummary = buildSubtitleLanguagePreferenceSummary(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE)
+    }
+  }
 
   build() {
     SettingContainer({
@@ -64,6 +83,19 @@ struct HomeSettingBuilderComponent {
           onItemClick: () => {
             this.controller.pushType(SettingType.RESOURCE_LIBRARY)
           },
+        })
+      }
+
+      SettingListItemGroup({
+        title: "字幕"
+      }) {
+        SettingListItem({
+          title: "字幕语言偏好",
+          value: this.subtitleLanguageSummary,
+          isLink: true,
+          onItemClick: () => {
+            this.controller.pushType(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
+          }
         })
       }
 

--- a/entry/src/main/ets/pages/settings/builders/HomeSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/HomeSettingBuilder.ets
@@ -29,6 +29,7 @@ function vipTitleBuilder() {
 struct HomeSettingBuilderComponent {
   @Consumer('settingsController') controller: SettingsController = new SettingsController()
   @Local subtitleLanguageSummary: string = buildSubtitleLanguagePreferenceSummary(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE)
+  @Local isSubtitleLanguageSummaryLoaded: boolean = false
 
   aboutToAppear(): void {
     this.loadSubtitlePreference()
@@ -38,8 +39,10 @@ struct HomeSettingBuilderComponent {
     try {
       const preference = await loadSubtitleLanguagePreference()
       this.subtitleLanguageSummary = buildSubtitleLanguagePreferenceSummary(preference)
+      this.isSubtitleLanguageSummaryLoaded = true
     } catch {
       this.subtitleLanguageSummary = buildSubtitleLanguagePreferenceSummary(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE)
+      this.isSubtitleLanguageSummaryLoaded = true
     }
   }
 
@@ -91,7 +94,7 @@ struct HomeSettingBuilderComponent {
       }) {
         SettingListItem({
           title: "字幕语言偏好",
-          value: this.subtitleLanguageSummary,
+          value: this.isSubtitleLanguageSummaryLoaded ? this.subtitleLanguageSummary : '正在加载…',
           isLink: true,
           onItemClick: () => {
             this.controller.pushType(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)

--- a/entry/src/main/ets/pages/settings/builders/HomeSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/HomeSettingBuilder.ets
@@ -8,7 +8,10 @@ import {
   DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
   loadSubtitleLanguagePreference
 } from "../../../subtitle/SubtitleLanguagePreference";
-import { buildSubtitleLanguagePreferenceEntryModel } from "./HomeSettingBuilderModel";
+import {
+  buildSubtitleLanguagePreferenceEntryValue,
+  navigateToSubtitleLanguagePreference
+} from "./HomeSettingBuilderModel";
 
 @Builder
 function vipTitleBuilder() {
@@ -93,11 +96,20 @@ struct HomeSettingBuilderComponent {
       SettingListItemGroup({
         title: "字幕"
       }) {
-        SettingListItem(buildSubtitleLanguagePreferenceEntryModel(
-          this.controller,
-          this.subtitleLanguageSummary,
-          this.isSubtitleLanguageSummaryLoaded
-        ))
+        SettingListItem({
+          title: "字幕语言偏好",
+          value: buildSubtitleLanguagePreferenceEntryValue(
+            this.subtitleLanguageSummary,
+            this.isSubtitleLanguageSummaryLoaded
+          ),
+          isLink: true,
+          onItemClick: () => {
+            navigateToSubtitleLanguagePreference(this.controller)
+          },
+          onRightIconClick: () => {
+            navigateToSubtitleLanguagePreference(this.controller)
+          }
+        })
       }
 
       SettingListItemGroup({

--- a/entry/src/main/ets/pages/settings/builders/HomeSettingBuilderModel.ets
+++ b/entry/src/main/ets/pages/settings/builders/HomeSettingBuilderModel.ets
@@ -1,0 +1,25 @@
+import { SettingsController } from "../SettingsController";
+import SettingType from "../SettingType";
+
+export interface HomeSettingListItemModel {
+  title: string
+  value: string
+  isLink: boolean
+  onItemClick: () => void
+  onRightIconClick: () => void
+}
+
+export function buildSubtitleLanguagePreferenceEntryModel(controller: SettingsController, subtitleLanguageSummary: string,
+  isSubtitleLanguageSummaryLoaded: boolean): HomeSettingListItemModel {
+  const navigateToSubtitleLanguagePreference = (): void => {
+    controller.pushType(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
+  }
+
+  return {
+    title: "字幕语言偏好",
+    value: isSubtitleLanguageSummaryLoaded ? subtitleLanguageSummary : "正在加载…",
+    isLink: true,
+    onItemClick: navigateToSubtitleLanguagePreference,
+    onRightIconClick: navigateToSubtitleLanguagePreference
+  }
+}

--- a/entry/src/main/ets/pages/settings/builders/HomeSettingBuilderModel.ets
+++ b/entry/src/main/ets/pages/settings/builders/HomeSettingBuilderModel.ets
@@ -1,25 +1,11 @@
-import { SettingsController } from "../SettingsController";
-import SettingType from "../SettingType";
+import { SettingsController } from "../SettingsController"
+import SettingType from "../SettingType"
 
-export interface HomeSettingListItemModel {
-  title: string
-  value: string
-  isLink: boolean
-  onItemClick: () => void
-  onRightIconClick: () => void
+export function buildSubtitleLanguagePreferenceEntryValue(subtitleLanguageSummary: string,
+  isSubtitleLanguageSummaryLoaded: boolean): string {
+  return isSubtitleLanguageSummaryLoaded ? subtitleLanguageSummary : "正在加载…"
 }
 
-export function buildSubtitleLanguagePreferenceEntryModel(controller: SettingsController, subtitleLanguageSummary: string,
-  isSubtitleLanguageSummaryLoaded: boolean): HomeSettingListItemModel {
-  const navigateToSubtitleLanguagePreference = (): void => {
-    controller.pushType(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
-  }
-
-  return {
-    title: "字幕语言偏好",
-    value: isSubtitleLanguageSummaryLoaded ? subtitleLanguageSummary : "正在加载…",
-    isLink: true,
-    onItemClick: navigateToSubtitleLanguagePreference,
-    onRightIconClick: navigateToSubtitleLanguagePreference
-  }
+export function navigateToSubtitleLanguagePreference(controller: SettingsController): void {
+  controller.pushType(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
 }

--- a/entry/src/main/ets/pages/settings/builders/SubtitleLanguagePreferenceBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/SubtitleLanguagePreferenceBuilder.ets
@@ -1,0 +1,276 @@
+import { SettingContainer } from "../SettingContainer"
+import { SettingListItemGroup } from "../SettingListItemGroup"
+import {
+  buildSubtitleLanguagePreferenceSummary,
+  DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
+  getSubtitleLanguageDisplayName,
+  loadSubtitleLanguagePreference,
+  moveSubtitleLanguagePreference,
+  saveSubtitleLanguagePreference,
+  SubtitleLanguageOption,
+  SubtitleLanguagePreference,
+  SUBTITLE_LANGUAGE_OPTIONS
+} from "../../../subtitle/SubtitleLanguagePreference"
+import { KeyCode } from '@kit.InputKit'
+
+@ComponentV2
+struct SubtitleLanguagePreferenceBuilderComponent {
+  @Local selectedLanguages: string[] = [...DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.languages]
+  @Local hideOtherLanguages: boolean = DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.hideOtherLanguages
+
+  aboutToAppear(): void {
+    this.loadPreference()
+  }
+
+  private async loadPreference(): Promise<void> {
+    try {
+      const preference = await loadSubtitleLanguagePreference()
+      this.selectedLanguages = [...preference.languages]
+      this.hideOtherLanguages = preference.hideOtherLanguages
+    } catch {
+      this.selectedLanguages = [...DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.languages]
+      this.hideOtherLanguages = DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.hideOtherLanguages
+    }
+  }
+
+  private buildPreference(): SubtitleLanguagePreference {
+    const preference: SubtitleLanguagePreference = {
+      languages: [...this.selectedLanguages],
+      hideOtherLanguages: this.hideOtherLanguages
+    }
+    return preference
+  }
+
+  private getLanguageRank(languageCode: string): number {
+    return this.selectedLanguages.indexOf(languageCode)
+  }
+
+  private isLanguageSelected(languageCode: string): boolean {
+    return this.getLanguageRank(languageCode) >= 0
+  }
+
+  private canMoveLanguageUp(languageCode: string): boolean {
+    return this.getLanguageRank(languageCode) > 0
+  }
+
+  private canMoveLanguageDown(languageCode: string): boolean {
+    const rank = this.getLanguageRank(languageCode)
+    return rank >= 0 && rank < this.selectedLanguages.length - 1
+  }
+
+  private getDisplayOptions(): SubtitleLanguageOption[] {
+    const selectedOptions: SubtitleLanguageOption[] = []
+    const remainingOptions: SubtitleLanguageOption[] = []
+    for (let index = 0; index < this.selectedLanguages.length; index++) {
+      const languageCode = this.selectedLanguages[index]
+      for (let optionIndex = 0; optionIndex < SUBTITLE_LANGUAGE_OPTIONS.length; optionIndex++) {
+        const option = SUBTITLE_LANGUAGE_OPTIONS[optionIndex]
+        if (option.code === languageCode) {
+          selectedOptions.push(option)
+          break
+        }
+      }
+    }
+    for (let optionIndex = 0; optionIndex < SUBTITLE_LANGUAGE_OPTIONS.length; optionIndex++) {
+      const option = SUBTITLE_LANGUAGE_OPTIONS[optionIndex]
+      if (!this.selectedLanguages.includes(option.code)) {
+        remainingOptions.push(option)
+      }
+    }
+    return [...selectedOptions, ...remainingOptions]
+  }
+
+  private showToast(message: string): void {
+    try {
+      this.getUIContext().getPromptAction().showToast({
+        message,
+        duration: 1500
+      })
+    } catch {
+      console.warn(`[SubtitleLanguagePreferenceBuilder] toast failed: ${message}`)
+    }
+  }
+
+  private async persistPreference(successMessage: string): Promise<void> {
+    await saveSubtitleLanguagePreference(this.buildPreference())
+    this.showToast(successMessage)
+  }
+
+  private async toggleLanguage(languageCode: string): Promise<void> {
+    if (this.isLanguageSelected(languageCode)) {
+      if (this.selectedLanguages.length === 1) {
+        this.showToast('至少保留 1 种语言')
+        return
+      }
+      this.selectedLanguages = this.selectedLanguages.filter((code: string) => code !== languageCode)
+      await this.persistPreference('已更新字幕语言偏好')
+      return
+    }
+
+    if (this.selectedLanguages.length >= 3) {
+      this.showToast('最多选择 3 种语言')
+      return
+    }
+    this.selectedLanguages = [...this.selectedLanguages, languageCode]
+    await this.persistPreference('已添加字幕语言')
+  }
+
+  private async moveLanguage(languageCode: string, direction: 'up' | 'down'): Promise<void> {
+    const nextPreference = moveSubtitleLanguagePreference(this.buildPreference(), languageCode, direction)
+    const beforeSnapshot = this.selectedLanguages.join(',')
+    const afterSnapshot = nextPreference.languages.join(',')
+    if (beforeSnapshot === afterSnapshot) {
+      return
+    }
+    this.selectedLanguages = [...nextPreference.languages]
+    await this.persistPreference(direction === 'up' ? '已上移语言优先级' : '已下移语言优先级')
+  }
+
+  private async updateHideOtherLanguages(isEnabled: boolean): Promise<void> {
+    this.hideOtherLanguages = isEnabled
+    await this.persistPreference(isEnabled ? '已隐藏非偏好语言' : '已显示全部语言')
+  }
+
+  private handleLanguageKeyEvent(languageCode: string, event: KeyEvent): void {
+    if (event.type !== KeyType.Down) {
+      return
+    }
+    if (event.keyCode === KeyCode.KEYCODE_DPAD_UP && this.canMoveLanguageUp(languageCode)) {
+      this.moveLanguage(languageCode, 'up')
+      return
+    }
+    if (event.keyCode === KeyCode.KEYCODE_DPAD_DOWN && this.canMoveLanguageDown(languageCode)) {
+      this.moveLanguage(languageCode, 'down')
+      return
+    }
+    if (event.keyCode === KeyCode.KEYCODE_DPAD_CENTER || event.keyCode === KeyCode.KEYCODE_ENTER) {
+      this.toggleLanguage(languageCode)
+    }
+  }
+
+  build() {
+    SettingContainer({
+      title: "字幕语言偏好"
+    }) {
+      SettingListItemGroup({
+        title: "当前配置"
+      }) {
+        ListItem() {
+          Column({ space: 8 }) {
+            Text(buildSubtitleLanguagePreferenceSummary(this.buildPreference()))
+              .fontSize(16)
+              .fontColor('#F5F5F5')
+              .maxLines(2)
+              .textOverflow({ overflow: TextOverflow.Ellipsis })
+            Text('最多选择 3 种语言；方向键聚焦到已选择语言后，可直接用上下键调整优先级。')
+              .fontSize(13)
+              .fontColor('#A0A0A0')
+              .maxLines(3)
+          }
+          .width('100%')
+          .alignItems(HorizontalAlign.Start)
+          .padding({ left: 16, right: 16, top: 16, bottom: 16 })
+          .backgroundColor('#333333')
+          .borderRadius(8)
+        }
+      }
+
+      SettingListItemGroup({
+        title: "语言优先级"
+      }) {
+        ForEach(this.getDisplayOptions(), (option: SubtitleLanguageOption) => {
+          ListItem() {
+            Row({ space: 12 }) {
+              Checkbox()
+                .select(this.isLanguageSelected(option.code))
+                .selectedColor('#4CAF50')
+                .onChange(() => {
+                  this.toggleLanguage(option.code)
+                })
+
+              Column({ space: 6 }) {
+                Text(option.label)
+                  .fontSize(16)
+                  .fontColor('#F5F5F5')
+                Text(this.isLanguageSelected(option.code)
+                  ? `优先级 #${this.getLanguageRank(option.code) + 1} · 搜索参数 ${option.code}`
+                  : `未启用 · 搜索参数 ${option.code}`)
+                  .fontSize(12)
+                  .fontColor('#A0A0A0')
+              }
+              .layoutWeight(1)
+              .alignItems(HorizontalAlign.Start)
+
+              if (this.isLanguageSelected(option.code)) {
+                Row({ space: 8 }) {
+                  Button('上移')
+                    .height(32)
+                    .fontSize(13)
+                    .enabled(this.canMoveLanguageUp(option.code))
+                    .onClick(() => {
+                      this.moveLanguage(option.code, 'up')
+                    })
+                  Button('下移')
+                    .height(32)
+                    .fontSize(13)
+                    .enabled(this.canMoveLanguageDown(option.code))
+                    .onClick(() => {
+                      this.moveLanguage(option.code, 'down')
+                    })
+                }
+              } else {
+                Text('可添加')
+                  .fontSize(12)
+                  .fontColor('#6F6F6F')
+              }
+            }
+            .width('100%')
+            .padding({ left: 16, right: 16, top: 14, bottom: 14 })
+            .alignItems(VerticalAlign.Center)
+            .backgroundColor('#333333')
+            .borderRadius(8)
+            .focusable(true)
+            .onKeyEvent((event: KeyEvent) => {
+              this.handleLanguageKeyEvent(option.code, event)
+            })
+          }
+        }, (option: SubtitleLanguageOption) => option.code)
+      }
+
+      SettingListItemGroup({
+        title: "结果过滤"
+      }) {
+        ListItem() {
+          Row({ space: 12 }) {
+            Column({ space: 6 }) {
+              Text('隐藏非偏好语言')
+                .fontSize(16)
+                .fontColor('#F5F5F5')
+              Text('开启后，后续字幕搜索结果只保留偏好语言；关闭时保留全部结果但优先语言置顶。')
+                .fontSize(12)
+                .fontColor('#A0A0A0')
+                .maxLines(3)
+            }
+            .layoutWeight(1)
+            .alignItems(HorizontalAlign.Start)
+
+            Toggle({ type: ToggleType.Switch, isOn: this.hideOtherLanguages })
+              .onChange((isOn: boolean) => {
+                this.updateHideOtherLanguages(isOn)
+              })
+          }
+          .width('100%')
+          .padding({ left: 16, right: 16, top: 16, bottom: 16 })
+          .alignItems(VerticalAlign.Center)
+          .backgroundColor('#333333')
+          .borderRadius(8)
+        }
+      }
+    }
+  }
+}
+
+@Builder
+export function SubtitleLanguagePreferenceBuilder() {
+  SubtitleLanguagePreferenceBuilderComponent()
+}

--- a/entry/src/main/ets/pages/settings/builders/SubtitleLanguagePreferenceBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/SubtitleLanguagePreferenceBuilder.ets
@@ -1,10 +1,10 @@
 import { SettingContainer } from "../SettingContainer"
 import { SettingListItemGroup } from "../SettingListItemGroup"
 import {
+  beginSubtitleLanguagePreferenceLoad,
   buildSubtitleLanguageActions,
   buildSubtitleLanguagePreferenceSummary,
   DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
-  getSubtitleLanguageDisplayName,
   loadSubtitleLanguagePreference,
   moveSubtitleLanguagePreference,
   saveSubtitleLanguagePreference,
@@ -30,8 +30,10 @@ struct SubtitleLanguagePreferenceBuilderComponent {
 
   private async loadPreference(): Promise<void> {
     this.isPreferenceLoaded = false
-    this.preferenceLoadVersion += 1
-    const currentLoadVersion = this.preferenceLoadVersion
+    const nextLoadContext = beginSubtitleLanguagePreferenceLoad(this.preferenceLoadVersion)
+    this.preferenceLoadVersion = nextLoadContext.loadVersion
+    this.hasLocalPreferenceChange = nextLoadContext.hasLocalChanges
+    const currentLoadVersion = nextLoadContext.loadVersion
     try {
       const preference = await loadSubtitleLanguagePreference()
       if (!shouldApplySubtitleLanguagePreferenceLoad(
@@ -72,15 +74,6 @@ struct SubtitleLanguagePreferenceBuilderComponent {
 
   private isLanguageSelected(languageCode: string): boolean {
     return this.getLanguageRank(languageCode) >= 0
-  }
-
-  private canMoveLanguageUp(languageCode: string): boolean {
-    return this.getLanguageRank(languageCode) > 0
-  }
-
-  private canMoveLanguageDown(languageCode: string): boolean {
-    const rank = this.getLanguageRank(languageCode)
-    return rank >= 0 && rank < this.selectedLanguages.length - 1
   }
 
   private getDisplayOptions(): SubtitleLanguageOption[] {

--- a/entry/src/main/ets/pages/settings/builders/SubtitleLanguagePreferenceBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/SubtitleLanguagePreferenceBuilder.ets
@@ -7,6 +7,7 @@ import {
   loadSubtitleLanguagePreference,
   moveSubtitleLanguagePreference,
   saveSubtitleLanguagePreference,
+  shouldApplySubtitleLanguagePreferenceLoad,
   SubtitleLanguageOption,
   SubtitleLanguagePreference,
   SUBTITLE_LANGUAGE_OPTIONS
@@ -17,19 +18,41 @@ import { KeyCode } from '@kit.InputKit'
 struct SubtitleLanguagePreferenceBuilderComponent {
   @Local selectedLanguages: string[] = [...DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.languages]
   @Local hideOtherLanguages: boolean = DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.hideOtherLanguages
+  @Local isPreferenceLoaded: boolean = false
+  private preferenceLoadVersion: number = 0
+  private hasLocalPreferenceChange: boolean = false
 
   aboutToAppear(): void {
     this.loadPreference()
   }
 
   private async loadPreference(): Promise<void> {
+    this.isPreferenceLoaded = false
+    this.preferenceLoadVersion += 1
+    const currentLoadVersion = this.preferenceLoadVersion
     try {
       const preference = await loadSubtitleLanguagePreference()
+      if (!shouldApplySubtitleLanguagePreferenceLoad(
+        currentLoadVersion,
+        this.preferenceLoadVersion,
+        this.hasLocalPreferenceChange
+      )) {
+        return
+      }
       this.selectedLanguages = [...preference.languages]
       this.hideOtherLanguages = preference.hideOtherLanguages
+      this.isPreferenceLoaded = true
     } catch {
+      if (!shouldApplySubtitleLanguagePreferenceLoad(
+        currentLoadVersion,
+        this.preferenceLoadVersion,
+        this.hasLocalPreferenceChange
+      )) {
+        return
+      }
       this.selectedLanguages = [...DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.languages]
       this.hideOtherLanguages = DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.hideOtherLanguages
+      this.isPreferenceLoaded = true
     }
   }
 
@@ -91,12 +114,24 @@ struct SubtitleLanguagePreferenceBuilderComponent {
     }
   }
 
+  private ensurePreferenceLoaded(): boolean {
+    if (this.isPreferenceLoaded) {
+      return true
+    }
+    this.showToast('正在读取已保存配置')
+    return false
+  }
+
   private async persistPreference(successMessage: string): Promise<void> {
+    this.hasLocalPreferenceChange = true
     await saveSubtitleLanguagePreference(this.buildPreference())
     this.showToast(successMessage)
   }
 
   private async toggleLanguage(languageCode: string): Promise<void> {
+    if (!this.ensurePreferenceLoaded()) {
+      return
+    }
     if (this.isLanguageSelected(languageCode)) {
       if (this.selectedLanguages.length === 1) {
         this.showToast('至少保留 1 种语言')
@@ -116,6 +151,9 @@ struct SubtitleLanguagePreferenceBuilderComponent {
   }
 
   private async moveLanguage(languageCode: string, direction: 'up' | 'down'): Promise<void> {
+    if (!this.ensurePreferenceLoaded()) {
+      return
+    }
     const nextPreference = moveSubtitleLanguagePreference(this.buildPreference(), languageCode, direction)
     const beforeSnapshot = this.selectedLanguages.join(',')
     const afterSnapshot = nextPreference.languages.join(',')
@@ -127,6 +165,9 @@ struct SubtitleLanguagePreferenceBuilderComponent {
   }
 
   private async updateHideOtherLanguages(isEnabled: boolean): Promise<void> {
+    if (!this.ensurePreferenceLoaded()) {
+      return
+    }
     this.hideOtherLanguages = isEnabled
     await this.persistPreference(isEnabled ? '已隐藏非偏好语言' : '已显示全部语言')
   }
@@ -141,10 +182,6 @@ struct SubtitleLanguagePreferenceBuilderComponent {
     }
     if (event.keyCode === KeyCode.KEYCODE_DPAD_DOWN && this.canMoveLanguageDown(languageCode)) {
       this.moveLanguage(languageCode, 'down')
-      return
-    }
-    if (event.keyCode === KeyCode.KEYCODE_DPAD_CENTER || event.keyCode === KeyCode.KEYCODE_ENTER) {
-      this.toggleLanguage(languageCode)
     }
   }
 
@@ -157,7 +194,9 @@ struct SubtitleLanguagePreferenceBuilderComponent {
       }) {
         ListItem() {
           Column({ space: 8 }) {
-            Text(buildSubtitleLanguagePreferenceSummary(this.buildPreference()))
+            Text(this.isPreferenceLoaded
+              ? buildSubtitleLanguagePreferenceSummary(this.buildPreference())
+              : '正在加载字幕语言偏好…')
               .fontSize(16)
               .fontColor('#F5F5F5')
               .maxLines(2)
@@ -178,63 +217,67 @@ struct SubtitleLanguagePreferenceBuilderComponent {
       SettingListItemGroup({
         title: "语言优先级"
       }) {
-        ForEach(this.getDisplayOptions(), (option: SubtitleLanguageOption) => {
+        if (!this.isPreferenceLoaded) {
           ListItem() {
-            Row({ space: 12 }) {
-              Checkbox()
-                .select(this.isLanguageSelected(option.code))
-                .selectedColor('#4CAF50')
-                .onChange(() => {
-                  this.toggleLanguage(option.code)
-                })
-
-              Column({ space: 6 }) {
-                Text(option.label)
-                  .fontSize(16)
-                  .fontColor('#F5F5F5')
-                Text(this.isLanguageSelected(option.code)
-                  ? `优先级 #${this.getLanguageRank(option.code) + 1} · 搜索参数 ${option.code}`
-                  : `未启用 · 搜索参数 ${option.code}`)
-                  .fontSize(12)
-                  .fontColor('#A0A0A0')
-              }
-              .layoutWeight(1)
-              .alignItems(HorizontalAlign.Start)
-
-              if (this.isLanguageSelected(option.code)) {
-                Row({ space: 8 }) {
-                  Button('上移')
-                    .height(32)
-                    .fontSize(13)
-                    .enabled(this.canMoveLanguageUp(option.code))
-                    .onClick(() => {
-                      this.moveLanguage(option.code, 'up')
-                    })
-                  Button('下移')
-                    .height(32)
-                    .fontSize(13)
-                    .enabled(this.canMoveLanguageDown(option.code))
-                    .onClick(() => {
-                      this.moveLanguage(option.code, 'down')
-                    })
-                }
-              } else {
-                Text('可添加')
-                  .fontSize(12)
-                  .fontColor('#6F6F6F')
-              }
-            }
-            .width('100%')
-            .padding({ left: 16, right: 16, top: 14, bottom: 14 })
-            .alignItems(VerticalAlign.Center)
-            .backgroundColor('#333333')
-            .borderRadius(8)
-            .focusable(true)
-            .onKeyEvent((event: KeyEvent) => {
-              this.handleLanguageKeyEvent(option.code, event)
-            })
+            Text('正在读取已保存配置，请稍候。')
+              .fontSize(14)
+              .fontColor('#A0A0A0')
+              .padding({ left: 16, right: 16, top: 18, bottom: 18 })
           }
-        }, (option: SubtitleLanguageOption) => option.code)
+          .backgroundColor('#333333')
+          .borderRadius(8)
+        } else {
+          ForEach(this.getDisplayOptions(), (option: SubtitleLanguageOption) => {
+            ListItem() {
+              Row({ space: 12 }) {
+                Checkbox()
+                  .select(this.isLanguageSelected(option.code))
+                  .selectedColor('#4CAF50')
+                  .hitTestBehavior(HitTestMode.Transparent)
+
+                Column({ space: 6 }) {
+                  Text(option.label)
+                    .fontSize(16)
+                    .fontColor('#F5F5F5')
+                  Text(this.isLanguageSelected(option.code)
+                    ? `优先级 #${this.getLanguageRank(option.code) + 1} · 搜索参数 ${option.code}`
+                    : `未启用 · 搜索参数 ${option.code}`)
+                    .fontSize(12)
+                    .fontColor('#A0A0A0')
+                }
+                .layoutWeight(1)
+                .alignItems(HorizontalAlign.Start)
+
+                if (this.isLanguageSelected(option.code)) {
+                  Row({ space: 8 }) {
+                    Text(this.canMoveLanguageUp(option.code) ? '↑ 上移' : '↑ 顶部')
+                      .fontSize(12)
+                      .fontColor(this.canMoveLanguageUp(option.code) ? '#F5F5F5' : '#6F6F6F')
+                    Text(this.canMoveLanguageDown(option.code) ? '↓ 下移' : '↓ 底部')
+                      .fontSize(12)
+                      .fontColor(this.canMoveLanguageDown(option.code) ? '#F5F5F5' : '#6F6F6F')
+                  }
+                } else {
+                  Text('按确认键添加')
+                    .fontSize(12)
+                    .fontColor('#6F6F6F')
+                }
+              }
+              .width('100%')
+              .padding({ left: 16, right: 16, top: 14, bottom: 14 })
+              .alignItems(VerticalAlign.Center)
+              .backgroundColor('#333333')
+              .borderRadius(8)
+              .focusable(true)
+              .onClick(() => {
+                this.toggleLanguage(option.code)
+              })
+              .onKeyEvent((event: KeyEvent) => {
+                this.handleLanguageKeyEvent(option.code, event)
+              })
+            }
+          }, (option: SubtitleLanguageOption) => option.code)
+        }
       }
 
       SettingListItemGroup({
@@ -255,6 +298,7 @@ struct SubtitleLanguagePreferenceBuilderComponent {
             .alignItems(HorizontalAlign.Start)
 
             Toggle({ type: ToggleType.Switch, isOn: this.hideOtherLanguages })
+              .enabled(this.isPreferenceLoaded)
               .onChange((isOn: boolean) => {
                 this.updateHideOtherLanguages(isOn)
               })

--- a/entry/src/main/ets/pages/settings/builders/SubtitleLanguagePreferenceBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/SubtitleLanguagePreferenceBuilder.ets
@@ -1,6 +1,7 @@
 import { SettingContainer } from "../SettingContainer"
 import { SettingListItemGroup } from "../SettingListItemGroup"
 import {
+  buildSubtitleLanguageActions,
   buildSubtitleLanguagePreferenceSummary,
   DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
   getSubtitleLanguageDisplayName,
@@ -8,11 +9,12 @@ import {
   moveSubtitleLanguagePreference,
   saveSubtitleLanguagePreference,
   shouldApplySubtitleLanguagePreferenceLoad,
+  SubtitleLanguageAction,
+  SubtitleLanguageActionType,
   SubtitleLanguageOption,
   SubtitleLanguagePreference,
   SUBTITLE_LANGUAGE_OPTIONS
 } from "../../../subtitle/SubtitleLanguagePreference"
-import { KeyCode } from '@kit.InputKit'
 
 @ComponentV2
 struct SubtitleLanguagePreferenceBuilderComponent {
@@ -172,17 +174,28 @@ struct SubtitleLanguagePreferenceBuilderComponent {
     await this.persistPreference(isEnabled ? '已隐藏非偏好语言' : '已显示全部语言')
   }
 
-  private handleLanguageKeyEvent(languageCode: string, event: KeyEvent): void {
-    if (event.type !== KeyType.Down) {
+  private getLanguageActions(languageCode: string): SubtitleLanguageAction[] {
+    return buildSubtitleLanguageActions(this.buildPreference(), languageCode)
+  }
+
+  private async handleLanguageAction(languageCode: string, actionType: SubtitleLanguageActionType): Promise<void> {
+    if (actionType === 'enable' || actionType === 'disable') {
+      await this.toggleLanguage(languageCode)
       return
     }
-    if (event.keyCode === KeyCode.KEYCODE_DPAD_UP && this.canMoveLanguageUp(languageCode)) {
-      this.moveLanguage(languageCode, 'up')
+    if (actionType === 'move-up') {
+      await this.moveLanguage(languageCode, 'up')
       return
     }
-    if (event.keyCode === KeyCode.KEYCODE_DPAD_DOWN && this.canMoveLanguageDown(languageCode)) {
-      this.moveLanguage(languageCode, 'down')
-    }
+    await this.moveLanguage(languageCode, 'down')
+  }
+
+  private getActionButtonFontColor(action: SubtitleLanguageAction): string {
+    return action.enabled ? '#F5F5F5' : '#6F6F6F'
+  }
+
+  private getActionButtonBackgroundColor(action: SubtitleLanguageAction): string {
+    return action.enabled ? '#3F3F3F' : '#2B2B2B'
   }
 
   build() {
@@ -248,19 +261,19 @@ struct SubtitleLanguagePreferenceBuilderComponent {
                 .layoutWeight(1)
                 .alignItems(HorizontalAlign.Start)
 
-                if (this.isLanguageSelected(option.code)) {
-                  Row({ space: 8 }) {
-                    Text(this.canMoveLanguageUp(option.code) ? '↑ 上移' : '↑ 顶部')
+                Row({ space: 8 }) {
+                  ForEach(this.getLanguageActions(option.code), (action: SubtitleLanguageAction) => {
+                    Button(action.label)
+                      .enabled(action.enabled)
                       .fontSize(12)
-                      .fontColor(this.canMoveLanguageUp(option.code) ? '#F5F5F5' : '#6F6F6F')
-                    Text(this.canMoveLanguageDown(option.code) ? '↓ 下移' : '↓ 底部')
-                      .fontSize(12)
-                      .fontColor(this.canMoveLanguageDown(option.code) ? '#F5F5F5' : '#6F6F6F')
-                  }
-                } else {
-                  Text('按确认键添加')
-                    .fontSize(12)
-                    .fontColor('#6F6F6F')
+                      .fontColor(this.getActionButtonFontColor(action))
+                      .backgroundColor(this.getActionButtonBackgroundColor(action))
+                      .borderRadius(8)
+                      .padding({ left: 12, right: 12, top: 8, bottom: 8 })
+                      .onClick(() => {
+                        this.handleLanguageAction(option.code, action.type)
+                      })
+                  }, (action: SubtitleLanguageAction): string => action.type)
                 }
               }
               .width('100%')
@@ -268,13 +281,6 @@ struct SubtitleLanguagePreferenceBuilderComponent {
               .alignItems(VerticalAlign.Center)
               .backgroundColor('#333333')
               .borderRadius(8)
-              .focusable(true)
-              .onClick(() => {
-                this.toggleLanguage(option.code)
-              })
-              .onKeyEvent((event: KeyEvent) => {
-                this.handleLanguageKeyEvent(option.code, event)
-              })
             }
           }, (option: SubtitleLanguageOption) => option.code)
         }

--- a/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
+++ b/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
@@ -166,6 +166,14 @@ export function buildSubtitleSearchPreferenceSnapshot(
   return snapshot
 }
 
+export function shouldApplySubtitleLanguagePreferenceLoad(
+  loadVersion: number,
+  currentLoadVersion: number,
+  hasLocalChanges: boolean
+): boolean {
+  return loadVersion === currentLoadVersion && !hasLocalChanges
+}
+
 function getSubtitleLanguageRank(language: string, preference: SubtitleLanguagePreference): number {
   const normalizedLanguage = language.trim().toLowerCase()
   for (let index = 0; index < preference.languages.length; index++) {

--- a/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
+++ b/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
@@ -31,6 +31,11 @@ export interface SubtitleLanguageSearchPreferenceSnapshot {
   hideOtherLanguages: boolean
 }
 
+export interface SubtitleLanguagePreferenceLoadContext {
+  loadVersion: number
+  hasLocalChanges: boolean
+}
+
 export interface SubtitleTrackLanguageCandidate {
   displayName: string
   language?: string
@@ -220,6 +225,16 @@ export function shouldApplySubtitleLanguagePreferenceLoad(
   hasLocalChanges: boolean
 ): boolean {
   return loadVersion === currentLoadVersion && !hasLocalChanges
+}
+
+export function beginSubtitleLanguagePreferenceLoad(
+  currentLoadVersion: number
+): SubtitleLanguagePreferenceLoadContext {
+  const nextLoadContext: SubtitleLanguagePreferenceLoadContext = {
+    loadVersion: currentLoadVersion + 1,
+    hasLocalChanges: false
+  }
+  return nextLoadContext
 }
 
 function getSubtitleLanguageRank(language: string, preference: SubtitleLanguagePreference): number {

--- a/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
+++ b/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
@@ -1,0 +1,263 @@
+import { AppPreferences, PrefKey } from '../utils/AppPreferences'
+
+export interface SubtitleLanguageOption {
+  code: string
+  label: string
+  searchCodes: string[]
+  resultAliases: string[]
+}
+
+export interface SubtitleLanguagePreference {
+  languages: string[]
+  hideOtherLanguages: boolean
+}
+
+export interface SubtitleSearchResultLike {
+  id: string
+  language: string
+}
+
+export interface SubtitleLanguageSearchPreferenceSnapshot {
+  languages: string[]
+  languagesParam: string
+  hideOtherLanguages: boolean
+}
+
+interface RawSubtitleLanguagePreference {
+  languages?: string[]
+  hideOtherLanguages?: boolean
+}
+
+const MAX_SUBTITLE_LANGUAGE_COUNT: number = 3
+
+export const SUBTITLE_LANGUAGE_OPTIONS: SubtitleLanguageOption[] = [
+  {
+    code: 'zh-CN',
+    label: '简体中文',
+    searchCodes: ['zh-CN'],
+    resultAliases: ['zh-cn', 'zh', 'chi', 'zho', 'chs']
+  },
+  {
+    code: 'zh-TW',
+    label: '繁体中文',
+    searchCodes: ['zh-TW'],
+    resultAliases: ['zh-tw', 'zh-hk', 'cht']
+  },
+  {
+    code: 'en',
+    label: '英语',
+    searchCodes: ['en'],
+    resultAliases: ['en', 'eng']
+  },
+  {
+    code: 'ja',
+    label: '日语',
+    searchCodes: ['ja'],
+    resultAliases: ['ja', 'jpn']
+  },
+  {
+    code: 'ko',
+    label: '韩语',
+    searchCodes: ['ko'],
+    resultAliases: ['ko', 'kor']
+  },
+  {
+    code: 'fr',
+    label: '法语',
+    searchCodes: ['fr'],
+    resultAliases: ['fr', 'fra', 'fre']
+  },
+  {
+    code: 'de',
+    label: '德语',
+    searchCodes: ['de'],
+    resultAliases: ['de', 'deu', 'ger']
+  },
+  {
+    code: 'es',
+    label: '西班牙语',
+    searchCodes: ['es'],
+    resultAliases: ['es', 'spa']
+  }
+]
+
+export const DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE: SubtitleLanguagePreference = {
+  languages: ['zh-CN', 'zh-TW'],
+  hideOtherLanguages: false
+}
+
+function findSubtitleLanguageOption(code: string): SubtitleLanguageOption | null {
+  const normalizedInput = code.trim().toLowerCase()
+  for (let index = 0; index < SUBTITLE_LANGUAGE_OPTIONS.length; index++) {
+    const option = SUBTITLE_LANGUAGE_OPTIONS[index]
+    if (option.code.toLowerCase() === normalizedInput) {
+      return option
+    }
+  }
+  return null
+}
+
+export function getSubtitleLanguageDisplayName(code: string): string {
+  const option = findSubtitleLanguageOption(code)
+  return option === null ? code : option.label
+}
+
+export function normalizeSubtitleLanguagePreference(preference: SubtitleLanguagePreference): SubtitleLanguagePreference {
+  const normalizedLanguages: string[] = []
+  for (let index = 0; index < preference.languages.length; index++) {
+    const option = findSubtitleLanguageOption(preference.languages[index])
+    if (option === null) {
+      continue
+    }
+    if (!normalizedLanguages.includes(option.code)) {
+      normalizedLanguages.push(option.code)
+    }
+    if (normalizedLanguages.length >= MAX_SUBTITLE_LANGUAGE_COUNT) {
+      break
+    }
+  }
+
+  const fallbackLanguages: string[] = normalizedLanguages.length > 0
+    ? normalizedLanguages
+    : [...DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.languages]
+  const normalizedPreference: SubtitleLanguagePreference = {
+    languages: fallbackLanguages,
+    hideOtherLanguages: preference.hideOtherLanguages === true
+  }
+  return normalizedPreference
+}
+
+export function moveSubtitleLanguagePreference(
+  preference: SubtitleLanguagePreference,
+  languageCode: string,
+  direction: 'up' | 'down'
+): SubtitleLanguagePreference {
+  const normalizedPreference = normalizeSubtitleLanguagePreference(preference)
+  const languages = [...normalizedPreference.languages]
+  const index = languages.indexOf(languageCode)
+  if (index < 0) {
+    return normalizedPreference
+  }
+
+  const targetIndex = direction === 'up' ? index - 1 : index + 1
+  if (targetIndex < 0 || targetIndex >= languages.length) {
+    return normalizedPreference
+  }
+
+  const currentValue = languages[index]
+  languages[index] = languages[targetIndex]
+  languages[targetIndex] = currentValue
+  const movedPreference: SubtitleLanguagePreference = {
+    languages,
+    hideOtherLanguages: normalizedPreference.hideOtherLanguages
+  }
+  return movedPreference
+}
+
+export function buildSubtitleSearchPreferenceSnapshot(
+  preference: SubtitleLanguagePreference
+): SubtitleLanguageSearchPreferenceSnapshot {
+  const normalizedPreference = normalizeSubtitleLanguagePreference(preference)
+  const snapshot: SubtitleLanguageSearchPreferenceSnapshot = {
+    languages: [...normalizedPreference.languages],
+    languagesParam: normalizedPreference.languages.join(','),
+    hideOtherLanguages: normalizedPreference.hideOtherLanguages
+  }
+  return snapshot
+}
+
+function getSubtitleLanguageRank(language: string, preference: SubtitleLanguagePreference): number {
+  const normalizedLanguage = language.trim().toLowerCase()
+  for (let index = 0; index < preference.languages.length; index++) {
+    const option = findSubtitleLanguageOption(preference.languages[index])
+    if (option === null) {
+      continue
+    }
+    if (option.resultAliases.includes(normalizedLanguage) || option.code.toLowerCase() === normalizedLanguage) {
+      return index
+    }
+  }
+  return -1
+}
+
+export function applySubtitleLanguagePreferenceToSearchResults<T extends SubtitleSearchResultLike>(
+  results: T[],
+  preference: SubtitleLanguagePreference
+): T[] {
+  const normalizedPreference = normalizeSubtitleLanguagePreference(preference)
+  const preferredBuckets: Array<T[]> = []
+  const fallbackResults: T[] = []
+  const orderedResults: T[] = []
+
+  for (let index = 0; index < normalizedPreference.languages.length; index++) {
+    preferredBuckets.push([])
+  }
+
+  for (let index = 0; index < results.length; index++) {
+    const result = results[index]
+    const rank = getSubtitleLanguageRank(result.language, normalizedPreference)
+    if (rank >= 0) {
+      preferredBuckets[rank].push(result)
+      continue
+    }
+    if (!normalizedPreference.hideOtherLanguages) {
+      fallbackResults.push(result)
+    }
+  }
+
+  for (let index = 0; index < preferredBuckets.length; index++) {
+    const bucket = preferredBuckets[index]
+    for (let bucketIndex = 0; bucketIndex < bucket.length; bucketIndex++) {
+      orderedResults.push(bucket[bucketIndex])
+    }
+  }
+
+  for (let index = 0; index < fallbackResults.length; index++) {
+    orderedResults.push(fallbackResults[index])
+  }
+  return orderedResults
+}
+
+export function buildSubtitleLanguagePreferenceSummary(preference: SubtitleLanguagePreference): string {
+  const normalizedPreference = normalizeSubtitleLanguagePreference(preference)
+  const labels: string[] = []
+  for (let index = 0; index < normalizedPreference.languages.length; index++) {
+    labels.push(getSubtitleLanguageDisplayName(normalizedPreference.languages[index]))
+  }
+  const summary = labels.join(' / ')
+  return normalizedPreference.hideOtherLanguages ? `${summary} · 仅偏好` : summary
+}
+
+export function deserializeSubtitleLanguagePreference(serializedPreference: string): SubtitleLanguagePreference {
+  if (serializedPreference.trim().length === 0) {
+    return normalizeSubtitleLanguagePreference(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE)
+  }
+  try {
+    const rawPreference = JSON.parse(serializedPreference) as RawSubtitleLanguagePreference
+    const preference: SubtitleLanguagePreference = {
+      languages: Array.isArray(rawPreference.languages) ? rawPreference.languages : [],
+      hideOtherLanguages: rawPreference.hideOtherLanguages === true
+    }
+    return normalizeSubtitleLanguagePreference(preference)
+  } catch {
+    return normalizeSubtitleLanguagePreference(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE)
+  }
+}
+
+export async function loadSubtitleLanguagePreference(): Promise<SubtitleLanguagePreference> {
+  const serializedPreference = await AppPreferences.get(PrefKey.SUBTITLE_LANGUAGE_PREFERENCE, '')
+  return deserializeSubtitleLanguagePreference(serializedPreference)
+}
+
+export async function saveSubtitleLanguagePreference(preference: SubtitleLanguagePreference): Promise<void> {
+  const normalizedPreference = normalizeSubtitleLanguagePreference(preference)
+  await AppPreferences.set(
+    PrefKey.SUBTITLE_LANGUAGE_PREFERENCE,
+    JSON.stringify(normalizedPreference)
+  )
+}
+
+export async function loadSubtitleSearchPreferenceSnapshot(): Promise<SubtitleLanguageSearchPreferenceSnapshot> {
+  const preference = await loadSubtitleLanguagePreference()
+  return buildSubtitleSearchPreferenceSnapshot(preference)
+}

--- a/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
+++ b/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
@@ -12,6 +12,14 @@ export interface SubtitleLanguagePreference {
   hideOtherLanguages: boolean
 }
 
+export type SubtitleLanguageActionType = 'enable' | 'disable' | 'move-up' | 'move-down'
+
+export interface SubtitleLanguageAction {
+  type: SubtitleLanguageActionType
+  label: string
+  enabled: boolean
+}
+
 export interface SubtitleSearchResultLike {
   id: string
   language: string
@@ -152,6 +160,41 @@ export function moveSubtitleLanguagePreference(
     hideOtherLanguages: normalizedPreference.hideOtherLanguages
   }
   return movedPreference
+}
+
+export function buildSubtitleLanguageActions(
+  preference: SubtitleLanguagePreference,
+  languageCode: string
+): SubtitleLanguageAction[] {
+  const normalizedPreference = normalizeSubtitleLanguagePreference(preference)
+  const index = normalizedPreference.languages.indexOf(languageCode)
+  if (index < 0) {
+    const enableAction: SubtitleLanguageAction = {
+      type: 'enable',
+      label: '启用',
+      enabled: normalizedPreference.languages.length < MAX_SUBTITLE_LANGUAGE_COUNT
+    }
+    return [enableAction]
+  }
+
+  const actions: SubtitleLanguageAction[] = [
+    {
+      type: 'move-up',
+      label: '上移',
+      enabled: index > 0
+    },
+    {
+      type: 'move-down',
+      label: '下移',
+      enabled: index < normalizedPreference.languages.length - 1
+    },
+    {
+      type: 'disable',
+      label: '取消启用',
+      enabled: normalizedPreference.languages.length > 1
+    }
+  ]
+  return actions
 }
 
 export function buildSubtitleSearchPreferenceSnapshot(

--- a/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
+++ b/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
@@ -31,6 +31,11 @@ export interface SubtitleLanguageSearchPreferenceSnapshot {
   hideOtherLanguages: boolean
 }
 
+export interface SubtitleTrackLanguageCandidate {
+  displayName: string
+  language?: string
+}
+
 interface RawSubtitleLanguagePreference {
   languages?: string[]
   hideOtherLanguages?: boolean
@@ -229,6 +234,98 @@ function getSubtitleLanguageRank(language: string, preference: SubtitleLanguageP
     }
   }
   return -1
+}
+
+function buildSubtitleDisplayMatchKeywords(languageCode: string): string[] {
+  const option = findSubtitleLanguageOption(languageCode)
+  if (option === null) {
+    return []
+  }
+
+  const baseKeywords: string[] = [
+    option.code,
+    option.label
+  ]
+  for (let index = 0; index < option.searchCodes.length; index++) {
+    baseKeywords.push(option.searchCodes[index])
+  }
+  for (let index = 0; index < option.resultAliases.length; index++) {
+    baseKeywords.push(option.resultAliases[index])
+  }
+
+  if (option.code === 'zh-CN') {
+    baseKeywords.push('简体', '简中', 'hans', 'simplified')
+  } else if (option.code === 'zh-TW') {
+    baseKeywords.push('繁体', '繁中', '香港', '臺灣', '台湾', 'hant', 'traditional')
+  } else if (option.code === 'en') {
+    baseKeywords.push('english')
+  } else if (option.code === 'ja') {
+    baseKeywords.push('japanese')
+  } else if (option.code === 'ko') {
+    baseKeywords.push('korean')
+  } else if (option.code === 'fr') {
+    baseKeywords.push('french')
+  } else if (option.code === 'de') {
+    baseKeywords.push('german')
+  } else if (option.code === 'es') {
+    baseKeywords.push('spanish')
+  }
+
+  const keywords: string[] = []
+  for (let index = 0; index < baseKeywords.length; index++) {
+    const keyword = baseKeywords[index].trim().toLowerCase()
+    if (keyword.length === 0 || keywords.includes(keyword)) {
+      continue
+    }
+    keywords.push(keyword)
+  }
+  return keywords
+}
+
+function getSubtitleTrackLanguageRank(
+  track: SubtitleTrackLanguageCandidate,
+  preference: SubtitleLanguagePreference
+): number {
+  const normalizedPreference = normalizeSubtitleLanguagePreference(preference)
+  const languageRank = track.language !== undefined
+    ? getSubtitleLanguageRank(track.language, normalizedPreference)
+    : -1
+  if (languageRank >= 0) {
+    return languageRank
+  }
+
+  const normalizedDisplayName = track.displayName.trim().toLowerCase()
+  for (let index = 0; index < normalizedPreference.languages.length; index++) {
+    const keywords = buildSubtitleDisplayMatchKeywords(normalizedPreference.languages[index])
+    for (let keywordIndex = 0; keywordIndex < keywords.length; keywordIndex++) {
+      if (normalizedDisplayName.includes(keywords[keywordIndex])) {
+        return index
+      }
+    }
+  }
+  return -1
+}
+
+export function findPreferredSubtitleTrackIndex(
+  tracks: SubtitleTrackLanguageCandidate[],
+  preference: SubtitleLanguagePreference
+): number {
+  const normalizedPreference = normalizeSubtitleLanguagePreference(preference)
+  let matchedTrackIndex = -1
+  let matchedTrackRank = normalizedPreference.languages.length
+
+  for (let index = 0; index < tracks.length; index++) {
+    const rank = getSubtitleTrackLanguageRank(tracks[index], normalizedPreference)
+    if (rank < 0) {
+      continue
+    }
+    if (rank < matchedTrackRank) {
+      matchedTrackRank = rank
+      matchedTrackIndex = index
+    }
+  }
+
+  return matchedTrackIndex
 }
 
 export function applySubtitleLanguagePreferenceToSearchResults<T extends SubtitleSearchResultLike>(

--- a/entry/src/main/ets/utils/AppPreferences.ets
+++ b/entry/src/main/ets/utils/AppPreferences.ets
@@ -22,6 +22,8 @@ export class PrefKey {
   static readonly PLAYER_EPISODE_AUTOPLAY_ENABLED = 'player_episode_autoplay_enabled';
   /** 自动切到下一集前的倒计时秒数 */
   static readonly PLAYER_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS = 'player_episode_autoplay_countdown_seconds';
+  /** 字幕语言偏好（JSON 序列化字符串） */
+  static readonly SUBTITLE_LANGUAGE_PREFERENCE = 'subtitle_language_preference';
 }
 
 // ─────────────────────────────────────────────

--- a/entry/src/main/ets/utils/AppPreferences.ets
+++ b/entry/src/main/ets/utils/AppPreferences.ets
@@ -2,6 +2,16 @@ import dataPreferences from '@ohos.data.preferences';
 import { Context } from '@ohos.abilityAccessCtrl';
 import { BusinessError } from '@kit.BasicServicesKit';
 
+export type AppPreferenceValue = string | number;
+
+export interface AppPreferencesStore {
+  get(key: string, defaultValue: AppPreferenceValue): Promise<AppPreferenceValue>;
+  put(key: string, value: AppPreferenceValue): Promise<void>;
+  flush(): Promise<void>;
+}
+
+export type AppPreferencesLoader = (context: Context, storeName: string) => Promise<AppPreferencesStore>;
+
 // ─────────────────────────────────────────────
 // Key 常量
 // ─────────────────────────────────────────────
@@ -32,6 +42,14 @@ export class PrefKey {
 
 const STORE_NAME = 'app_preferences';
 
+const DEFAULT_APP_PREFERENCES_LOADER: AppPreferencesLoader = async (
+  context: Context,
+  storeName: string
+): Promise<AppPreferencesStore> => {
+  const store = await dataPreferences.getPreferences(context, storeName);
+  return store as AppPreferencesStore;
+};
+
 /**
  * 应用偏好设置工具（EL1）
  *
@@ -44,31 +62,68 @@ const STORE_NAME = 'app_preferences';
  * ```
  */
 export class AppPreferences {
-  private static store: dataPreferences.Preferences | null = null;
+  private static store: AppPreferencesStore | null = null;
+  private static initPromise: Promise<void> | null = null;
+  private static storeLoader: AppPreferencesLoader = DEFAULT_APP_PREFERENCES_LOADER;
+
+  static setStoreLoaderForTesting(loader: AppPreferencesLoader | null): void {
+    AppPreferences.storeLoader = loader ?? DEFAULT_APP_PREFERENCES_LOADER;
+    AppPreferences.store = null;
+    AppPreferences.initPromise = null;
+  }
+
+  static resetForTesting(): void {
+    AppPreferences.store = null;
+    AppPreferences.initPromise = null;
+  }
 
   /** 在 EntryAbility.onCreate 里调用一次 */
   static async init(context: Context): Promise<void> {
     if (AppPreferences.store !== null) {
       return;
     }
-    try {
-      AppPreferences.store = await dataPreferences.getPreferences(context, STORE_NAME);
-      console.info('[AppPreferences] 初始化成功');
-    } catch (e) {
-      const err = e as BusinessError;
-      console.error(`[AppPreferences] 初始化失败: ${err.message ?? JSON.stringify(e)}`);
-      throw new Error(`AppPreferences init failed: ${err.message}`);
+    if (AppPreferences.initPromise !== null) {
+      return AppPreferences.initPromise;
     }
+    AppPreferences.initPromise = (async () => {
+      try {
+        AppPreferences.store = await AppPreferences.storeLoader(context, STORE_NAME);
+        console.info('[AppPreferences] 初始化成功');
+      } catch (e) {
+        const err = e as BusinessError;
+        console.error(`[AppPreferences] 初始化失败: ${err.message ?? JSON.stringify(e)}`);
+        throw new Error(`AppPreferences init failed: ${err.message}`);
+      } finally {
+        AppPreferences.initPromise = null;
+      }
+    })();
+    return AppPreferences.initPromise;
+  }
+
+  private static async waitForStore(): Promise<AppPreferencesStore | null> {
+    if (AppPreferences.store !== null) {
+      return AppPreferences.store;
+    }
+    if (AppPreferences.initPromise !== null) {
+      try {
+        await AppPreferences.initPromise;
+      } catch {
+        return null;
+      }
+      return AppPreferences.store;
+    }
+    return null;
   }
 
   /** 读取字符串值 */
   static async get(key: string, defaultValue: string): Promise<string> {
-    if (!AppPreferences.store) {
+    const store = await AppPreferences.waitForStore();
+    if (!store) {
       console.warn(`[AppPreferences] 未初始化，key=${key} 返回默认值`);
       return defaultValue;
     }
     try {
-      const val = await AppPreferences.store.get(key, defaultValue);
+      const val = await store.get(key, defaultValue);
       return val as string;
     } catch {
       return defaultValue;
@@ -77,12 +132,13 @@ export class AppPreferences {
 
   /** 读取数字值 */
   static async getNumber(key: string, defaultValue: number): Promise<number> {
-    if (!AppPreferences.store) {
+    const store = await AppPreferences.waitForStore();
+    if (!store) {
       console.warn(`[AppPreferences] 未初始化，key=${key} 返回默认值`);
       return defaultValue;
     }
     try {
-      const val = await AppPreferences.store.get(key, defaultValue);
+      const val = await store.get(key, defaultValue);
       return val as number;
     } catch {
       return defaultValue;
@@ -91,13 +147,14 @@ export class AppPreferences {
 
   /** 写入值（string 或 number） */
   static async set(key: string, value: string | number): Promise<void> {
-    if (!AppPreferences.store) {
+    const store = await AppPreferences.waitForStore();
+    if (!store) {
       console.warn(`[AppPreferences] 未初始化，key=${key} 写入失败`);
       return;
     }
     try {
-      await AppPreferences.store.put(key, value);
-      await AppPreferences.store.flush();
+      await store.put(key, value);
+      await store.flush();
       console.info(`[AppPreferences] 写入 key=${key}`);
     } catch (e) {
       const err = e as BusinessError;

--- a/entry/src/test/AppPreferences.test.ets
+++ b/entry/src/test/AppPreferences.test.ets
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
+import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
+import { Context } from '@ohos.abilityAccessCtrl';
+import {
+  AppPreferences,
+  AppPreferencesLoader,
+  AppPreferencesStore
+} from '../main/ets/utils/AppPreferences';
+import {
+  loadSubtitleLanguagePreference,
+  saveSubtitleLanguagePreference,
+  SubtitleLanguagePreference
+} from '../main/ets/subtitle/SubtitleLanguagePreference';
+
+class InMemoryAppPreferencesStore implements AppPreferencesStore {
+  private readonly values: Map<string, string | number> = new Map<string, string | number>();
+
+  seed(key: string, value: string | number): void {
+    this.values.set(key, value);
+  }
+
+  async get(key: string, defaultValue: string | number): Promise<string | number> {
+    const value = this.values.get(key);
+    return value === undefined ? defaultValue : value;
+  }
+
+  async put(key: string, value: string | number): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async flush(): Promise<void> {
+  }
+}
+
+class DeferredAppPreferencesLoader {
+  private resolveStore: ((store: AppPreferencesStore) => void) | null = null;
+  readonly promise: Promise<AppPreferencesStore> = new Promise<AppPreferencesStore>((resolve) => {
+    this.resolveStore = resolve;
+  });
+
+  release(store: AppPreferencesStore): void {
+    if (this.resolveStore !== null) {
+      const resolve = this.resolveStore;
+      this.resolveStore = null;
+      resolve(store);
+    }
+  }
+}
+
+export default function appPreferencesTest() {
+  describe('AppPreferences_pending_init', () => {
+    beforeEach(() => {
+      AppPreferences.resetForTesting();
+    });
+
+    afterEach(() => {
+      AppPreferences.setStoreLoaderForTesting(null);
+      AppPreferences.resetForTesting();
+    });
+
+    it('should wait pending init before loading subtitle preference', 0, async () => {
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      const deferredLoader = new DeferredAppPreferencesLoader();
+      const store = new InMemoryAppPreferencesStore();
+      const loader: AppPreferencesLoader = async () => deferredLoader.promise;
+      store.seed('subtitle_language_preference', JSON.stringify({
+        languages: ['en', 'zh-CN'],
+        hideOtherLanguages: true
+      }));
+
+      AppPreferences.setStoreLoaderForTesting(loader);
+      const initPromise = AppPreferences.init(ctx);
+      const loadPromise = loadSubtitleLanguagePreference();
+
+      deferredLoader.release(store);
+      const loadedPreference = await loadPromise;
+      await initPromise;
+
+      expect(loadedPreference.languages.length).assertEqual(2);
+      expect(loadedPreference.languages[0]).assertEqual('en');
+      expect(loadedPreference.languages[1]).assertEqual('zh-CN');
+      expect(loadedPreference.hideOtherLanguages).assertTrue();
+    });
+
+    it('should wait pending init before saving subtitle preference', 0, async () => {
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      const deferredLoader = new DeferredAppPreferencesLoader();
+      const store = new InMemoryAppPreferencesStore();
+      const loader: AppPreferencesLoader = async () => deferredLoader.promise;
+      const nextPreference: SubtitleLanguagePreference = {
+        languages: ['en', 'zh-CN'],
+        hideOtherLanguages: false
+      };
+
+      AppPreferences.setStoreLoaderForTesting(loader);
+      const initPromise = AppPreferences.init(ctx);
+      const savePromise = saveSubtitleLanguagePreference(nextPreference);
+
+      deferredLoader.release(store);
+      await savePromise;
+      await initPromise;
+
+      const loadedPreference = await loadSubtitleLanguagePreference();
+      expect(loadedPreference.languages.length).assertEqual(2);
+      expect(loadedPreference.languages[0]).assertEqual('en');
+      expect(loadedPreference.languages[1]).assertEqual('zh-CN');
+      expect(loadedPreference.hideOtherLanguages).assertFalse();
+    });
+  });
+}

--- a/entry/src/test/HomeSettingBuilderModel.test.ets
+++ b/entry/src/test/HomeSettingBuilderModel.test.ets
@@ -1,7 +1,10 @@
 import { describe, it, expect } from '@ohos/hypium'
 import { SettingsController } from '../main/ets/pages/settings/SettingsController'
 import SettingType from '../main/ets/pages/settings/SettingType'
-import { buildSubtitleLanguagePreferenceEntryModel } from '../main/ets/pages/settings/builders/HomeSettingBuilderModel'
+import {
+  buildSubtitleLanguagePreferenceEntryValue,
+  navigateToSubtitleLanguagePreference
+} from '../main/ets/pages/settings/builders/HomeSettingBuilderModel'
 
 const LONG_SUBTITLE_LANGUAGE_SUMMARY: string =
   '简体中文（中国大陆） > 繁體中文（台灣） > English > 日本語 > 한국어 > Español > Français'
@@ -10,25 +13,32 @@ export default function homeSettingBuilderModelTest() {
   describe('HomeSettingBuilderModel', () => {
     it('首页字幕语言偏好入口右侧摘要区域点击后应进入偏好页', 0, () => {
       const controller = new SettingsController()
-      const entryModel = buildSubtitleLanguagePreferenceEntryModel(controller, '简体中文 > English', true)
 
-      entryModel.onRightIconClick()
+      navigateToSubtitleLanguagePreference(controller)
 
       expect(controller.type).assertEqual(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
     })
 
     it('首页字幕语言偏好入口长摘要文本不应影响整行与右侧区域跳转', 0, () => {
       const controller = new SettingsController()
-      const entryModel = buildSubtitleLanguagePreferenceEntryModel(controller, LONG_SUBTITLE_LANGUAGE_SUMMARY, true)
+      const loadedValue = buildSubtitleLanguagePreferenceEntryValue(LONG_SUBTITLE_LANGUAGE_SUMMARY, true)
 
-      expect(entryModel.value).assertEqual(LONG_SUBTITLE_LANGUAGE_SUMMARY)
+      expect(loadedValue).assertEqual(LONG_SUBTITLE_LANGUAGE_SUMMARY)
 
-      entryModel.onItemClick()
+      navigateToSubtitleLanguagePreference(controller)
       expect(controller.type).assertEqual(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
 
       controller.reset()
-      entryModel.onRightIconClick()
+      navigateToSubtitleLanguagePreference(controller)
       expect(controller.type).assertEqual(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
+    })
+
+    it('首页字幕语言偏好入口在摘要加载完成后应显示已设置语言而不是加载文案', 0, () => {
+      const loadingValue = buildSubtitleLanguagePreferenceEntryValue('简体中文 / 英语', false)
+      const loadedValue = buildSubtitleLanguagePreferenceEntryValue('简体中文 / 英语', true)
+
+      expect(loadingValue).assertEqual('正在加载…')
+      expect(loadedValue).assertEqual('简体中文 / 英语')
     })
   })
 }

--- a/entry/src/test/HomeSettingBuilderModel.test.ets
+++ b/entry/src/test/HomeSettingBuilderModel.test.ets
@@ -1,0 +1,34 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { SettingsController } from '../main/ets/pages/settings/SettingsController'
+import SettingType from '../main/ets/pages/settings/SettingType'
+import { buildSubtitleLanguagePreferenceEntryModel } from '../main/ets/pages/settings/builders/HomeSettingBuilderModel'
+
+const LONG_SUBTITLE_LANGUAGE_SUMMARY: string =
+  '简体中文（中国大陆） > 繁體中文（台灣） > English > 日本語 > 한국어 > Español > Français'
+
+export default function homeSettingBuilderModelTest() {
+  describe('HomeSettingBuilderModel', () => {
+    it('首页字幕语言偏好入口右侧摘要区域点击后应进入偏好页', 0, () => {
+      const controller = new SettingsController()
+      const entryModel = buildSubtitleLanguagePreferenceEntryModel(controller, '简体中文 > English', true)
+
+      entryModel.onRightIconClick()
+
+      expect(controller.type).assertEqual(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
+    })
+
+    it('首页字幕语言偏好入口长摘要文本不应影响整行与右侧区域跳转', 0, () => {
+      const controller = new SettingsController()
+      const entryModel = buildSubtitleLanguagePreferenceEntryModel(controller, LONG_SUBTITLE_LANGUAGE_SUMMARY, true)
+
+      expect(entryModel.value).assertEqual(LONG_SUBTITLE_LANGUAGE_SUMMARY)
+
+      entryModel.onItemClick()
+      expect(controller.type).assertEqual(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
+
+      controller.reset()
+      entryModel.onRightIconClick()
+      expect(controller.type).assertEqual(SettingType.SUBTITLE_LANGUAGE_PREFERENCE)
+    })
+  })
+}

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -19,6 +19,7 @@ import fileExplorerControllerTest from './FileExplorerController.test';
 import fileExplorerAdapterTest from './FileExplorerAdapter.test';
 import imagePreviewSessionControllerTest from './ImagePreviewSessionController.test';
 import subtitleLanguagePreferenceTest from './SubtitleLanguagePreference.test';
+import appPreferencesTest from './AppPreferences.test';
 // 需要真实 Context 和 .so 的集成测试放在 UnitTestBuild 侧（entry 模块本身，包含 native .so）
 // ohosTest(entry_test HAP) 不包含 .so，不能 import VideoScannerUtil / WebDAVClient
 import fileSourceDatabaseTest from './FileSourceDatabase.test';
@@ -46,6 +47,7 @@ export default function testsuite() {
   fileExplorerAdapterTest();
   imagePreviewSessionControllerTest();
   subtitleLanguagePreferenceTest();
+  appPreferencesTest();
   fileSourceDatabaseTest();
   videoScannerTest();
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -18,6 +18,7 @@ import videoPlayerControllerTest from './VideoPlayerController.test';
 import fileExplorerControllerTest from './FileExplorerController.test';
 import fileExplorerAdapterTest from './FileExplorerAdapter.test';
 import imagePreviewSessionControllerTest from './ImagePreviewSessionController.test';
+import subtitleLanguagePreferenceTest from './SubtitleLanguagePreference.test';
 // 需要真实 Context 和 .so 的集成测试放在 UnitTestBuild 侧（entry 模块本身，包含 native .so）
 // ohosTest(entry_test HAP) 不包含 .so，不能 import VideoScannerUtil / WebDAVClient
 import fileSourceDatabaseTest from './FileSourceDatabase.test';
@@ -44,6 +45,7 @@ export default function testsuite() {
   fileExplorerControllerTest();
   fileExplorerAdapterTest();
   imagePreviewSessionControllerTest();
+  subtitleLanguagePreferenceTest();
   fileSourceDatabaseTest();
   videoScannerTest();
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -20,6 +20,7 @@ import fileExplorerAdapterTest from './FileExplorerAdapter.test';
 import imagePreviewSessionControllerTest from './ImagePreviewSessionController.test';
 import subtitleLanguagePreferenceTest from './SubtitleLanguagePreference.test';
 import appPreferencesTest from './AppPreferences.test';
+import homeSettingBuilderModelTest from './HomeSettingBuilderModel.test';
 // 需要真实 Context 和 .so 的集成测试放在 UnitTestBuild 侧（entry 模块本身，包含 native .so）
 // ohosTest(entry_test HAP) 不包含 .so，不能 import VideoScannerUtil / WebDAVClient
 import fileSourceDatabaseTest from './FileSourceDatabase.test';
@@ -48,6 +49,7 @@ export default function testsuite() {
   imagePreviewSessionControllerTest();
   subtitleLanguagePreferenceTest();
   appPreferencesTest();
+  homeSettingBuilderModelTest();
   fileSourceDatabaseTest();
   videoScannerTest();
 }

--- a/entry/src/test/SubtitleBridgeAdapter.test.ets
+++ b/entry/src/test/SubtitleBridgeAdapter.test.ets
@@ -79,6 +79,27 @@ export default function subtitleBridgeAdapterTest() {
       done();
     });
 
+    it('AvSubtitleBridgeAdapter: 无偏好匹配时不自动切换到非偏好字幕', 0, async (done: () => void) => {
+      const player = new MockPlayer();
+      player.trackInfos = [
+        { trackIndex: 0, trackType: 'video' },
+        { trackIndex: 4, trackType: 'subtitle', language: 'eng' }
+      ];
+
+      const adapter = new AvSubtitleBridgeAdapter();
+      const videoData: VideoData = {
+        type: VideoDataType.FILE_URI,
+        videoSrc: 'file:///english-only.mp4'
+      };
+
+      await adapter.init(player, videoData);
+      const state = adapter.getState();
+      expect(state.allSubtitleTracks.length).assertEqual(1);
+      expect(state.activeSubtitleIndex).assertEqual(-1);
+      expect(player.selectedTrack).assertEqual(-99);
+      done();
+    });
+
     it('IjkSubtitleBridgeAdapter: 当前策略下隐藏内嵌字幕轨', 0, async (done: () => void) => {
       const player = new MockPlayer();
       const adapter = new IjkSubtitleBridgeAdapter();

--- a/entry/src/test/SubtitleLanguagePreference.test.ets
+++ b/entry/src/test/SubtitleLanguagePreference.test.ets
@@ -56,8 +56,9 @@ export default function subtitleLanguagePreferenceTest() {
 
       expect(movedUp.languages[0]).assertEqual('en')
       expect(movedUp.languages[1]).assertEqual('zh-CN')
-      expect(movedDown.languages[0]).assertEqual('zh-CN')
-      expect(movedDown.languages[1]).assertEqual('en')
+      expect(movedDown.languages[0]).assertEqual('en')
+      expect(movedDown.languages[1]).assertEqual('ja')
+      expect(movedDown.languages[2]).assertEqual('zh-CN')
     })
 
     it('should expose search snapshot and sort subtitle results by preferred language aliases', 0, () => {

--- a/entry/src/test/SubtitleLanguagePreference.test.ets
+++ b/entry/src/test/SubtitleLanguagePreference.test.ets
@@ -1,6 +1,7 @@
 import { describe, it, expect } from '@ohos/hypium'
 import {
   buildSubtitleLanguageActions,
+  beginSubtitleLanguagePreferenceLoad,
   DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
   applySubtitleLanguagePreferenceToSearchResults,
   buildSubtitleSearchPreferenceSnapshot,
@@ -193,6 +194,13 @@ export default function subtitleLanguagePreferenceTest() {
   describe('SubtitleLanguagePreference async load guard', () => {
     it('用户已修改字幕语言偏好后不再应用旧的异步加载结果', 0, () => {
       expect(shouldApplySubtitleLanguagePreferenceLoad(1, 1, true)).assertFalse()
+    })
+
+    it('字幕偏好页开始新一轮加载时会清除旧的本地修改标记', 0, () => {
+      const nextLoad = beginSubtitleLanguagePreferenceLoad(3)
+
+      expect(nextLoad.loadVersion).assertEqual(4)
+      expect(nextLoad.hasLocalChanges).assertFalse()
     })
 
     it('字幕偏好页重新打开后只接受最新一次加载结果', 0, () => {

--- a/entry/src/test/SubtitleLanguagePreference.test.ets
+++ b/entry/src/test/SubtitleLanguagePreference.test.ets
@@ -1,0 +1,102 @@
+import { describe, it, expect } from '@ohos/hypium'
+import {
+  DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
+  applySubtitleLanguagePreferenceToSearchResults,
+  buildSubtitleSearchPreferenceSnapshot,
+  moveSubtitleLanguagePreference,
+  normalizeSubtitleLanguagePreference,
+  SubtitleLanguagePreference,
+  SubtitleSearchResultLike
+} from '../main/ets/subtitle/SubtitleLanguagePreference'
+
+interface MockSubtitleSearchResult extends SubtitleSearchResultLike {
+  releaseName: string
+}
+
+function createSearchResult(id: string, language: string, releaseName: string): MockSubtitleSearchResult {
+  return {
+    id,
+    language,
+    releaseName
+  }
+}
+
+export default function subtitleLanguagePreferenceTest() {
+  describe('SubtitleLanguagePreference', () => {
+    it('should expose confirmed default subtitle preference', 0, () => {
+      expect(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.languages.length).assertEqual(2)
+      expect(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.languages[0]).assertEqual('zh-CN')
+      expect(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.languages[1]).assertEqual('zh-TW')
+      expect(DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE.hideOtherLanguages).assertFalse()
+    })
+
+    it('should normalize duplicates unsupported codes and keep at most three languages', 0, () => {
+      const rawPreference: SubtitleLanguagePreference = {
+        languages: ['en', 'zh-CN', 'en', 'ja', 'xx', 'fr'],
+        hideOtherLanguages: true
+      }
+
+      const normalized = normalizeSubtitleLanguagePreference(rawPreference)
+
+      expect(normalized.languages.length).assertEqual(3)
+      expect(normalized.languages[0]).assertEqual('en')
+      expect(normalized.languages[1]).assertEqual('zh-CN')
+      expect(normalized.languages[2]).assertEqual('ja')
+      expect(normalized.hideOtherLanguages).assertTrue()
+    })
+
+    it('should move enabled subtitle languages by priority', 0, () => {
+      const preference: SubtitleLanguagePreference = {
+        languages: ['zh-CN', 'en', 'ja'],
+        hideOtherLanguages: false
+      }
+
+      const movedUp = moveSubtitleLanguagePreference(preference, 'en', 'up')
+      const movedDown = moveSubtitleLanguagePreference(movedUp, 'zh-CN', 'down')
+
+      expect(movedUp.languages[0]).assertEqual('en')
+      expect(movedUp.languages[1]).assertEqual('zh-CN')
+      expect(movedDown.languages[0]).assertEqual('zh-CN')
+      expect(movedDown.languages[1]).assertEqual('en')
+    })
+
+    it('should expose search snapshot and sort subtitle results by preferred language aliases', 0, () => {
+      const preference: SubtitleLanguagePreference = {
+        languages: ['zh-CN', 'en'],
+        hideOtherLanguages: false
+      }
+      const results: MockSubtitleSearchResult[] = [
+        createSearchResult('3', 'fra', 'French release'),
+        createSearchResult('2', 'eng', 'English release'),
+        createSearchResult('1', 'chi', 'Chinese release')
+      ]
+
+      const snapshot = buildSubtitleSearchPreferenceSnapshot(preference)
+      const ordered = applySubtitleLanguagePreferenceToSearchResults(results, preference)
+
+      expect(snapshot.languagesParam).assertEqual('zh-CN,en')
+      expect(snapshot.hideOtherLanguages).assertFalse()
+      expect(ordered.length).assertEqual(3)
+      expect(ordered[0].id).assertEqual('1')
+      expect(ordered[1].id).assertEqual('2')
+      expect(ordered[2].id).assertEqual('3')
+    })
+
+    it('should hide non preferred subtitles when hideOtherLanguages is enabled', 0, () => {
+      const preference: SubtitleLanguagePreference = {
+        languages: ['zh-TW'],
+        hideOtherLanguages: true
+      }
+      const results: MockSubtitleSearchResult[] = [
+        createSearchResult('1', 'eng', 'English release'),
+        createSearchResult('2', 'cht', 'Traditional Chinese release'),
+        createSearchResult('3', 'chi', 'Simplified Chinese release')
+      ]
+
+      const filtered = applySubtitleLanguagePreferenceToSearchResults(results, preference)
+
+      expect(filtered.length).assertEqual(1)
+      expect(filtered[0].id).assertEqual('2')
+    })
+  })
+}

--- a/entry/src/test/SubtitleLanguagePreference.test.ets
+++ b/entry/src/test/SubtitleLanguagePreference.test.ets
@@ -5,6 +5,7 @@ import {
   buildSubtitleSearchPreferenceSnapshot,
   moveSubtitleLanguagePreference,
   normalizeSubtitleLanguagePreference,
+  shouldApplySubtitleLanguagePreferenceLoad,
   SubtitleLanguagePreference,
   SubtitleSearchResultLike
 } from '../main/ets/subtitle/SubtitleLanguagePreference'
@@ -98,6 +99,17 @@ export default function subtitleLanguagePreferenceTest() {
 
       expect(filtered.length).assertEqual(1)
       expect(filtered[0].id).assertEqual('2')
+    })
+  })
+
+  describe('SubtitleLanguagePreference async load guard', () => {
+    it('用户已修改字幕语言偏好后不再应用旧的异步加载结果', 0, () => {
+      expect(shouldApplySubtitleLanguagePreferenceLoad(1, 1, true)).assertFalse()
+    })
+
+    it('字幕偏好页重新打开后只接受最新一次加载结果', 0, () => {
+      expect(shouldApplySubtitleLanguagePreferenceLoad(1, 2, false)).assertFalse()
+      expect(shouldApplySubtitleLanguagePreferenceLoad(2, 2, false)).assertTrue()
     })
   })
 }

--- a/entry/src/test/SubtitleLanguagePreference.test.ets
+++ b/entry/src/test/SubtitleLanguagePreference.test.ets
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@ohos/hypium'
 import {
+  buildSubtitleLanguageActions,
   DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
   applySubtitleLanguagePreferenceToSearchResults,
   buildSubtitleSearchPreferenceSnapshot,
@@ -60,6 +61,32 @@ export default function subtitleLanguagePreferenceTest() {
       expect(movedDown.languages[0]).assertEqual('en')
       expect(movedDown.languages[1]).assertEqual('ja')
       expect(movedDown.languages[2]).assertEqual('zh-CN')
+    })
+
+    it('should expose explicit actions for enabled and disabled subtitle languages', 0, () => {
+      const preference: SubtitleLanguagePreference = {
+        languages: ['zh-CN', 'en', 'ja'],
+        hideOtherLanguages: false
+      }
+      const availablePreference: SubtitleLanguagePreference = {
+        languages: ['zh-CN', 'en'],
+        hideOtherLanguages: false
+      }
+
+      const enabledActions = buildSubtitleLanguageActions(preference, 'en')
+      const disabledActions = buildSubtitleLanguageActions(availablePreference, 'fr')
+
+      expect(enabledActions.length).assertEqual(3)
+      expect(enabledActions[0].type).assertEqual('move-up')
+      expect(enabledActions[0].enabled).assertTrue()
+      expect(enabledActions[1].type).assertEqual('move-down')
+      expect(enabledActions[1].enabled).assertTrue()
+      expect(enabledActions[2].type).assertEqual('disable')
+      expect(enabledActions[2].enabled).assertTrue()
+
+      expect(disabledActions.length).assertEqual(1)
+      expect(disabledActions[0].type).assertEqual('enable')
+      expect(disabledActions[0].enabled).assertTrue()
     })
 
     it('should expose search snapshot and sort subtitle results by preferred language aliases', 0, () => {

--- a/entry/src/test/SubtitleLanguagePreference.test.ets
+++ b/entry/src/test/SubtitleLanguagePreference.test.ets
@@ -4,15 +4,20 @@ import {
   DEFAULT_SUBTITLE_LANGUAGE_PREFERENCE,
   applySubtitleLanguagePreferenceToSearchResults,
   buildSubtitleSearchPreferenceSnapshot,
+  findPreferredSubtitleTrackIndex,
   moveSubtitleLanguagePreference,
   normalizeSubtitleLanguagePreference,
   shouldApplySubtitleLanguagePreferenceLoad,
   SubtitleLanguagePreference,
-  SubtitleSearchResultLike
+  SubtitleSearchResultLike,
+  SubtitleTrackLanguageCandidate
 } from '../main/ets/subtitle/SubtitleLanguagePreference'
 
 interface MockSubtitleSearchResult extends SubtitleSearchResultLike {
   releaseName: string
+}
+
+interface MockSubtitleTrackCandidate extends SubtitleTrackLanguageCandidate {
 }
 
 function createSearchResult(id: string, language: string, releaseName: string): MockSubtitleSearchResult {
@@ -21,6 +26,16 @@ function createSearchResult(id: string, language: string, releaseName: string): 
     language,
     releaseName
   }
+}
+
+function createTrackCandidate(displayName: string, language?: string): MockSubtitleTrackCandidate {
+  const candidate: MockSubtitleTrackCandidate = {
+    displayName
+  }
+  if (language !== undefined) {
+    candidate.language = language
+  }
+  return candidate
 }
 
 export default function subtitleLanguagePreferenceTest() {
@@ -126,6 +141,52 @@ export default function subtitleLanguagePreferenceTest() {
 
       expect(filtered.length).assertEqual(1)
       expect(filtered[0].id).assertEqual('2')
+    })
+
+    it('should pick the highest priority subtitle track that matches preferred languages', 0, () => {
+      const preference: SubtitleLanguagePreference = {
+        languages: ['ja', 'en', 'zh-CN'],
+        hideOtherLanguages: false
+      }
+      const tracks: MockSubtitleTrackCandidate[] = [
+        createTrackCandidate('简体中文 (ASS)'),
+        createTrackCandidate('English (SRT)', 'eng'),
+        createTrackCandidate('日语 (ASS)', 'jpn')
+      ]
+
+      const preferredIndex = findPreferredSubtitleTrackIndex(tracks, preference)
+
+      expect(preferredIndex).assertEqual(2)
+    })
+
+    it('should match preferred subtitle language from display name when track language is missing', 0, () => {
+      const preference: SubtitleLanguagePreference = {
+        languages: ['zh-TW', 'en'],
+        hideOtherLanguages: false
+      }
+      const tracks: MockSubtitleTrackCandidate[] = [
+        createTrackCandidate('繁体中文 [外部·ASS]'),
+        createTrackCandidate('English [外部·SRT]')
+      ]
+
+      const preferredIndex = findPreferredSubtitleTrackIndex(tracks, preference)
+
+      expect(preferredIndex).assertEqual(0)
+    })
+
+    it('should keep subtitle disabled when no track matches preferred languages', 0, () => {
+      const preference: SubtitleLanguagePreference = {
+        languages: ['zh-CN', 'zh-TW'],
+        hideOtherLanguages: false
+      }
+      const tracks: MockSubtitleTrackCandidate[] = [
+        createTrackCandidate('English (ASS)', 'eng'),
+        createTrackCandidate('French (SRT)', 'fra')
+      ]
+
+      const preferredIndex = findPreferredSubtitleTrackIndex(tracks, preference)
+
+      expect(preferredIndex).assertEqual(-1)
     })
   })
 


### PR DESCRIPTION
## Summary
- close out Issue #29 for subtitle language preference integration and keep the branch ready for review
- fix the home entry hit area so the subtitle language preference row is fully focusable/clickable on TV
- fix the home summary display so the selected subtitle language preference summary renders correctly
- apply subtitle default selection by user preference during playback; if no preferred track matches, subtitles remain off

## Scope
- setting home entry interaction fix
- setting home summary display fix
- playback default subtitle selection by preference

## Validation
- completed QA verification for the integrated changes
- completed user real-device acceptance for the covered scenarios

## Notes
- this PR is for review only and is not merged
- issue remains open until merge is confirmed

Refs #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Subtitle Language Preference screen and settings entry to pick up to 3 prioritized subtitle languages, reorder them, and persist choices.
  * New "hide non-preference languages" toggle and loading/summary UI with toast feedback.

* **Bug Fixes**
  * Subtitle auto-selection now awaits and respects saved preferences and won’t automatically pick a non-matching track.

* **Tests**
  * Added unit and integration tests covering preference load/save, UI behavior, and selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->