### PR TITLE
修复: API 23 eac3 静默失败——PREPARED 时主动 codec 检测触发 fallback (#212)

### DIFF
--- a/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
@@ -365,14 +365,8 @@ export class AVPlayerAdapter implements IPlayer {
           // demux 可识别 eac3 进入 PREPARED，但 decoder 静默放弃导致无声、不报 error。
           // 在此主动检测所有音频轨道 codec，全为不支持格式时触发 fallback，而非直接调 _onReadyCb。
           player.getTrackDescription().then((tracks: Array<media.MediaDescription>) => {
-            // [DIAG] 保留轨道诊断日志
             hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-              `[DIAG] PREPARED trackCount=${tracks.length}`);
-            for (let i = 0; i < tracks.length; i++) {
-              const t = tracks[i];
-              hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-                `[DIAG] track[${i}] codec=${t[media.MediaDescriptionKey.MD_KEY_CODEC_MIME] ?? 'N/A'} type=${t[media.MediaDescriptionKey.MD_KEY_TRACK_TYPE] ?? 'N/A'} channels=${t[media.MediaDescriptionKey.MD_KEY_AUD_CHANNEL_COUNT] ?? 'N/A'}`);
-            }
+              `PREPARED trackCount=${tracks.length}`);
             // 统计音频轨道中属于不支持格式的数量
             let audioCount = 0;
             let unsupportedCount = 0;
@@ -401,7 +395,7 @@ export class AVPlayerAdapter implements IPlayer {
             if (this._onReadyCb) { this._onReadyCb(); }
           }).catch((e: BusinessError) => {
             hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-              `[DIAG] getTrackDescription 失败: ${e.message}`);
+              `getTrackDescription 失败: ${e.message}`);
             // 无法读取轨道时降级为正常 ready，避免永久阻塞
             if (this._onReadyCb) { this._onReadyCb(); }
           });

--- a/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
@@ -13,6 +13,20 @@ const TAG = '[AVPlayerAdapter]';
 const ENABLE_AVPLAYER_TRACK_DIAG_LOG = true;
 const ENABLE_AVPLAYER_SUBTITLE_DIAG_LOG = false;
 
