### PR TITLE
修复: 字幕关闭后仍渲染问题 (Issue #206)

### DIFF
--- a/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
+++ b/entry/src/main/ets/components/core/player/SubtitleBridgeAdapter.ets
@@ -540,6 +540,10 @@ export class BaseSubtitleBridgeAdapter implements ISubtitleBridgeAdapter {
   }
 
   onSubtitleUpdate(info: SubtitleInfo): void {
+    // 字幕已关闭时（activeSubtitleIndex < 0），忽略 AVPlayer 仍在推送的 onTimedText 回调
+    if (this.activeSubtitleIndex < 0) {
+      return;
+    }
     if (this.srtEntries.length > 0) {
       return;
     }

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -741,6 +741,10 @@ export class VideoPlayerController {
       }
       this.subtitleAdapter.onSubtitleUpdate(info);
       this.applySubtitleBridgeState(this.subtitleAdapter.getState());
+      // 字幕已关闭（activeSubtitleIndex < 0），忽略后续定时器与文本更新
+      if (this.activeSubtitleIndex < 0) {
+        return;
+      }
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `内嵌字幕回调: text="${info.text?.substring(0, 80)}" startTime=${info.startTime}ms duration=${info.duration}ms`);
       if (info.text) {


### PR DESCRIPTION
## 问题

关闭字幕后，AVPlayer 的 `onTimedText` 仍在异步推送回调，导致两处代码在未检查 `activeSubtitleIndex < 0` 的情况下直接更新 `currentSubtitleText`，字幕持续渲染。

## 根因

1. `BaseSubtitleBridgeAdapter.onSubtitleUpdate` — 未检查 `activeSubtitleIndex < 0`，直接更新适配器层的 `currentSubtitleText`
2. `VideoPlayerController` 内嵌字幕回调 — `applySubtitleBridgeState` 之后再次直接赋值 `this.currentSubtitleText = info.text`，绕过适配器层的状态控制

## 修复方案

两处均在入口处增加 `activeSubtitleIndex < 0` 门控，提前 return：

- **`SubtitleBridgeAdapter.ets`**：`onSubtitleUpdate` 开头增加 `if (this.activeSubtitleIndex < 0) return`
- **`VideoPlayerController.ets`**：`applySubtitleBridgeState` 之后增加 `if (this.activeSubtitleIndex < 0) return`，阻断定时器启动与文本直接写入

## 验证

- ✅ 编译通过（`BUILD SUCCESSFUL`）
- ✅ 安装到华为智慧屏 MateTV Pro（EDIS-790A 5.1.0.243）真机验证通过

Closes #206


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where subtitle text could continue updating even after subtitles were disabled or turned off, ensuring cleaner subtitle behavior when toggling subtitles on and off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->