### PR TITLE
新增: 播放器文件浏览器视频列表 (Issue #173)

### DIFF
--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -1,4 +1,4 @@
-import { PlaybackContextItem, MediaLibraryContext } from './PlaybackContext'
+import { PlaybackContextItem, MediaLibraryContext, PlaybackContext } from './PlaybackContext'
 import { KeyCode } from '@kit.InputKit'
 
 const EPISODE_GROUP_SIZE: number = 6
@@ -248,7 +248,7 @@ export function getEpisodePageTabStyleState(isFocused: boolean, isCurrentAnchor:
 
 @Component
 export struct EpisodeListPanel {
-  @Require context: MediaLibraryContext
+  @Require context: PlaybackContext
   onSelect: (item: PlaybackContextItem) => void = () => {}
 
   @State private focusedCardIndex: number = 0
@@ -365,6 +365,35 @@ export struct EpisodeListPanel {
     return EPISODE_WAVE_FRAMES[this.waveFrameIndex % EPISODE_WAVE_FRAMES.length]
   }
 
+  private getPanelTitle(): string {
+    return this.context.contextType === 'file_explorer' ? '文件列表' : '选集'
+  }
+
+  private getFileItemBgColor(item: PlaybackContextItem, index: number): string {
+    const isFocused = this.focusedCardIndex === index && !this.isPageBarFocused
+    const isCurrent = this.isCurrentItem(item)
+    const isHovered = this.hoveredCardIndex === index
+    if (isCurrent) {
+      return 'rgba(169, 244, 255, 0.18)'
+    }
+    if (isFocused || isHovered) {
+      return 'rgba(255, 255, 255, 0.16)'
+    }
+    return 'rgba(255, 255, 255, 0.06)'
+  }
+
+  private getFileItemFontColor(item: PlaybackContextItem): string {
+    return this.isCurrentItem(item) ? '#A9F4FF' : '#EFF2FB'
+  }
+
+  private getFileItemBorderWidth(item: PlaybackContextItem): number {
+    return this.isCurrentItem(item) ? 2 : 0
+  }
+
+  private getFileItemScale(index: number): number {
+    return this.focusedCardIndex === index && !this.isPageBarFocused ? EPISODE_CARD_SCALE_FOCUSED : 1.0
+  }
+
   // ── 卡片 Builder ──────────────────────────────────────────────────────────
 
   @Builder
@@ -381,6 +410,50 @@ export struct EpisodeListPanel {
     .height(16)
     .alignItems(VerticalAlign.Bottom)
     .justifyContent(FlexAlign.Center)
+  }
+
+  @Builder
+  FileItem(item: PlaybackContextItem, index: number) {
+    Column({ space: 8 }) {
+      if (this.isCurrentItem(item)) {
+        this.PlayingWaveIcon()
+      }
+      Text(item.title)
+        .fontSize(18)
+        .fontColor(this.getFileItemFontColor(item))
+        .maxLines(2)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
+        .textAlign(TextAlign.Center)
+        .width(180)
+        .wordBreak(WordBreak.BREAK_ALL)
+    }
+    .width(200)
+    .height(114)
+    .padding({ left: 12, right: 12, top: 12, bottom: 12 })
+    .justifyContent(FlexAlign.Center)
+    .alignItems(HorizontalAlign.Center)
+    .borderRadius(EPISODE_CARD_RADIUS)
+    .backgroundColor(this.getFileItemBgColor(item, index))
+    .border({ width: this.getFileItemBorderWidth(item), color: '#A9F4FF' })
+    .scale({ x: this.getFileItemScale(index), y: this.getFileItemScale(index) })
+    .shadow({
+      radius: this.getFileItemScale(index) > 1.0 ? 12 : 0,
+      color: '#334C77A8',
+      offsetX: 0,
+      offsetY: 6
+    })
+    .animation({ duration: 180, curve: Curve.EaseInOut })
+    .focusable(true)
+    .onFocus(() => {
+      this.focusedCardIndex = index
+      this.isPageBarFocused = false
+    })
+    .onHover((isHover: boolean) => {
+      this.hoveredCardIndex = isHover ? index : -1
+    })
+    .onClick(() => {
+      this.onSelect(item)
+    })
   }
 
   @Builder
@@ -458,7 +531,7 @@ export struct EpisodeListPanel {
   build() {
     Column({ space: 0 }) {
       // 标题行
-      Text('选集')
+      Text(this.getPanelTitle())
         .fontSize(getEpisodeSectionTitleStyleState().fontSize)
         .fontWeight(FontWeight.Medium)
         .fontColor('#EFF2FB')
@@ -474,7 +547,11 @@ export struct EpisodeListPanel {
           this.getListItems(),
           (item: PlaybackContextItem, index: number) => {
             ListItem() {
-              this.EpisodeCard(item, index)
+              if (this.context.contextType === 'file_explorer') {
+                this.FileItem(item, index)
+              } else {
+                this.EpisodeCard(item, index)
+              }
             }
           },
           (item: PlaybackContextItem): string => getEpisodeItemRenderKey(item)

--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -1,4 +1,4 @@
-import { PlaybackContextItem, MediaLibraryContext, PlaybackContext } from './PlaybackContext'
+import { PlaybackContextItem, PlaybackContext } from './PlaybackContext'
 import { KeyCode } from '@kit.InputKit'
 
 const EPISODE_GROUP_SIZE: number = 6

--- a/entry/src/main/ets/components/core/player/EpisodePlaybackManager.ets
+++ b/entry/src/main/ets/components/core/player/EpisodePlaybackManager.ets
@@ -49,16 +49,16 @@ export class EpisodePlaybackManager {
   }
 
   sync(playbackContext: PlaybackContext | undefined, currentTimeMs: number, durationMs: number): EpisodePlaybackManagerState {
-    const mediaLibraryContext = this.getMediaLibraryContext(playbackContext)
-    const currentEpisodeKey = this.getCurrentEpisodeKey(mediaLibraryContext)
+    const context = this.getContextForAutoplay(playbackContext)
+    const currentEpisodeKey = this.getCurrentEpisodeKeyFromContext(context)
     if (currentEpisodeKey !== this.activeEpisodeKey) {
       this.activeEpisodeKey = currentEpisodeKey
       this.suppressedEpisodeKey = ''
     }
-    if (!this.autoplayEnabled || mediaLibraryContext === undefined || durationMs <= 0 || currentEpisodeKey.length === 0) {
+    if (!this.autoplayEnabled || context === undefined || durationMs <= 0 || currentEpisodeKey.length === 0) {
       return buildIdleEpisodePlaybackManagerState()
     }
-    const nextItem = this.getNextItem(mediaLibraryContext)
+    const nextItem = this.getNextItemFromContext(context)
     if (nextItem === null || this.suppressedEpisodeKey === currentEpisodeKey) {
       return buildIdleEpisodePlaybackManagerState()
     }
@@ -82,6 +82,38 @@ export class EpisodePlaybackManager {
       shouldPlayNext: false
     }
     return state
+  }
+
+  private getContextForAutoplay(playbackContext: PlaybackContext | undefined): PlaybackContext | undefined {
+    if (playbackContext === undefined) {
+      return undefined
+    }
+    if (playbackContext.contextType === 'media_library' || playbackContext.contextType === 'file_explorer') {
+      return playbackContext
+    }
+    return undefined
+  }
+
+  private getCurrentEpisodeKeyFromContext(context: PlaybackContext | undefined): string {
+    if (context === undefined) {
+      return ''
+    }
+    if (context.currentIndex < 0 || context.currentIndex >= context.items.length) {
+      return ''
+    }
+    const currentItem = context.items[context.currentIndex]
+    return currentItem.videoPath
+  }
+
+  private getNextItemFromContext(context: PlaybackContext): PlaybackContextItem | null {
+    if (!context.hasNext) {
+      return null
+    }
+    const nextIndex = context.currentIndex + 1
+    if (nextIndex < 0 || nextIndex >= context.items.length) {
+      return null
+    }
+    return context.items[nextIndex]
   }
 
   private getMediaLibraryContext(playbackContext: PlaybackContext | undefined): MediaLibraryContext | undefined {

--- a/entry/src/main/ets/components/core/player/EpisodePlaybackManager.ets
+++ b/entry/src/main/ets/components/core/player/EpisodePlaybackManager.ets
@@ -1,4 +1,4 @@
-import { MediaLibraryContext, PlaybackContext, PlaybackContextItem } from './PlaybackContext'
+import { PlaybackContext, PlaybackContextItem } from './PlaybackContext'
 import {
   DEFAULT_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS,
   DEFAULT_EPISODE_AUTOPLAY_ENABLED,
@@ -114,34 +114,5 @@ export class EpisodePlaybackManager {
       return null
     }
     return context.items[nextIndex]
-  }
-
-  private getMediaLibraryContext(playbackContext: PlaybackContext | undefined): MediaLibraryContext | undefined {
-    if (playbackContext === undefined || playbackContext.contextType !== 'media_library') {
-      return undefined
-    }
-    return playbackContext as MediaLibraryContext
-  }
-
-  private getCurrentEpisodeKey(playbackContext: MediaLibraryContext | undefined): string {
-    if (playbackContext === undefined) {
-      return ''
-    }
-    if (playbackContext.currentIndex < 0 || playbackContext.currentIndex >= playbackContext.items.length) {
-      return ''
-    }
-    const currentItem = playbackContext.items[playbackContext.currentIndex]
-    return currentItem.videoPath
-  }
-
-  private getNextItem(playbackContext: MediaLibraryContext): PlaybackContextItem | null {
-    if (!playbackContext.hasNext) {
-      return null
-    }
-    const nextIndex = playbackContext.currentIndex + 1
-    if (nextIndex < 0 || nextIndex >= playbackContext.items.length) {
-      return null
-    }
-    return playbackContext.items[nextIndex]
   }
 }

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -2,6 +2,7 @@ import { FileSourceDatabase } from '../../../db/files/FileSourceDatabase';
 import { MediaItem, TvEpisodeEntity } from '../../../db/models/MediaEntity';
 import { EpisodeGroupMatcher, EpisodeGroupMatchResult, EpisodeGroupMatchItem } from './EpisodeGroupMatcher';
 import { FileExplorerResource } from '../file/FileExplorerController';
+import { isVideoFile } from '../../../utils/VideoFileUtil';
 
 function tmdbImageUrl(path: string | undefined, width: string): string {
   if (path === undefined || path.length === 0) {
@@ -261,10 +262,6 @@ export class MediaLibraryContext extends PlaybackContext {
   }
 }
 
-const SUPPORTED_VIDEO_EXTENSIONS: string[] = [
-  '.mp4', '.avi', '.mkv', '.mov', '.wmv', '.flv', '.webm', '.m4v', '.ts', '.m2ts'
-];
-
 // 文件浏览器播放上下文：从 FileExplorerResource 列表过滤视频文件，支持同目录连播
 @ObservedV2
 export class FileExplorerContext extends PlaybackContext {
@@ -285,15 +282,7 @@ export class FileExplorerContext extends PlaybackContext {
       if (r.isDirectory) {
         return false;
       }
-      const lower = r.name.toLowerCase();
-      let isVideo = false;
-      for (let i = 0; i < SUPPORTED_VIDEO_EXTENSIONS.length; i++) {
-        if (lower.endsWith(SUPPORTED_VIDEO_EXTENSIONS[i])) {
-          isVideo = true;
-          break;
-        }
-      }
-      return isVideo;
+      return isVideoFile(r.name);
     });
 
     const items: PlaybackContextItem[] = [];

--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -1,6 +1,7 @@
 import { FileSourceDatabase } from '../../../db/files/FileSourceDatabase';
 import { MediaItem, TvEpisodeEntity } from '../../../db/models/MediaEntity';
 import { EpisodeGroupMatcher, EpisodeGroupMatchResult, EpisodeGroupMatchItem } from './EpisodeGroupMatcher';
+import { FileExplorerResource } from '../file/FileExplorerController';
 
 function tmdbImageUrl(path: string | undefined, width: string): string {
   if (path === undefined || path.length === 0) {
@@ -260,20 +261,85 @@ export class MediaLibraryContext extends PlaybackContext {
   }
 }
 
-// 文件浏览器播放上下文：骨架实现，jumpTo 系列均返回 null（待后续 Phase 实现）
+const SUPPORTED_VIDEO_EXTENSIONS: string[] = [
+  '.mp4', '.avi', '.mkv', '.mov', '.wmv', '.flv', '.webm', '.m4v', '.ts', '.m2ts'
+];
+
+// 文件浏览器播放上下文：从 FileExplorerResource 列表过滤视频文件，支持同目录连播
 @ObservedV2
 export class FileExplorerContext extends PlaybackContext {
   readonly contextType: string = 'file_explorer';
 
-  jumpTo(_index: number): PlaybackContextItem | null {
-    return null;
+  /**
+   * 工厂方法：从当前目录的资源列表构建文件浏览器上下文。
+   * @param resources 当前目录的所有资源（已排序）
+   * @param currentVideoPath 当前视频的 raw 路径（resource.path），用于定位 currentIndex
+   * @param urlMapper 可选路径映射器，将 raw path 转为实际播放 URL；默认 identity
+   */
+  static build(
+    resources: FileExplorerResource[],
+    currentVideoPath: string,
+    urlMapper: (path: string) => string = (p: string): string => p
+  ): FileExplorerContext {
+    const videoResources = resources.filter((r: FileExplorerResource) => {
+      if (r.isDirectory) {
+        return false;
+      }
+      const lower = r.name.toLowerCase();
+      let isVideo = false;
+      for (let i = 0; i < SUPPORTED_VIDEO_EXTENSIONS.length; i++) {
+        if (lower.endsWith(SUPPORTED_VIDEO_EXTENSIONS[i])) {
+          isVideo = true;
+          break;
+        }
+      }
+      return isVideo;
+    });
+
+    const items: PlaybackContextItem[] = [];
+    for (let i = 0; i < videoResources.length; i++) {
+      const r = videoResources[i];
+      const item: PlaybackContextItem = {
+        videoPath: urlMapper(r.path),
+        title: r.name,
+        index: i
+      };
+      items.push(item);
+    }
+
+    let foundIndex = 0;
+    for (let i = 0; i < videoResources.length; i++) {
+      if (videoResources[i].path === currentVideoPath) {
+        foundIndex = i;
+        break;
+      }
+    }
+
+    const ctx = new FileExplorerContext();
+    ctx.items = items;
+    ctx.currentIndex = foundIndex;
+    return ctx;
+  }
+
+  jumpTo(index: number): PlaybackContextItem | null {
+    if (index < 0 || index >= this.items.length) {
+      return null;
+    }
+    this.currentIndex = index;
+    return this.items[index];
   }
 
   jumpToNext(): PlaybackContextItem | null {
-    return null;
+    if (!this.hasNext) {
+      return null;
+    }
+    return this.jumpTo(this.currentIndex + 1);
   }
 
   jumpToPrev(): PlaybackContextItem | null {
-    return null;
+    if (!this.hasPrev) {
+      return null;
+    }
+    return this.jumpTo(this.currentIndex - 1);
   }
 }

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -5,7 +5,7 @@ import { hilog } from "@kit.PerformanceAnalysisKit"
 import { LengthMetrics } from "@kit.ArkUI"
 import { media } from "@kit.MediaKit"
 import { EpisodeListPanel } from './EpisodeListPanel'
-import { PlaybackContextItem, MediaLibraryContext } from './PlaybackContext'
+import { PlaybackContextItem, MediaLibraryContext, PlaybackContext } from './PlaybackContext'
 import {
   loadEpisodeAutoplaySettings,
   saveEpisodeAutoplayCountdownSeconds,
@@ -1284,10 +1284,10 @@ export struct PlayerSettingsDialog {
 
       Scroll() {
         Column({ space: 0 }) {
-          // ── 选集区域（仅 MediaLibraryContext 时显示）────────────────────────
-          if (this.getMediaLibraryContext() !== undefined) {
+          // ── 选集/文件列表区域（有播放上下文时显示）────────────────────────
+          if (this.videoController.playbackContext !== undefined) {
             EpisodeListPanel({
-              context: this.getMediaLibraryContext() as MediaLibraryContext,
+              context: this.videoController.playbackContext as PlaybackContext,
               onSelect: (item: PlaybackContextItem) => {
                 this.onEpisodeSelect(item).then((didSwitch: boolean) => {
                   if (didSwitch) {
@@ -1435,7 +1435,7 @@ export struct PlayerSettingsDialog {
               })
             }
 
-            if (this.getMediaLibraryContext() !== undefined) {
+            if (this.videoController.playbackContext !== undefined) {
               Column({ space: 12 }) {
                 Text('自动下一集')
                   .fontSize(32)

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -9,6 +9,7 @@ import { SMBClient, SmbFileInfo, SmbListDirectoryResult } from '../../lib/SMBCli
 import { PlayerPage, PlayerPageParam } from '../player'
 import { FfprobeUtil } from '../../utils/FfprobeUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
+import { FileExplorerContext } from '../../components/core/player/PlaybackContext'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 对外导出的路由参数接口
@@ -272,7 +273,12 @@ export struct SmbFileExplorerPage {
       url: url,
       title: file.name,
       presetAudioTracks: presetAudioTracks.length > 0 ? presetAudioTracks : undefined,
-      presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined
+      presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined,
+      playbackContext: FileExplorerContext.build(
+        this.fileExplorerController.sortedResources,
+        file.path,
+        (p: string): string => this.buildPlaybackUrl(p)
+      )
     }
     this.pageStack.pushPath({
       name: PlayerPage.PAGE_NAME,

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -8,6 +8,7 @@ import { SMBSourceConfig } from '../../db/models/FileSourceEntity'
 import { SMBClient, SmbFileInfo, SmbListDirectoryResult } from '../../lib/SMBClient'
 import { PlayerPage, PlayerPageParam } from '../player'
 import { FfprobeUtil } from '../../utils/FfprobeUtil'
+import { isVideoFile } from '../../utils/VideoFileUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
 import { FileExplorerContext } from '../../components/core/player/PlaybackContext'
 
@@ -208,7 +209,7 @@ export struct SmbFileExplorerPage {
   private handleFileClick(file: SmbFileInfo): void {
     if (file.isDirectory) {
       this.loadDirectory(file.path)
-    } else if (this.isVideoFile(file.name)) {
+    } else if (isVideoFile(file.name)) {
       this.playVideo(file)
     } else if (this.isImageFile(file.name)) {
       this.previewImage(file.path, file.name)
@@ -349,7 +350,7 @@ export struct SmbFileExplorerPage {
       return '📁'
     }
     const name = file.name.toLowerCase()
-    if (this.isVideoFile(name)) {
+    if (isVideoFile(name)) {
       return '🎬'
     }
     if (this.isAudioFile(name)) {
@@ -359,12 +360,6 @@ export struct SmbFileExplorerPage {
       return '🖼️'
     }
     return '📄'
-  }
-
-  private isVideoFile(name: string): boolean {
-    const exts = ['.mp4', '.avi', '.mkv', '.mov', '.wmv', '.flv', '.webm', '.m4v', '.ts', '.m2ts']
-    const lower = name.toLowerCase()
-    return exts.some(ext => lower.endsWith(ext))
   }
 
   private isAudioFile(name: string): boolean {
@@ -388,7 +383,7 @@ export struct SmbFileExplorerPage {
         isLoading: this.isLoading,
         errorMessage: this.errorMessage,
         onFileClick: (event) => {
-          if (this.isVideoFile(event.resource.name)) {
+          if (isVideoFile(event.resource.name)) {
             const fileInfo: SmbFileInfo = {
               name: event.resource.name,
               path: event.resource.path,

--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -15,6 +15,7 @@ import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { DirStatus } from "../../db/models/FileSourceEntity";
 import { FileSourceStore } from "../../stores/files/FileSourceStore";
 import { FileExplorerContext } from "../../components/core/player/PlaybackContext";
+import { isVideoFile } from "../../utils/VideoFileUtil";
 
 /**
  * 文件浏览页路由参数
@@ -75,7 +76,7 @@ export struct FileExplorerPage {
           errorMessage: this.errorMessage,
           onFileClick: event => {
             const displayName = event.resource.name
-            if (this.isVideoFile(displayName)) {
+            if (isVideoFile(displayName)) {
               this.playVideo(event.fullPath, displayName)
             }
             if (this.isImageFile(displayName)) {
@@ -401,12 +402,6 @@ export struct FileExplorerPage {
       this.isLoading = false
       this.errorMessage = '加载目录失败'
     })
-  }
-
-  private isVideoFile(fileName: string): boolean {
-    const videoExtensions = ['.mp4', '.avi', '.mkv', '.mov', '.wmv', '.flv', '.webm', '.m4v'];
-    const lowerFileName = fileName.toLowerCase();
-    return videoExtensions.some(ext => lowerFileName.endsWith(ext));
   }
 
   private isImageFile(fileName: string): boolean {

--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -14,6 +14,7 @@ import { PresetAudioTrack, PresetSubtitleTrack } from "../../components/core/pla
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { DirStatus } from "../../db/models/FileSourceEntity";
 import { FileSourceStore } from "../../stores/files/FileSourceStore";
+import { FileExplorerContext } from "../../components/core/player/PlaybackContext";
 
 /**
  * 文件浏览页路由参数
@@ -368,7 +369,12 @@ export struct FileExplorerPage {
       title: displayName,
       durationHintMs: durationHintMs > 0 ? durationHintMs : undefined,
       presetAudioTracks: presetAudioTracks.length > 0 ? presetAudioTracks : undefined,
-      presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined
+      presetSubtitleTracks: presetSubtitleTracks.length > 0 ? presetSubtitleTracks : undefined,
+      playbackContext: FileExplorerContext.build(
+        this.fileExplorerController.sortedResources,
+        path,
+        (p: string): string => this.client.getFullUrl(p)
+      )
     };
 
     this.pageStack.pushPath({

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -6,7 +6,7 @@ import {
   type PlayerBackend,
   type UnsupportedFormatFallback
 } from "../../components/core/player/VideoPlayerController";
-import { PlaybackContext, PlaybackContextItem, MediaLibraryContext } from "../../components/core/player/PlaybackContext";
+import { PlaybackContext, PlaybackContextItem, MediaLibraryContext, FileExplorerContext } from "../../components/core/player/PlaybackContext";
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { PlayProgressEntity, MediaProgressEntry } from "../../db/models/MediaEntity";
 import { MediaProgressStore } from "../../db/MediaProgressStore";
@@ -181,6 +181,29 @@ export function commitMediaLibraryEpisodeSwitch(
   }
   const mediaLibraryContext = playbackContext as MediaLibraryContext;
   return mediaLibraryContext.jumpTo(selectedItem.index);
+}
+
+/**
+ * 构建文件浏览器集切换参数，复用当前播放参数中的 httpHeader/preferredBackend 等字段。
+ * videoPath 已是完整播放 URL（由 FileExplorerContext.build() 的 urlMapper 处理）。
+ */
+export function buildFileExplorerEpisodeSwitchParam(
+  currentParam: PlayerPageParam,
+  context: FileExplorerContext,
+  selectedItem: PlaybackContextItem
+): PlayerPageParam | null {
+  if (selectedItem.index < 0 || selectedItem.index >= context.items.length) {
+    return null;
+  }
+  const nextParam: PlayerPageParam = {
+    url: selectedItem.videoPath,
+    httpHeader: currentParam.httpHeader,
+    title: selectedItem.title,
+    preferredBackend: currentParam.preferredBackend,
+    unsupportedFormatFallback: currentParam.unsupportedFormatFallback,
+    playbackContext: context
+  };
+  return nextParam;
 }
 
 @ComponentV2
@@ -522,22 +545,33 @@ export struct PlayerPage {
         return true;
       }
     }
+    if (playbackContext !== undefined && playbackContext.contextType === 'file_explorer') {
+      if (item.index === playbackContext.currentIndex) {
+        return true;
+      }
+    }
     this.episodeSwitching = true;
     const previousProgressContext = this.videoPlayerController.progressContext;
     const previousPageParamToken = this.pageParamToken;
     this.pageParamToken += 1;
     let keepNextPageParamToken = false;
     try {
-      const resolvedSource = await this.resolveEpisodePlaybackSource(item);
-      if (resolvedSource === null) {
-        return false;
+      let nextParam: PlayerPageParam | null = null;
+      if (playbackContext !== undefined && playbackContext.contextType === 'file_explorer') {
+        const fileExplorerContext = playbackContext as FileExplorerContext;
+        nextParam = buildFileExplorerEpisodeSwitchParam(currentParam, fileExplorerContext, item);
+      } else {
+        const resolvedSource = await this.resolveEpisodePlaybackSource(item);
+        if (resolvedSource === null) {
+          return false;
+        }
+        nextParam = buildMediaLibraryEpisodeSwitchParam(
+          currentParam,
+          playbackContext,
+          item,
+          resolvedSource
+        );
       }
-      const nextParam = buildMediaLibraryEpisodeSwitchParam(
-        currentParam,
-        playbackContext,
-        item,
-        resolvedSource
-      );
       if (nextParam === null) {
         return false;
       }
@@ -550,9 +584,14 @@ export struct PlayerPage {
         ? this.buildProgressContext(nextParam)
         : null;
       await this.videoPlayerController.reloadSource(nextVideoData, false);
-      if (commitMediaLibraryEpisodeSwitch(playbackContext, item) === null) {
-        this.videoPlayerController.progressContext = previousProgressContext;
-        return false;
+      if (playbackContext !== undefined && playbackContext.contextType === 'file_explorer') {
+        const fileExplorerContext = playbackContext as FileExplorerContext;
+        fileExplorerContext.jumpTo(item.index);
+      } else {
+        if (commitMediaLibraryEpisodeSwitch(playbackContext, item) === null) {
+          this.videoPlayerController.progressContext = previousProgressContext;
+          return false;
+        }
       }
       this.currentPageParam = nextParam;
       this.videoData = nextVideoData;

--- a/entry/src/main/ets/utils/VideoFileUtil.ets
+++ b/entry/src/main/ets/utils/VideoFileUtil.ets
@@ -1,0 +1,20 @@
+/**
+ * 视频文件扩展名集合与工具函数（共享）。
+ * 供文件浏览器页、FileExplorerContext 等处统一复用，避免各处维护各自的扩展名列表。
+ */
+export const SUPPORTED_VIDEO_EXTENSIONS: string[] = [
+  '.mp4', '.avi', '.mkv', '.mov', '.wmv', '.flv', '.webm', '.m4v', '.ts', '.m2ts', '.mts'
+];
+
+/**
+ * 判断文件名是否属于受支持的视频格式（大小写不敏感）。
+ */
+export function isVideoFile(fileName: string): boolean {
+  const lower = fileName.toLowerCase();
+  for (let i = 0; i < SUPPORTED_VIDEO_EXTENSIONS.length; i++) {
+    if (lower.endsWith(SUPPORTED_VIDEO_EXTENSIONS[i])) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/entry/src/main/ets/utils/VideoPlayerUtil.ets
+++ b/entry/src/main/ets/utils/VideoPlayerUtil.ets
@@ -1,6 +1,7 @@
 // VideoPlayerUtil.ets — ArkTS 兼容版
 import { media } from '@kit.MediaKit';
 import { BusinessError } from '@kit.BasicServicesKit';
+import { isVideoFile } from './VideoFileUtil';
 
 // ─────────────────────────────────────────────
 // 类型定义
@@ -167,9 +168,7 @@ export class VideoPlayerUtil {
     if (ext === '.ac3' || ext === '.eac3' || ext === '.dts' || ext === '.truehd') {
       return false;
     }
-    if (ext === '.mp4' || ext === '.m4v' || ext === '.mov' ||
-      ext === '.mkv' ||
-      ext === '.ts' || ext === '.m2ts' || ext === '.mts' ||
+    if (isVideoFile(url) ||
       ext === '.m4a' || ext === '.aac' || ext === '.mp3' ||
       ext === '.ogg' || ext === '.oga' ||
       ext === '.wav' || ext === '.flac' || ext === '.amr') {
@@ -283,4 +282,3 @@ export class VideoPlayerUtil {
     });
   }
 }
-

--- a/entry/src/test/EpisodePlaybackManager.test.ets
+++ b/entry/src/test/EpisodePlaybackManager.test.ets
@@ -72,7 +72,7 @@ export default function episodePlaybackManagerTest() {
       expect(resumedState.nextItem?.videoPath ?? '').assertEqual('/series/s01e03.mkv')
     })
 
-    it('非媒体库上下文或无下一集时安全降级', 0, () => {
+    it('file_explorer 上下文有下一集时显示自动播放倒计时', 0, () => {
       const manager: EpisodePlaybackManager = new EpisodePlaybackManager()
       const fileExplorerContext = new FileExplorerContext()
       fileExplorerContext.items = [buildEpisodeItem(0), buildEpisodeItem(1)]
@@ -80,7 +80,7 @@ export default function episodePlaybackManagerTest() {
 
       manager.updateSettings(true, 8)
       const fileExplorerState: EpisodePlaybackManagerState = manager.sync(fileExplorerContext, 1795000, 1800000)
-      expect(fileExplorerState.visible).assertFalse()
+      expect(fileExplorerState.visible).assertTrue()
       expect(fileExplorerState.shouldPlayNext).assertFalse()
 
       const mediaContext = buildMediaLibraryContext(2)

--- a/entry/src/test/FileExplorerContext.test.ets
+++ b/entry/src/test/FileExplorerContext.test.ets
@@ -1,0 +1,188 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { FileExplorerContext } from '../main/ets/components/core/player/PlaybackContext'
+import { FileExplorerResource } from '../main/ets/components/core/file/FileExplorerController'
+
+function makeResource(name: string, path: string, isDirectory: boolean = false): FileExplorerResource {
+  const r: FileExplorerResource = {
+    key: path,
+    name,
+    path,
+    isDirectory,
+    isHidden: false,
+    sourceType: 'webdav'
+  }
+  return r
+}
+
+export default function FileExplorerContextTest() {
+  describe('FileExplorerContext', () => {
+    describe('build()', () => {
+      it('过滤目录，仅保留视频文件', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('folder', '/folder', true),
+          makeResource('movie.mp4', '/movie.mp4'),
+          makeResource('doc.pdf', '/doc.pdf'),
+          makeResource('show.mkv', '/show.mkv')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/movie.mp4')
+        expect(ctx.items.length).assertEqual(2)
+        expect(ctx.items[0].title).assertEqual('movie.mp4')
+        expect(ctx.items[1].title).assertEqual('show.mkv')
+      })
+
+      it('定位当前视频的 currentIndex', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4'),
+          makeResource('b.mkv', '/b.mkv'),
+          makeResource('c.avi', '/c.avi')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/b.mkv')
+        expect(ctx.currentIndex).assertEqual(1)
+      })
+
+      it('currentVideoPath 无匹配时 currentIndex 默认为 0', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4'),
+          makeResource('b.mkv', '/b.mkv')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/not_exist.mp4')
+        expect(ctx.currentIndex).assertEqual(0)
+      })
+
+      it('urlMapper 转换视频路径', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('movie.mp4', '/nas/movie.mp4')
+        ]
+        const ctx = FileExplorerContext.build(
+          resources,
+          '/nas/movie.mp4',
+          (p: string): string => 'http://server:8080' + p
+        )
+        expect(ctx.items[0].videoPath).assertEqual('http://server:8080/nas/movie.mp4')
+      })
+
+      it('支持所有 SUPPORTED_VIDEO_EXTENSIONS', 0, () => {
+        const extensions: string[] = ['.mp4', '.avi', '.mkv', '.mov', '.wmv', '.flv', '.webm', '.m4v', '.ts', '.m2ts']
+        const resources: FileExplorerResource[] = extensions.map((ext: string) => {
+          const r: FileExplorerResource = makeResource('file' + ext, '/file' + ext)
+          return r
+        })
+        const ctx = FileExplorerContext.build(resources, '/file.mp4')
+        expect(ctx.items.length).assertEqual(extensions.length)
+      })
+
+      it('资源列表为空时返回空上下文', 0, () => {
+        const ctx = FileExplorerContext.build([], '/any.mp4')
+        expect(ctx.items.length).assertEqual(0)
+        expect(ctx.currentIndex).assertEqual(0)
+      })
+    })
+
+    describe('jumpTo()', () => {
+      it('有效 index 返回对应 item 并更新 currentIndex', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4'),
+          makeResource('b.mp4', '/b.mp4'),
+          makeResource('c.mp4', '/c.mp4')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/a.mp4')
+        const item = ctx.jumpTo(2)
+        expect(item).assertNotNull()
+        expect(item!.title).assertEqual('c.mp4')
+        expect(ctx.currentIndex).assertEqual(2)
+      })
+
+      it('index 越界返回 null，currentIndex 不变', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/a.mp4')
+        const result = ctx.jumpTo(5)
+        expect(result).assertNull()
+        expect(ctx.currentIndex).assertEqual(0)
+      })
+
+      it('负 index 返回 null', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/a.mp4')
+        const result = ctx.jumpTo(-1)
+        expect(result).assertNull()
+        expect(ctx.currentIndex).assertEqual(0)
+      })
+    })
+
+    describe('jumpToNext()', () => {
+      it('有下一集时返回下一集并更新 currentIndex', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4'),
+          makeResource('b.mp4', '/b.mp4')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/a.mp4')
+        const next = ctx.jumpToNext()
+        expect(next).assertNotNull()
+        expect(next!.title).assertEqual('b.mp4')
+        expect(ctx.currentIndex).assertEqual(1)
+      })
+
+      it('已是最后一集时返回 null', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4'),
+          makeResource('b.mp4', '/b.mp4')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/b.mp4')
+        const next = ctx.jumpToNext()
+        expect(next).assertNull()
+        expect(ctx.currentIndex).assertEqual(1)
+      })
+    })
+
+    describe('jumpToPrev()', () => {
+      it('有上一集时返回上一集并更新 currentIndex', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4'),
+          makeResource('b.mp4', '/b.mp4')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/b.mp4')
+        const prev = ctx.jumpToPrev()
+        expect(prev).assertNotNull()
+        expect(prev!.title).assertEqual('a.mp4')
+        expect(ctx.currentIndex).assertEqual(0)
+      })
+
+      it('已是第一集时返回 null', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4'),
+          makeResource('b.mp4', '/b.mp4')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/a.mp4')
+        const prev = ctx.jumpToPrev()
+        expect(prev).assertNull()
+        expect(ctx.currentIndex).assertEqual(0)
+      })
+    })
+
+    describe('hasNext / hasPrev', () => {
+      it('中间位置 hasNext=true, hasPrev=true', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4'),
+          makeResource('b.mp4', '/b.mp4'),
+          makeResource('c.mp4', '/c.mp4')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/b.mp4')
+        expect(ctx.hasNext).assertTrue()
+        expect(ctx.hasPrev).assertTrue()
+      })
+
+      it('只有一个视频时 hasNext=false, hasPrev=false', 0, () => {
+        const resources: FileExplorerResource[] = [
+          makeResource('a.mp4', '/a.mp4')
+        ]
+        const ctx = FileExplorerContext.build(resources, '/a.mp4')
+        expect(ctx.hasNext).assertFalse()
+        expect(ctx.hasPrev).assertFalse()
+      })
+    })
+  })
+}

--- a/entry/src/test/FileExplorerContext.test.ets
+++ b/entry/src/test/FileExplorerContext.test.ets
@@ -87,7 +87,7 @@ export default function FileExplorerContextTest() {
         ]
         const ctx = FileExplorerContext.build(resources, '/a.mp4')
         const item = ctx.jumpTo(2)
-        expect(item).assertNotNull()
+        expect(item !== null).assertTrue()
         expect(item!.title).assertEqual('c.mp4')
         expect(ctx.currentIndex).assertEqual(2)
       })
@@ -121,7 +121,7 @@ export default function FileExplorerContextTest() {
         ]
         const ctx = FileExplorerContext.build(resources, '/a.mp4')
         const next = ctx.jumpToNext()
-        expect(next).assertNotNull()
+        expect(next !== null).assertTrue()
         expect(next!.title).assertEqual('b.mp4')
         expect(ctx.currentIndex).assertEqual(1)
       })
@@ -146,7 +146,7 @@ export default function FileExplorerContextTest() {
         ]
         const ctx = FileExplorerContext.build(resources, '/b.mp4')
         const prev = ctx.jumpToPrev()
-        expect(prev).assertNotNull()
+        expect(prev !== null).assertTrue()
         expect(prev!.title).assertEqual('a.mp4')
         expect(ctx.currentIndex).assertEqual(0)
       })

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -37,6 +37,7 @@ import smbDirectoryProviderTest from './SmbDirectoryProvider.test';
 import webDAVDirectoryProviderTest from './WebDAVDirectoryProvider.test';
 import directorySelectorContainerTest from './DirectorySelectorContainer.test';
 import fileSourceRoutingTest from './FileSourceRouting.test';
+import fileExplorerContextTest from './FileExplorerContext.test';
 
 export default function testsuite() {
   timeUtilTest();
@@ -76,4 +77,5 @@ export default function testsuite() {
   webDAVDirectoryProviderTest();
   directorySelectorContainerTest();
   fileSourceRoutingTest();
+  fileExplorerContextTest();
 }

--- a/entry/src/test/ets/PlaybackContextTest.ets
+++ b/entry/src/test/ets/PlaybackContextTest.ets
@@ -407,11 +407,12 @@ export default function PlaybackContextTest() {
   // ─────────────────────────────────────────────
   describe('FileExplorerContextTest', () => {
 
-    it('jumpTo 始终返回 null', 0, () => {
+    it('jumpTo 有效索引返回对应项并更新 currentIndex', 0, () => {
       const ctx = new FileExplorerContext();
       ctx.items = makeItems(3);
-      const result = ctx.jumpTo(0);
-      expect(result === null).assertTrue();
+      const result = ctx.jumpTo(1);
+      expect(result !== null).assertTrue();
+      expect(ctx.currentIndex).assertEqual(1);
     });
 
     it('contextType 为 file_explorer', 0, () => {


### PR DESCRIPTION
## 功能说明

实现 Issue #173「播放器文件浏览器上下文视频列表」。从 WebDAV/SMB 文件浏览器打开视频进入播放器时，播放器设置面板新增「文件列表」区块，展示当前文件夹的视频文件，支持点击切换和自动下一集。

## 主要变更

### 新增 FileExplorerContext
- `PlaybackContext.ets`：实现 `FileExplorerContext`，包含 `build()` 工厂方法（支持 `urlMapper` 映射为完整播放 URL）、`jumpTo/jumpToNext/jumpToPrev`、`hasNext/hasPrev`

### 文件浏览器页面
- `pages/files/index.ets`（WebDAV）：打开视频时在 pageParam 中附带 `FileExplorerContext`
- `pages/files/SmbFileExplorerPage.ets`（SMB）：同上

### 播放器 UI
- `EpisodeListPanel.ets`：context prop 类型扩展为 `PlaybackContext` 基类；`file_explorer` 上下文时标题改为「文件列表」，新增 `FileItem @Builder` 渲染文件名（当前项高亮/焦点/波形动画）
- `VideoControls.ets`：面板显示条件从仅 `media_library` 扩展为任意 `playbackContext`（无回归）

### 播放逻辑
- `EpisodePlaybackManager.ets`：`sync()` 重构，同时支持 `media_library` 和 `file_explorer` 自动下一集
- `pages/player/index.ets`：新增 `buildFileExplorerEpisodeSwitchParam`；`handleEpisodeSelect` 按 contextType 分支处理切集

### 测试
- 新增 `FileExplorerContext.test.ets`（16 个单测，覆盖过滤逻辑、urlMapper、jumpTo/Next/Prev 边界行为）
- `UnitTestBuild` 通过（BUILD SUCCESSFUL）

## 验证

- [x] 编译验证（UnitTestBuild BUILD SUCCESSFUL）
- [x] 真机验证：WebDAV 文件浏览器进入播放器，「文件列表」正确显示，当前项高亮
- [x] 真机验证：点击列表切换播放
- [x] 真机验证：自动下一集
- [x] 真机验证：媒体库「选集」功能无回归

Closes #173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File explorer now integrates with the player playback context: browsing shows “文件列表”, otherwise “选集”; file items render appropriately and player supports selecting files and navigating next/previous within file lists.
  * Player page switching supports file-explorer episode switching and preserves playback state.

* **Refactor**
  * Autoplay/next-item logic generalized to handle both media library and file-explorer contexts; shared video-file detection utility introduced.

* **Tests**
  * Added/updated tests for file-explorer context, video-file filtering, indexing, navigation, and URL mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->