+// AVPlayer 在 API 23+ 的 demux 层可识别这些 codec 并进入 PREPARED，
+// 但 decoder 层静默放弃解码导致无声（Issue #212）。
+// 需在 PREPARED 时主动检测，若全部音频轨道均属此列则触发 fallback。
+// 与 VideoPlayerController.SYSTEM_SOFT_FALLBACK_CODECS 保持内容同步（MIME 格式）。
+const UNSUPPORTED_AUDIO_CODECS: string[] = [
+  'audio/ac3',        // Dolby Digital (AC-3)
+  'audio/eac3',       // Dolby Digital Plus / Atmos (E-AC-3)
+  'audio/truehd',     // Dolby TrueHD / Atmos
+  'audio/vnd.dts',    // DTS Core
+  'audio/vnd.dts.hd', // DTS-HD
+  'audio/mlp',        // MLP (Meridian Lossless Packing)
+  'audio/vivid',      // Audio Vivid
+];
+
 /**
  * AVPlayer 播放内核适配器
  *
@@ -347,8 +361,11 @@ export class AVPlayerAdapter implements IPlayer {
           });
           break;
         case AVPlayerState.PREPARED:
-          // 诊断日志：打印所有轨道信息（用于 Issue #212 eac3 静默失败排查）
+          // API 23 eac3 静默失败修复（Issue #212）：
+          // demux 可识别 eac3 进入 PREPARED，但 decoder 静默放弃导致无声、不报 error。
+          // 在此主动检测所有音频轨道 codec，全为不支持格式时触发 fallback，而非直接调 _onReadyCb。
           player.getTrackDescription().then((tracks: Array<media.MediaDescription>) => {
+            // [DIAG] 保留轨道诊断日志
             hilog.info(CommonConstants.LOG_DOMAIN, TAG,
               `[DIAG] PREPARED trackCount=${tracks.length}`);
             for (let i = 0; i < tracks.length; i++) {
@@ -356,12 +373,38 @@ export class AVPlayerAdapter implements IPlayer {
               hilog.info(CommonConstants.LOG_DOMAIN, TAG,
                 `[DIAG] track[${i}] codec=${t[media.MediaDescriptionKey.MD_KEY_CODEC_MIME] ?? 'N/A'} type=${t[media.MediaDescriptionKey.MD_KEY_TRACK_TYPE] ?? 'N/A'} channels=${t[media.MediaDescriptionKey.MD_KEY_AUD_CHANNEL_COUNT] ?? 'N/A'}`);
             }
+            // 统计音频轨道中属于不支持格式的数量
+            let audioCount = 0;
+            let unsupportedCount = 0;
+            for (let i = 0; i < tracks.length; i++) {
+              const t = tracks[i];
+              const trackType = t[media.MediaDescriptionKey.MD_KEY_TRACK_TYPE] as number;
+              if (trackType !== media.MediaType.MEDIA_TYPE_AUD) {
+                continue;
+              }
+              audioCount++;
+              const mimeType = t[media.MediaDescriptionKey.MD_KEY_CODEC_MIME] as string | undefined;
+              if (mimeType !== undefined) {
+                const codecLower = mimeType.toLowerCase();
+                if (UNSUPPORTED_AUDIO_CODECS.indexOf(codecLower) >= 0) {
+                  unsupportedCount++;
+                }
+              }
+            }
+            if (audioCount > 0 && audioCount === unsupportedCount) {
+              hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+                `所有音频轨道均为不支持格式，主动触发 fallback（音频轨道数=${audioCount}）`);
+              if (this._onUnsupportedFormatCb) { this._onUnsupportedFormatCb(); }
+              return;
+            }
+            // 正常 ready 路径
+            if (this._onReadyCb) { this._onReadyCb(); }
           }).catch((e: BusinessError) => {
             hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
               `[DIAG] getTrackDescription 失败: ${e.message}`);
+            // 无法读取轨道时降级为正常 ready，避免永久阻塞
+            if (this._onReadyCb) { this._onReadyCb(); }
           });
-          // 准备完成，通知 Controller
-          if (this._onReadyCb) { this._onReadyCb(); }
           break;
         case AVPlayerState.PLAYING:
           if (this._onPlayCb) { this._onPlayCb(); }


### PR DESCRIPTION
## 问题

Issue #212：API 23 上含 E-AC-3（eac3）音轨的视频播放无声。

**根因**：API 23 AVPlayer demux 层升级后可识别 eac3 codec 并进入 `PREPARED` 状态，但 decoder 层静默放弃解码导致无声，且不触发 `error` 事件（code=5400106）。原有的 `onUnsupportedFormat` fallback 链路依赖 error 事件，因此在 API 23 上失效。

## 修复方案

在 `AVPlayerAdapter.ets` 的 `PREPARED` 状态处理器中，主动调用 `getTrackDescription()` 检测所有音频轨道的 codec MIME 类型：

- 若**所有**音频轨道均属于 `UNSUPPORTED_AUDIO_CODECS` 列表 → 主动调用 `_onUnsupportedFormatCb()`，触发 fallback 到 ijkplayer
- 若存在至少一条支持的音频轨道 → 正常调用 `_onReadyCb()`，AVPlayer 播放
- `getTrackDescription()` 失败时降级为 `_onReadyCb()`，避免永久阻塞

**API 19 兼容性**：API 19 上 eac3 在 `prepare()` 阶段直接报 error，不进入 `PREPARED`，新检测逻辑不执行，行为不变 ✅

## 变更文件

- `entry/src/main/ets/components/core/player/AVPlayerAdapter.ets`
  - 新增 `UNSUPPORTED_AUDIO_CODECS` 常量（7 种 MIME：ac3/eac3/truehd/vnd.dts/vnd.dts.hd/mlp/vivid）
  - 改造 `PREPARED` handler：`getTrackDescription()` 异步 codec 检测 + fallback 决策

## 测试验证

- ✅ 3.1 本地编译通过（无 ArkTS 错误）
- ✅ 3.2 真机（API 23）：纯 eac3 文件 → PREPARED 检测触发 fallback → ijkplayer 接管，音频正常
- ✅ 3.3a 真机：混合 AAC+eac3 文件 → PREPARED 检测不误触 fallback（`play_result=success` 确认）
- ✅ 3.4 API 19 设备：eac3 文件仍通过旧 error 路径 fallback，行为不变
- ✅ 3.5 本地 Hypium 单测无回归

## 注意

- 3.3b（端到端混合音轨文件 AVPlayer 正常播放 AAC）：**blocked by #214**
  - 混合文件中音轨偏好恢复选中 eac3 → 旧 error 路径 5400106 触发 fallback（与本 fix 无关）
  - 修复路径已在 Issue #214 跟踪：音轨偏好选择时对不支持 codec 自动降级

Closes #212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported audio codec detection during playback initialization, with enhanced fallback behavior when audio tracks cannot be played.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->