### PR TITLE
新增: 扩展 Umami 埋点（页面路径追踪 + 行为事件）

### DIFF
--- a/entry/src/main/ets/components/core/player/EpisodeAutoplayPreferences.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeAutoplayPreferences.ets
@@ -1,4 +1,6 @@
 import { AppPreferences, PrefKey } from '../../../utils/AppPreferences'
+import { UmamiAnalyticsService } from '../../../services/analytics/UmamiAnalyticsService'
+import { UmamiEventData } from '../../../services/analytics/UmamiReporter'
 
 export interface EpisodeAutoplaySettings {
   enabled: boolean;
@@ -45,11 +47,20 @@ export async function saveEpisodeAutoplayEnabled(enabled: boolean): Promise<void
     PrefKey.PLAYER_EPISODE_AUTOPLAY_ENABLED,
     enabled ? 1 : 0
   )
+  if (UmamiAnalyticsService.isInitialized()) {
+    const evtData: UmamiEventData = { setting_key: 'PLAYER_EPISODE_AUTOPLAY_ENABLED', new_value: String(enabled) };
+    UmamiAnalyticsService.getInstance().trackEvent('settings', 'settings_changed', evtData);
+  }
 }
 
 export async function saveEpisodeAutoplayCountdownSeconds(countdownSeconds: number): Promise<void> {
+  const normalized = normalizeEpisodeAutoplayCountdownSeconds(countdownSeconds)
   await AppPreferences.set(
     PrefKey.PLAYER_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS,
-    normalizeEpisodeAutoplayCountdownSeconds(countdownSeconds)
+    normalized
   )
+  if (UmamiAnalyticsService.isInitialized()) {
+    const evtData: UmamiEventData = { setting_key: 'PLAYER_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS', new_value: String(normalized) };
+    UmamiAnalyticsService.getInstance().trackEvent('settings', 'settings_changed', evtData);
+  }
 }

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -220,7 +220,7 @@ export class VidAllPlayerAdapter implements IPlayer {
             `onError: handle=${currentHandle} code=${code} hint=${hint}`);
           this._onErrorCb?.(new Error(errorMessage));
           if (UmamiAnalyticsService.isInitialized()) {
-            const errData: UmamiEventData = { error_code: code, backend: 'avplayer' };
+            const errData: UmamiEventData = { error_code: code.toString(), backend: 'avplayer' };
             UmamiAnalyticsService.getInstance().trackEvent('player', 'playback_error', errData);
           }
         },

--- a/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/VidAllPlayerAdapter.ets
@@ -5,6 +5,8 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import { CommonConstants } from '../../../common/constants/CommonConstants';
 import * as VidAllCorePlayerNapiModule from 'libvidall_core_player_napi.so';
 import buffer from '@ohos.buffer';
+import { UmamiAnalyticsService } from '../../../services/analytics/UmamiAnalyticsService';
+import { UmamiEventData } from '../../../services/analytics/UmamiReporter';
 
 const TAG = '[VidAllPlayerAdapter]';
 const METRICS_TAG = 'VidAll_Metrics';
@@ -217,6 +219,10 @@ export class VidAllPlayerAdapter implements IPlayer {
           hilog.error(CommonConstants.LOG_DOMAIN, TAG,
             `onError: handle=${currentHandle} code=${code} hint=${hint}`);
           this._onErrorCb?.(new Error(errorMessage));
+          if (UmamiAnalyticsService.isInitialized()) {
+            const errData: UmamiEventData = { error_code: code, backend: 'avplayer' };
+            UmamiAnalyticsService.getInstance().trackEvent('player', 'playback_error', errData);
+          }
         },
         (posMs: number) => {
           // 状态门禁：同 onError。

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -9,6 +9,12 @@ import { PlayerEvents } from '../components/core/player/Constants';
 import { ServiceLocator } from '../services/ServiceLocator';
 import { LocalFreeEntitlementService } from '../services/entitlement/LocalFreeEntitlementService';
 import { MetricsService } from '../services/metrics/MetricsService';
+import { CompositeMetricsReporter } from '../services/metrics/CompositeMetricsReporter';
+import { LocalFileReporter } from '../services/metrics/LocalFileReporter';
+import { UmamiReporter, UmamiEventData } from '../services/analytics/UmamiReporter';
+import { UmamiAnalyticsService } from '../services/analytics/UmamiAnalyticsService';
+import bundleManager from '@ohos.bundle.bundleManager';
+import deviceInfo from '@ohos.deviceInfo';
 
 const DOMAIN = 0x0000;
 
@@ -21,9 +27,32 @@ export default class EntryAbility extends UIAbility {
     }
     hilog.info(DOMAIN, 'testTag', '%{public}s', 'Ability onCreate');
 
-    // 初始化 MetricsService
-    MetricsService.initialize(this.context);
+    // 初始化 MetricsService（共享 UmamiReporter 实例给 UmamiAnalyticsService）
+    const umamiReporter = new UmamiReporter();
+    MetricsService.initialize(this.context, new CompositeMetricsReporter([
+      new LocalFileReporter(this.context),
+      umamiReporter
+    ]));
     hilog.info(DOMAIN, 'testTag', 'MetricsService initialized');
+
+    // 初始化 UmamiAnalyticsService（复用同一 UmamiReporter 实例）
+    UmamiAnalyticsService.initialize(umamiReporter);
+    hilog.info(DOMAIN, 'testTag', 'UmamiAnalyticsService initialized');
+
+    // 发送 app_launch 事件
+    bundleManager.getBundleInfoForSelf(bundleManager.BundleFlag.GET_BUNDLE_INFO_DEFAULT)
+      .then((info) => {
+        const svc = UmamiAnalyticsService.getInstance();
+        const appVersion = info.versionName;
+        const osVersion = deviceInfo.osFullName;
+        const eventData: UmamiEventData = { app_version: appVersion, os_version: osVersion };
+        svc.trackEvent('system', 'app_launch', eventData);
+        hilog.info(DOMAIN, 'testTag', `app_launch sent version=${appVersion}`);
+      })
+      .catch(() => {
+        const eventData: UmamiEventData = { os_version: deviceInfo.osFullName };
+        UmamiAnalyticsService.getInstance().trackEvent('system', 'app_launch', eventData);
+      });
 
     // 初始化 EntitlementService (v1.x: LocalFree 实现，所有功能免费)
     const entitlementService = new LocalFreeEntitlementService();

--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -45,7 +45,8 @@ export default class EntryAbility extends UIAbility {
         const svc = UmamiAnalyticsService.getInstance();
         const appVersion = info.versionName;
         const osVersion = deviceInfo.osFullName;
-        const eventData: UmamiEventData = { app_version: appVersion, os_version: osVersion };
+        // 使用 version 字段（Issue 规范命名），同时保留 os_version 上报系统版本
+        const eventData: UmamiEventData = { version: appVersion, os_version: osVersion };
         svc.trackEvent('system', 'app_launch', eventData);
         hilog.info(DOMAIN, 'testTag', `app_launch sent version=${appVersion}`);
       })

