### PR TITLE
feat: #201 Umami 事件上报集成（playback_attempt / subtitle_usage / scan_coverage）

### DIFF
--- a/entry/src/main/ets/services/analytics/UmamiReporter.ets
+++ b/entry/src/main/ets/services/analytics/UmamiReporter.ets
@@ -3,6 +3,7 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { AppPreferences } from '../../utils/AppPreferences';
 import { MediaIdentity, MetricsReporter } from '../metrics/MetricsReporter';
+import { getMetricsTraceLogger } from '../metrics/MetricsTraceLogger';
 
 const TAG = 'UmamiReporter';
 const DOMAIN = 0x0001;
@@ -176,7 +177,13 @@ export class UmamiReporter implements MetricsReporter {
     this.requestFactory = requestFactory;
   }
 
+  getReporterName(): string {
+    return 'UmamiReporter';
+  }
+
   recordPlaybackAttempt(success: boolean, firstFrameMs: number, media?: MediaIdentity, sourceType?: string): void {
+    getMetricsTraceLogger().info(TAG,
+      `Umami record playback_attempt success=${success ? 1 : 0} queue=${this.pendingQueue.length}`);
     const payload = buildUmamiEventPayload(
       this.config,
       'player',
@@ -187,6 +194,8 @@ export class UmamiReporter implements MetricsReporter {
   }
 
   recordSubtitleUsage(language: string | null): void {
+    getMetricsTraceLogger().info(TAG,
+      `Umami record subtitle_usage subtitle=${language === null ? 'off' : 'on'} queue=${this.pendingQueue.length}`);
     const payload = buildUmamiEventPayload(
       this.config,
       'player',
@@ -197,6 +206,8 @@ export class UmamiReporter implements MetricsReporter {
   }
 
   recordScanCoverage(scanned: number, total: number): void {
+    getMetricsTraceLogger().info(TAG,
+      `Umami record scan_coverage scanned=${scanned} total=${total} queue=${this.pendingQueue.length}`);
     const payload = buildUmamiEventPayload(
       this.config,
       'scanner',
@@ -207,17 +218,18 @@ export class UmamiReporter implements MetricsReporter {
   }
 
   async flush(): Promise<void> {
-    hilog.info(DOMAIN, TAG, `Umami flush entered: queue=${this.pendingQueue.length} sending=${this.isSending}`);
+    getMetricsTraceLogger().info(TAG, `Umami flush entered: queue=${this.pendingQueue.length} sending=${this.isSending}`);
     await this.ensureIdentifyQueued();
     if (this.activeDrainPromise !== null) {
-      hilog.info(DOMAIN, TAG, 'Umami flush waiting for in-flight send');
+      getMetricsTraceLogger().info(TAG, 'Umami flush waiting for in-flight send');
     }
     await this.processQueue();
   }
 
   private enqueue(payload: UmamiSendRequest): void {
     this.pendingQueue.push(payload);
-    hilog.info(DOMAIN, TAG, `Umami enqueue: type=${payload.type} name=${payload.payload.name} queue=${this.pendingQueue.length}`);
+    getMetricsTraceLogger().info(TAG,
+      `Umami enqueue: type=${payload.type} name=${payload.payload.name} queue=${this.pendingQueue.length}`);
     void this.kickoffProcessing();
   }
 
@@ -249,7 +261,7 @@ export class UmamiReporter implements MetricsReporter {
       }
       this.pendingQueue.unshift(buildUmamiIdentifyPayload(this.config, deviceUuid));
       this.identifyQueued = true;
-      hilog.info(DOMAIN, TAG, `Umami identify queued: queue=${this.pendingQueue.length}`);
+      getMetricsTraceLogger().info(TAG, `Umami identify queued: queue=${this.pendingQueue.length}`);
     } finally {
       this.identifyQueuePromise = null;
     }
@@ -291,6 +303,8 @@ export class UmamiReporter implements MetricsReporter {
   private async sendPayload(payload: UmamiSendRequest): Promise<boolean> {
     const request = this.requestFactory();
     try {
+      getMetricsTraceLogger().info(TAG,
+        `Umami send start: type=${payload.type} name=${payload.payload.name} queue=${this.pendingQueue.length}`);
       const response = await request.request(`${this.config.baseUrl}/api/send`, {
         method: http.RequestMethod.POST,
         header: {
@@ -302,15 +316,15 @@ export class UmamiReporter implements MetricsReporter {
       });
       const ok = response.responseCode >= 200 && response.responseCode < 300;
       if (ok) {
-        hilog.info(DOMAIN, TAG, `Umami send success: type=${payload.type} name=${payload.payload.name}`);
+        getMetricsTraceLogger().info(TAG, `Umami send success: type=${payload.type} name=${payload.payload.name}`);
       }
       if (!ok) {
-        hilog.warn(DOMAIN, TAG, `Umami send failed: type=${payload.type} code=${response.responseCode}`);
+        getMetricsTraceLogger().warn(TAG, `Umami send failed: type=${payload.type} code=${response.responseCode}`);
       }
       return ok;
     } catch (e) {
       const err = e as BusinessError;
-      hilog.warn(DOMAIN, TAG, `Umami send error: type=${payload.type} message=${err.message ?? String(e)}`);
+      getMetricsTraceLogger().warn(TAG, `Umami send failed: type=${payload.type} message=${err.message ?? String(e)}`);
       return false;
     } finally {
       request.destroy();

--- a/entry/src/main/ets/services/analytics/UmamiReporter.ets
+++ b/entry/src/main/ets/services/analytics/UmamiReporter.ets
@@ -17,7 +17,7 @@ export interface UmamiConfig {
 export const DEFAULT_UMAMI_CONFIG: UmamiConfig = {
   baseUrl: 'https://analytics.yaoshining.space',
   websiteId: 'a212474c-ad81-4e9e-80a0-39d735941f44',
-  hostname: 'vidall-tv'
+  hostname: 'vidall-tv.yaoshining.com'
 };
 
 export interface UmamiEventData {

--- a/entry/src/main/ets/services/analytics/UmamiReporter.ets
+++ b/entry/src/main/ets/services/analytics/UmamiReporter.ets
@@ -308,7 +308,8 @@ export class UmamiReporter implements MetricsReporter {
       const response = await request.request(`${this.config.baseUrl}/api/send`, {
         method: http.RequestMethod.POST,
         header: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'User-Agent': 'Mozilla/5.0 (HarmonyOS; TV) VidAll/1.0'
         },
         extraData: JSON.stringify(payload),
         connectTimeout: 15000,

--- a/entry/src/main/ets/services/analytics/UmamiReporter.ets
+++ b/entry/src/main/ets/services/analytics/UmamiReporter.ets
@@ -1,0 +1,319 @@
+import http from '@ohos.net.http';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { AppPreferences } from '../../utils/AppPreferences';
+import { MediaIdentity, MetricsReporter } from '../metrics/MetricsReporter';
+
+const TAG = 'UmamiReporter';
+const DOMAIN = 0x0001;
+
+export interface UmamiConfig {
+  baseUrl: string;
+  websiteId: string;
+  hostname: string;
+}
+
+export const DEFAULT_UMAMI_CONFIG: UmamiConfig = {
+  baseUrl: 'https://analytics.yaoshining.space',
+  websiteId: 'a212474c-ad81-4e9e-80a0-39d735941f44',
+  hostname: 'vidall-tv'
+};
+
+export interface UmamiEventData {
+  success?: boolean;
+  first_frame_ms?: number;
+  source_type?: string | null;
+  local_id?: number | null;
+  provider?: string | null;
+  provider_id?: string | null;
+  title?: string | null;
+  year?: number | null;
+  file_name?: string | null;
+  language?: string | null;
+  has_subtitle?: boolean;
+  scanned?: number;
+  total?: number;
+  coverage_pct?: number;
+}
+
+export interface UmamiEventRequestPayload {
+  website: string;
+  hostname: string;
+  url: string;
+  name: string;
+  data: UmamiEventData;
+}
+
+export interface UmamiIdentifyRequestPayload {
+  website: string;
+  hostname: string;
+  url: string;
+  name: string;
+  value: string;
+}
+
+export interface UmamiEventRequest {
+  type: 'event';
+  payload: UmamiEventRequestPayload;
+}
+
+export interface UmamiIdentifyRequest {
+  type: 'identify';
+  payload: UmamiIdentifyRequestPayload;
+}
+
+export type UmamiSendRequest = UmamiEventRequest | UmamiIdentifyRequest;
+
+export interface UmamiHttpResponse {
+  responseCode: number;
+  result: string | Object;
+}
+
+export interface UmamiHttpRequest {
+  request(url: string, options: http.HttpRequestOptions): Promise<UmamiHttpResponse>;
+  destroy(): void;
+}
+
+export type UmamiHttpRequestFactory = () => UmamiHttpRequest;
+
+function createDefaultUmamiHttpRequest(): UmamiHttpRequest {
+  return http.createHttp() as UmamiHttpRequest;
+}
+
+function buildUmamiUrl(config: UmamiConfig, feature: string, eventName: string): string {
+  return `app://${config.hostname}/${feature}/${eventName}`;
+}
+
+export function buildUmamiEventPayload(
+  config: UmamiConfig,
+  feature: string,
+  eventName: string,
+  data: UmamiEventData
+): UmamiEventRequest {
+  const payload: UmamiEventRequest = {
+    type: 'event',
+    payload: {
+      website: config.websiteId,
+      hostname: config.hostname,
+      url: buildUmamiUrl(config, feature, eventName),
+      name: eventName,
+      data
+    }
+  };
+  return payload;
+}
+
+export function buildUmamiIdentifyPayload(
+  config: UmamiConfig,
+  deviceUuid: string
+): UmamiIdentifyRequest {
+  const payload: UmamiIdentifyRequest = {
+    type: 'identify',
+    payload: {
+      website: config.websiteId,
+      hostname: config.hostname,
+      url: buildUmamiUrl(config, 'system', 'identify'),
+      name: 'device_uuid',
+      value: deviceUuid
+    }
+  };
+  return payload;
+}
+
+function buildPlaybackAttemptData(
+  success: boolean,
+  firstFrameMs: number,
+  media?: MediaIdentity,
+  sourceType?: string
+): UmamiEventData {
+  const data: UmamiEventData = {
+    success,
+    first_frame_ms: firstFrameMs,
+    source_type: sourceType ?? null,
+    local_id: media?.local_id ?? null,
+    provider: media?.provider ?? null,
+    provider_id: media?.provider_id ?? null,
+    title: media?.title ?? null,
+    year: media?.year ?? null,
+    file_name: media?.file_name ?? null
+  };
+  return data;
+}
+
+function buildSubtitleUsageData(language: string | null): UmamiEventData {
+  const data: UmamiEventData = {
+    language,
+    has_subtitle: language !== null
+  };
+  return data;
+}
+
+function buildScanCoverageData(scanned: number, total: number): UmamiEventData {
+  const coverage = total > 0 ? Math.round((scanned / total) * 10000) / 100 : 0;
+  const data: UmamiEventData = {
+    scanned,
+    total,
+    coverage_pct: coverage
+  };
+  return data;
+}
+
+export class UmamiReporter implements MetricsReporter {
+  private readonly config: UmamiConfig;
+  private readonly requestFactory: UmamiHttpRequestFactory;
+  private readonly pendingQueue: UmamiSendRequest[] = [];
+  private isSending: boolean = false;
+  private activeDrainPromise: Promise<void> | null = null;
+  private identifyQueuePromise: Promise<void> | null = null;
+  private identifyQueued: boolean = false;
+  private identifySent: boolean = false;
+
+  constructor(
+    config: UmamiConfig = DEFAULT_UMAMI_CONFIG,
+    requestFactory: UmamiHttpRequestFactory = createDefaultUmamiHttpRequest
+  ) {
+    this.config = config;
+    this.requestFactory = requestFactory;
+  }
+
+  recordPlaybackAttempt(success: boolean, firstFrameMs: number, media?: MediaIdentity, sourceType?: string): void {
+    const payload = buildUmamiEventPayload(
+      this.config,
+      'player',
+      'playback_attempt',
+      buildPlaybackAttemptData(success, firstFrameMs, media, sourceType)
+    );
+    this.enqueue(payload);
+  }
+
+  recordSubtitleUsage(language: string | null): void {
+    const payload = buildUmamiEventPayload(
+      this.config,
+      'player',
+      'subtitle_usage',
+      buildSubtitleUsageData(language)
+    );
+    this.enqueue(payload);
+  }
+
+  recordScanCoverage(scanned: number, total: number): void {
+    const payload = buildUmamiEventPayload(
+      this.config,
+      'scanner',
+      'scan_coverage',
+      buildScanCoverageData(scanned, total)
+    );
+    this.enqueue(payload);
+  }
+
+  async flush(): Promise<void> {
+    hilog.info(DOMAIN, TAG, `Umami flush entered: queue=${this.pendingQueue.length} sending=${this.isSending}`);
+    await this.ensureIdentifyQueued();
+    if (this.activeDrainPromise !== null) {
+      hilog.info(DOMAIN, TAG, 'Umami flush waiting for in-flight send');
+    }
+    await this.processQueue();
+  }
+
+  private enqueue(payload: UmamiSendRequest): void {
+    this.pendingQueue.push(payload);
+    hilog.info(DOMAIN, TAG, `Umami enqueue: type=${payload.type} name=${payload.payload.name} queue=${this.pendingQueue.length}`);
+    void this.kickoffProcessing();
+  }
+
+  private async kickoffProcessing(): Promise<void> {
+    await this.ensureIdentifyQueued();
+    await this.processQueue();
+  }
+
+  private async ensureIdentifyQueued(): Promise<void> {
+    if (this.identifySent || this.identifyQueued) {
+      return;
+    }
+    if (this.identifyQueuePromise !== null) {
+      return this.identifyQueuePromise;
+    }
+    const queuePromise = this.queueIdentifyPayload();
+    this.identifyQueuePromise = queuePromise;
+    return queuePromise;
+  }
+
+  private async queueIdentifyPayload(): Promise<void> {
+    try {
+      if (this.identifySent || this.identifyQueued) {
+        return;
+      }
+      const deviceUuid = await AppPreferences.getOrCreateDeviceUuid();
+      if (this.identifySent || this.identifyQueued || deviceUuid.length === 0) {
+        return;
+      }
+      this.pendingQueue.unshift(buildUmamiIdentifyPayload(this.config, deviceUuid));
+      this.identifyQueued = true;
+      hilog.info(DOMAIN, TAG, `Umami identify queued: queue=${this.pendingQueue.length}`);
+    } finally {
+      this.identifyQueuePromise = null;
+    }
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.activeDrainPromise !== null) {
+      return this.activeDrainPromise;
+    }
+    const drainPromise = this.drainQueue();
+    this.activeDrainPromise = drainPromise;
+    return drainPromise;
+  }
+
+  private async drainQueue(): Promise<void> {
+    this.isSending = true;
+    try {
+      while (this.pendingQueue.length > 0) {
+        const payload = this.pendingQueue[0];
+        const sent = await this.sendPayload(payload);
+        if (!sent) {
+          break;
+        }
+        this.pendingQueue.shift();
+        if (payload.type === 'identify') {
+          this.identifySent = true;
+          this.identifyQueued = false;
+        }
+      }
+    } finally {
+      this.isSending = false;
+      this.activeDrainPromise = null;
+      if (this.pendingQueue.length > 0) {
+        void this.processQueue();
+      }
+    }
+  }
+
+  private async sendPayload(payload: UmamiSendRequest): Promise<boolean> {
+    const request = this.requestFactory();
+    try {
+      const response = await request.request(`${this.config.baseUrl}/api/send`, {
+        method: http.RequestMethod.POST,
+        header: {
+          'Content-Type': 'application/json'
+        },
+        extraData: JSON.stringify(payload),
+        connectTimeout: 15000,
+        readTimeout: 15000
+      });
+      const ok = response.responseCode >= 200 && response.responseCode < 300;
+      if (ok) {
+        hilog.info(DOMAIN, TAG, `Umami send success: type=${payload.type} name=${payload.payload.name}`);
+      }
+      if (!ok) {
+        hilog.warn(DOMAIN, TAG, `Umami send failed: type=${payload.type} code=${response.responseCode}`);
+      }
+      return ok;
+    } catch (e) {
+      const err = e as BusinessError;
+      hilog.warn(DOMAIN, TAG, `Umami send error: type=${payload.type} message=${err.message ?? String(e)}`);
+      return false;
+    } finally {
+      request.destroy();
+    }
+  }
+}

--- a/entry/src/main/ets/services/analytics/UmamiReporter.ets
+++ b/entry/src/main/ets/services/analytics/UmamiReporter.ets
@@ -219,7 +219,9 @@ export class UmamiReporter implements MetricsReporter {
 
   async flush(): Promise<void> {
     getMetricsTraceLogger().info(TAG, `Umami flush entered: queue=${this.pendingQueue.length} sending=${this.isSending}`);
-    await this.ensureIdentifyQueued();
+    if (this.pendingQueue.length > 0) {
+      await this.ensureIdentifyQueued();
+    }
     if (this.activeDrainPromise !== null) {
       getMetricsTraceLogger().info(TAG, 'Umami flush waiting for in-flight send');
     }
@@ -278,11 +280,13 @@ export class UmamiReporter implements MetricsReporter {
 
   private async drainQueue(): Promise<void> {
     this.isSending = true;
+    let sendFailed = false;
     try {
       while (this.pendingQueue.length > 0) {
         const payload = this.pendingQueue[0];
         const sent = await this.sendPayload(payload);
         if (!sent) {
+          sendFailed = true;
           break;
         }
         this.pendingQueue.shift();
@@ -294,7 +298,7 @@ export class UmamiReporter implements MetricsReporter {
     } finally {
       this.isSending = false;
       this.activeDrainPromise = null;
-      if (this.pendingQueue.length > 0) {
+      if (this.pendingQueue.length > 0 && !sendFailed) {
         void this.processQueue();
       }
     }

--- a/entry/src/main/ets/services/metrics/CompositeMetricsReporter.ets
+++ b/entry/src/main/ets/services/metrics/CompositeMetricsReporter.ets
@@ -1,0 +1,33 @@
+import { MediaIdentity, MetricsReporter } from './MetricsReporter';
+
+export class CompositeMetricsReporter implements MetricsReporter {
+  private readonly reporters: MetricsReporter[];
+
+  constructor(reporters: MetricsReporter[]) {
+    this.reporters = reporters;
+  }
+
+  recordPlaybackAttempt(success: boolean, firstFrameMs: number, media?: MediaIdentity, sourceType?: string): void {
+    for (let i = 0; i < this.reporters.length; i++) {
+      this.reporters[i].recordPlaybackAttempt(success, firstFrameMs, media, sourceType);
+    }
+  }
+
+  recordSubtitleUsage(language: string | null): void {
+    for (let i = 0; i < this.reporters.length; i++) {
+      this.reporters[i].recordSubtitleUsage(language);
+    }
+  }
+
+  recordScanCoverage(scanned: number, total: number): void {
+    for (let i = 0; i < this.reporters.length; i++) {
+      this.reporters[i].recordScanCoverage(scanned, total);
+    }
+  }
+
+  async flush(): Promise<void> {
+    for (let i = 0; i < this.reporters.length; i++) {
+      await this.reporters[i].flush();
+    }
+  }
+}

--- a/entry/src/main/ets/services/metrics/CompositeMetricsReporter.ets
+++ b/entry/src/main/ets/services/metrics/CompositeMetricsReporter.ets
@@ -1,4 +1,7 @@
 import { MediaIdentity, MetricsReporter } from './MetricsReporter';
+import { getMetricsTraceLogger } from './MetricsTraceLogger';
+
+const TAG = 'CompositeMetricsReporter';
 
 export class CompositeMetricsReporter implements MetricsReporter {
   private readonly reporters: MetricsReporter[];
@@ -7,27 +10,46 @@ export class CompositeMetricsReporter implements MetricsReporter {
     this.reporters = reporters;
   }
 
+  getReporterName(): string {
+    return 'CompositeMetricsReporter';
+  }
+
   recordPlaybackAttempt(success: boolean, firstFrameMs: number, media?: MediaIdentity, sourceType?: string): void {
     for (let i = 0; i < this.reporters.length; i++) {
+      getMetricsTraceLogger().info(TAG,
+        `Composite forward event=playback_attempt target=${this.describeReporter(this.reporters[i], i)} index=${i + 1}/${this.reporters.length}`);
       this.reporters[i].recordPlaybackAttempt(success, firstFrameMs, media, sourceType);
     }
   }
 
   recordSubtitleUsage(language: string | null): void {
     for (let i = 0; i < this.reporters.length; i++) {
+      getMetricsTraceLogger().info(TAG,
+        `Composite forward event=subtitle_usage target=${this.describeReporter(this.reporters[i], i)} index=${i + 1}/${this.reporters.length}`);
       this.reporters[i].recordSubtitleUsage(language);
     }
   }
 
   recordScanCoverage(scanned: number, total: number): void {
     for (let i = 0; i < this.reporters.length; i++) {
+      getMetricsTraceLogger().info(TAG,
+        `Composite forward event=scan_coverage target=${this.describeReporter(this.reporters[i], i)} index=${i + 1}/${this.reporters.length}`);
       this.reporters[i].recordScanCoverage(scanned, total);
     }
   }
 
   async flush(): Promise<void> {
     for (let i = 0; i < this.reporters.length; i++) {
+      getMetricsTraceLogger().info(TAG,
+        `Composite forward event=flush target=${this.describeReporter(this.reporters[i], i)} index=${i + 1}/${this.reporters.length}`);
       await this.reporters[i].flush();
     }
+  }
+
+  private describeReporter(reporter: MetricsReporter, index: number): string {
+    if (reporter.getReporterName !== undefined) {
+      return reporter.getReporterName();
+    }
+    return `reporter_${index + 1}`;
   }
 }

--- a/entry/src/main/ets/services/metrics/LocalFileReporter.ets
+++ b/entry/src/main/ets/services/metrics/LocalFileReporter.ets
@@ -134,6 +134,10 @@ export class LocalFileReporter implements MetricsReporter {
   private metricsData: MetricsData;
   private lock: Promise<void> = Promise.resolve();
 
+  getReporterName(): string {
+    return 'LocalFileReporter';
+  }
+
   constructor(context: Context) {
     this.context = context;
     this.metricsData = this.initializeMetricsData();

--- a/entry/src/main/ets/services/metrics/MetricsReporter.ets
+++ b/entry/src/main/ets/services/metrics/MetricsReporter.ets
@@ -41,6 +41,11 @@ export interface MediaIdentity {
  */
 export interface MetricsReporter {
   /**
+   * Optional reporter label for diagnostics and observability.
+   */
+  getReporterName?(): string;
+
+  /**
    * Record a playback attempt and its outcome
    *
    * @param success - Whether the playback attempt succeeded (first frame rendered)

--- a/entry/src/main/ets/services/metrics/MetricsService.ets
+++ b/entry/src/main/ets/services/metrics/MetricsService.ets
@@ -23,6 +23,7 @@ import { LocalFileReporter } from './LocalFileReporter';
 import { CompositeMetricsReporter } from './CompositeMetricsReporter';
 import { UmamiReporter } from '../analytics/UmamiReporter';
 import { hilog } from '@kit.PerformanceAnalysisKit';
+import { getMetricsTraceLogger } from './MetricsTraceLogger';
 
 const TAG = 'MetricsService';
 const DOMAIN = 0x0001;
@@ -36,6 +37,13 @@ export class MetricsService {
 
   private constructor(reporter: MetricsReporter) {
     this.reporter = reporter;
+  }
+
+  private static describeReporter(reporter: MetricsReporter): string {
+    if (reporter.getReporterName !== undefined) {
+      return reporter.getReporterName();
+    }
+    return 'CustomMetricsReporter';
   }
 
   /**
@@ -56,6 +64,7 @@ export class MetricsService {
       new UmamiReporter()
     ]);
     MetricsService.instance = new MetricsService(reporter);
+    getMetricsTraceLogger().info(TAG, `MetricsService initialized reporter=${MetricsService.describeReporter(reporter)}`);
     hilog.info(DOMAIN, TAG, 'MetricsService initialized');
   }
 
@@ -96,6 +105,8 @@ export class MetricsService {
    */
   recordPlaybackAttempt(success: boolean, firstFrameMs: number, media?: MediaIdentity, sourceType?: string): void {
     try {
+      getMetricsTraceLogger().info(TAG,
+        `MetricsService forward event=playback_attempt reporter=${MetricsService.describeReporter(this.reporter)} success=${success ? 1 : 0}`);
       this.reporter.recordPlaybackAttempt(success, firstFrameMs, media, sourceType);
     } catch (e) {
       hilog.error(DOMAIN, TAG, `Failed to record playback attempt: ${e}`);
@@ -107,6 +118,8 @@ export class MetricsService {
    */
   recordSubtitleUsage(language: string | null): void {
     try {
+      getMetricsTraceLogger().info(TAG,
+        `MetricsService forward event=subtitle_usage reporter=${MetricsService.describeReporter(this.reporter)} subtitle=${language === null ? 'off' : 'on'}`);
       this.reporter.recordSubtitleUsage(language);
     } catch (e) {
       hilog.error(DOMAIN, TAG, `Failed to record subtitle usage: ${e}`);
@@ -118,6 +131,8 @@ export class MetricsService {
    */
   recordScanCoverage(scanned: number, total: number): void {
     try {
+      getMetricsTraceLogger().info(TAG,
+        `MetricsService forward event=scan_coverage reporter=${MetricsService.describeReporter(this.reporter)} scanned=${scanned} total=${total}`);
       this.reporter.recordScanCoverage(scanned, total);
     } catch (e) {
       hilog.error(DOMAIN, TAG, `Failed to record scan coverage: ${e}`);
@@ -129,6 +144,7 @@ export class MetricsService {
    */
   async flush(): Promise<void> {
     try {
+      getMetricsTraceLogger().info(TAG, `MetricsService flush reporter=${MetricsService.describeReporter(this.reporter)}`);
       await this.reporter.flush();
     } catch (e) {
       hilog.error(DOMAIN, TAG, `Failed to flush metrics: ${e}`);

--- a/entry/src/main/ets/services/metrics/MetricsService.ets
+++ b/entry/src/main/ets/services/metrics/MetricsService.ets
@@ -51,7 +51,7 @@ export class MetricsService {
    * Should be called once in Application/Ability onCreate
    * 
    * @param context - Application context for accessing storage
-   * @param customReporter - Optional custom reporter (default: LocalFileReporter)
+   * @param customReporter - Optional custom reporter (default: CompositeMetricsReporter with LocalFileReporter and UmamiReporter)
    */
   static initialize(context: Context, customReporter?: MetricsReporter): void {
     if (MetricsService.instance) {

--- a/entry/src/main/ets/services/metrics/MetricsService.ets
+++ b/entry/src/main/ets/services/metrics/MetricsService.ets
@@ -20,6 +20,8 @@
 import { Context } from '@ohos.abilityAccessCtrl';
 import { MetricsReporter, MediaIdentity } from './MetricsReporter';
 import { LocalFileReporter } from './LocalFileReporter';
+import { CompositeMetricsReporter } from './CompositeMetricsReporter';
+import { UmamiReporter } from '../analytics/UmamiReporter';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 
 const TAG = 'MetricsService';
@@ -49,7 +51,10 @@ export class MetricsService {
       return;
     }
 
-    const reporter = customReporter || new LocalFileReporter(context);
+    const reporter = customReporter || new CompositeMetricsReporter([
+      new LocalFileReporter(context),
+      new UmamiReporter()
+    ]);
     MetricsService.instance = new MetricsService(reporter);
     hilog.info(DOMAIN, TAG, 'MetricsService initialized');
   }

--- a/entry/src/main/ets/services/metrics/MetricsTraceLogger.ets
+++ b/entry/src/main/ets/services/metrics/MetricsTraceLogger.ets
@@ -1,0 +1,34 @@
+import { hilog } from '@kit.PerformanceAnalysisKit';
+
+const DOMAIN = 0x0001;
+
+export interface MetricsTraceLogger {
+  info(tag: string, message: string): void;
+  warn(tag: string, message: string): void;
+  error(tag: string, message: string): void;
+}
+
+class HilogMetricsTraceLogger implements MetricsTraceLogger {
+  info(tag: string, message: string): void {
+    hilog.info(DOMAIN, tag, '%{public}s', message);
+  }
+
+  warn(tag: string, message: string): void {
+    hilog.warn(DOMAIN, tag, '%{public}s', message);
+  }
+
+  error(tag: string, message: string): void {
+    hilog.error(DOMAIN, tag, '%{public}s', message);
+  }
+}
+
+const DEFAULT_METRICS_TRACE_LOGGER: MetricsTraceLogger = new HilogMetricsTraceLogger();
+let activeMetricsTraceLogger: MetricsTraceLogger = DEFAULT_METRICS_TRACE_LOGGER;
+
+export function getMetricsTraceLogger(): MetricsTraceLogger {
+  return activeMetricsTraceLogger;
+}
+
+export function setMetricsTraceLoggerForTesting(logger: MetricsTraceLogger | null): void {
+  activeMetricsTraceLogger = logger ?? DEFAULT_METRICS_TRACE_LOGGER;
+}

--- a/entry/src/main/ets/services/metrics/index.ets
+++ b/entry/src/main/ets/services/metrics/index.ets
@@ -10,6 +10,7 @@ export { MetricsReporter } from './MetricsReporter';
 
 // Implementation
 export { LocalFileReporter } from './LocalFileReporter';
+export { CompositeMetricsReporter } from './CompositeMetricsReporter';
 
 // Singleton service (recommended for application code)
 export { MetricsService } from './MetricsService';

--- a/entry/src/main/ets/utils/AppPreferences.ets
+++ b/entry/src/main/ets/utils/AppPreferences.ets
@@ -178,6 +178,7 @@ export class AppPreferences {
     }
     const nextUuid = AppPreferences.generateDeviceUuid();
     await AppPreferences.set(PrefKey.METRICS_DEVICE_UUID, nextUuid);
-    return nextUuid;
+    const verified = await AppPreferences.get(PrefKey.METRICS_DEVICE_UUID, '');
+    return verified.length > 0 ? verified : '';
   }
 }

--- a/entry/src/main/ets/utils/AppPreferences.ets
+++ b/entry/src/main/ets/utils/AppPreferences.ets
@@ -34,6 +34,8 @@ export class PrefKey {
   static readonly PLAYER_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS = 'player_episode_autoplay_countdown_seconds';
   /** 字幕语言偏好（JSON 序列化字符串） */
   static readonly SUBTITLE_LANGUAGE_PREFERENCE = 'subtitle_language_preference';
+  /** 指标上报使用的持久化设备 UUID */
+  static readonly METRICS_DEVICE_UUID = 'metrics_device_uuid';
 }
 
 // ─────────────────────────────────────────────
@@ -65,6 +67,13 @@ export class AppPreferences {
   private static store: AppPreferencesStore | null = null;
   private static initPromise: Promise<void> | null = null;
   private static storeLoader: AppPreferencesLoader = DEFAULT_APP_PREFERENCES_LOADER;
+
+  private static generateDeviceUuid(): string {
+    const segment = (): string => {
+      return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+    };
+    return `${segment()}${segment()}-${segment()}-${segment()}-${segment()}-${segment()}${segment()}${segment()}`;
+  }
 
   static setStoreLoaderForTesting(loader: AppPreferencesLoader | null): void {
     AppPreferences.storeLoader = loader ?? DEFAULT_APP_PREFERENCES_LOADER;
@@ -160,5 +169,15 @@ export class AppPreferences {
       const err = e as BusinessError;
       console.error(`[AppPreferences] 写入失败 key=${key}: ${err.message ?? JSON.stringify(e)}`);
     }
+  }
+
+  static async getOrCreateDeviceUuid(): Promise<string> {
+    const existingUuid = await AppPreferences.get(PrefKey.METRICS_DEVICE_UUID, '');
+    if (existingUuid.length > 0) {
+      return existingUuid;
+    }
+    const nextUuid = AppPreferences.generateDeviceUuid();
+    await AppPreferences.set(PrefKey.METRICS_DEVICE_UUID, nextUuid);
+    return nextUuid;
   }
 }

--- a/entry/src/test/AppPreferences.test.ets
+++ b/entry/src/test/AppPreferences.test.ets
@@ -4,7 +4,8 @@ import { Context } from '@ohos.abilityAccessCtrl';
 import {
   AppPreferences,
   AppPreferencesLoader,
-  AppPreferencesStore
+  AppPreferencesStore,
+  PrefKey
 } from '../main/ets/utils/AppPreferences';
 import {
   loadSubtitleLanguagePreference,
@@ -105,6 +106,50 @@ export default function appPreferencesTest() {
       expect(loadedPreference.languages[0]).assertEqual('en');
       expect(loadedPreference.languages[1]).assertEqual('zh-CN');
       expect(loadedPreference.hideOtherLanguages).assertFalse();
+    });
+  });
+
+  describe('AppPreferences_device_uuid', () => {
+    beforeEach(() => {
+      AppPreferences.resetForTesting();
+    });
+
+    afterEach(() => {
+      AppPreferences.setStoreLoaderForTesting(null);
+      AppPreferences.resetForTesting();
+    });
+
+    it('should expose device uuid preference key', 0, () => {
+      expect(PrefKey.METRICS_DEVICE_UUID).assertEqual('metrics_device_uuid');
+    });
+
+    it('should create and persist device uuid when missing', 0, async () => {
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      const store = new InMemoryAppPreferencesStore();
+      const loader: AppPreferencesLoader = async () => store;
+
+      AppPreferences.setStoreLoaderForTesting(loader);
+      await AppPreferences.init(ctx);
+
+      const deviceUuid = await AppPreferences.getOrCreateDeviceUuid();
+      const persistedValue = await AppPreferences.get(PrefKey.METRICS_DEVICE_UUID, '');
+
+      expect(deviceUuid.length > 0).assertTrue();
+      expect(persistedValue).assertEqual(deviceUuid);
+    });
+
+    it('should reuse persisted device uuid when present', 0, async () => {
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      const store = new InMemoryAppPreferencesStore();
+      const loader: AppPreferencesLoader = async () => store;
+
+      store.seed(PrefKey.METRICS_DEVICE_UUID, 'existing-device-uuid');
+      AppPreferences.setStoreLoaderForTesting(loader);
+      await AppPreferences.init(ctx);
+
+      const deviceUuid = await AppPreferences.getOrCreateDeviceUuid();
+
+      expect(deviceUuid).assertEqual('existing-device-uuid');
     });
   });
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -38,6 +38,8 @@ import webDAVDirectoryProviderTest from './WebDAVDirectoryProvider.test';
 import directorySelectorContainerTest from './DirectorySelectorContainer.test';
 import fileSourceRoutingTest from './FileSourceRouting.test';
 import fileExplorerContextTest from './FileExplorerContext.test';
+import umamiReporterTest from './ets/services/analytics/UmamiReporter.test';
+import compositeMetricsReporterTest from './ets/services/metrics/CompositeMetricsReporter.test';
 
 export default function testsuite() {
   timeUtilTest();
@@ -78,4 +80,6 @@ export default function testsuite() {
   directorySelectorContainerTest();
   fileSourceRoutingTest();
   fileExplorerContextTest();
+  umamiReporterTest();
+  compositeMetricsReporterTest();
 }

--- a/entry/src/test/ets/services/analytics/UmamiReporter.test.ets
+++ b/entry/src/test/ets/services/analytics/UmamiReporter.test.ets
@@ -1,0 +1,429 @@
+import http from '@ohos.net.http';
+import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
+import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
+import { Context } from '@ohos.abilityAccessCtrl';
+import { AppPreferences, AppPreferencesLoader, AppPreferencesStore, PrefKey } from '../../../../main/ets/utils/AppPreferences';
+import { MediaIdentity } from '../../../../main/ets/services/metrics/MetricsReporter';
+import {
+  DEFAULT_UMAMI_CONFIG,
+  buildUmamiEventPayload,
+  UmamiHttpRequest,
+  UmamiHttpResponse,
+  UmamiReporter
+} from '../../../../main/ets/services/analytics/UmamiReporter';
+
+class InMemoryAppPreferencesStore implements AppPreferencesStore {
+  private readonly values: Map<string, string | number> = new Map<string, string | number>();
+
+  seed(key: string, value: string | number): void {
+    this.values.set(key, value);
+  }
+
+  async get(key: string, defaultValue: string | number): Promise<string | number> {
+    const value = this.values.get(key);
+    return value === undefined ? defaultValue : value;
+  }
+
+  async put(key: string, value: string | number): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async flush(): Promise<void> {
+  }
+}
+
+interface MockResponse {
+  responseCode: number;
+  result: string;
+}
+
+class DeferredHttpResponse {
+  private resolveResponse: ((response: UmamiHttpResponse) => void) | null = null;
+  readonly promise: Promise<UmamiHttpResponse> = new Promise<UmamiHttpResponse>((resolve) => {
+    this.resolveResponse = resolve;
+  });
+
+  succeed(): void {
+    if (this.resolveResponse !== null) {
+      const resolve = this.resolveResponse;
+      this.resolveResponse = null;
+      resolve({
+        responseCode: 200,
+        result: '{"beep":"boop"}'
+      });
+    }
+  }
+}
+
+class RequestCountWaiter {
+  readonly expectedCount: number;
+  private resolveWaiter: (() => void) | null;
+
+  constructor(expectedCount: number, resolveWaiter: () => void) {
+    this.expectedCount = expectedCount;
+    this.resolveWaiter = resolveWaiter;
+  }
+
+  tryResolve(currentCount: number): boolean {
+    if (currentCount < this.expectedCount || this.resolveWaiter === null) {
+      return false;
+    }
+    const resolve = this.resolveWaiter;
+    this.resolveWaiter = null;
+    resolve();
+    return true;
+  }
+}
+
+class MockRequestState {
+  readonly urls: string[] = [];
+  readonly bodies: string[] = [];
+  readonly responses: MockResponse[];
+  private readonly deferredResponses: DeferredHttpResponse[] = [];
+  private readonly countWaiters: RequestCountWaiter[] = [];
+
+  constructor(responses: MockResponse[]) {
+    this.responses = responses;
+  }
+
+  createDeferredResponse(): DeferredHttpResponse {
+    const deferredResponse = new DeferredHttpResponse();
+    this.deferredResponses.push(deferredResponse);
+    return deferredResponse;
+  }
+
+  async waitForRequestCount(expectedCount: number): Promise<void> {
+    if (this.bodies.length >= expectedCount) {
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.countWaiters.push(new RequestCountWaiter(expectedCount, resolve));
+    });
+  }
+
+  notifyRequestCountChanged(): void {
+    const remainingWaiters: RequestCountWaiter[] = [];
+    for (let i = 0; i < this.countWaiters.length; i++) {
+      const waiter = this.countWaiters[i];
+      if (!waiter.tryResolve(this.bodies.length)) {
+        remainingWaiters.push(waiter);
+      }
+    }
+    this.countWaiters.length = 0;
+    for (let i = 0; i < remainingWaiters.length; i++) {
+      this.countWaiters.push(remainingWaiters[i]);
+    }
+  }
+
+  takeDeferredResponse(): DeferredHttpResponse | null {
+    if (this.deferredResponses.length === 0) {
+      return null;
+    }
+    const deferredResponse = this.deferredResponses.shift();
+    return deferredResponse === undefined ? null : deferredResponse;
+  }
+}
+
+class MockUmamiHttpRequest implements UmamiHttpRequest {
+  private readonly state: MockRequestState;
+
+  constructor(state: MockRequestState) {
+    this.state = state;
+  }
+
+  async request(url: string, options: http.HttpRequestOptions): Promise<UmamiHttpResponse> {
+    this.state.urls.push(url);
+    const body = typeof options.extraData === 'string' ? options.extraData : '';
+    this.state.bodies.push(body);
+    this.state.notifyRequestCountChanged();
+
+    const deferredResponse = this.state.takeDeferredResponse();
+    if (deferredResponse !== null) {
+      return deferredResponse.promise;
+    }
+
+    if (this.state.responses.length === 0) {
+      return {
+        responseCode: 200,
+        result: '{"beep":"boop"}'
+      };
+    }
+
+    const nextResponse = this.state.responses.shift();
+    if (nextResponse === undefined) {
+      return {
+        responseCode: 200,
+        result: '{"beep":"boop"}'
+      };
+    }
+    return nextResponse;
+  }
+
+  destroy(): void {
+  }
+}
+
+function buildMediaIdentity(): MediaIdentity {
+  return {
+    local_id: 123,
+    provider: 'tmdb',
+    provider_id: '550',
+    title: 'Fight Club',
+    year: null,
+    file_name: 'Fight Club.mkv'
+  };
+}
+
+async function initPreferences(deviceUuid?: string): Promise<InMemoryAppPreferencesStore> {
+  const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+  const store = new InMemoryAppPreferencesStore();
+  if (deviceUuid !== undefined) {
+    store.seed(PrefKey.METRICS_DEVICE_UUID, deviceUuid);
+  }
+  const loader: AppPreferencesLoader = async () => store;
+  AppPreferences.setStoreLoaderForTesting(loader);
+  await AppPreferences.init(ctx);
+  return store;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function countBodiesContaining(bodies: string[], keyword: string): number {
+  let count = 0;
+  for (let i = 0; i < bodies.length; i++) {
+    if (bodies[i].indexOf(keyword) >= 0) {
+      count++;
+    }
+  }
+  return count;
+}
+
+export default function umamiReporterTest() {
+  describe('UmamiReporter_http_behavior', () => {
+    beforeEach(() => {
+      AppPreferences.resetForTesting();
+    });
+
+    afterEach(() => {
+      AppPreferences.setStoreLoaderForTesting(null);
+      AppPreferences.resetForTesting();
+    });
+
+    it('should send identify once and reuse persisted device uuid', 0, async () => {
+      await initPreferences('persisted-device-uuid');
+      const state = new MockRequestState([]);
+      const reporter = new UmamiReporter(
+        DEFAULT_UMAMI_CONFIG,
+        () => new MockUmamiHttpRequest(state)
+      );
+
+      reporter.recordPlaybackAttempt(true, 450, buildMediaIdentity(), 'network');
+      await reporter.flush();
+      reporter.recordSubtitleUsage('zh');
+      await reporter.flush();
+
+      expect(state.urls.length).assertEqual(3);
+      expect(state.urls[0]).assertEqual('https://analytics.yaoshining.space/api/send');
+      expect(countBodiesContaining(state.bodies, '"type":"identify"')).assertEqual(1);
+      expect(state.bodies[0].indexOf('"value":"persisted-device-uuid"') >= 0).assertTrue();
+      expect(state.bodies[1].indexOf('"name":"playback_attempt"') >= 0).assertTrue();
+      expect(state.bodies[1].indexOf('"source_type":"network"') >= 0).assertTrue();
+      expect(state.bodies[2].indexOf('"name":"subtitle_usage"') >= 0).assertTrue();
+    });
+
+    it('should generate and persist device uuid before first send when missing', 0, async () => {
+      const store = await initPreferences();
+      const state = new MockRequestState([]);
+      const reporter = new UmamiReporter(
+        DEFAULT_UMAMI_CONFIG,
+        () => new MockUmamiHttpRequest(state)
+      );
+
+      reporter.recordScanCoverage(4, 5);
+      await reporter.flush();
+
+      const persisted = await store.get(PrefKey.METRICS_DEVICE_UUID, '');
+      const persistedUuid = persisted as string;
+
+      expect(persistedUuid.length > 0).assertTrue();
+      expect(state.bodies.length).assertEqual(2);
+      expect(state.bodies[0].indexOf(`"value":"${persistedUuid}"`) >= 0).assertTrue();
+      expect(state.bodies[1].indexOf('"name":"scan_coverage"') >= 0).assertTrue();
+      expect(state.bodies[1].indexOf('"coverage_pct":80') >= 0).assertTrue();
+    });
+
+    it('should retain failed payload and retry on next flush', 0, async () => {
+      await initPreferences('retry-device-uuid');
+      const state = new MockRequestState([
+        { responseCode: 200, result: '{"beep":"boop"}' },
+        { responseCode: 500, result: '{"error":"temporary"}' },
+        { responseCode: 200, result: '{"beep":"boop"}' }
+      ]);
+      const reporter = new UmamiReporter(
+        DEFAULT_UMAMI_CONFIG,
+        () => new MockUmamiHttpRequest(state)
+      );
+
+      reporter.recordPlaybackAttempt(false, 0, undefined, 'network');
+      await reporter.flush();
+      await reporter.flush();
+
+      expect(countBodiesContaining(state.bodies, '"type":"identify"')).assertEqual(1);
+      expect(countBodiesContaining(state.bodies, '"name":"playback_attempt"')).assertEqual(2);
+      expect(state.bodies.length).assertEqual(3);
+    });
+
+    it('should wait for in-flight send when flush follows enqueue', 0, async () => {
+      await initPreferences('waiting-device-uuid');
+      const state = new MockRequestState([]);
+      const firstResponse = state.createDeferredResponse();
+      const reporter = new UmamiReporter(
+        DEFAULT_UMAMI_CONFIG,
+        () => new MockUmamiHttpRequest(state)
+      );
+
+      reporter.recordPlaybackAttempt(true, 450, buildMediaIdentity(), 'network');
+      await state.waitForRequestCount(1);
+
+      let flushResolved = false;
+      const flushPromise = reporter.flush().then(() => {
+        flushResolved = true;
+      });
+      await flushMicrotasks();
+
+      expect(flushResolved).assertFalse();
+
+      firstResponse.succeed();
+      await flushPromise;
+
+      expect(countBodiesContaining(state.bodies, '"type":"identify"')).assertEqual(1);
+      expect(countBodiesContaining(state.bodies, '"name":"playback_attempt"')).assertEqual(1);
+      expect(state.bodies.length).assertEqual(2);
+    });
+
+    it('should keep queued playback and subtitle events until background flush completes', 0, async () => {
+      await initPreferences('background-flush-device-uuid');
+      const state = new MockRequestState([]);
+      const identifyResponse = state.createDeferredResponse();
+      const playbackResponse = state.createDeferredResponse();
+      const reporter = new UmamiReporter(
+        DEFAULT_UMAMI_CONFIG,
+        () => new MockUmamiHttpRequest(state)
+      );
+
+      reporter.recordPlaybackAttempt(true, 320, buildMediaIdentity(), 'network');
+      await state.waitForRequestCount(1);
+
+      reporter.recordSubtitleUsage('zh-CN');
+
+      let flushResolved = false;
+      const flushPromise = reporter.flush().then(() => {
+        flushResolved = true;
+      });
+      await flushMicrotasks();
+      expect(flushResolved).assertFalse();
+
+      identifyResponse.succeed();
+      await state.waitForRequestCount(2);
+      await flushMicrotasks();
+      expect(flushResolved).assertFalse();
+
+      playbackResponse.succeed();
+      await state.waitForRequestCount(3);
+      await flushPromise;
+
+      expect(countBodiesContaining(state.bodies, '"type":"identify"')).assertEqual(1);
+      expect(countBodiesContaining(state.bodies, '"name":"playback_attempt"')).assertEqual(1);
+      expect(countBodiesContaining(state.bodies, '"name":"subtitle_usage"')).assertEqual(1);
+      expect(state.bodies.length).assertEqual(3);
+    });
+
+    it('should not issue duplicate requests while flush joins the active send path', 0, async () => {
+      await initPreferences('joined-send-device-uuid');
+      const state = new MockRequestState([]);
+      const identifyResponse = state.createDeferredResponse();
+      const reporter = new UmamiReporter(
+        DEFAULT_UMAMI_CONFIG,
+        () => new MockUmamiHttpRequest(state)
+      );
+
+      reporter.recordPlaybackAttempt(true, 180, undefined, 'network');
+      await state.waitForRequestCount(1);
+
+      const flushPromise = reporter.flush();
+      await flushMicrotasks();
+      expect(state.bodies.length).assertEqual(1);
+
+      identifyResponse.succeed();
+      await flushPromise;
+
+      expect(countBodiesContaining(state.bodies, '"type":"identify"')).assertEqual(1);
+      expect(countBodiesContaining(state.bodies, '"name":"playback_attempt"')).assertEqual(1);
+      expect(state.bodies.length).assertEqual(2);
+    });
+  });
+
+  describe('UmamiReporter_config', () => {
+    it('should expose default Umami config', 0, () => {
+      expect(DEFAULT_UMAMI_CONFIG.baseUrl).assertEqual('https://analytics.yaoshining.space');
+      expect(DEFAULT_UMAMI_CONFIG.websiteId).assertEqual('a212474c-ad81-4e9e-80a0-39d735941f44');
+      expect(DEFAULT_UMAMI_CONFIG.hostname).assertEqual('vidall-tv');
+    });
+  });
+
+  describe('UmamiReporter_payload_mapping', () => {
+    it('should build playback_attempt event payload', 0, () => {
+      const payload = buildUmamiEventPayload(
+        DEFAULT_UMAMI_CONFIG,
+        'player',
+        'playback_attempt',
+        {
+          success: true,
+          first_frame_ms: 450,
+          source_type: 'network',
+          local_id: 123,
+          provider: 'tmdb',
+          provider_id: '550',
+          title: 'Fight Club',
+          year: null,
+          file_name: 'Fight Club.mkv'
+        }
+      );
+
+      expect(payload.type).assertEqual('event');
+      expect(payload.payload.website).assertEqual('a212474c-ad81-4e9e-80a0-39d735941f44');
+      expect(payload.payload.hostname).assertEqual('vidall-tv');
+      expect(payload.payload.url).assertEqual('app://vidall-tv/player/playback_attempt');
+      expect(payload.payload.name).assertEqual('playback_attempt');
+      expect(payload.payload.data.success as boolean).assertTrue();
+      expect(payload.payload.data.first_frame_ms as number).assertEqual(450);
+      expect(payload.payload.data.file_name as string).assertEqual('Fight Club.mkv');
+    });
+
+    it('should include media identity fields when mapping playback metrics', 0, () => {
+      const media = buildMediaIdentity();
+      const payload = buildUmamiEventPayload(
+        DEFAULT_UMAMI_CONFIG,
+        'player',
+        'playback_attempt',
+        {
+          local_id: media.local_id,
+          provider: media.provider,
+          provider_id: media.provider_id,
+          title: media.title,
+          year: media.year,
+          file_name: media.file_name
+        }
+      );
+
+      expect(payload.payload.data.local_id as number).assertEqual(123);
+      expect(payload.payload.data.provider as string).assertEqual('tmdb');
+      expect(payload.payload.data.provider_id as string).assertEqual('550');
+      expect(payload.payload.data.title as string).assertEqual('Fight Club');
+    });
+  });
+}

--- a/entry/src/test/ets/services/analytics/UmamiReporter.test.ets
+++ b/entry/src/test/ets/services/analytics/UmamiReporter.test.ets
@@ -420,7 +420,7 @@ export default function umamiReporterTest() {
     it('should expose default Umami config', 0, () => {
       expect(DEFAULT_UMAMI_CONFIG.baseUrl).assertEqual('https://analytics.yaoshining.space');
       expect(DEFAULT_UMAMI_CONFIG.websiteId).assertEqual('a212474c-ad81-4e9e-80a0-39d735941f44');
-      expect(DEFAULT_UMAMI_CONFIG.hostname).assertEqual('vidall-tv');
+      expect(DEFAULT_UMAMI_CONFIG.hostname).assertEqual('vidall-tv.yaoshining.com');
     });
   });
 
@@ -445,8 +445,8 @@ export default function umamiReporterTest() {
 
       expect(payload.type).assertEqual('event');
       expect(payload.payload.website).assertEqual('a212474c-ad81-4e9e-80a0-39d735941f44');
-      expect(payload.payload.hostname).assertEqual('vidall-tv');
-      expect(payload.payload.url).assertEqual('app://vidall-tv/player/playback_attempt');
+      expect(payload.payload.hostname).assertEqual('vidall-tv.yaoshining.com');
+      expect(payload.payload.url).assertEqual('app://vidall-tv.yaoshining.com/player/playback_attempt');
       expect(payload.payload.name).assertEqual('playback_attempt');
       expect(payload.payload.data.success as boolean).assertTrue();
       expect(payload.payload.data.first_frame_ms as number).assertEqual(450);

--- a/entry/src/test/ets/services/analytics/UmamiReporter.test.ets
+++ b/entry/src/test/ets/services/analytics/UmamiReporter.test.ets
@@ -4,6 +4,7 @@ import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry
 import { Context } from '@ohos.abilityAccessCtrl';
 import { AppPreferences, AppPreferencesLoader, AppPreferencesStore, PrefKey } from '../../../../main/ets/utils/AppPreferences';
 import { MediaIdentity } from '../../../../main/ets/services/metrics/MetricsReporter';
+import { MetricsTraceLogger, setMetricsTraceLoggerForTesting } from '../../../../main/ets/services/metrics/MetricsTraceLogger';
 import {
   DEFAULT_UMAMI_CONFIG,
   buildUmamiEventPayload,
@@ -163,6 +164,31 @@ class MockUmamiHttpRequest implements UmamiHttpRequest {
   }
 }
 
+class CapturingMetricsTraceLogger implements MetricsTraceLogger {
+  readonly entries: string[] = [];
+
+  info(tag: string, message: string): void {
+    this.entries.push(`${tag}:${message}`);
+  }
+
+  warn(tag: string, message: string): void {
+    this.entries.push(`${tag}:${message}`);
+  }
+
+  error(tag: string, message: string): void {
+    this.entries.push(`${tag}:${message}`);
+  }
+
+  contains(keyword: string): boolean {
+    for (let i = 0; i < this.entries.length; i++) {
+      if (this.entries[i].indexOf(keyword) >= 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
 function buildMediaIdentity(): MediaIdentity {
   return {
     local_id: 123,
@@ -206,11 +232,13 @@ export default function umamiReporterTest() {
   describe('UmamiReporter_http_behavior', () => {
     beforeEach(() => {
       AppPreferences.resetForTesting();
+      setMetricsTraceLoggerForTesting(null);
     });
 
     afterEach(() => {
       AppPreferences.setStoreLoaderForTesting(null);
       AppPreferences.resetForTesting();
+      setMetricsTraceLoggerForTesting(null);
     });
 
     it('should send identify once and reuse persisted device uuid', 0, async () => {
@@ -364,6 +392,27 @@ export default function umamiReporterTest() {
       expect(countBodiesContaining(state.bodies, '"type":"identify"')).assertEqual(1);
       expect(countBodiesContaining(state.bodies, '"name":"playback_attempt"')).assertEqual(1);
       expect(state.bodies.length).assertEqual(2);
+    });
+
+    it('should emit observable traces from record through send success', 0, async () => {
+      await initPreferences('observable-device-uuid');
+      const logger = new CapturingMetricsTraceLogger();
+      setMetricsTraceLoggerForTesting(logger);
+      const state = new MockRequestState([]);
+      const reporter = new UmamiReporter(
+        DEFAULT_UMAMI_CONFIG,
+        () => new MockUmamiHttpRequest(state)
+      );
+
+      reporter.recordPlaybackAttempt(true, 450, buildMediaIdentity(), 'network');
+      reporter.recordSubtitleUsage('zh');
+      await reporter.flush();
+
+      expect(logger.contains('Umami record playback_attempt')).assertTrue();
+      expect(logger.contains('Umami record subtitle_usage')).assertTrue();
+      expect(logger.contains('Umami flush entered')).assertTrue();
+      expect(logger.contains('Umami send start')).assertTrue();
+      expect(logger.contains('Umami send success')).assertTrue();
     });
   });
 

--- a/entry/src/test/ets/services/metrics/CompositeMetricsReporter.test.ets
+++ b/entry/src/test/ets/services/metrics/CompositeMetricsReporter.test.ets
@@ -3,12 +3,47 @@ import { Context } from '@ohos.abilityAccessCtrl';
 import { CompositeMetricsReporter } from '../../../../main/ets/services/metrics/CompositeMetricsReporter';
 import { MetricsReporter } from '../../../../main/ets/services/metrics/MetricsReporter';
 import { MetricsService } from '../../../../main/ets/services/metrics/MetricsService';
+import { MetricsTraceLogger, setMetricsTraceLoggerForTesting } from '../../../../main/ets/services/metrics/MetricsTraceLogger';
+
+class CapturingMetricsTraceLogger implements MetricsTraceLogger {
+  readonly entries: string[] = [];
+
+  info(tag: string, message: string): void {
+    this.entries.push(`${tag}:${message}`);
+  }
+
+  warn(tag: string, message: string): void {
+    this.entries.push(`${tag}:${message}`);
+  }
+
+  error(tag: string, message: string): void {
+    this.entries.push(`${tag}:${message}`);
+  }
+
+  contains(keyword: string): boolean {
+    for (let i = 0; i < this.entries.length; i++) {
+      if (this.entries[i].indexOf(keyword) >= 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
 
 class RecordingReporter implements MetricsReporter {
+  private readonly reporterName: string;
   playbackCalls: number = 0;
   subtitleCalls: number = 0;
   scanCalls: number = 0;
   flushCalls: number = 0;
+
+  constructor(reporterName: string = 'RecordingReporter') {
+    this.reporterName = reporterName;
+  }
+
+  getReporterName(): string {
+    return this.reporterName;
+  }
 
   recordPlaybackAttempt(): void {
     this.playbackCalls++;
@@ -30,8 +65,8 @@ class RecordingReporter implements MetricsReporter {
 export default function compositeMetricsReporterTest() {
   describe('CompositeMetricsReporter', () => {
     it('should delegate playback, subtitle, scan and flush to both reporters', 0, async () => {
-      const first = new RecordingReporter();
-      const second = new RecordingReporter();
+      const first = new RecordingReporter('LocalFileReporter');
+      const second = new RecordingReporter('UmamiReporter');
       const reporter = new CompositeMetricsReporter([first, second]);
 
       reporter.recordPlaybackAttempt(true, 450);
@@ -48,11 +83,30 @@ export default function compositeMetricsReporterTest() {
       expect(first.flushCalls).assertEqual(1);
       expect(second.flushCalls).assertEqual(1);
     });
+
+    it('should emit forwarding traces for both child reporters', 0, async () => {
+      const logger = new CapturingMetricsTraceLogger();
+      setMetricsTraceLoggerForTesting(logger);
+      const first = new RecordingReporter('LocalFileReporter');
+      const second = new RecordingReporter('UmamiReporter');
+      const reporter = new CompositeMetricsReporter([first, second]);
+
+      reporter.recordPlaybackAttempt(true, 450);
+      reporter.recordSubtitleUsage('zh');
+      await reporter.flush();
+
+      expect(logger.contains('Composite forward event=playback_attempt target=LocalFileReporter')).assertTrue();
+      expect(logger.contains('Composite forward event=playback_attempt target=UmamiReporter')).assertTrue();
+      expect(logger.contains('Composite forward event=subtitle_usage target=UmamiReporter')).assertTrue();
+      expect(logger.contains('Composite forward event=flush target=UmamiReporter')).assertTrue();
+      setMetricsTraceLoggerForTesting(null);
+    });
   });
 
   describe('MetricsService_default_dual_write', () => {
     beforeEach(() => {
       MetricsService.resetForTesting();
+      setMetricsTraceLoggerForTesting(null);
     });
 
     it('should initialize default reporter as composite reporter', 0, () => {
@@ -60,6 +114,16 @@ export default function compositeMetricsReporterTest() {
       const reporter = MetricsService.getInstance().getReporter();
 
       expect(reporter instanceof CompositeMetricsReporter).assertTrue();
+    });
+
+    it('should emit default reporter type trace during initialization', 0, () => {
+      const logger = new CapturingMetricsTraceLogger();
+      setMetricsTraceLoggerForTesting(logger);
+
+      MetricsService.initialize({} as Context);
+
+      expect(logger.contains('MetricsService initialized reporter=CompositeMetricsReporter')).assertTrue();
+      setMetricsTraceLoggerForTesting(null);
     });
   });
 }

--- a/entry/src/test/ets/services/metrics/CompositeMetricsReporter.test.ets
+++ b/entry/src/test/ets/services/metrics/CompositeMetricsReporter.test.ets
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from '@ohos/hypium';
+import { Context } from '@ohos.abilityAccessCtrl';
+import { CompositeMetricsReporter } from '../../../../main/ets/services/metrics/CompositeMetricsReporter';
+import { MetricsReporter } from '../../../../main/ets/services/metrics/MetricsReporter';
+import { MetricsService } from '../../../../main/ets/services/metrics/MetricsService';
+
+class RecordingReporter implements MetricsReporter {
+  playbackCalls: number = 0;
+  subtitleCalls: number = 0;
+  scanCalls: number = 0;
+  flushCalls: number = 0;
+
+  recordPlaybackAttempt(): void {
+    this.playbackCalls++;
+  }
+
+  recordSubtitleUsage(): void {
+    this.subtitleCalls++;
+  }
+
+  recordScanCoverage(): void {
+    this.scanCalls++;
+  }
+
+  async flush(): Promise<void> {
+    this.flushCalls++;
+  }
+}
+
+export default function compositeMetricsReporterTest() {
+  describe('CompositeMetricsReporter', () => {
+    it('should delegate playback, subtitle, scan and flush to both reporters', 0, async () => {
+      const first = new RecordingReporter();
+      const second = new RecordingReporter();
+      const reporter = new CompositeMetricsReporter([first, second]);
+
+      reporter.recordPlaybackAttempt(true, 450);
+      reporter.recordSubtitleUsage('zh');
+      reporter.recordScanCoverage(4, 5);
+      await reporter.flush();
+
+      expect(first.playbackCalls).assertEqual(1);
+      expect(second.playbackCalls).assertEqual(1);
+      expect(first.subtitleCalls).assertEqual(1);
+      expect(second.subtitleCalls).assertEqual(1);
+      expect(first.scanCalls).assertEqual(1);
+      expect(second.scanCalls).assertEqual(1);
+      expect(first.flushCalls).assertEqual(1);
+      expect(second.flushCalls).assertEqual(1);
+    });
+  });
+
+  describe('MetricsService_default_dual_write', () => {
+    beforeEach(() => {
+      MetricsService.resetForTesting();
+    });
+
+    it('should initialize default reporter as composite reporter', 0, () => {
+      MetricsService.initialize({} as Context);
+      const reporter = MetricsService.getInstance().getReporter();
+
+      expect(reporter instanceof CompositeMetricsReporter).assertTrue();
+    });
+  });
+}


### PR DESCRIPTION
## 概述

集成 Umami Analytics 云端事件上报，与现有 LocalFileReporter 组合双写。本 PR 完成 Issue #201 的全部实现。

## 变更内容

### 新增文件
- `services/analytics/UmamiReporter.ets` — Umami 上报核心，实现 `MetricsReporter` 接口，含 queue/drain/flush 机制
- `services/metrics/CompositeMetricsReporter.ets` — 多 reporter 分发器
- `services/metrics/MetricsTraceLogger.ets` — 上报链路 trace 日志工具

### 修改文件
- `services/metrics/MetricsService.ets` — 默认初始化双写 reporter
- `utils/AppPreferences.ets` — 新增设备 UUID 持久化
- `entryability/EntryAbility.ets` — `onBackground` 触发 flush

### 关键技术决策
- **User-Agent**：Umami 官方文档明确要求，无 UA 请求静默丢弃，已添加 `Mozilla/5.0 (HarmonyOS; TV) VidAll/1.0`
- **hostname**：`vidall-tv.yaoshining.com`，与 Umami 网站域名配置一致
- **identify 前置**：每次发事件前确保先发 identify（设备 UUID），仅发一次

## 验证结果
- ✅ 编译：`assembleHap BUILD SUCCESSFUL`
- ✅ 单测：`UnitTestBuild BUILD SUCCESSFUL`  
- ✅ 真机：Umami 仪表板已收到 `playback_attempt` / `subtitle_usage` 事件，sessionId + visitId 正常

## 后续
扩展埋点（页面路径、app_launch 等）已拆分至 Issue #204，依赖本 PR 合并后实施。

Closes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Umami analytics integration for sending events and identify payloads.
  * Composite metrics reporter to forward metrics to multiple reporters.
  * Persistent device UUID generation and reuse for metrics.

* **Chores**
  * Improved diagnostics/trace logging for metrics operations.
  * Metrics reporter API extended to expose reporter identity.

* **Tests**
  * Added tests for Umami reporter, composite reporter, and device-UUID behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->