### PR TITLE
修复: 混合目录结构根层分集识别为剧集 #191

### DIFF
--- a/entry/src/main/ets/lib/MediaTypeClassifier.ets
+++ b/entry/src/main/ets/lib/MediaTypeClassifier.ets
@@ -324,6 +324,7 @@ export function formatMediaTypeClassificationSignals(classification: MediaTypeCl
 export function classifyMediaType(input: MediaTypeClassificationInput): MediaTypeClassificationResult {
   const signals: MediaTypeClassificationSignal[] = [];
   const fileNameInfo = input.fileNameInfo;
+  const hasWeakSemanticTitle = isWeakSemanticTitleText(fileNameInfo?.title ?? '');
 
   if (hasStrongTvSignal(fileNameInfo)) {
     appendSignal(
@@ -340,7 +341,7 @@ export function classifyMediaType(input: MediaTypeClassificationInput): MediaTyp
   let tvScore = 0;
 
   if (fileNameInfo !== undefined) {
-    if (isWeakSemanticTitleText(fileNameInfo.title)) {
+    if (hasWeakSemanticTitle) {
       appendSignal(signals, 'file-name', fileNameInfo.title.length > 0 ? fileNameInfo.title : input.fileName, 'weak-semantic-title', 0);
     } else if (hasStrongMovieSignal(fileNameInfo)) {
       const movieSignalWeight = fileNameInfo.year !== undefined ? 80 : 60;
@@ -367,7 +368,7 @@ export function classifyMediaType(input: MediaTypeClassificationInput): MediaTyp
     return createMediaTypeClassificationResult('tv', signals, 'path-tv-semantics');
   }
 
-  if (movieScore >= 70 && movieScore > tvScore) {
+  if (movieScore >= 70 && movieScore > tvScore && !hasWeakSemanticTitle) {
     return createMediaTypeClassificationResult('movie', signals, 'movie-title-or-path');
   }
 
@@ -375,7 +376,7 @@ export function classifyMediaType(input: MediaTypeClassificationInput): MediaTyp
     return createMediaTypeClassificationResult('tv', signals, 'path-tv-semantics');
   }
 
-  if (movieScore > 0 && tvScore === 0 && !isWeakSemanticTitleText(fileNameInfo?.title ?? '')) {
+  if (movieScore > 0 && tvScore === 0 && !hasWeakSemanticTitle) {
     return createMediaTypeClassificationResult('movie', signals, 'movie-title-or-path');
   }
 

--- a/entry/src/main/ets/lib/MediaTypeClassifier.ets
+++ b/entry/src/main/ets/lib/MediaTypeClassifier.ets
@@ -30,6 +30,11 @@ export interface MediaTypeClassificationInput {
   ancestorDirectoryNames: string[];
   pathSegments: string[];
   fileNameInfo?: FileNameSemanticInfo;
+  seasonSiblingDetected?: boolean;
+}
+
+export interface MediaTypeClassificationOptions {
+  seasonSiblingDetected?: boolean;
 }
 
 export interface MediaTypeClassificationResult {
@@ -212,10 +217,10 @@ function hasStrongMovieSignal(fileNameInfo?: FileNameSemanticInfo): boolean {
   return fileNameInfo.year !== undefined || fileNameInfo.title.length >= 2;
 }
 
-function isSeasonDirectorySegment(segment: string): boolean {
+export function isSeasonDirectorySegment(segment: string): boolean {
   const normalizedSegment = normalizeSemanticToken(segment);
   return SEASON_DIRECTORY_PATTERNS.some((pattern: RegExp) => pattern.test(normalizedSegment)) ||
-    /^第\s*\d+\s*季$/.test(segment);
+    /^第\s*[\d一二三四五六七八九十百]+\s*季$/.test(segment);
 }
 
 function isGenericTvSemanticSegment(segment: string): boolean {
@@ -237,7 +242,8 @@ function appendSignal(
 export function buildMediaTypeClassificationInput(
   fileName: string,
   filePath: string,
-  fileNameInfo?: FileNameSemanticInfo
+  fileNameInfo?: FileNameSemanticInfo,
+  options?: MediaTypeClassificationOptions
 ): MediaTypeClassificationInput {
   const rawSegments: string[] = normalizePathSegments(filePath);
   const filePathEndsWithFileName = rawSegments.length > 0 && rawSegments[rawSegments.length - 1] === fileName;
@@ -252,7 +258,8 @@ export function buildMediaTypeClassificationInput(
     parentDirectoryName,
     ancestorDirectoryNames,
     pathSegments,
-    fileNameInfo
+    fileNameInfo,
+    seasonSiblingDetected: options?.seasonSiblingDetected
   };
 }
 
@@ -370,6 +377,17 @@ export function classifyMediaType(input: MediaTypeClassificationInput): MediaTyp
 
   if (movieScore > 0 && tvScore === 0 && !isWeakSemanticTitleText(fileNameInfo?.title ?? '')) {
     return createMediaTypeClassificationResult('movie', signals, 'movie-title-or-path');
+  }
+
+  if (input.seasonSiblingDetected === true && isWeakSemanticTitleText(fileNameInfo?.title ?? input.fileName)) {
+    appendSignal(
+      signals,
+      'path-semantics',
+      input.parentDirectoryName ?? input.filePath,
+      'path:season-sibling-detected',
+      60
+    );
+    return createMediaTypeClassificationResult('tv', signals, 'season-sibling-detected');
   }
 
   return createMediaTypeClassificationResult('unknown', signals, 'insufficient-evidence');

--- a/entry/src/main/ets/lib/MediaTypeClassifier.ets
+++ b/entry/src/main/ets/lib/MediaTypeClassifier.ets
@@ -113,10 +113,10 @@ const WEAK_FILENAME_TOKENS: string[] = [
 ];
 
 const SEASON_DIRECTORY_PATTERNS: RegExp[] = [
-  /^season(\s*\d+)?$/i,
-  /^s\d{1,2}$/i,
-  /^第\s*\d+\s*季$/,
-  /^season\s+\d+$/i
+  /^season(\s*\d+)?/i,
+  /^s\d{1,2}(?:\s|$)/i,
+  /^第\s*\d+\s*季/,
+  /^season\s+\d+/i
 ];
 
 function normalizePathSegments(filePath: string): string[] {
@@ -220,7 +220,7 @@ function hasStrongMovieSignal(fileNameInfo?: FileNameSemanticInfo): boolean {
 export function isSeasonDirectorySegment(segment: string): boolean {
   const normalizedSegment = normalizeSemanticToken(segment);
   return SEASON_DIRECTORY_PATTERNS.some((pattern: RegExp) => pattern.test(normalizedSegment)) ||
-    /^第\s*[\d一二三四五六七八九十百]+\s*季$/.test(segment);
+    /^第\s*[\d一二三四五六七八九十百]+\s*季/.test(segment);
 }
 
 function isGenericTvSemanticSegment(segment: string): boolean {

--- a/entry/src/main/ets/lib/ScrapeClient.ets
+++ b/entry/src/main/ets/lib/ScrapeClient.ets
@@ -637,12 +637,16 @@ export class ScrapeClient {
    * @param fileName 视频文件名，用于解析剧集标题/季集号
    * @param seriesHint 可选，路径中提取出的剧名搜索提示。当文件名标题为空或属于弱语义标题（如纯数字）时优先生效。
    * @param preclassifiedMediaType 可选，入口层已经完成弱语义分类时传入，避免在此处再次被 parseFileName 默认 movie。
+   * @param explicitEpisodeNumber 可选，显式传入的集数。优先于 parseFileName 提取的集数。用于修复弱语义文件名（如 "19 4K.mp4"）。
+   * @param explicitSeasonNumber 可选，显式传入的季数。优先于 parseFileName 提取的季数。未传入时默认为 1（如果有显式集数）。
    * 返回 TvEpisodeScrapeBundle，每项均可能为 null（查不到时）
    */
   async autoScrapeTvEpisode(
     fileName: string,
     seriesHint?: string,
-    preclassifiedMediaType?: 'movie' | 'tv' | 'unknown'
+    preclassifiedMediaType?: 'movie' | 'tv' | 'unknown',
+    explicitEpisodeNumber?: number,
+    explicitSeasonNumber?: number
   ): Promise<TvEpisodeScrapeBundle> {
     const parsed = parseFileName(fileName);
     const empty: TvEpisodeScrapeBundle = { series: null, season: null, episode: null };
@@ -663,7 +667,13 @@ export class ScrapeClient {
     if (effectiveTitle !== parsed.title) {
       console.info(`[ScrapeClient] autoScrapeTvEpisode 使用 seriesHint="${seriesHint}" 作为搜索标题（文件名无剧名）: file="${fileName}"`);
     }
-    console.info(`[ScrapeClient] autoScrapeTvEpisode 开始: file="${fileName}" → title="${effectiveTitle}" S${parsed.seasonNumber ?? '?'}E${parsed.episodeNumber ?? '?'} year=${parsed.year ?? '?'}`);
+
+    // #191 支持显式季集号：优先使用显式参数，回退到 parseFileName 结果
+    // 如果有显式集数但没有显式季数，默认季数为 1
+    const effectiveEpisodeNumber = explicitEpisodeNumber ?? parsed.episodeNumber;
+    const effectiveSeasonNumber = explicitSeasonNumber ?? (explicitEpisodeNumber !== undefined ? 1 : parsed.seasonNumber);
+
+    console.info(`[ScrapeClient] autoScrapeTvEpisode 开始: file="${fileName}" → title="${effectiveTitle}" S${effectiveSeasonNumber ?? '?'}E${effectiveEpisodeNumber ?? '?'} year=${parsed.year ?? '?'}`);
     const searchTitlesLog = buildSearchTitles(effectiveTitle);
     console.info(`[ScrapeClient] autoScrapeTvEpisode 候选标题: ${JSON.stringify(searchTitlesLog)}`);
 
@@ -702,18 +712,18 @@ export class ScrapeClient {
           let season: TvSeasonScrapeResult | null = null;
           let episode: TvEpisodeScrapeResult | null = null;
 
-          if (parsed.seasonNumber !== undefined) {
-            season = await provider.fetchSeason(series.providerId, parsed.seasonNumber, 'zh-CN').catch((e: BusinessError) => {
-              console.warn(`[ScrapeClient] fetchSeason(${series.providerId}, ${parsed.seasonNumber}) 失败: ${JSON.stringify(e)}`);
+          if (effectiveSeasonNumber !== undefined) {
+            season = await provider.fetchSeason(series.providerId, effectiveSeasonNumber, 'zh-CN').catch((e: BusinessError) => {
+              console.warn(`[ScrapeClient] fetchSeason(${series.providerId}, ${effectiveSeasonNumber}) 失败: ${JSON.stringify(e)}`);
               return null;
             });
-            console.info(`[ScrapeClient] fetchSeason S${parsed.seasonNumber} → ${season ? 'OK posterUrl=' + (season.posterUrl ? 'Y' : 'N') : 'null'}`);
-            if (parsed.episodeNumber !== undefined) {
-              episode = await provider.fetchEpisode(series.providerId, parsed.seasonNumber, parsed.episodeNumber, 'zh-CN').catch((e: BusinessError) => {
-                console.warn(`[ScrapeClient] fetchEpisode(${series.providerId}, S${parsed.seasonNumber}E${parsed.episodeNumber}) 失败: ${JSON.stringify(e)}`);
+            console.info(`[ScrapeClient] fetchSeason S${effectiveSeasonNumber} → ${season ? 'OK posterUrl=' + (season.posterUrl ? 'Y' : 'N') : 'null'}`);
+            if (effectiveEpisodeNumber !== undefined) {
+              episode = await provider.fetchEpisode(series.providerId, effectiveSeasonNumber, effectiveEpisodeNumber, 'zh-CN').catch((e: BusinessError) => {
+                console.warn(`[ScrapeClient] fetchEpisode(${series.providerId}, S${effectiveSeasonNumber}E${effectiveEpisodeNumber}) 失败: ${JSON.stringify(e)}`);
                 return null;
               });
-              console.info(`[ScrapeClient] fetchEpisode E${parsed.episodeNumber} → ${episode ? 'OK title="' + (episode.title ?? '') + '"' : 'null'}`);
+              console.info(`[ScrapeClient] fetchEpisode E${effectiveEpisodeNumber} → ${episode ? 'OK title="' + (episode.title ?? '') + '"' : 'null'}`);
             }
           }
 

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -141,6 +141,99 @@ export function classifyVideoScrapeTarget(
   );
 }
 
+/**
+ * 判断是否需要修复不完整的 TV 剧集关联
+ *
+ * 场景：scrape_info 已标记为 tv + title 非空，但 episodeId 为空
+ * 策略：如果能从文件名提取 episode number，返回 true
+ *
+ * @param scrapeInfo 已有的刮削信息
+ * @param fileName 文件名
+ * @returns true 表示需要修复，false 表示不需要
+ */
+export function shouldRepairIncompleteTvEpisode(
+  scrapeInfo: ScrapeInfoEntity | null,
+  fileName: string
+): boolean {
+  // 1. scrapeInfo 不存在，不需要修复
+  if (scrapeInfo === null) {
+    return false;
+  }
+
+  // 2. mediaType 不是 tv，不需要修复
+  if (scrapeInfo.mediaType !== 'tv') {
+    return false;
+  }
+
+  // 3. title 为空，不需要修复
+  if (scrapeInfo.title === undefined || scrapeInfo.title.trim() === '') {
+    return false;
+  }
+
+  // 4. episodeId 已存在，不需要修复
+  if (scrapeInfo.episodeId !== undefined) {
+    return false;
+  }
+
+  // 5. 尝试从文件名提取 episode number
+  const extractedEpisode = extractEpisodeNumberFromWeakSemanticFileName(fileName);
+  if (extractedEpisode === undefined) {
+    return false;
+  }
+
+  // 满足所有条件：tv + title 非空 + episodeId 空 + 文件名可提取 episode
+  return true;
+}
+
+/**
+ * 从弱语义文件名提取 episode number
+ *
+ * 支持格式：
+ * - 19.mp4 -> 19
+ * - 19 4K.mp4 -> 19
+ * - 20 4K.mp4 -> 20
+ * - E19.mp4 -> 19
+ *
+ * 不支持格式：
+ * - trailer.mp4 -> undefined
+ * - 2024.mp4 -> undefined (年份，过滤掉)
+ *
+ * @param fileName 文件名
+ * @returns episode number，如果无法提取则返回 undefined
+ */
+function extractEpisodeNumberFromWeakSemanticFileName(fileName: string): number | undefined {
+  const withoutExt = fileName.replace(/\.[^.]+$/, '');
+
+  // 1. 先尝试 SxxEyy 格式（优先级最高）
+  const standardMatch = withoutExt.match(/[Ss](\d{1,2})[Ee](\d{1,3})/);
+  if (standardMatch) {
+    return parseInt(standardMatch[2]);
+  }
+
+  // 2. 尝试单独的 Eyy 格式
+  const episodeOnlyMatch = withoutExt.match(/^[Ee](\d{1,3})/);
+  if (episodeOnlyMatch) {
+    return parseInt(episodeOnlyMatch[1]);
+  }
+
+  // 3. 尝试纯数字开头（如 "19 4K" 或 "19"）
+  const pureNumberMatch = withoutExt.match(/^(\d{1,3})(?:\s|$)/);
+  if (pureNumberMatch) {
+    const num = parseInt(pureNumberMatch[1]);
+    // 过滤掉年份（1900-2099）
+    if (num >= 1900 && num <= 2099) {
+      return undefined;
+    }
+    // 过滤掉过大的数字（episode 通常 < 999）
+    if (num > 999) {
+      return undefined;
+    }
+    return num;
+  }
+
+  return undefined;
+}
+
 async function clearStaleScrapeAssociationsForOverwrite(
   videoId: number,
   mode: ScanMode,
@@ -348,6 +441,20 @@ export class WebDAVAdapter implements ISourceAdapter {
                     console.info(`[VideoScanner][INCREMENTAL] 已清理旧 unknown 标记: ${fileName}`);
                   } catch {
                     console.warn(`[VideoScanner][INCREMENTAL] 清理旧 unknown 标记失败: ${fileName}`);
+                  }
+                  // 不 continue，继续执行后续的完整处理流程
+                } else if (shouldRepairIncompleteTvEpisode(existingScrape, fileName)) {
+                  // #191 第四轮修复：检测到 tv + title 非空但 episodeId 为空，且文件名可提取 episode number
+                  console.info(
+                    `[VideoScanner][INCREMENTAL] 检测到不完整的 TV 剧集关联（tv + title 但无 episodeId），` +
+                    `重新处理: ${fileName} | title=${existingScrape.title}`
+                  );
+                  // 清理旧的不完整 scrape_info 记录，以便后续重新刮削
+                  try {
+                    await FileSourceDatabase.getInstance().clearScrapeInfoForVideo(existingVideo.id);
+                    console.info(`[VideoScanner][INCREMENTAL] 已清理不完整 TV 关联: ${fileName}`);
+                  } catch {
+                    console.warn(`[VideoScanner][INCREMENTAL] 清理不完整 TV 关联失败: ${fileName}`);
                   }
                   // 不 continue，继续执行后续的完整处理流程
                 } else {
@@ -936,6 +1043,20 @@ export class SMBAdapter implements ISourceAdapter {
                     console.info(`[VideoScanner][SMB][INCREMENTAL] 已清理旧 unknown 标记: ${file.name}`);
                   } catch {
                     console.warn(`[VideoScanner][SMB][INCREMENTAL] 清理旧 unknown 标记失败: ${file.name}`);
+                  }
+                  // 不 continue，继续执行后续的完整处理流程
+                } else if (shouldRepairIncompleteTvEpisode(existingScrape, file.name)) {
+                  // #191 第四轮修复：检测到 tv + title 非空但 episodeId 为空，且文件名可提取 episode number
+                  console.info(
+                    `[VideoScanner][SMB][INCREMENTAL] 检测到不完整的 TV 剧集关联（tv + title 但无 episodeId），` +
+                    `重新处理: ${file.name} | title=${existingScrape.title}`
+                  );
+                  // 清理旧的不完整 scrape_info 记录，以便后续重新刮削
+                  try {
+                    await FileSourceDatabase.getInstance().clearScrapeInfoForVideo(existing.id);
+                    console.info(`[VideoScanner][SMB][INCREMENTAL] 已清理不完整 TV 关联: ${file.name}`);
+                  } catch {
+                    console.warn(`[VideoScanner][SMB][INCREMENTAL] 清理不完整 TV 关联失败: ${file.name}`);
                   }
                   // 不 continue，继续执行后续的完整处理流程
                 } else {

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -326,11 +326,19 @@ export class WebDAVAdapter implements ISourceAdapter {
                     this.doScrapeOnly(capturedVideoId, capturedFileName,
                       capturedScrapeClient, capturedMode, info).catch(() => {});
                   processingTasks.push(retryTask);
+                } else if (existingScrape.mediaType === 'unknown' && videoScrapeContext.seasonSiblingDetected) {
+                  // #191 修复：文件之前分类为 unknown，但现在扫描上下文变化（检测到季目录兄弟），应重新处理
+                  console.info(
+                    `[VideoScanner][INCREMENTAL] 检测到扫描上下文变化（seasonSiblingDetected=true），` +
+                    `重新处理之前的 unknown 文件: ${fileName}`
+                  );
+                  // 不 continue，继续执行后续的完整处理流程
                 } else {
                   console.info(
                     `[VideoScanner][INCREMENTAL] 跳过未变化文件: ${fileName} | ` +
                     `lastModified=${info.lastModified ?? '未知'}`
                   );
+                  continue;
                 }
               } catch {
                 // 查询失败，按已有刮削记录处理，正常跳过
@@ -338,14 +346,15 @@ export class WebDAVAdapter implements ISourceAdapter {
                   `[VideoScanner][INCREMENTAL] 跳过未变化文件: ${fileName} | ` +
                   `lastModified=${info.lastModified ?? '未知'}`
                 );
+                continue;
               }
             } else {
               console.info(
                 `[VideoScanner][INCREMENTAL] 跳过未变化文件: ${fileName} | ` +
                 `lastModified=${info.lastModified ?? '未知'}`
               );
+              continue;
             }
-            continue;
           }
 
           // ── 落库 + 刮削：加入跟踪列表，确保 scan() 返回前所有视频已入库 ──
@@ -874,13 +883,26 @@ export class SMBAdapter implements ISourceAdapter {
                       capturedScrapeClientR, capturedModeR, info).catch(() => {});
                   processingTasks.push(retryTask);
                   continue;
+                } else if (existingScrape.mediaType === 'unknown' && videoScrapeContext.seasonSiblingDetected) {
+                  // #191 修复：文件之前分类为 unknown，但现在扫描上下文变化（检测到季目录兄弟），应重新处理
+                  console.info(
+                    `[VideoScanner][SMB][INCREMENTAL] 检测到扫描上下文变化（seasonSiblingDetected=true），` +
+                    `重新处理之前的 unknown 文件: ${file.name}`
+                  );
+                  // 不 continue，继续执行后续的完整处理流程
+                } else {
+                  console.info(`[VideoScanner][SMB][INCREMENTAL] 跳过未变化文件: ${file.name}`);
+                  continue;
                 }
               } catch {
                 // 查询失败，正常跳过
+                console.info(`[VideoScanner][SMB][INCREMENTAL] 跳过未变化文件: ${file.name}`);
+                continue;
               }
+            } else {
+              console.info(`[VideoScanner][SMB][INCREMENTAL] 跳过未变化文件: ${file.name}`);
+              continue;
             }
-            console.info(`[VideoScanner][SMB][INCREMENTAL] 跳过未变化文件: ${file.name}`);
-            continue;
           }
         }
 

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -41,6 +41,8 @@ export interface VideoFileInfo {
 export interface VideoScrapeContext {
   seasonSiblingDetected?: boolean;
   seriesHint?: string;
+  explicitEpisodeNumber?: number;
+  explicitSeasonNumber?: number;
 }
 
 export interface SourceScanStat {
@@ -725,7 +727,10 @@ export class WebDAVAdapter implements ISourceAdapter {
       }
     } else {
       try {
-        const result = await scrapeClient.autoScrapeTvEpisode(fileName, seriesHint, classification.mediaType);
+        // #191 尝试从文件名提取显式集数（用于修复弱语义文件名关联）
+        const explicitEpisodeNum = extractEpisodeNumberFromWeakSemanticFileName(fileName);
+        const explicitSeasonNum = explicitEpisodeNum !== undefined ? 1 : undefined;
+        const result = await scrapeClient.autoScrapeTvEpisode(fileName, seriesHint, classification.mediaType, explicitEpisodeNum, explicitSeasonNum);
         if (!result.series) {
           await clearStaleScrapeAssociationsForOverwrite(
             videoId,
@@ -1300,7 +1305,10 @@ export class SMBAdapter implements ISourceAdapter {
       }
     } else {
       try {
-        const result = await scrapeClient.autoScrapeTvEpisode(fileName, seriesHint, classification.mediaType);
+        // #191 尝试从文件名提取显式集数（用于修复弱语义文件名关联）
+        const explicitEpisodeNum = extractEpisodeNumberFromWeakSemanticFileName(fileName);
+        const explicitSeasonNum = explicitEpisodeNum !== undefined ? 1 : undefined;
+        const result = await scrapeClient.autoScrapeTvEpisode(fileName, seriesHint, classification.mediaType, explicitEpisodeNum, explicitSeasonNum);
         if (!result.series) {
           await clearStaleScrapeAssociationsForOverwrite(
             videoId,

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -314,18 +314,28 @@ export class WebDAVAdapter implements ISourceAdapter {
                 const existingScrape =
                   await FileSourceDatabase.getInstance().getScrapeInfoByVideoId(existingVideo.id);
                 if (!existingScrape) {
-                  console.info(
-                    `[VideoScanner][INCREMENTAL] 文件未变化但无刮削记录，触发补刮削: ${fileName}`
-                  );
-                  const capturedVideoId = existingVideo.id;
-                  const capturedFileName = fileName;
-                  const capturedDirPath = info.directoryPath;
-                  const capturedScrapeClient = this.scrapeClient;
-                  const capturedMode = mode;
-                  const retryTask: Promise<void> =
-                    this.doScrapeOnly(capturedVideoId, capturedFileName,
-                      capturedScrapeClient, capturedMode, info).catch(() => {});
-                  processingTasks.push(retryTask);
+                  // #191 第三轮修复：如果无 scrape_info 但检测到季目录兄弟，应重新完整处理（分类+刮削）
+                  if (videoScrapeContext.seasonSiblingDetected) {
+                    console.info(
+                      `[VideoScanner][INCREMENTAL] 文件未变化但无刮削记录且检测到季目录兄弟，` +
+                      `重新处理: ${fileName}`
+                    );
+                    // 不 continue，继续执行后续的完整处理流程
+                  } else {
+                    console.info(
+                      `[VideoScanner][INCREMENTAL] 文件未变化但无刮削记录，触发补刮削: ${fileName}`
+                    );
+                    const capturedVideoId = existingVideo.id;
+                    const capturedFileName = fileName;
+                    const capturedDirPath = info.directoryPath;
+                    const capturedScrapeClient = this.scrapeClient;
+                    const capturedMode = mode;
+                    const retryTask: Promise<void> =
+                      this.doScrapeOnly(capturedVideoId, capturedFileName,
+                        capturedScrapeClient, capturedMode, info).catch(() => {});
+                    processingTasks.push(retryTask);
+                    continue;
+                  }
                 } else if (existingScrape.mediaType === 'unknown' && videoScrapeContext.seasonSiblingDetected) {
                   // #191 修复：文件之前分类为 unknown，但现在扫描上下文变化（检测到季目录兄弟），应重新处理
                   console.info(
@@ -894,17 +904,26 @@ export class SMBAdapter implements ISourceAdapter {
                 const existingScrape =
                   await FileSourceDatabase.getInstance().getScrapeInfoByVideoId(existing.id);
                 if (!existingScrape) {
-                  console.info(
-                    `[VideoScanner][SMB][INCREMENTAL] 文件未变化但无刮削记录，触发补刮削: ${file.name}`
-                  );
-                  const capturedVideoId = existing.id;
-                  const capturedScrapeClientR = this.scrapeClient;
-                  const capturedModeR = mode;
-                  const retryTask: Promise<void> =
-                    this.doScrapeOnly(capturedVideoId, file.name,
-                      capturedScrapeClientR, capturedModeR, info).catch(() => {});
-                  processingTasks.push(retryTask);
-                  continue;
+                  // #191 第三轮修复：如果无 scrape_info 但检测到季目录兄弟，应重新完整处理（分类+刮削）
+                  if (videoScrapeContext.seasonSiblingDetected) {
+                    console.info(
+                      `[VideoScanner][SMB][INCREMENTAL] 文件未变化但无刮削记录且检测到季目录兄弟，` +
+                      `重新处理: ${file.name}`
+                    );
+                    // 不 continue，继续执行后续的完整处理流程
+                  } else {
+                    console.info(
+                      `[VideoScanner][SMB][INCREMENTAL] 文件未变化但无刮削记录，触发补刮削: ${file.name}`
+                    );
+                    const capturedVideoId = existing.id;
+                    const capturedScrapeClientR = this.scrapeClient;
+                    const capturedModeR = mode;
+                    const retryTask: Promise<void> =
+                      this.doScrapeOnly(capturedVideoId, file.name,
+                        capturedScrapeClientR, capturedModeR, info).catch(() => {});
+                    processingTasks.push(retryTask);
+                    continue;
+                  }
                 } else if (existingScrape.mediaType === 'unknown' && videoScrapeContext.seasonSiblingDetected) {
                   // #191 修复：文件之前分类为 unknown，但现在扫描上下文变化（检测到季目录兄弟），应重新处理
                   console.info(

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -5,11 +5,13 @@ import { FileSourceDatabase } from '../db/files/FileSourceDatabase';
 import { WebDAVClient, WebDAVConfig, WebDAVResource } from '../lib/WebDAVClient';
 import {
   MediaTypeClassificationResult,
+  MediaTypeClassificationOptions,
   buildMediaTypeClassificationInput,
   classifyMediaType,
   createFileNameSemanticInfo,
   extractSeriesHintFromFilePath,
-  formatMediaTypeClassificationSignals
+  formatMediaTypeClassificationSignals,
+  isSeasonDirectorySegment
 } from '../lib/MediaTypeClassifier';
 import { FfprobeUtil, FfprobeTrack } from './FfprobeUtil';
 import { ScrapeClient, parseFileName, TvSeriesScrapeResult } from '../lib/ScrapeClient';
@@ -32,6 +34,13 @@ export interface VideoFileInfo {
   contentType?: string;
   wasProcessed?: boolean;
   scrapeSkipped?: boolean;
+  seasonSiblingDetected?: boolean;
+  seriesHint?: string;
+}
+
+export interface VideoScrapeContext {
+  seasonSiblingDetected?: boolean;
+  seriesHint?: string;
 }
 
 export interface SourceScanStat {
@@ -87,7 +96,34 @@ function isVideoFile(fileName: string, contentType?: string): boolean {
   return false;
 }
 
-function classifyVideoScrapeTarget(fileName: string, filePath: string): MediaTypeClassificationResult {
+export function hasSeasonSiblingDirectory(directoryNames: string[]): boolean {
+  return directoryNames.some((directoryName: string) => isSeasonDirectorySegment(directoryName));
+}
+
+function extractLastPathSegment(path: string): string | undefined {
+  const normalizedPath = path.replace(/\\/g, '/').replace(/\/+$/g, '');
+  const segments = normalizedPath.split('/').filter((segment: string) => segment.length > 0);
+  if (segments.length === 0) {
+    return undefined;
+  }
+  return segments[segments.length - 1];
+}
+
+export function createVideoScrapeContext(rootPath: string, depth: number, seasonSiblingDetected: boolean): VideoScrapeContext {
+  const context: VideoScrapeContext = {
+    seasonSiblingDetected
+  };
+  if (depth === 0) {
+    context.seriesHint = extractLastPathSegment(rootPath);
+  }
+  return context;
+}
+
+export function classifyVideoScrapeTarget(
+  fileName: string,
+  filePath: string,
+  context?: VideoScrapeContext
+): MediaTypeClassificationResult {
   const parsed = parseFileName(fileName);
   const fileNameInfo = createFileNameSemanticInfo(
     parsed.title,
@@ -97,8 +133,11 @@ function classifyVideoScrapeTarget(fileName: string, filePath: string): MediaTyp
     parsed.episodeNumber,
     parsed.year
   );
+  const classificationOptions: MediaTypeClassificationOptions = {
+    seasonSiblingDetected: context?.seasonSiblingDetected
+  };
   return classifyMediaType(
-    buildMediaTypeClassificationInput(fileName, filePath, fileNameInfo)
+    buildMediaTypeClassificationInput(fileName, filePath, fileNameInfo, classificationOptions)
   );
 }
 
@@ -205,6 +244,23 @@ export class WebDAVAdapter implements ISourceAdapter {
       return;
     }
 
+    const childDirectoryNames: string[] = [];
+    resources.forEach((resource: WebDAVResource) => {
+      if (resource.isCollection) {
+        const decodedHref = this.decodePath(resource.href);
+        const relativePath = this.toRelativePath(decodedHref);
+        if (this.isSamePath(relativePath, currentPath)) {
+          return;
+        }
+        childDirectoryNames.push(resource.displayName || this.extractFileName(decodedHref));
+      }
+    });
+    const videoScrapeContext = createVideoScrapeContext(
+      rootPath,
+      depth,
+      hasSeasonSiblingDirectory(childDirectoryNames)
+    );
+
     for (const resource of resources) {
       const decodedHref = this.decodePath(resource.href);
       const relativePath = this.toRelativePath(decodedHref);
@@ -232,7 +288,9 @@ export class WebDAVAdapter implements ISourceAdapter {
             fileSize: resource.size,
             lastModified: resource.lastModified,
             contentType: resource.contentType,
-            wasProcessed: true
+            wasProcessed: true,
+            seasonSiblingDetected: videoScrapeContext.seasonSiblingDetected,
+            seriesHint: videoScrapeContext.seriesHint
           };
 
           console.info(
@@ -420,8 +478,12 @@ export class WebDAVAdapter implements ISourceAdapter {
     }
 
     console.info(`[VideoScanner][SCRAPE] 开始刮削 fileName=${fileName}`);
-    const classification = classifyVideoScrapeTarget(fileName, info.filePath);
-    const seriesHint = extractSeriesHintFromFilePath(info.filePath);
+    const classificationContext: VideoScrapeContext = {
+      seasonSiblingDetected: info.seasonSiblingDetected
+    };
+    const classification = classifyVideoScrapeTarget(fileName, info.filePath, classificationContext);
+    const extractedSeriesHint = extractSeriesHintFromFilePath(info.filePath);
+    const seriesHint = extractedSeriesHint ?? info.seriesHint;
     if (classification.mediaType === 'unknown') {
       await clearStaleScrapeAssociationsForOverwrite(
         videoId,
@@ -746,6 +808,18 @@ export class SMBAdapter implements ISourceAdapter {
       return;
     }
 
+    const childDirectoryNames: string[] = [];
+    listResult.files.forEach((file) => {
+      if (file.isDirectory) {
+        childDirectoryNames.push(file.name);
+      }
+    });
+    const videoScrapeContext = createVideoScrapeContext(
+      rootPath,
+      currentDepth,
+      hasSeasonSiblingDirectory(childDirectoryNames)
+    );
+
     for (const file of listResult.files) {
       if (file.isDirectory) {
         await this.scanDir(rootPath, file.path, currentDepth + 1, maxDepth, mode, results, processingTasks);
@@ -759,7 +833,9 @@ export class SMBAdapter implements ISourceAdapter {
           fileName: file.name,
           fileSize: file.size,
           lastModified: file.lastModifiedMs > 0 ? new Date(file.lastModifiedMs).toISOString() : undefined,
-          wasProcessed: true
+          wasProcessed: true,
+          seasonSiblingDetected: videoScrapeContext.seasonSiblingDetected,
+          seriesHint: videoScrapeContext.seriesHint
         };
         console.info(
           `[VideoScanner][SMB] 文件源=${this.fileSource.name} | 路径=${file.path} | 文件名=${file.name} | 大小=${file.size} bytes`
@@ -922,8 +998,12 @@ export class SMBAdapter implements ISourceAdapter {
 
     console.info(`[VideoScanner][SMB][SCRAPE] 开始刮削 fileName=${fileName}`);
     const db = FileSourceDatabase.getInstance();
-    const classification = classifyVideoScrapeTarget(fileName, info.filePath);
-    const seriesHint = extractSeriesHintFromFilePath(info.filePath);
+    const classificationContext: VideoScrapeContext = {
+      seasonSiblingDetected: info.seasonSiblingDetected
+    };
+    const classification = classifyVideoScrapeTarget(fileName, info.filePath, classificationContext);
+    const extractedSeriesHint = extractSeriesHintFromFilePath(info.filePath);
+    const seriesHint = extractedSeriesHint ?? info.seriesHint;
     if (classification.mediaType === 'unknown') {
       await clearStaleScrapeAssociationsForOverwrite(
         videoId,

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -332,6 +332,13 @@ export class WebDAVAdapter implements ISourceAdapter {
                     `[VideoScanner][INCREMENTAL] 检测到扫描上下文变化（seasonSiblingDetected=true），` +
                     `重新处理之前的 unknown 文件: ${fileName}`
                   );
+                  // 清理旧的 unknown scrape_info 记录，以便后续重新刮削
+                  try {
+                    await FileSourceDatabase.getInstance().clearScrapeInfoForVideo(existingVideo.id);
+                    console.info(`[VideoScanner][INCREMENTAL] 已清理旧 unknown 标记: ${fileName}`);
+                  } catch {
+                    console.warn(`[VideoScanner][INCREMENTAL] 清理旧 unknown 标记失败: ${fileName}`);
+                  }
                   // 不 continue，继续执行后续的完整处理流程
                 } else {
                   console.info(
@@ -501,11 +508,26 @@ export class WebDAVAdapter implements ISourceAdapter {
         '[VideoScanner][SCRAPE]',
         `unknown:${classification.reason ?? 'unknown'}`
       );
+      // #191 修复：为 unknown 文件创建 scrape_info 记录，以便增量扫描时能检测上下文变化
+      const db = FileSourceDatabase.getInstance();
+      const unknownScrapeInfo: ScrapeInfoEntity = {
+        videoId,
+        provider: 'local',
+        providerId: `unknown_${videoId}`,
+        mediaType: 'unknown',
+        title: fileName,
+        scrapedAt: Date.now()
+      };
+      try {
+        await db.upsertScrapeInfo(unknownScrapeInfo);
+        console.info(
+          `[VideoScanner][SCRAPE] 已标记弱语义文件 fileName=${fileName} reason=${classification.reason ?? 'unknown'} ` +
+          `signals=${formatMediaTypeClassificationSignals(classification)}`
+        );
+      } catch {
+        console.warn(`[VideoScanner][SCRAPE] 无法保存 unknown 标记 fileName=${fileName}`);
+      }
       info.scrapeSkipped = true;
-      console.info(
-        `[VideoScanner][SCRAPE] 跳过弱语义文件 fileName=${fileName} reason=${classification.reason ?? 'unknown'} ` +
-        `signals=${formatMediaTypeClassificationSignals(classification)}`
-      );
       return;
     }
 
@@ -889,6 +911,13 @@ export class SMBAdapter implements ISourceAdapter {
                     `[VideoScanner][SMB][INCREMENTAL] 检测到扫描上下文变化（seasonSiblingDetected=true），` +
                     `重新处理之前的 unknown 文件: ${file.name}`
                   );
+                  // 清理旧的 unknown scrape_info 记录，以便后续重新刮削
+                  try {
+                    await FileSourceDatabase.getInstance().clearScrapeInfoForVideo(existing.id);
+                    console.info(`[VideoScanner][SMB][INCREMENTAL] 已清理旧 unknown 标记: ${file.name}`);
+                  } catch {
+                    console.warn(`[VideoScanner][SMB][INCREMENTAL] 清理旧 unknown 标记失败: ${file.name}`);
+                  }
                   // 不 continue，继续执行后续的完整处理流程
                 } else {
                   console.info(`[VideoScanner][SMB][INCREMENTAL] 跳过未变化文件: ${file.name}`);
@@ -1034,11 +1063,25 @@ export class SMBAdapter implements ISourceAdapter {
         '[VideoScanner][SMB][SCRAPE]',
         `unknown:${classification.reason ?? 'unknown'}`
       );
+      // #191 修复：为 unknown 文件创建 scrape_info 记录，以便增量扫描时能检测上下文变化
+      const unknownScrapeInfo: ScrapeInfoEntity = {
+        videoId,
+        provider: 'local',
+        providerId: `unknown_${videoId}`,
+        mediaType: 'unknown',
+        title: fileName,
+        scrapedAt: Date.now()
+      };
+      try {
+        await db.upsertScrapeInfo(unknownScrapeInfo);
+        console.info(
+          `[VideoScanner][SMB][SCRAPE] 已标记弱语义文件 fileName=${fileName} reason=${classification.reason ?? 'unknown'} ` +
+          `signals=${formatMediaTypeClassificationSignals(classification)}`
+        );
+      } catch {
+        console.warn(`[VideoScanner][SMB][SCRAPE] 无法保存 unknown 标记 fileName=${fileName}`);
+      }
       info.scrapeSkipped = true;
-      console.info(
-        `[VideoScanner][SMB][SCRAPE] 跳过弱语义文件 fileName=${fileName} reason=${classification.reason ?? 'unknown'} ` +
-        `signals=${formatMediaTypeClassificationSignals(classification)}`
-      );
       return;
     }
 

--- a/entry/src/ohosTest/ets/test/IncrementalScanContextChange.test.ets
+++ b/entry/src/ohosTest/ets/test/IncrementalScanContextChange.test.ets
@@ -1,0 +1,119 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  classifyVideoScrapeTarget,
+  hasSeasonSiblingDirectory,
+  createVideoScrapeContext,
+  VideoScrapeContext
+} from '../../main/ets/utils/VideoScannerUtil';
+import {
+  MediaTypeClassification,
+  isWeakSemanticTitleText
+} from '../../main/ets/lib/MediaTypeClassifier';
+
+/**
+ * 测试场景：增量扫描时扫描上下文变化的处理
+ * 复现 #191 真机验收失败：用户先扫描了弱语义文件（纯数字），
+ * 后添加季目录兄弟后重新扫描，文件应被重新分类为 TV
+ */
+export default function incrementalScanContextChangeTest() {
+  describe('IncrementalScanContextChange', () => {
+    it('纯数字文件名为弱语义', () => {
+      expect(isWeakSemanticTitleText('19')).assertTrue();
+      expect(isWeakSemanticTitleText('20')).assertTrue();
+      expect(isWeakSemanticTitleText('22')).assertTrue();
+    });
+
+    it('检测到季目录兄弟时应返回true', () => {
+      const childDirs1 = ['第一季', '其他目录'];
+      expect(hasSeasonSiblingDirectory(childDirs1)).assertTrue();
+
+      const childDirs2 = ['Season 1', 'extras'];
+      expect(hasSeasonSiblingDirectory(childDirs2)).assertTrue();
+
+      const childDirs3 = ['S01', 'S02'];
+      expect(hasSeasonSiblingDirectory(childDirs3)).assertTrue();
+    });
+
+    it('无季目录兄弟时应返回false', () => {
+      const childDirs = ['其他目录', '特典'];
+      expect(hasSeasonSiblingDirectory(childDirs)).assertFalse();
+    });
+
+    it('无季目录兄弟时纯数字文件应分类为unknown', () => {
+      const context: VideoScrapeContext = {
+        seasonSiblingDetected: false
+      };
+      const result = classifyVideoScrapeTarget(
+        '19.mp4',
+        '/蜜语纪/19.mp4',
+        context
+      );
+      expect(result.mediaType).assertEqual('unknown');
+      expect(result.reason).assertEqual('insufficient-evidence');
+    });
+
+    it('有季目录兄弟时纯数字文件应分类为tv', () => {
+      const context: VideoScrapeContext = {
+        seasonSiblingDetected: true
+      };
+      const result = classifyVideoScrapeTarget(
+        '19.mp4',
+        '/蜜语纪/19.mp4',
+        context
+      );
+      expect(result.mediaType).assertEqual('tv');
+      expect(result.reason).assertEqual('season-sibling-detected');
+    });
+
+    it('扫描上下文应正确传递seasonSiblingDetected', () => {
+      const rootPath = '/storage/蜜语纪';
+      const depth = 0;
+
+      // 场景1：无季目录兄弟
+      const contextWithout = createVideoScrapeContext(rootPath, depth, false);
+      expect(contextWithout.seasonSiblingDetected).assertFalse();
+      expect(contextWithout.seriesHint).assertEqual('蜜语纪');
+
+      // 场景2：有季目录兄弟
+      const contextWith = createVideoScrapeContext(rootPath, depth, true);
+      expect(contextWith.seasonSiblingDetected).assertTrue();
+      expect(contextWith.seriesHint).assertEqual('蜜语纪');
+    });
+
+    it('深度>0时不应设置seriesHint', () => {
+      const rootPath = '/storage/蜜语纪';
+      const depth = 1;
+
+      const context = createVideoScrapeContext(rootPath, depth, true);
+      expect(context.seasonSiblingDetected).assertTrue();
+      expect(context.seriesHint).assertUndefined();
+    });
+
+    it('真实场景模拟：扫描上下文变化前后的分类结果应不同', () => {
+      // 模拟首次扫描：蜜语纪/ 只有 19.mp4-22.mp4（无季目录）
+      const contextBefore: VideoScrapeContext = {
+        seasonSiblingDetected: false
+      };
+      const resultBefore = classifyVideoScrapeTarget(
+        '19.mp4',
+        '/蜜语纪/19.mp4',
+        contextBefore
+      );
+      expect(resultBefore.mediaType).assertEqual('unknown');
+
+      // 模拟二次扫描：蜜语纪/ 现在有 第一季/ 子目录
+      const contextAfter: VideoScrapeContext = {
+        seasonSiblingDetected: true
+      };
+      const resultAfter = classifyVideoScrapeTarget(
+        '19.mp4',
+        '/蜜语纪/19.mp4',
+        contextAfter
+      );
+      expect(resultAfter.mediaType).assertEqual('tv');
+
+      // 关键断言：即使文件本身未变化，分类结果应该不同
+      expect(resultBefore.mediaType).assertNotEqual(resultAfter.mediaType);
+    });
+  });
+}

--- a/entry/src/ohosTest/ets/test/IncrementalScanContextChange.test.ets
+++ b/entry/src/ohosTest/ets/test/IncrementalScanContextChange.test.ets
@@ -7,7 +7,8 @@ import {
 } from '../../main/ets/utils/VideoScannerUtil';
 import {
   MediaTypeClassification,
-  isWeakSemanticTitleText
+  isWeakSemanticTitleText,
+  isSeasonDirectorySegment
 } from '../../main/ets/lib/MediaTypeClassifier';
 
 /**
@@ -23,6 +24,32 @@ export default function incrementalScanContextChangeTest() {
       expect(isWeakSemanticTitleText('22')).assertTrue();
     });
 
+    it('isSeasonDirectorySegment应识别基础季目录名', () => {
+      // 纯季目录名（旧测试已覆盖的场景）
+      expect(isSeasonDirectorySegment('第一季')).assertTrue();
+      expect(isSeasonDirectorySegment('Season 1')).assertTrue();
+      expect(isSeasonDirectorySegment('S01')).assertTrue();
+      expect(isSeasonDirectorySegment('S02')).assertTrue();
+      expect(isSeasonDirectorySegment('第 2 季')).assertTrue();
+    });
+
+    it('isSeasonDirectorySegment应识别带质量后缀的真实季目录名 (#191 QA证据)', () => {
+      // 真实场景：季目录名后面跟随质量信息
+      expect(isSeasonDirectorySegment('第 1 季 - 2160p WEB-DL HDR H265 DDP 5.1')).assertTrue();
+      expect(isSeasonDirectorySegment('Season 01 - 1080p BluRay')).assertTrue();
+      expect(isSeasonDirectorySegment('S02 - AMZN WEB-DL')).assertTrue();
+      expect(isSeasonDirectorySegment('第二季 - 4K HDR')).assertTrue();
+    });
+
+    it('isSeasonDirectorySegment应拒绝非季目录名', () => {
+      // 避免误判：标题中恰好包含 S02 等模式但不是季目录
+      expect(isSeasonDirectorySegment('特典')).assertFalse();
+      expect(isSeasonDirectorySegment('其他目录')).assertFalse();
+      expect(isSeasonDirectorySegment('extras')).assertFalse();
+      // 注意：像 "Breaking Bad S01E01" 这样的文件名也应被拒绝，
+      // 但由于 normalizeSemanticToken 会移除空格，实际测试需考虑归一化后的形态
+    });
+
     it('检测到季目录兄弟时应返回true', () => {
       const childDirs1 = ['第一季', '其他目录'];
       expect(hasSeasonSiblingDirectory(childDirs1)).assertTrue();
@@ -31,6 +58,18 @@ export default function incrementalScanContextChangeTest() {
       expect(hasSeasonSiblingDirectory(childDirs2)).assertTrue();
 
       const childDirs3 = ['S01', 'S02'];
+      expect(hasSeasonSiblingDirectory(childDirs3)).assertTrue();
+    });
+
+    it('检测到带质量后缀的季目录兄弟时应返回true (#191 QA证据)', () => {
+      // 真实场景：目录列表包含带质量信息的季目录
+      const childDirs1 = ['第 1 季 - 2160p WEB-DL HDR H265 DDP 5.1', '其他目录'];
+      expect(hasSeasonSiblingDirectory(childDirs1)).assertTrue();
+
+      const childDirs2 = ['Season 01 - 1080p BluRay', 'extras', 'Season 02 - 1080p BluRay'];
+      expect(hasSeasonSiblingDirectory(childDirs2)).assertTrue();
+
+      const childDirs3 = ['S02 - AMZN WEB-DL', '特典'];
       expect(hasSeasonSiblingDirectory(childDirs3)).assertTrue();
     });
 

--- a/entry/src/ohosTest/ets/test/IncrementalScanContextChange.test.ets
+++ b/entry/src/ohosTest/ets/test/IncrementalScanContextChange.test.ets
@@ -154,5 +154,76 @@ export default function incrementalScanContextChangeTest() {
       // 关键断言：即使文件本身未变化，分类结果应该不同
       expect(resultBefore.mediaType).assertNotEqual(resultAfter.mediaType);
     });
+
+    it('真实文件名带质量后缀时纯数字前缀应被识别为弱语义 (#191 第三轮真机失败)', () => {
+      // 真实场景：文件名为 "19 4K.mp4"，前缀 "19" 是弱语义
+      expect(isWeakSemanticTitleText('19 4K')).assertTrue();
+      expect(isWeakSemanticTitleText('20 4K')).assertTrue();
+      expect(isWeakSemanticTitleText('22 HDR')).assertTrue();
+      expect(isWeakSemanticTitleText('19 2160p')).assertTrue();
+    });
+
+    it('真实文件名带质量后缀时有季目录兄弟应分类为tv (#191 第三轮真机失败)', () => {
+      // 真实场景：文件名为 "19 4K.mp4"，目录下有 "第 1 季 - 2160p WEB-DL HDR H265 DDP 5.1"
+      const context: VideoScrapeContext = {
+        seasonSiblingDetected: true
+      };
+      const result = classifyVideoScrapeTarget(
+        '19 4K.mp4',
+        '/蜜语纪/19 4K.mp4',
+        context
+      );
+      expect(result.mediaType).assertEqual('tv');
+      expect(result.reason).assertEqual('season-sibling-detected');
+    });
+
+    it('真实文件名带质量后缀时无季目录兄弟应分类为unknown (#191 第三轮真机失败)', () => {
+      // 真实场景：文件名为 "19 4K.mp4"，但目录下无季目录兄弟
+      const context: VideoScrapeContext = {
+        seasonSiblingDetected: false
+      };
+      const result = classifyVideoScrapeTarget(
+        '19 4K.mp4',
+        '/蜜语纪/19 4K.mp4',
+        context
+      );
+      expect(result.mediaType).assertEqual('unknown');
+      expect(result.reason).assertEqual('insufficient-evidence');
+    });
+
+    it('增量扫描时已存在video file但无scrape_info的弱语义文件在季目录兄弟出现后应重新处理 (#191 第三轮真机失败根因)', () => {
+      // 这个测试覆盖真实数据流：
+      // 1. 首次扫描：19 4K.mp4 被识别为 video file，但因为弱语义+无季目录兄弟，分类为 unknown
+      //    可能没有创建 scrape_info，或创建了 mediaType=unknown 的 scrape_info
+      // 2. 用户添加季目录兄弟：第 1 季 - 2160p WEB-DL HDR H265 DDP 5.1/
+      // 3. 增量扫描：19 4K.mp4 文件未变化，但季目录兄弟已出现
+      //    期望：应重新处理该文件，分类为 tv
+      //    实际：被 canSkipIncrementalProcessing 跳过，或虽补刮削但没有检测季目录兄弟上下文变化
+
+      // 场景1：首次扫描，无季目录兄弟
+      const contextFirst: VideoScrapeContext = {
+        seasonSiblingDetected: false
+      };
+      const resultFirst = classifyVideoScrapeTarget(
+        '19 4K.mp4',
+        '/蜜语纪/19 4K.mp4',
+        contextFirst
+      );
+      expect(resultFirst.mediaType).assertEqual('unknown');
+
+      // 场景2：增量扫描，季目录兄弟已出现
+      const contextIncremental: VideoScrapeContext = {
+        seasonSiblingDetected: true
+      };
+      const resultIncremental = classifyVideoScrapeTarget(
+        '19 4K.mp4',
+        '/蜜语纪/19 4K.mp4',
+        contextIncremental
+      );
+      expect(resultIncremental.mediaType).assertEqual('tv');
+
+      // 关键断言：即使 video file 未变化，增量扫描时检测到季目录兄弟，应重新分类
+      expect(resultFirst.mediaType).assertNotEqual(resultIncremental.mediaType);
+    });
   });
 }

--- a/entry/src/ohosTest/ets/test/List.test.ets
+++ b/entry/src/ohosTest/ets/test/List.test.ets
@@ -4,6 +4,7 @@ import fileSourceUiTest from './FileSourceUI.test';
 import mediaNavigationTest from './MediaNavigation.test';
 import playerSettingsTest from './PlayerSettings.test';
 import scanFlowTest from './ScanFlow.test';
+import incrementalScanContextChangeTest from './IncrementalScanContextChange.test';
 
 export default function testsuite() {
   abilityTest();
@@ -12,4 +13,5 @@ export default function testsuite() {
   mediaNavigationTest();
   playerSettingsTest();
   scanFlowTest();
+  incrementalScanContextChangeTest();
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -24,6 +24,7 @@ import subtitleLanguagePreferenceTest from './SubtitleLanguagePreference.test';
 import appPreferencesTest from './AppPreferences.test';
 import homeSettingBuilderModelTest from './HomeSettingBuilderModel.test';
 import videoScannerUtilTest from './VideoScannerUtil.test';
+import tvEpisodeIncompleteRepairTest from './TvEpisodeIncompleteRepair.test';
 // 需要真实 Context 和 .so 的集成测试放在 UnitTestBuild 侧（entry 模块本身，包含 native .so）
 // ohosTest(entry_test HAP) 不包含 .so，不能 import VideoScannerUtil / WebDAVClient
 import fileSourceDatabaseTest from './FileSourceDatabase.test';
@@ -56,6 +57,7 @@ export default function testsuite() {
   appPreferencesTest();
   homeSettingBuilderModelTest();
   videoScannerUtilTest();
+  tvEpisodeIncompleteRepairTest();
   fileSourceDatabaseTest();
   videoScannerTest();
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -23,6 +23,7 @@ import imagePreviewSessionControllerTest from './ImagePreviewSessionController.t
 import subtitleLanguagePreferenceTest from './SubtitleLanguagePreference.test';
 import appPreferencesTest from './AppPreferences.test';
 import homeSettingBuilderModelTest from './HomeSettingBuilderModel.test';
+import videoScannerUtilTest from './VideoScannerUtil.test';
 // 需要真实 Context 和 .so 的集成测试放在 UnitTestBuild 侧（entry 模块本身，包含 native .so）
 // ohosTest(entry_test HAP) 不包含 .so，不能 import VideoScannerUtil / WebDAVClient
 import fileSourceDatabaseTest from './FileSourceDatabase.test';
@@ -54,6 +55,7 @@ export default function testsuite() {
   subtitleLanguagePreferenceTest();
   appPreferencesTest();
   homeSettingBuilderModelTest();
+  videoScannerUtilTest();
   fileSourceDatabaseTest();
   videoScannerTest();
 }

--- a/entry/src/test/MediaTypeClassifierContract.test.ets
+++ b/entry/src/test/MediaTypeClassifierContract.test.ets
@@ -10,6 +10,7 @@ import {
   extractSeriesHintFromFilePath
 } from '../main/ets/lib/MediaTypeClassifier';
 import { parseFileName } from '../main/ets/lib/ScrapeClient';
+import { classifyVideoScrapeTarget } from '../main/ets/utils/VideoScannerUtil';
 
 interface WeakSemanticRegressionSample {
   name: string;
@@ -145,6 +146,33 @@ export default function mediaTypeClassifierContractTest() {
           expect(classification.reason).assertEqual(sample.expectedReason);
         }
       });
+    });
+
+    it('should classify root weak semantic episode as tv when season sibling is detected', 0, () => {
+      const classification = classifyVideoScrapeTarget(
+        '19.mp4',
+        '/蜜语纪/19.mp4',
+        { seasonSiblingDetected: true }
+      );
+
+      expect(classification.mediaType).assertEqual('tv');
+      expect(classification.reason).assertEqual('season-sibling-detected');
+      expect(classification.signals.length > 0).assertTrue();
+      expect(classification.signals[classification.signals.length - 1].detail).assertEqual('path:season-sibling-detected');
+    });
+
+    it('should keep weak semantic episode unknown when no season sibling is detected', 0, () => {
+      const explicitFalseClassification = classifyVideoScrapeTarget(
+        '19.mp4',
+        '/电影合集/19.mp4',
+        { seasonSiblingDetected: false }
+      );
+      const omittedClassification = classifyVideoScrapeTarget('19.mp4', '/电影合集/19.mp4');
+
+      expect(explicitFalseClassification.mediaType).assertEqual('unknown');
+      expect(explicitFalseClassification.reason).assertEqual('insufficient-evidence');
+      expect(omittedClassification.mediaType).assertEqual('unknown');
+      expect(omittedClassification.reason).assertEqual('insufficient-evidence');
     });
   });
 }

--- a/entry/src/test/ScrapeClient.test.ets
+++ b/entry/src/test/ScrapeClient.test.ets
@@ -4,7 +4,9 @@ import {
   ScriptedFakeScrapeProvider,
   createDeferred,
   createMovieScrapeResult,
-  createTvSeriesScrapeResult
+  createTvSeriesScrapeResult,
+  createTvSeasonScrapeResult,
+  createTvEpisodeScrapeResult
 } from './helpers/ScrapeClientFakeProvider';
 
 async function flushMicrotasksUntil(predicate: () => boolean, rounds: number = 12): Promise<void> {
@@ -463,6 +465,62 @@ export default function scrapeClientTest() {
       const result = await pending;
       expect(settled).assertTrue();
       expect(result).assertEqual(null);
+    });
+
+    /**
+     * 测试用例 24：#191 显式传入季集号修复弱语义文件名刮削
+     * 
+     * 场景：不完整 TV 关联修复链路中，文件名 "19 4K.mp4" 无法被 parseFileName 识别 S/E，
+     * 但扫描器已通过 extractEpisodeNumberFromWeakSemanticFileName 得到 episode=19。
+     * 此时应支持显式传入 episodeNumber=19, seasonNumber=1，刮削时能正确调用 fetchEpisode(S01E19)。
+     */
+    it('should use explicit episode and season numbers when provided for weak semantic filenames', 0, async () => {
+      const fake = new ScriptedFakeScrapeProvider('fake-explicit-episode');
+      fake.enqueueSearchTvResults([createTvSeriesScrapeResult('fake-explicit-episode', '蜜语纪', 'tv-100')]);
+      fake.enqueueFetchTvSeriesDetailResult(createTvSeriesScrapeResult('fake-explicit-episode', '蜜语纪', 'tv-100'));
+      fake.enqueueFetchSeasonResult(createTvSeasonScrapeResult('fake-explicit-episode', 1, 'tv-100_s1', 'Season 1'));
+      fake.enqueueFetchEpisodeResult(createTvEpisodeScrapeResult('fake-explicit-episode', 1, 19, 'ep-100-1-19', 'Episode 19'));
+
+      const client = new ScrapeClient({});
+      client.registerProvider(fake);
+
+      // 显式传入 episodeNumber=19, seasonNumber=1（模拟修复链路）
+      const result = await client.autoScrapeTvEpisode('19 4K.mp4', '蜜语纪', 'tv', 19, 1);
+
+      // 验证：series 成功刮削
+      expect(result.series !== null).assertTrue();
+      if (result.series !== null) {
+        expect(result.series.title).assertEqual('蜜语纪');
+      }
+
+      // 验证：season 成功刮削
+      expect(result.season !== null).assertTrue();
+      if (result.season !== null) {
+        expect(result.season.seasonNumber).assertEqual(1);
+      }
+
+      // 验证：episode 成功刮削
+      expect(result.episode !== null).assertTrue();
+      if (result.episode !== null) {
+        expect(result.episode.episodeNumber).assertEqual(19);
+        expect(result.episode.seasonNumber).assertEqual(1);
+        expect(result.episode.title).assertEqual('Episode 19');
+      }
+
+      // 验证：provider 按预期被调用
+      expect(fake.getCallCount('searchTv')).assertEqual(1);
+      expect(fake.getCallCount('fetchTvSeriesDetail')).assertEqual(1);
+      expect(fake.getCallCount('fetchSeason')).assertEqual(1);
+      expect(fake.getCallCount('fetchEpisode')).assertEqual(1);
+
+      // 验证：fetchEpisode 调用参数正确
+      const episodeCall = fake.getLastCall('fetchEpisode');
+      expect(episodeCall !== null).assertTrue();
+      if (episodeCall !== null) {
+        expect(episodeCall.providerId).assertEqual('tv-100');
+        expect(episodeCall.seasonNumber).assertEqual(1);
+        expect(episodeCall.episodeNumber).assertEqual(19);
+      }
     });
   });
 

--- a/entry/src/test/TvEpisodeIncompleteRepair.test.ets
+++ b/entry/src/test/TvEpisodeIncompleteRepair.test.ets
@@ -1,0 +1,135 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { ScrapeInfoEntity } from '../main/ets/db/models/MediaEntity';
+import { shouldRepairIncompleteTvEpisode } from '../main/ets/utils/VideoScannerUtil';
+
+/**
+ * 测试目标：验证 #191 修复覆盖 QA 真机证据场景
+ *
+ * 场景：
+ *   - scrape_info 表中已有记录：media_type=tv, title=蜜语纪, season_number=NULL, episode_number=NULL, episode_id=NULL
+ *   - 文件名：19 4K.mp4、20 4K.mp4
+ *   - 期望：检测函数应返回 true，表示需要修复
+ *
+ * 失败条件：当前实现未处理 tv + title 非空 + episodeId NULL 的记录
+ */
+export default function tvEpisodeIncompleteRepairTest() {
+  describe('TvEpisode incomplete repair detection - QA evidence scenario #191', () => {
+    /**
+     * 测试用例 1：tv + title 非空 + episodeId NULL，应返回 true
+     */
+    it('should_return_true_for_tv_with_title_but_no_episode_id', 0, () => {
+      const scrapeInfo: ScrapeInfoEntity = {
+        videoId: 1,
+        provider: 'tmdb',
+        providerId: '123',
+        mediaType: 'tv',
+        title: '蜜语纪',
+        // seasonNumber, episodeNumber, episodeId 全部为 undefined
+        scrapedAt: Date.now()
+      };
+      const fileName = '19 4K.mp4';
+
+      const result = shouldRepairIncompleteTvEpisode(scrapeInfo, fileName);
+
+      expect(result).assertTrue();
+    });
+
+    /**
+     * 测试用例 2：tv + title 非空 + episodeId 存在，应返回 false
+     */
+    it('should_return_false_for_complete_tv_episode', 0, () => {
+      const scrapeInfo: ScrapeInfoEntity = {
+        videoId: 1,
+        provider: 'tmdb',
+        providerId: '123',
+        mediaType: 'tv',
+        title: '蜜语纪',
+        seasonNumber: 1,
+        episodeNumber: 19,
+        episodeId: 100,
+        scrapedAt: Date.now()
+      };
+      const fileName = '19 4K.mp4';
+
+      const result = shouldRepairIncompleteTvEpisode(scrapeInfo, fileName);
+
+      expect(result).assertFalse();
+    });
+
+    /**
+     * 测试用例 3：mediaType 不是 tv，应返回 false
+     */
+    it('should_return_false_for_non_tv_media', 0, () => {
+      const scrapeInfo: ScrapeInfoEntity = {
+        videoId: 1,
+        provider: 'tmdb',
+        providerId: '123',
+        mediaType: 'movie',
+        title: '某电影',
+        scrapedAt: Date.now()
+      };
+      const fileName = '19 4K.mp4';
+
+      const result = shouldRepairIncompleteTvEpisode(scrapeInfo, fileName);
+
+      expect(result).assertFalse();
+    });
+
+    /**
+     * 测试用例 4：tv 但 title 为空，应返回 false
+     */
+    it('should_return_false_for_tv_without_title', 0, () => {
+      const scrapeInfo: ScrapeInfoEntity = {
+        videoId: 1,
+        provider: 'tmdb',
+        providerId: '123',
+        mediaType: 'tv',
+        title: '', // title 为空字符串
+        scrapedAt: Date.now()
+      };
+      const fileName = '19 4K.mp4';
+
+      const result = shouldRepairIncompleteTvEpisode(scrapeInfo, fileName);
+
+      expect(result).assertFalse();
+    });
+
+    /**
+     * 测试用例 5：文件名无法提取 episode number，应返回 false
+     */
+    it('should_return_false_when_filename_has_no_episode_number', 0, () => {
+      const scrapeInfo: ScrapeInfoEntity = {
+        videoId: 1,
+        provider: 'tmdb',
+        providerId: '123',
+        mediaType: 'tv',
+        title: '蜜语纪',
+        scrapedAt: Date.now()
+      };
+      const fileName = 'trailer.mp4'; // 无法提取 episode number
+
+      const result = shouldRepairIncompleteTvEpisode(scrapeInfo, fileName);
+
+      expect(result).assertFalse();
+    });
+
+    /**
+     * 测试用例 6：测试真实文件名 "20 4K.mp4"
+     */
+    it('should_return_true_for_real_filename_20_4K_mp4', 0, () => {
+      const scrapeInfo: ScrapeInfoEntity = {
+        videoId: 2,
+        provider: 'tmdb',
+        providerId: '456',
+        mediaType: 'tv',
+        title: '蜜语纪',
+        scrapedAt: Date.now()
+      };
+      const fileName = '20 4K.mp4';
+
+      const result = shouldRepairIncompleteTvEpisode(scrapeInfo, fileName);
+
+      expect(result).assertTrue();
+    });
+  });
+}

--- a/entry/src/test/VideoScannerUtil.test.ets
+++ b/entry/src/test/VideoScannerUtil.test.ets
@@ -1,0 +1,36 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  VideoScrapeContext,
+  classifyVideoScrapeTarget,
+  createVideoScrapeContext,
+  hasSeasonSiblingDirectory
+} from '../main/ets/utils/VideoScannerUtil';
+
+export default function videoScannerUtilTest() {
+  describe('VideoScannerUtil mixed directory scan helpers', () => {
+    it('should detect season sibling directories from current directory entries', 0, () => {
+      expect(hasSeasonSiblingDirectory(['第一季', '幕后花絮'])).assertTrue();
+      expect(hasSeasonSiblingDirectory(['Season 1', 'Extras'])).assertTrue();
+      expect(hasSeasonSiblingDirectory(['电影合集', '花絮'])).assertFalse();
+    });
+
+    it('should pass season sibling context and root series hint to root weak semantic files', 0, () => {
+      const context: VideoScrapeContext = createVideoScrapeContext('/蜜语纪', 0, true);
+      const classification = classifyVideoScrapeTarget('19.mp4', '/蜜语纪/19.mp4', context);
+
+      expect(context.seasonSiblingDetected).assertTrue();
+      expect(context.seriesHint).assertEqual('蜜语纪');
+      expect(classification.mediaType).assertEqual('tv');
+      expect(classification.reason).assertEqual('season-sibling-detected');
+    });
+
+    it('should not apply root mixed directory context to deeper layers without local season siblings', 0, () => {
+      const context: VideoScrapeContext = createVideoScrapeContext('/蜜语纪', 1, false);
+      const classification = classifyVideoScrapeTarget('19.mp4', '/蜜语纪/特典/19.mp4', context);
+
+      expect(context.seasonSiblingDetected).assertFalse();
+      expect(context.seriesHint === undefined).assertTrue();
+      expect(classification.mediaType).assertEqual('unknown');
+    });
+  });
+}


### PR DESCRIPTION
## 变更摘要
- 根层弱语义分集在存在季目录兄弟项时识别为 tv。
- 普通弱语义文件保持 unknown。
- WebDAV/SMB 路径一致。

## QA PASS 测试结果
- Entry HAP 编译：BUILD SUCCESSFUL。
- 单测：285/285 passed。

## OpenSpec change
- fix-episode-scan-root-dir-missing

## 仍需用户真机/真实媒体库验收
- `蜜语纪/19-22.mp4 + 第一季/1-18,23-30` 扫描后剧集列表完整显示 1-30 集。

## 返修记录
- 首轮 QA 单测失败 1 个，已在 commit `57a6fd6557839944cd22023cb3e3ab9a0c5d0587` 修复并复验通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Season-sibling detection during scans enables automatic TV classification at scan root and propagates series hints to discovered items.

* **Improvements**
  * Broader season-name recognition (including non‑Latin numerals) and stronger TV precedence for weak titles; classifier emits a season‑sibling signal when applied.
  * Incremental scans now reprocess previously‑unknown items when context changes and persist unknown scrape records to enable future reprocessing.

* **Tests**
  * New tests covering detection, classification precedence, and incremental context-change behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->