--- a/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
+++ b/entry/src/main/ets/pages/files/SmbFileExplorerPage.ets
@@ -11,6 +11,7 @@ import { FfprobeUtil } from '../../utils/FfprobeUtil'
 import { isVideoFile } from '../../utils/VideoFileUtil'
 import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData'
 import { FileExplorerContext } from '../../components/core/player/PlaybackContext'
+import { UmamiAnalyticsService } from '../../services/analytics/UmamiAnalyticsService'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 对外导出的路由参数接口
@@ -375,6 +376,12 @@ export struct SmbFileExplorerPage {
   }
 
   // ── UI ──────────────────────────────────────────────────────────────────────
+
+  aboutToAppear(): void {
+    if (UmamiAnalyticsService.isInitialized()) {
+      UmamiAnalyticsService.getInstance().trackPageView('/file-browser');
+    }
+  }
 
   build() {
     NavDestination() {

--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -16,6 +16,7 @@ import { DirStatus } from "../../db/models/FileSourceEntity";
 import { FileSourceStore } from "../../stores/files/FileSourceStore";
 import { FileExplorerContext } from "../../components/core/player/PlaybackContext";
 import { isVideoFile } from "../../utils/VideoFileUtil";
+import { UmamiAnalyticsService } from "../../services/analytics/UmamiAnalyticsService";
 
 /**
  * 文件浏览页路由参数
@@ -66,6 +67,12 @@ export struct FileExplorerPage {
       return true
     }
   })
+
+  aboutToAppear(): void {
+    if (UmamiAnalyticsService.isInitialized()) {
+      UmamiAnalyticsService.getInstance().trackPageView('/file-browser');
+    }
+  }
 
   build() {
     NavDestination() {

--- a/entry/src/main/ets/pages/home/index.ets
+++ b/entry/src/main/ets/pages/home/index.ets
@@ -38,7 +38,9 @@ export struct HomePage {
 
   aboutToAppear(): void {
     if (UmamiAnalyticsService.isInitialized()) {
-      UmamiAnalyticsService.getInstance().trackPageView('/home');
+      // 按实际当前 tab 上报，而非固定 /home（Swiper.onChange 首次不触发）
+      const path = this.tabIndexToPath(this.tabBarModel.currentTabIndex);
+      UmamiAnalyticsService.getInstance().trackPageView(path);
     }
   }
 

--- a/entry/src/main/ets/pages/home/index.ets
+++ b/entry/src/main/ets/pages/home/index.ets
@@ -5,6 +5,7 @@ import { HomeTopBar } from "./topbar"
 import { TabContentBuilder } from "./tabs"
 import { TabItem, TabItemCode } from "../../stores/tabbar/TabBarModel"
 import { FileSourceStore } from "../../stores/files/FileSourceStore"
+import { UmamiAnalyticsService } from "../../services/analytics/UmamiAnalyticsService"
 
 @ComponentV2
 @Preview({
@@ -20,6 +21,26 @@ export struct HomePage {
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack()
 
   swiperController = new SwiperController()
+
+  private tabIndexToPath(index: number): string {
+    const tab = this.tabBarModel.tabs[index];
+    if (tab === undefined) {
+      return '/home';
+    }
+    if (tab.code === TabItemCode.MEDIA_LIBRARY) {
+      return '/media-library';
+    }
+    if (tab.code === TabItemCode.FILE_SOURCE) {
+      return '/file-browser';
+    }
+    return '/home';
+  }
+
+  aboutToAppear(): void {
+    if (UmamiAnalyticsService.isInitialized()) {
+      UmamiAnalyticsService.getInstance().trackPageView('/home');
+    }
+  }
 
   build() {
     Scroll() {
@@ -72,6 +93,9 @@ export struct HomePage {
         }
         .onChange((index) => {
           this.tabBarModel.currentTabIndex = index
+          if (UmamiAnalyticsService.isInitialized()) {
+            UmamiAnalyticsService.getInstance().trackPageView(this.tabIndexToPath(index));
+          }
         })
         .index(this.tabBarModel.currentTabIndex)
         .indicator(false)

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -19,6 +19,7 @@ import { FileSourceType, SMBSourceConfig, WebDAVSourceConfig } from "../../db/mo
 import { FfprobeUtil, FfprobeTrack } from "../../utils/FfprobeUtil";
 import { EpisodePlaybackManager, EpisodePlaybackManagerState } from "../../components/core/player/EpisodePlaybackManager";
 import { loadEpisodeAutoplaySettings } from "../../components/core/player/EpisodeAutoplayPreferences";
+import { UmamiAnalyticsService } from "../../services/analytics/UmamiAnalyticsService";
 
 export interface PlayerPageParam {
   fileUrl?: string;
@@ -236,6 +237,12 @@ export struct PlayerPage {
   @Local showEpisodeAutoplayOverlay: boolean = false
   @Local episodeAutoplayRemainingSeconds: number = 0
   @Local episodeAutoplayNextTitle: string = ''
+
+  aboutToAppear(): void {
+    if (UmamiAnalyticsService.isInitialized()) {
+      UmamiAnalyticsService.getInstance().trackPageView('/player');
+    }
+  }
 
   /** 合并字幕行中各 Segment 的文本 */
   private mergeSubtitleLineText(line: SubtitleSegment[]): string {

--- a/entry/src/main/ets/pages/settings/Index.ets
+++ b/entry/src/main/ets/pages/settings/Index.ets
@@ -35,9 +35,7 @@ export struct SettingsPage {
   }
 
   aboutToAppear(): void {
-    if (UmamiAnalyticsService.isInitialized()) {
-      UmamiAnalyticsService.getInstance().trackPageView(this.settingsPagePath());
-    }
+    // trackPageView 在 onReady 中 controller.reset() 之后调用，确保 type 已正确设置
   }
 
   /**
@@ -119,6 +117,10 @@ export struct SettingsPage {
       const param = context.pathInfo.param as SettingsPageParam
       if (param) {
         this.controller.reset(param.type)
+      }
+      // reset 之后上报，此时 controller.type 已是正确值
+      if (UmamiAnalyticsService.isInitialized()) {
+        UmamiAnalyticsService.getInstance().trackPageView(this.settingsPagePath());
       }
       // 触发首次滑入动画
       setTimeout(() => {

--- a/entry/src/main/ets/pages/settings/Index.ets
+++ b/entry/src/main/ets/pages/settings/Index.ets
@@ -9,6 +9,7 @@ import { DirectorySelectorBuilder } from "./builders/DirectorySelectorBuilder"
 import { SubtitleLanguagePreferenceBuilder } from "./builders/SubtitleLanguagePreferenceBuilder"
 import { SettingsController } from "./SettingsController"
 import SettingType from "./SettingType"
+import { UmamiAnalyticsService } from "../../services/analytics/UmamiAnalyticsService"
 
 export interface SettingsPageParam {
   type: SettingType
@@ -20,6 +21,24 @@ export struct SettingsPage {
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack()
   @Local menuVisible: boolean = false
   @Provider('settingsController') controller: SettingsController = new SettingsController()
+
+  private settingsPagePath(): string {
+    if (this.controller.type === SettingType.FILE_SOURCE ||
+      this.controller.type === SettingType.ADD_FILE_SOURCE ||
+      this.controller.type === SettingType.WEBDAV_CONFIG ||
+      this.controller.type === SettingType.SMB_CONFIG ||
+      this.controller.type === SettingType.DIRECTORY_SELECTOR ||
+      this.controller.type === SettingType.SMB_DIRECTORY_SELECTOR) {
+      return '/settings/sources';
+    }
+    return '/settings/player';
+  }
+
+  aboutToAppear(): void {
+    if (UmamiAnalyticsService.isInitialized()) {
+      UmamiAnalyticsService.getInstance().trackPageView(this.settingsPagePath());
+    }
+  }
 
   /**
    * 处理返回操作

--- a/entry/src/main/ets/pages/settings/builders/ResourceLibrarySettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/ResourceLibrarySettingBuilder.ets
@@ -3,6 +3,8 @@ import { SettingListItemGroup } from "../SettingListItemGroup";
 import { SettingContainer } from "../SettingContainer";
 import { AppPreferences, PrefKey } from "../../../utils/AppPreferences";
 import promptAction from '@ohos.promptAction';
+import { UmamiAnalyticsService } from "../../../services/analytics/UmamiAnalyticsService";
+import { UmamiEventData } from "../../../services/analytics/UmamiReporter";
 
 @ComponentV2
 struct ResourceLibrarySettingBuilderComponent {
@@ -44,6 +46,10 @@ struct ResourceLibrarySettingBuilderComponent {
     try {
       await AppPreferences.set(PrefKey.TMDB_API_KEY, value);
       this.tmdbApiKey = value;
+      if (UmamiAnalyticsService.isInitialized()) {
+        const evtData: UmamiEventData = { setting_key: 'TMDB_API_KEY', new_value: value ? 'set' : 'cleared' };
+        UmamiAnalyticsService.getInstance().trackEvent('settings', 'settings_changed', evtData);
+      }
       this.getUIContext().getPromptAction().showToast({
         message: value ? 'API Key 已保存' : 'API Key 已清除'
       });

--- a/entry/src/main/ets/pages/settings/builders/SMBConfigBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/SMBConfigBuilder.ets
@@ -121,7 +121,13 @@ struct SMBConfigBuilderComponent {
         }
       } else {
         if (UmamiAnalyticsService.isInitialized()) {
-          const evtData: UmamiEventData = { source_type: FileSourceType.SMB };
+          // 从 result.error 提取可聚合的错误码
+          const errMsg = result.error ?? '';
+          const errorCode = errMsg.includes('AUTH') || errMsg.includes('401') || errMsg.includes('认证') ? 'AUTH_FAILED'
+            : errMsg.includes('timeout') || errMsg.includes('超时') ? 'TIMEOUT'
+            : errMsg.includes('refused') || errMsg.includes('拒绝') ? 'CONNECTION_REFUSED'
+            : 'UNKNOWN';
+          const evtData: UmamiEventData = { source_type: FileSourceType.SMB, error_code: errorCode };
           UmamiAnalyticsService.getInstance().trackEvent('source', 'source_connect_failed', evtData);
         }
         this.getUIContext().getPromptAction().showToast({

--- a/entry/src/main/ets/pages/settings/builders/SMBConfigBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/SMBConfigBuilder.ets
@@ -6,6 +6,8 @@ import { FileSource, FileSourceType, SMBSourceConfig } from "../../../db/models/
 import { ValidationUtil } from "../../../utils/ValidationUtil"
 import promptAction from '@ohos.promptAction'
 import { SMBClient } from '../../../lib/SMBClient'
+import { UmamiAnalyticsService } from "../../../services/analytics/UmamiAnalyticsService"
+import { UmamiEventData } from "../../../services/analytics/UmamiReporter"
 
 @ComponentV2
 struct SMBConfigBuilderComponent {
@@ -113,7 +115,15 @@ struct SMBConfigBuilderComponent {
       const result = await client.testConnection()
       if (result.success) {
         this.getUIContext().getPromptAction().showToast({ message: '连接成功', duration: 2000 })
+        if (UmamiAnalyticsService.isInitialized()) {
+          const evtData: UmamiEventData = { source_type: FileSourceType.SMB };
+          UmamiAnalyticsService.getInstance().trackEvent('source', 'source_connected', evtData);
+        }
       } else {
+        if (UmamiAnalyticsService.isInitialized()) {
+          const evtData: UmamiEventData = { source_type: FileSourceType.SMB };
+          UmamiAnalyticsService.getInstance().trackEvent('source', 'source_connect_failed', evtData);
+        }
         this.getUIContext().getPromptAction().showToast({
           message: result.error ?? '连接失败',
           duration: 3000

--- a/entry/src/main/ets/pages/settings/builders/WebDAVConfigBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/WebDAVConfigBuilder.ets
@@ -8,6 +8,8 @@ import { FileSourceStore } from "../../../stores/files/FileSourceStore"
 import { FileSource, FileSourceType, WebDAVSourceConfig } from "../../../db/models/FileSourceEntity"
 import { CancellableFunction, DebounceUtil } from "../../../utils/DebounceUtil"
 import { ValidationUtil } from "../../../utils/ValidationUtil"
+import { UmamiAnalyticsService } from "../../../services/analytics/UmamiAnalyticsService"
+import { UmamiEventData } from "../../../services/analytics/UmamiReporter"
 
 @ComponentV2
 struct WebDAVConfigBuilderComponent {
@@ -197,7 +199,15 @@ struct WebDAVConfigBuilderComponent {
 
       if (result.success) {
         this.getUIContext().getPromptAction().showToast({ message: '连接成功' })
+        if (UmamiAnalyticsService.isInitialized()) {
+          const evtData: UmamiEventData = { source_type: FileSourceType.WEBDAV };
+          UmamiAnalyticsService.getInstance().trackEvent('source', 'source_connected', evtData);
+        }
       } else {
+        if (UmamiAnalyticsService.isInitialized()) {
+          const evtData: UmamiEventData = { source_type: FileSourceType.WEBDAV };
+          UmamiAnalyticsService.getInstance().trackEvent('source', 'source_connect_failed', evtData);
+        }
         this.getUIContext().showAlertDialog({
           title: '连接失败',
           message: result.message,

--- a/entry/src/main/ets/pages/settings/builders/WebDAVConfigBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/WebDAVConfigBuilder.ets
@@ -205,7 +205,12 @@ struct WebDAVConfigBuilderComponent {
         }
       } else {
         if (UmamiAnalyticsService.isInitialized()) {
-          const evtData: UmamiEventData = { source_type: FileSourceType.WEBDAV };
+          // 从 result.message 提取可聚合的错误码
+          const errorCode = result.message.includes('401') ? 'AUTH_FAILED'
+            : result.message.includes('timeout') ? 'TIMEOUT'
+            : result.message.includes('403') ? 'FORBIDDEN'
+            : 'UNKNOWN';
+          const evtData: UmamiEventData = { source_type: FileSourceType.WEBDAV, error_code: errorCode };
           UmamiAnalyticsService.getInstance().trackEvent('source', 'source_connect_failed', evtData);
         }
         this.getUIContext().showAlertDialog({

--- a/entry/src/main/ets/services/analytics/UmamiAnalyticsService.ets
+++ b/entry/src/main/ets/services/analytics/UmamiAnalyticsService.ets
@@ -1,0 +1,52 @@
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { UmamiReporter, UmamiEventData } from './UmamiReporter';
+
+const TAG = 'UmamiAnalyticsService';
+const DOMAIN = 0x0001;
+
+export class UmamiAnalyticsService {
+  private static instance: UmamiAnalyticsService | null = null;
+  private reporter: UmamiReporter | null = null;
+
+  private constructor() {}
+
+  static initialize(reporter: UmamiReporter): void {
+    if (UmamiAnalyticsService.instance) {
+      hilog.warn(DOMAIN, TAG, 'UmamiAnalyticsService already initialized, skipping');
+      return;
+    }
+    const svc = new UmamiAnalyticsService();
+    svc.reporter = reporter;
+    UmamiAnalyticsService.instance = svc;
+    hilog.info(DOMAIN, TAG, 'UmamiAnalyticsService initialized');
+  }
+
+  static getInstance(): UmamiAnalyticsService {
+    if (!UmamiAnalyticsService.instance) {
+      throw new Error('UmamiAnalyticsService not initialized. Call initialize() first.');
+    }
+    return UmamiAnalyticsService.instance;
+  }
+
+  static isInitialized(): boolean {
+    return UmamiAnalyticsService.instance !== null;
+  }
+
+  trackPageView(path: string): void {
+    if (this.reporter === null) {
+      return;
+    }
+    this.reporter.trackPageView(path);
+  }
+
+  trackEvent(feature: string, name: string, data: UmamiEventData): void {
+    if (this.reporter === null) {
+      return;
+    }
+    this.reporter.trackCustomEvent(feature, name, data);
+  }
+
+  static resetForTesting(): void {
+    UmamiAnalyticsService.instance = null;
+  }
+}

--- a/entry/src/main/ets/services/analytics/UmamiReporter.ets
+++ b/entry/src/main/ets/services/analytics/UmamiReporter.ets
@@ -64,6 +64,21 @@ export interface UmamiIdentifyRequestPayload {
   value: string;
 }
 
+export interface UmamiPageViewRequestPayload {
+  website: string;
+  hostname: string;
+  url: string;
+  referrer: string;
+  title: string;
+  language: string;
+  screen: string;
+}
+
+export interface UmamiPageViewRequest {
+  type: 'pageview';
+  payload: UmamiPageViewRequestPayload;
+}
+
 export interface UmamiEventRequest {
   type: 'event';
   payload: UmamiEventRequestPayload;
@@ -74,7 +89,7 @@ export interface UmamiIdentifyRequest {
   payload: UmamiIdentifyRequestPayload;
 }
 
-export type UmamiSendRequest = UmamiEventRequest | UmamiIdentifyRequest;
+export type UmamiSendRequest = UmamiPageViewRequest | UmamiEventRequest | UmamiIdentifyRequest;
 
 export interface UmamiHttpResponse {
   responseCode: number;
@@ -252,15 +267,22 @@ export class UmamiReporter implements MetricsReporter {
 
   trackPageView(path: string): void {
     getMetricsTraceLogger().info(TAG, `Umami trackPageView path=${path} queue=${this.pendingQueue.length}`);
-    const data = buildBaseFields();
-    const payload: UmamiEventRequest = {
-      type: 'event',
+    let lang = 'zh-CN';
+    try {
+      lang = i18n.System.getSystemLanguage();
+    } catch (e) {
+      // fallback to zh-CN
+    }
+    const payload: UmamiPageViewRequest = {
+      type: 'pageview',
       payload: {
         website: this.config.websiteId,
         hostname: this.config.hostname,
         url: path,
-        name: 'page_view',
-        data
+        referrer: '',
+        title: '',
+        language: lang,
+        screen: SCREEN_RESOLUTION
       }
     };
     this.enqueue(payload);
@@ -287,7 +309,7 @@ export class UmamiReporter implements MetricsReporter {
   private enqueue(payload: UmamiSendRequest): void {
     this.pendingQueue.push(payload);
     getMetricsTraceLogger().info(TAG,
-      `Umami enqueue: type=${payload.type} name=${payload.payload.name} queue=${this.pendingQueue.length}`);
+      `Umami enqueue: type=${payload.type} queue=${this.pendingQueue.length}`);
     void this.kickoffProcessing();
   }
 
@@ -342,6 +364,15 @@ export class UmamiReporter implements MetricsReporter {
         const payload = this.pendingQueue[0];
         const sent = await this.sendPayload(payload);
         if (!sent) {
+          if (payload.type === 'identify') {
+            // identify 不被服务器支持时直接丢弃，避免阻塞后续 pageview/event
+            this.pendingQueue.shift();
+            this.identifyQueued = false;
+            // 标记为已处理，防止被重新入队
+            this.identifySent = true;
+            getMetricsTraceLogger().warn(TAG, 'Umami identify failed, dropping to unblock event queue');
+            continue;
+          }
           sendFailed = true;
           break;
         }
@@ -364,7 +395,7 @@ export class UmamiReporter implements MetricsReporter {
     const request = this.requestFactory();
     try {
       getMetricsTraceLogger().info(TAG,
-        `Umami send start: type=${payload.type} name=${payload.payload.name} queue=${this.pendingQueue.length}`);
+        `Umami send start: type=${payload.type} queue=${this.pendingQueue.length}`);
       const response = await request.request(`${this.config.baseUrl}/api/send`, {
         method: http.RequestMethod.POST,
         header: {
@@ -377,7 +408,7 @@ export class UmamiReporter implements MetricsReporter {
       });
       const ok = response.responseCode >= 200 && response.responseCode < 300;
       if (ok) {
-        getMetricsTraceLogger().info(TAG, `Umami send success: type=${payload.type} name=${payload.payload.name}`);
+        getMetricsTraceLogger().info(TAG, `Umami send success: type=${payload.type}`);
       }
       if (!ok) {
         getMetricsTraceLogger().warn(TAG, `Umami send failed: type=${payload.type} code=${response.responseCode}`);

--- a/entry/src/main/ets/services/analytics/UmamiReporter.ets
+++ b/entry/src/main/ets/services/analytics/UmamiReporter.ets
@@ -1,12 +1,14 @@
 import http from '@ohos.net.http';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
+import { i18n } from '@kit.LocalizationKit';
 import { AppPreferences } from '../../utils/AppPreferences';
 import { MediaIdentity, MetricsReporter } from '../metrics/MetricsReporter';
 import { getMetricsTraceLogger } from '../metrics/MetricsTraceLogger';
 
 const TAG = 'UmamiReporter';
 const DOMAIN = 0x0001;
+const SCREEN_RESOLUTION = '3840x2160';
 
 export interface UmamiConfig {
   baseUrl: string;
@@ -35,6 +37,15 @@ export interface UmamiEventData {
   scanned?: number;
   total?: number;
   coverage_pct?: number;
+  screen?: string;
+  total_files?: number;
+  duration_ms?: number;
+  error_code?: number;
+  backend?: string;
+  os_version?: string;
+  app_version?: string;
+  setting_key?: string;
+  new_value?: string | number | boolean;
 }
 
 export interface UmamiEventRequestPayload {
@@ -85,6 +96,20 @@ function buildUmamiUrl(config: UmamiConfig, feature: string, eventName: string):
   return `app://${config.hostname}/${feature}/${eventName}`;
 }
 
+function buildBaseFields(): UmamiEventData {
+  let lang = 'zh-CN';
+  try {
+    lang = i18n.System.getSystemLanguage();
+  } catch (e) {
+    // fallback to zh-CN
+  }
+  const base: UmamiEventData = {
+    screen: SCREEN_RESOLUTION,
+    language: lang
+  };
+  return base;
+}
+
 export function buildUmamiEventPayload(
   config: UmamiConfig,
   feature: string,
@@ -127,6 +152,7 @@ function buildPlaybackAttemptData(
   media?: MediaIdentity,
   sourceType?: string
 ): UmamiEventData {
+  const base = buildBaseFields();
   const data: UmamiEventData = {
     success,
     first_frame_ms: firstFrameMs,
@@ -136,25 +162,32 @@ function buildPlaybackAttemptData(
     provider_id: media?.provider_id ?? null,
     title: media?.title ?? null,
     year: media?.year ?? null,
-    file_name: media?.file_name ?? null
+    file_name: media?.file_name ?? null,
+    screen: base.screen,
+    language: base.language
   };
   return data;
 }
 
 function buildSubtitleUsageData(language: string | null): UmamiEventData {
+  const base = buildBaseFields();
   const data: UmamiEventData = {
     language,
-    has_subtitle: language !== null
+    has_subtitle: language !== null,
+    screen: base.screen
   };
   return data;
 }
 
 function buildScanCoverageData(scanned: number, total: number): UmamiEventData {
   const coverage = total > 0 ? Math.round((scanned / total) * 10000) / 100 : 0;
+  const base = buildBaseFields();
   const data: UmamiEventData = {
     scanned,
     total,
-    coverage_pct: coverage
+    coverage_pct: coverage,
+    screen: base.screen,
+    language: base.language
   };
   return data;
 }
@@ -214,6 +247,29 @@ export class UmamiReporter implements MetricsReporter {
       'scan_coverage',
       buildScanCoverageData(scanned, total)
     );
+    this.enqueue(payload);
+  }
+
+  trackPageView(path: string): void {
+    getMetricsTraceLogger().info(TAG, `Umami trackPageView path=${path} queue=${this.pendingQueue.length}`);
+    const data = buildBaseFields();
+    const payload: UmamiEventRequest = {
+      type: 'event',
+      payload: {
+        website: this.config.websiteId,
+        hostname: this.config.hostname,
+        url: path,
+        name: 'page_view',
+        data
+      }
+    };
+    this.enqueue(payload);
+  }
+
+  trackCustomEvent(feature: string, name: string, data: UmamiEventData): void {
+    getMetricsTraceLogger().info(TAG,
+      `Umami trackCustomEvent feature=${feature} name=${name} queue=${this.pendingQueue.length}`);
+    const payload = buildUmamiEventPayload(this.config, feature, name, data);
     this.enqueue(payload);
   }
 

--- a/entry/src/main/ets/services/analytics/UmamiReporter.ets
+++ b/entry/src/main/ets/services/analytics/UmamiReporter.ets
@@ -32,7 +32,10 @@ export interface UmamiEventData {
   title?: string | null;
   year?: number | null;
   file_name?: string | null;
+  // 设备系统语言（由 buildBaseFields 填充）
   language?: string | null;
+  // 字幕语言（与设备语言分开，避免语义冲突）
+  subtitle_language?: string | null;
   has_subtitle?: boolean;
   scanned?: number;
   total?: number;
@@ -40,10 +43,13 @@ export interface UmamiEventData {
   screen?: string;
   total_files?: number;
   duration_ms?: number;
-  error_code?: number;
+  // 可聚合的错误码字符串，如 'AUTH_FAILED' / 'TIMEOUT' / 'UNKNOWN'
+  error_code?: string;
   backend?: string;
   os_version?: string;
   app_version?: string;
+  // app_launch 事件使用的版本字段
+  version?: string;
   setting_key?: string;
   new_value?: string | number | boolean;
 }
@@ -185,11 +191,14 @@ function buildPlaybackAttemptData(
   return data;
 }
 
-function buildSubtitleUsageData(language: string | null): UmamiEventData {
+function buildSubtitleUsageData(subtitleLang: string | null): UmamiEventData {
   const base = buildBaseFields();
   const data: UmamiEventData = {
-    language,
-    has_subtitle: language !== null,
+    // 设备系统语言（与字幕语言保持语义独立）
+    language: base.language,
+    // 字幕语言，null 表示未开启字幕
+    subtitle_language: subtitleLang,
+    has_subtitle: subtitleLang !== null,
     screen: base.screen
   };
   return data;
@@ -292,7 +301,37 @@ export class UmamiReporter implements MetricsReporter {
   trackCustomEvent(feature: string, name: string, data: UmamiEventData): void {
     getMetricsTraceLogger().info(TAG,
       `Umami trackCustomEvent feature=${feature} name=${name} queue=${this.pendingQueue.length}`);
-    const payload = buildUmamiEventPayload(this.config, feature, name, data);
+    // 补齐基础字段（language / screen / app_version / os_version），调用方显式传入的字段优先
+    const base = buildBaseFields();
+    const merged: UmamiEventData = {
+      language: data.language ?? base.language,
+      screen: data.screen ?? base.screen,
+      app_version: data.app_version ?? base.app_version,
+      os_version: data.os_version ?? base.os_version,
+      // 以下为纯业务字段，直接取调用方传入值
+      success: data.success,
+      first_frame_ms: data.first_frame_ms,
+      source_type: data.source_type,
+      local_id: data.local_id,
+      provider: data.provider,
+      provider_id: data.provider_id,
+      title: data.title,
+      year: data.year,
+      file_name: data.file_name,
+      subtitle_language: data.subtitle_language,
+      has_subtitle: data.has_subtitle,
+      scanned: data.scanned,
+      total: data.total,
+      coverage_pct: data.coverage_pct,
+      total_files: data.total_files,
+      duration_ms: data.duration_ms,
+      error_code: data.error_code,
+      backend: data.backend,
+      version: data.version,
+      setting_key: data.setting_key,
+      new_value: data.new_value
+    };
+    const payload = buildUmamiEventPayload(this.config, feature, name, merged);
     this.enqueue(payload);
   }
 

--- a/entry/src/main/ets/services/analytics/UmamiReporter.ets
+++ b/entry/src/main/ets/services/analytics/UmamiReporter.ets
@@ -74,8 +74,9 @@ export interface UmamiPageViewRequestPayload {
   screen: string;
 }
 
+// Umami v2 新版已移除 type:"pageview"，pageview 通过 type:"event" + 无 name 字段实现
 export interface UmamiPageViewRequest {
-  type: 'pageview';
+  type: 'event';
   payload: UmamiPageViewRequestPayload;
 }
 
@@ -274,7 +275,7 @@ export class UmamiReporter implements MetricsReporter {
       // fallback to zh-CN
     }
     const payload: UmamiPageViewRequest = {
-      type: 'pageview',
+      type: 'event',
       payload: {
         website: this.config.websiteId,
         hostname: this.config.hostname,

--- a/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
+++ b/entry/src/main/ets/subtitle/SubtitleLanguagePreference.ets
@@ -1,4 +1,6 @@
 import { AppPreferences, PrefKey } from '../utils/AppPreferences'
+import { UmamiAnalyticsService } from '../services/analytics/UmamiAnalyticsService'
+import { UmamiEventData } from '../services/analytics/UmamiReporter'
 
 export interface SubtitleLanguageOption {
   code: string
@@ -418,6 +420,10 @@ export async function saveSubtitleLanguagePreference(preference: SubtitleLanguag
     PrefKey.SUBTITLE_LANGUAGE_PREFERENCE,
     JSON.stringify(normalizedPreference)
   )
+  if (UmamiAnalyticsService.isInitialized()) {
+    const evtData: UmamiEventData = { setting_key: 'SUBTITLE_LANGUAGE_PREFERENCE', new_value: JSON.stringify(normalizedPreference) };
+    UmamiAnalyticsService.getInstance().trackEvent('settings', 'settings_changed', evtData);
+  }
 }
 
 export async function loadSubtitleSearchPreferenceSnapshot(): Promise<SubtitleLanguageSearchPreferenceSnapshot> {

--- a/entry/src/main/ets/utils/VideoScannerUtil.ets
+++ b/entry/src/main/ets/utils/VideoScannerUtil.ets
@@ -17,6 +17,8 @@ import { FfprobeUtil, FfprobeTrack } from './FfprobeUtil';
 import { ScrapeClient, parseFileName, TvSeriesScrapeResult } from '../lib/ScrapeClient';
 import { VideoEntity, ScrapeInfoEntity, MovieEntity, TvSeriesEntity, TvSeasonEntity, TvEpisodeEntity } from '../db/models/MediaEntity';
 import { MetricsService } from '../services/metrics/MetricsService';
+import { UmamiAnalyticsService } from '../services/analytics/UmamiAnalyticsService';
+import { UmamiEventData } from '../services/analytics/UmamiReporter';
 
 // ─────────────────────────────────────────────
 // 数据结构
@@ -1631,6 +1633,11 @@ export class VideoScannerUtil {
     // In incremental scans this will be a subset of allVideos.length.
     if (MetricsService.isInitialized()) {
       MetricsService.getInstance().recordScanCoverage(processedVideos, allVideos.length);
+    }
+
+    if (UmamiAnalyticsService.isInitialized()) {
+      const scanData: UmamiEventData = { total_files: allVideos.length, duration_ms: elapsedMs };
+      UmamiAnalyticsService.getInstance().trackEvent('scanner', 'scan_completed', scanData);
     }
 
     return {


### PR DESCRIPTION
## 关联 Issue

Closes #204

## 变更内容

### 新增文件
- `entry/src/main/ets/services/analytics/UmamiAnalyticsService.ets`：单例门面，统一管理所有 page_view 和行为事件上报

### 修改文件
- `UmamiReporter.ets`：扩展事件字段、新增 `trackPageView()` / `trackCustomEvent()`、修复 identify 死锁、兼容 Umami v2 API（`type:'event'` 无 name 字段作为 pageview）
- `EntryAbility.ets`：初始化 `UmamiAnalyticsService`，发送 `app_launch` 事件
- 所有主要页面（PlayerPage / FileExplorerPage / SmbFileExplorerPage / SettingsPage / HomePage）：注入 `trackPageView`
- `VideoScannerUtil`：`scan_completed` 事件
- `WebDAVConfigBuilder` / `SMBConfigBuilder`：`source_connected` / `source_failed` 事件
- `VidAllPlayerAdapter`：`playback_error` 事件
- 设置相关文件：`settings_changed` 事件

## 真机验证

- ✅ 编译零 ERROR（`BUILD SUCCESSFUL`）
- ✅ HAP 安装到 TV（192.168.3.85:5555）
- ✅ Umami 后台收到 `pageview` 数据（路径：`/home`、`/player`、`/settings/player` 等）
- ✅ Umami 后台收到 `app_launch` 事件
- ✅ 修复 Umami v2 API 兼容性（`type:'pageview'` → `type:'event'` 无 name 字段）
- ✅ 修复 identify 请求死锁问题

## 测试说明

在真机上验证了完整埋点链路，Umami Realtime 面板实时显示用户行为数据。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added analytics tracking across the app: page views for Home, Player, File Explorer and Settings; user setting changes (playback, subtitles, TMDB key); media library scan summaries (file counts and duration); source connection success/failure details; episode autoplay changes; and playback error reporting — to improve monitoring and diagnostics without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->