### PR TITLE
修复: 统一真实设备续播恢复链路

### DIFF
--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -124,6 +124,27 @@ interface FallbackLogRecord {
   detailMessage: string;
 }
 
+interface ResumeDiagnosticLogRecord {
+  event: string;
+  sessionId: number;
+  backend: PlayerBackend;
+  videoId: number;
+  seriesProviderId: string;
+  seasonNumber: number;
+  episodeNumber: number;
+  resumeSource: string;
+  captureBackend: PlayerBackend;
+  pendingResumeMs: number;
+  effectiveResumeMs: number;
+  autoResumePlay: boolean;
+  autoplayDecision: string;
+  queuedSeekMs: number;
+  isSeeking: boolean;
+  currentTimeMs: number;
+  durationMs: number;
+  filePath: string;
+}
+
 interface NativeXComponentFallbackContext {
 }
 
@@ -292,6 +313,20 @@ export class VideoPlayerController {
   private pendingBackendResumeTimeMs: number = -1;
   /** 后端自动 fallback 后，是否在 seek 完成后自动续播 */
   private pendingBackendResumePlay: boolean = false;
+  /** 待恢复续播点来源（用于真机结构化日志串联） */
+  private pendingBackendResumeSource: string = '';
+  /** 捕获待恢复续播点时的原后端 */
+  private pendingBackendResumeCaptureBackend: PlayerBackend = 'avplayer';
+  /** 待恢复续播 seek 是否进行中 */
+  private pendingResumeSeekInFlight: boolean = false;
+  /** 当前待恢复续播 seek 的来源 */
+  private pendingResumeSeekSource: string = '';
+  /** 当前待恢复续播 seek 的捕获后端 */
+  private pendingResumeSeekCaptureBackend: PlayerBackend = 'avplayer';
+  /** 当前待恢复续播 seek 的目标时间 */
+  private pendingResumeSeekTargetMs: number = -1;
+  /** 当前待恢复续播 seek 完成后是否自动恢复播放 */
+  private pendingResumeSeekAutoPlay: boolean = false;
   /** SMB 源当前是否通过 HTTP 代理运行（用于 release 时触发 cleanupOrphanedProxies） */
   private smbProxyActive: boolean = false;
   /** 保存原始 smb:// URL，供 avplayer→ijkplayer fallback 时重新启动代理 */
@@ -388,7 +423,14 @@ export class VideoPlayerController {
     if (!shouldPreserveBackendResume) {
       this.pendingBackendResumeTimeMs = -1;
       this.pendingBackendResumePlay = false;
+      this.pendingBackendResumeSource = '';
+      this.pendingBackendResumeCaptureBackend = 'avplayer';
     }
+    this.pendingResumeSeekInFlight = false;
+    this.pendingResumeSeekSource = '';
+    this.pendingResumeSeekCaptureBackend = 'avplayer';
+    this.pendingResumeSeekTargetMs = -1;
+    this.pendingResumeSeekAutoPlay = false;
     this.suppressPlayAfterSeekOnce = false;
     if (ENABLE_SESSION_DIAG_LOG) {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
@@ -711,7 +753,7 @@ export class VideoPlayerController {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         `AVPlayer 不支持当前格式，自动切换到 ${targetBackend}...`);
       this.isLoading = true;
-      this.capturePendingResumeForFallback();
+      this.capturePendingResumeForFallback('avplayer_unsupported_format');
       // 先把 player 引用清空，防止后续调用
       const oldPlayer = this.player;
       this.player = undefined;
@@ -732,15 +774,43 @@ export class VideoPlayerController {
         hilog.info(CommonConstants.LOG_DOMAIN, METRICS_TAG,
           `{"event":"seek_result","backend":"${this.backend}","result":"done","elapsed_ms":${seekElapsed}}`);
       }
+      const resumeSeekInFlight = this.pendingResumeSeekInFlight;
+      const resumeSeekSource = this.pendingResumeSeekSource;
+      const resumeSeekCaptureBackend = this.pendingResumeSeekCaptureBackend;
+      const resumeSeekTargetMs = this.pendingResumeSeekTargetMs;
+      const resumeSeekAutoPlay = this.pendingResumeSeekAutoPlay;
+      if (resumeSeekInFlight) {
+        this.logResumeDiagnostic('resume_seek_done', resumeSeekSource, resumeSeekCaptureBackend, resumeSeekTargetMs,
+          resumeSeekTargetMs, resumeSeekAutoPlay, 'pending', this.timeToSeek);
+      }
       if (this.timeToSeek >= 0) {
+        if (resumeSeekInFlight) {
+          this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
+            resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'queued_seek', this.timeToSeek);
+        }
         adapter.seek(this.timeToSeek);
         this.timeToSeek = -1;
       } else {
         if (this.suppressPlayAfterSeekOnce) {
+          if (resumeSeekInFlight) {
+            this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
+              resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'suppress', -1);
+          }
           this.suppressPlayAfterSeekOnce = false;
         } else {
+          if (resumeSeekInFlight) {
+            this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
+              resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'play', -1);
+          }
           this.player?.play().catch(() => {});
         }
+      }
+      if (resumeSeekInFlight) {
+        this.pendingResumeSeekInFlight = false;
+        this.pendingResumeSeekSource = '';
+        this.pendingResumeSeekCaptureBackend = 'avplayer';
+        this.pendingResumeSeekTargetMs = -1;
+        this.pendingResumeSeekAutoPlay = false;
       }
       this.isSeeking = false;
     });
@@ -1860,9 +1930,13 @@ export class VideoPlayerController {
     
     const resumeTimeMs = this.pendingBackendResumeTimeMs;
     const shouldResumePlay = this.pendingBackendResumePlay;
+    const resumeSource = this.pendingBackendResumeSource;
+    const resumeCaptureBackend = this.pendingBackendResumeCaptureBackend;
     if (resumeTimeMs >= 0) {
       this.pendingBackendResumeTimeMs = -1;
       this.pendingBackendResumePlay = false;
+      this.pendingBackendResumeSource = '';
+      this.pendingBackendResumeCaptureBackend = 'avplayer';
     }
     emitter.emit(PlayerEvents.PREPARED);
     // 重新应用播放速率（后端切换或重新 init 后，保持用户设置的倍速）
@@ -1885,23 +1959,39 @@ export class VideoPlayerController {
       }
       MetricsService.getInstance().recordSubtitleUsage(startSubtitleLang);
     }
+    const effectiveResumeTimeMs = resumeTimeMs > 0 && this.duration > 0 && resumeTimeMs > this.duration
+      ? this.duration
+      : (resumeTimeMs > 0 ? resumeTimeMs : 0);
+    if (resumeTimeMs >= 0) {
+      this.logResumeDiagnostic('resume_pending_consume', resumeSource, resumeCaptureBackend, resumeTimeMs,
+        effectiveResumeTimeMs, shouldResumePlay, 'pending', -1);
+    }
     
     if (resumeTimeMs > 0 && this.player) {
-      const safeResumeTimeMs = this.duration > 0 && resumeTimeMs > this.duration
-        ? this.duration
-        : resumeTimeMs;
+      const safeResumeTimeMs = effectiveResumeTimeMs;
       this.currentTime = safeResumeTimeMs;
       this.progress = this.duration > 0 ? safeResumeTimeMs / this.duration : 0;
       this.subtitleAdapter.onSeekSync();
       this.applySubtitleBridgeState(this.subtitleAdapter.getState());
       this.isSeeking = true;
       this.suppressPlayAfterSeekOnce = !shouldResumePlay;
+      this.pendingResumeSeekInFlight = true;
+      this.pendingResumeSeekSource = resumeSource;
+      this.pendingResumeSeekCaptureBackend = resumeCaptureBackend;
+      this.pendingResumeSeekTargetMs = safeResumeTimeMs;
+      this.pendingResumeSeekAutoPlay = shouldResumePlay;
+      this.logResumeDiagnostic('resume_seek_dispatch', resumeSource, resumeCaptureBackend, resumeTimeMs,
+        safeResumeTimeMs, shouldResumePlay, shouldResumePlay ? 'play_after_seek' : 'suppress_after_seek', -1);
       this.player.seek(safeResumeTimeMs);
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `后端切换续播定位: backend=${this.backend} time=${safeResumeTimeMs}`);
       return;
     }
     if (shouldResumePlay && !this.isPlaying) {
+      if (resumeTimeMs >= 0) {
+        this.logResumeDiagnostic('resume_autoplay_decision', resumeSource, resumeCaptureBackend, resumeTimeMs,
+          effectiveResumeTimeMs, shouldResumePlay, 'play_no_seek', -1);
+      }
       await this.play();
     }
   }
@@ -1952,6 +2042,10 @@ export class VideoPlayerController {
     this.clearNativeReadyGuardTimer();
     this.pendingBackendResumeTimeMs = safeFallbackPosition;
     this.pendingBackendResumePlay = shouldResumePlay;
+    this.pendingBackendResumeSource = fallbackReason;
+    this.pendingBackendResumeCaptureBackend = 'native';
+    this.logResumeDiagnostic('resume_pending_capture', fallbackReason, 'native', safeFallbackPosition,
+      safeFallbackPosition, shouldResumePlay, 'pending', -1);
     this.currentTime = safeFallbackPosition;
     this.progress = this.duration > 0 ? safeFallbackPosition / this.duration : 0;
     const oldPlayer = this.player;
@@ -1960,7 +2054,7 @@ export class VideoPlayerController {
     oldPlayer?.release().catch(() => {});
   }
 
-  private capturePendingResumeForFallback(): void {
+  private capturePendingResumeForFallback(source: string): void {
     const playerPosition = this.player?.currentTime ?? 0;
     const controllerPosition = this.currentTime > 0 ? this.currentTime : 0;
     const latestPosition = playerPosition > controllerPosition ? playerPosition : controllerPosition;
@@ -1969,6 +2063,10 @@ export class VideoPlayerController {
       : latestPosition;
     this.pendingBackendResumeTimeMs = safePosition;
     this.pendingBackendResumePlay = this.isPlaying || this.isSeeking;
+    this.pendingBackendResumeSource = source;
+    this.pendingBackendResumeCaptureBackend = this.backend;
+    this.logResumeDiagnostic('resume_pending_capture', source, this.backend, safePosition, safePosition,
+      this.pendingBackendResumePlay, 'pending', -1);
     this.currentTime = safePosition;
     this.progress = this.duration > 0 ? safePosition / this.duration : 0;
   }
@@ -1992,6 +2090,39 @@ export class VideoPlayerController {
     // 指标埋点：play_result=fallback（便于 VidAll_Metrics 过滤统计兜底触发率）
     hilog.warn(CommonConstants.LOG_DOMAIN, METRICS_TAG,
       `{"event":"play_result","backend":"${fallbackFrom}","video_id":${structured.videoId},"result":"fallback","fallback_from":"${fallbackFrom}","fallback_to":"${fallbackTo}","reason":"${fallbackReason}"}`);
+  }
+
+  private logResumeDiagnostic(
+    event: string,
+    resumeSource: string,
+    captureBackend: PlayerBackend,
+    pendingResumeMs: number,
+    effectiveResumeMs: number,
+    autoResumePlay: boolean,
+    autoplayDecision: string,
+    queuedSeekMs: number
+  ): void {
+    const record: ResumeDiagnosticLogRecord = {
+      event,
+      sessionId: this.playbackSessionId,
+      backend: this.backend,
+      videoId: this.progressContext?.videoId ?? -1,
+      seriesProviderId: this.progressContext?.seriesProviderId ?? '',
+      seasonNumber: this.progressContext?.seasonNumber ?? 0,
+      episodeNumber: this.progressContext?.episodeNumber ?? 0,
+      resumeSource,
+      captureBackend,
+      pendingResumeMs,
+      effectiveResumeMs,
+      autoResumePlay,
+      autoplayDecision,
+      queuedSeekMs,
+      isSeeking: this.isSeeking,
+      currentTimeMs: this.currentTime,
+      durationMs: this.duration,
+      filePath: this.sanitizeLogFilePath(this.currentVideoData?.videoSrc ?? '')
+    };
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG, `[resume] ${JSON.stringify(record)}`);
   }
 
   private extractFileName(filePath: string): string {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -329,6 +329,10 @@ export class VideoPlayerController {
   private pendingResumeSeekTargetMs: number = -1;
   /** 当前待恢复续播 seek 完成后是否自动恢复播放 */
   private pendingResumeSeekAutoPlay: boolean = false;
+  /** fallback resume seek 完成后，是否需要补做 ready 阶段的轨道初始化 */
+  private pendingReadyTrackInitAfterSeek: boolean = false;
+  /** fallback resume seek 完成后，轨道初始化结束是否需要恢复播放 */
+  private pendingReadyTrackInitResumePlay: boolean = false;
   /** SMB 源当前是否通过 HTTP 代理运行（用于 release 时触发 cleanupOrphanedProxies） */
   private smbProxyActive: boolean = false;
   /** 保存原始 smb:// URL，供 avplayer→ijkplayer fallback 时重新启动代理 */
@@ -533,6 +537,8 @@ export class VideoPlayerController {
     this.pendingResumeSeekCaptureBackend = 'avplayer';
     this.pendingResumeSeekTargetMs = -1;
     this.pendingResumeSeekAutoPlay = false;
+    this.pendingReadyTrackInitAfterSeek = false;
+    this.pendingReadyTrackInitResumePlay = false;
     this.suppressPlayAfterSeekOnce = false;
     if (ENABLE_SESSION_DIAG_LOG) {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
@@ -889,24 +895,18 @@ export class VideoPlayerController {
         if (resumeSeekInFlight) {
           this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
             resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'queued_seek', this.timeToSeek);
+          this.pendingResumeSeekInFlight = false;
+          this.pendingResumeSeekSource = '';
+          this.pendingResumeSeekCaptureBackend = 'avplayer';
+          this.pendingResumeSeekTargetMs = -1;
+          this.pendingResumeSeekAutoPlay = false;
         }
         adapter.seek(this.timeToSeek);
         this.timeToSeek = -1;
-      } else {
-        if (this.suppressPlayAfterSeekOnce) {
-          if (resumeSeekInFlight) {
-            this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
-              resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'suppress', -1);
-          }
-          this.suppressPlayAfterSeekOnce = false;
-        } else {
-          if (resumeSeekInFlight) {
-            this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
-              resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'play', -1);
-          }
-          this.player?.play().catch(() => {});
-        }
+        this.isSeeking = false;
+        return;
       }
+      const shouldContinuePendingReadyAfterSeek = this.pendingReadyTrackInitAfterSeek;
       if (resumeSeekInFlight) {
         this.pendingResumeSeekInFlight = false;
         this.pendingResumeSeekSource = '';
@@ -915,6 +915,24 @@ export class VideoPlayerController {
         this.pendingResumeSeekAutoPlay = false;
       }
       this.isSeeking = false;
+      if (shouldContinuePendingReadyAfterSeek) {
+        this.suppressPlayAfterSeekOnce = false;
+        this.continuePendingReadyAfterSeek(currentSessionId).catch(() => {});
+        return;
+      }
+      if (this.suppressPlayAfterSeekOnce) {
+        if (resumeSeekInFlight) {
+          this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
+            resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'suppress', -1);
+        }
+        this.suppressPlayAfterSeekOnce = false;
+      } else {
+        if (resumeSeekInFlight) {
+          this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
+            resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'play', -1);
+        }
+        this.player?.play().catch(() => {});
+      }
     });
     adapter.onSubtitleUpdate((info) => {
       if (currentSessionId !== this.playbackSessionId) {
@@ -2008,6 +2026,7 @@ export class VideoPlayerController {
 
   /** prepared 后回调：读取 duration、加载字幕轨道和音轨 */
   private async onPlayerReady(): Promise<void> {
+    const readySessionId = this.playbackSessionId;
     this.clearNativeReadyGuardTimer();
     this.hasPrepared = true;
     const playerDuration = this.player?.duration ?? 0;
@@ -2017,42 +2036,24 @@ export class VideoPlayerController {
     this.currentTime = this.player?.currentTime ?? 0;
     this.isReady = true;
     this.isLoading = false;
-    // 指标埋点：首帧到达 + play_result=success
     const firstFrameElapsed = Date.now() - this.metricsLoadStartMs;
     hilog.info(CommonConstants.LOG_DOMAIN, METRICS_TAG,
       `{"event":"first_frame","backend":"${this.backend}","video_id":${this.progressContext?.videoId ?? -1},"elapsed_ms":${firstFrameElapsed}}`);
     hilog.info(CommonConstants.LOG_DOMAIN, METRICS_TAG,
       `{"event":"play_result","backend":"${this.backend}","video_id":${this.progressContext?.videoId ?? -1},"result":"success","elapsed_ms":${firstFrameElapsed}}`);
-    
-    // Task 4.4: Record successful playback attempt with first frame time
     if (MetricsService.isInitialized()) {
-      // 升级为 MediaIdentity 对象，服务端可通过 provider/provider_id 唯一识别视频
       const sourceType = this.currentVideoData?.type === VideoDataType.FILE_URI ? 'local' : 'network';
       MetricsService.getInstance().recordPlaybackAttempt(true, firstFrameElapsed, this.metricsMedia ?? undefined, sourceType);
     }
-    
+
     const pendingResumeState = this.consumePendingResumeState();
     emitter.emit(PlayerEvents.PREPARED);
-    // 重新应用播放速率（后端切换或重新 init 后，保持用户设置的倍速）
     if (this.playbackSpeed !== 1.0 && this.player) {
       this.player.setPlaybackSpeed(this.playbackSpeed);
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `onPlayerReady: 重新应用播放速率 speed=${this.playbackSpeed}`);
     }
-    await this.loadSubtitleTracks();
-    await this.loadAudioTracks();
-    
-    // Task 5.5: Record subtitle usage at playback start (once per session, avoid double-counting)
-    // 缺陷 2 修复：移除 activeSubtitleIndex < 0 的条件判断，始终记录一次，
-    //   并取当前激活轨道的语言（auto-select 已在 loadSubtitleTracks 内完成）。
-    // switchSubtitleTrack 中不再调用 recordSubtitleUsage，防止同一播放会话重复计数。
-    if (MetricsService.isInitialized()) {
-      let startSubtitleLang: string | null = null;
-      if (this.activeSubtitleIndex >= 0 && this.activeSubtitleIndex < this.allSubtitleTracks.length) {
-        startSubtitleLang = this.allSubtitleTracks[this.activeSubtitleIndex].language ?? null;
-      }
-      MetricsService.getInstance().recordSubtitleUsage(startSubtitleLang);
-    }
+
     const resumeTimeMs = pendingResumeState?.positionMs ?? -1;
     const shouldResumePlay = pendingResumeState?.shouldResumePlay ?? false;
     const resumeSource = pendingResumeState?.reason ?? '';
@@ -2064,7 +2065,7 @@ export class VideoPlayerController {
       this.logResumeDiagnostic('resume_pending_consume', resumeSource, resumeCaptureBackend, resumeTimeMs,
         effectiveResumeTimeMs, shouldResumePlay, 'pending', -1);
     }
-    
+
     if (pendingResumeState !== null && pendingResumeState.positionMs > 0 && this.player) {
       const safeResumeTimeMs = effectiveResumeTimeMs;
       this.currentTime = safeResumeTimeMs;
@@ -2072,7 +2073,9 @@ export class VideoPlayerController {
       this.subtitleAdapter.onSeekSync();
       this.applySubtitleBridgeState(this.subtitleAdapter.getState());
       this.isSeeking = true;
-      this.suppressPlayAfterSeekOnce = !shouldResumePlay;
+      this.suppressPlayAfterSeekOnce = true;
+      this.pendingReadyTrackInitAfterSeek = true;
+      this.pendingReadyTrackInitResumePlay = shouldResumePlay;
       this.pendingResumeSeekInFlight = true;
       this.pendingResumeSeekSource = resumeSource;
       this.pendingResumeSeekCaptureBackend = resumeCaptureBackend;
@@ -2085,9 +2088,56 @@ export class VideoPlayerController {
         `后端切换续播定位: backend=${this.backend} time=${safeResumeTimeMs}`);
       return;
     }
+
+    await this.finalizePlayerReadyTrackInitialization(readySessionId);
     if (pendingResumeState !== null && pendingResumeState.shouldResumePlay && !this.isPlaying) {
       this.logResumeDiagnostic('resume_autoplay_decision', resumeSource, resumeCaptureBackend, resumeTimeMs,
         effectiveResumeTimeMs, shouldResumePlay, 'play_no_seek', -1);
+      await this.play();
+    }
+  }
+
+  private async finalizePlayerReadyTrackInitialization(sessionId: number = this.playbackSessionId): Promise<void> {
+    if (sessionId !== this.playbackSessionId) {
+      return;
+    }
+    await this.loadSubtitleTracks();
+    if (sessionId !== this.playbackSessionId) {
+      return;
+    }
+    await this.loadAudioTracks();
+    if (sessionId !== this.playbackSessionId) {
+      return;
+    }
+    this.recordSubtitleUsageAtPlaybackStart();
+  }
+
+  private recordSubtitleUsageAtPlaybackStart(): void {
+    // Task 5.5: Record subtitle usage at playback start (once per session, avoid double-counting)
+    // 缺陷 2 修复：移除 activeSubtitleIndex < 0 的条件判断，始终记录一次，
+    //   并取当前激活轨道的语言（auto-select 已在 loadSubtitleTracks 内完成）。
+    // switchSubtitleTrack 中不再调用 recordSubtitleUsage，防止同一播放会话重复计数。
+    if (MetricsService.isInitialized()) {
+      let startSubtitleLang: string | null = null;
+      if (this.activeSubtitleIndex >= 0 && this.activeSubtitleIndex < this.allSubtitleTracks.length) {
+        startSubtitleLang = this.allSubtitleTracks[this.activeSubtitleIndex].language ?? null;
+      }
+      MetricsService.getInstance().recordSubtitleUsage(startSubtitleLang);
+    }
+  }
+
+  private async continuePendingReadyAfterSeek(sessionId: number = this.playbackSessionId): Promise<void> {
+    if (sessionId !== this.playbackSessionId || !this.pendingReadyTrackInitAfterSeek) {
+      return;
+    }
+    const shouldResumePlay = this.pendingReadyTrackInitResumePlay;
+    this.pendingReadyTrackInitAfterSeek = false;
+    this.pendingReadyTrackInitResumePlay = false;
+    await this.finalizePlayerReadyTrackInitialization(sessionId);
+    if (sessionId !== this.playbackSessionId) {
+      return;
+    }
+    if (shouldResumePlay && !this.isPlaying) {
       await this.play();
     }
   }

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -145,6 +145,14 @@ interface ResumeDiagnosticLogRecord {
   filePath: string;
 }
 
+interface PendingResumeState {
+  positionMs: number;
+  shouldResumePlay: boolean;
+  sourceKey: string;
+  reason: string;
+  captureBackend: PlayerBackend;
+}
+
 interface NativeXComponentFallbackContext {
 }
 
@@ -309,14 +317,8 @@ export class VideoPlayerController {
   private nativeSeekDiagLogEnabled: boolean = DEFAULT_NATIVE_SEEK_DIAG_LOG_ENABLED;
   /** native 初始化就绪保护定时器：超时后自动回退到 ijkplayer */
   private nativeReadyGuardTimer?: number;
-  /** 后端自动 fallback（如 avplayer/native → ijkplayer）时，待恢复的播放进度 */
-  private pendingBackendResumeTimeMs: number = -1;
-  /** 后端自动 fallback 后，是否在 seek 完成后自动续播 */
-  private pendingBackendResumePlay: boolean = false;
-  /** 待恢复续播点来源（用于真机结构化日志串联） */
-  private pendingBackendResumeSource: string = '';
-  /** 捕获待恢复续播点时的原后端 */
-  private pendingBackendResumeCaptureBackend: PlayerBackend = 'avplayer';
+  /** 后端自动 fallback / 实例重建时待恢复的续播状态（一次性消费） */
+  private pendingResumeState: PendingResumeState | null = null;
   /** 待恢复续播 seek 是否进行中 */
   private pendingResumeSeekInFlight: boolean = false;
   /** 当前待恢复续播 seek 的来源 */
@@ -370,6 +372,109 @@ export class VideoPlayerController {
   /** ffmpeg 连续预览：远程 chunk 不稳定时切到单帧模式 */
   private ffmpegSingleFrameMode: boolean = false;
 
+  private get pendingBackendResumeTimeMs(): number {
+    return this.pendingResumeState?.positionMs ?? -1;
+  }
+
+  private set pendingBackendResumeTimeMs(value: number) {
+    const pendingState = this.ensurePendingResumeState();
+    pendingState.positionMs = value;
+    this.prunePendingResumeState();
+  }
+
+  private get pendingBackendResumePlay(): boolean {
+    return this.pendingResumeState?.shouldResumePlay ?? false;
+  }
+
+  private set pendingBackendResumePlay(value: boolean) {
+    const pendingState = this.ensurePendingResumeState();
+    pendingState.shouldResumePlay = value;
+    this.prunePendingResumeState();
+  }
+
+  private ensurePendingResumeState(): PendingResumeState {
+    if (this.pendingResumeState === null) {
+      const pendingState: PendingResumeState = {
+        positionMs: -1,
+        shouldResumePlay: false,
+        sourceKey: this.buildPendingResumeSourceKey(this.currentVideoData),
+        reason: 'compat_override',
+        captureBackend: this.backend
+      };
+      this.pendingResumeState = pendingState;
+    }
+    return this.pendingResumeState;
+  }
+
+  private prunePendingResumeState(): void {
+    if (this.pendingResumeState === null) {
+      return;
+    }
+    if (this.pendingResumeState.positionMs < 0 && !this.pendingResumeState.shouldResumePlay) {
+      this.pendingResumeState = null;
+    }
+  }
+
+  private clearPendingResumeState(): void {
+    this.pendingResumeState = null;
+  }
+
+  private buildPendingResumeSourceKey(videoData: VideoData | undefined): string {
+    if (videoData === undefined) {
+      return '';
+    }
+    if (this.smbOriginalSrc.length > 0 && videoData.videoSrc.startsWith('http://127.0.0.1')) {
+      return this.smbOriginalSrc;
+    }
+    return videoData.videoSrc;
+  }
+
+  private shouldPreservePendingResume(videoData: VideoData): boolean {
+    if (this.pendingResumeState === null) {
+      return false;
+    }
+    const nextSourceKey = this.buildPendingResumeSourceKey(videoData);
+    if (nextSourceKey.length === 0) {
+      return false;
+    }
+    return nextSourceKey === this.pendingResumeState.sourceKey;
+  }
+
+  private consumePendingResumeState(): PendingResumeState | null {
+    const pendingState = this.pendingResumeState;
+    this.pendingResumeState = null;
+    return pendingState;
+  }
+
+  private normalizePendingResumePosition(positionMs: number): number {
+    let safePosition = positionMs > 0 ? positionMs : 0;
+    if (this.duration > 0 && safePosition > this.duration) {
+      safePosition = this.duration;
+    }
+    return safePosition;
+  }
+
+  private savePendingResumeState(
+    positionMs: number,
+    shouldResumePlay: boolean,
+    reason: string,
+    captureBackend: PlayerBackend
+  ): void {
+    const safePosition = this.normalizePendingResumePosition(positionMs);
+    const pendingState: PendingResumeState = {
+      positionMs: safePosition,
+      shouldResumePlay,
+      sourceKey: this.buildPendingResumeSourceKey(this.currentVideoData),
+      reason,
+      captureBackend
+    };
+    this.pendingResumeState = pendingState;
+    this.currentTime = safePosition;
+    this.progress = this.duration > 0 ? safePosition / this.duration : 0;
+    this.logResumeDiagnostic('resume_pending_capture', reason, captureBackend, safePosition,
+      safePosition, shouldResumePlay, 'pending', -1);
+  }
+
   /**
    * 初始化播放器。
    * - backend='avplayer'：直接用 surfaceId 初始化，与之前行为一致。
@@ -419,12 +524,9 @@ export class VideoPlayerController {
       VidAllPlayerAdapter.cleanupOrphanedProxies();
       this.smbProxyActive = false;
     }
-    const shouldPreserveBackendResume = this.backend === 'ijkplayer' && this.pendingBackendResumeTimeMs >= 0;
-    if (!shouldPreserveBackendResume) {
-      this.pendingBackendResumeTimeMs = -1;
-      this.pendingBackendResumePlay = false;
-      this.pendingBackendResumeSource = '';
-      this.pendingBackendResumeCaptureBackend = 'avplayer';
+    const shouldPreservePendingResume = this.shouldPreservePendingResume(videoData);
+    if (!shouldPreservePendingResume) {
+      this.clearPendingResumeState();
     }
     this.pendingResumeSeekInFlight = false;
     this.pendingResumeSeekSource = '';
@@ -1568,6 +1670,7 @@ export class VideoPlayerController {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG, 'reloadSource: surfaceId 为空，忽略切源请求');
       throw new Error('reloadSource requires surfaceId');
     }
+    this.clearPendingResumeState();
     this.rejectPendingReload(new Error('reload superseded'));
     const reloadToken = this.pendingReloadToken + 1;
     this.pendingReloadToken = reloadToken;
@@ -1928,16 +2031,7 @@ export class VideoPlayerController {
       MetricsService.getInstance().recordPlaybackAttempt(true, firstFrameElapsed, this.metricsMedia ?? undefined, sourceType);
     }
     
-    const resumeTimeMs = this.pendingBackendResumeTimeMs;
-    const shouldResumePlay = this.pendingBackendResumePlay;
-    const resumeSource = this.pendingBackendResumeSource;
-    const resumeCaptureBackend = this.pendingBackendResumeCaptureBackend;
-    if (resumeTimeMs >= 0) {
-      this.pendingBackendResumeTimeMs = -1;
-      this.pendingBackendResumePlay = false;
-      this.pendingBackendResumeSource = '';
-      this.pendingBackendResumeCaptureBackend = 'avplayer';
-    }
+    const pendingResumeState = this.consumePendingResumeState();
     emitter.emit(PlayerEvents.PREPARED);
     // 重新应用播放速率（后端切换或重新 init 后，保持用户设置的倍速）
     if (this.playbackSpeed !== 1.0 && this.player) {
@@ -1959,15 +2053,19 @@ export class VideoPlayerController {
       }
       MetricsService.getInstance().recordSubtitleUsage(startSubtitleLang);
     }
+    const resumeTimeMs = pendingResumeState?.positionMs ?? -1;
+    const shouldResumePlay = pendingResumeState?.shouldResumePlay ?? false;
+    const resumeSource = pendingResumeState?.reason ?? '';
+    const resumeCaptureBackend = pendingResumeState?.captureBackend ?? this.backend;
     const effectiveResumeTimeMs = resumeTimeMs > 0 && this.duration > 0 && resumeTimeMs > this.duration
       ? this.duration
       : (resumeTimeMs > 0 ? resumeTimeMs : 0);
-    if (resumeTimeMs >= 0) {
+    if (pendingResumeState !== null) {
       this.logResumeDiagnostic('resume_pending_consume', resumeSource, resumeCaptureBackend, resumeTimeMs,
         effectiveResumeTimeMs, shouldResumePlay, 'pending', -1);
     }
     
-    if (resumeTimeMs > 0 && this.player) {
+    if (pendingResumeState !== null && pendingResumeState.positionMs > 0 && this.player) {
       const safeResumeTimeMs = effectiveResumeTimeMs;
       this.currentTime = safeResumeTimeMs;
       this.progress = this.duration > 0 ? safeResumeTimeMs / this.duration : 0;
@@ -1987,11 +2085,9 @@ export class VideoPlayerController {
         `后端切换续播定位: backend=${this.backend} time=${safeResumeTimeMs}`);
       return;
     }
-    if (shouldResumePlay && !this.isPlaying) {
-      if (resumeTimeMs >= 0) {
-        this.logResumeDiagnostic('resume_autoplay_decision', resumeSource, resumeCaptureBackend, resumeTimeMs,
-          effectiveResumeTimeMs, shouldResumePlay, 'play_no_seek', -1);
-      }
+    if (pendingResumeState !== null && pendingResumeState.shouldResumePlay && !this.isPlaying) {
+      this.logResumeDiagnostic('resume_autoplay_decision', resumeSource, resumeCaptureBackend, resumeTimeMs,
+        effectiveResumeTimeMs, shouldResumePlay, 'play_no_seek', -1);
       await this.play();
     }
   }
@@ -2040,14 +2136,7 @@ export class VideoPlayerController {
     this.lastErrorMessage = userMessage;
     this.isLoading = true;
     this.clearNativeReadyGuardTimer();
-    this.pendingBackendResumeTimeMs = safeFallbackPosition;
-    this.pendingBackendResumePlay = shouldResumePlay;
-    this.pendingBackendResumeSource = fallbackReason;
-    this.pendingBackendResumeCaptureBackend = 'native';
-    this.logResumeDiagnostic('resume_pending_capture', fallbackReason, 'native', safeFallbackPosition,
-      safeFallbackPosition, shouldResumePlay, 'pending', -1);
-    this.currentTime = safeFallbackPosition;
-    this.progress = this.duration > 0 ? safeFallbackPosition / this.duration : 0;
+    this.savePendingResumeState(safeFallbackPosition, shouldResumePlay, fallbackReason, 'native');
     const oldPlayer = this.player;
     this.player = undefined;
     this.backend = 'ijkplayer';
@@ -2058,17 +2147,7 @@ export class VideoPlayerController {
     const playerPosition = this.player?.currentTime ?? 0;
     const controllerPosition = this.currentTime > 0 ? this.currentTime : 0;
     const latestPosition = playerPosition > controllerPosition ? playerPosition : controllerPosition;
-    const safePosition = this.duration > 0 && latestPosition > this.duration
-      ? this.duration
-      : latestPosition;
-    this.pendingBackendResumeTimeMs = safePosition;
-    this.pendingBackendResumePlay = this.isPlaying || this.isSeeking;
-    this.pendingBackendResumeSource = source;
-    this.pendingBackendResumeCaptureBackend = this.backend;
-    this.logResumeDiagnostic('resume_pending_capture', source, this.backend, safePosition, safePosition,
-      this.pendingBackendResumePlay, 'pending', -1);
-    this.currentTime = safePosition;
-    this.progress = this.duration > 0 ? safePosition / this.duration : 0;
+    this.savePendingResumeState(latestPosition, this.isPlaying || this.isSeeking, source, this.backend);
   }
 
   private logFallbackEvent(

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -121,26 +121,47 @@ export interface ResumeDiagnosticLogPayload {
   resumePositionMs: number;
 }
 
+export function resolveSavedProgressResumeAction(
+  positionMs: number,
+  savedDurationMs: number,
+  currentDurationMs: number
+): MediaProgressResumeAction {
+  if (positionMs <= 0) {
+    return { action: 'play' };
+  }
+  const effectiveDurationMs = currentDurationMs > 0 ? currentDurationMs : savedDurationMs;
+  if (MediaProgressStore.isNearEnd(positionMs, effectiveDurationMs)) {
+    return { action: 'clear_and_play' };
+  }
+  return {
+    action: 'seek',
+    positionMs
+  };
+}
+
 export function resolveMediaProgressResumeAction(
   saved: MediaProgressEntry | null,
   currentDurationMs: number,
   currentSeason: number,
   currentEpisode: number
 ): MediaProgressResumeAction {
-  if (saved === null || saved.positionMs <= 0) {
+  if (saved === null) {
     return { action: 'play' };
   }
   if (saved.seasonNumber !== currentSeason || saved.episodeNumber !== currentEpisode) {
     return { action: 'play' };
   }
-  const effectiveDurationMs = currentDurationMs > 0 ? currentDurationMs : saved.durationMs;
-  if (MediaProgressStore.isNearEnd(saved.positionMs, effectiveDurationMs)) {
-    return { action: 'clear_and_play' };
+  return resolveSavedProgressResumeAction(saved.positionMs, saved.durationMs, currentDurationMs);
+}
+
+export function resolvePlayProgressResumeAction(
+  saved: PlayProgressEntity | null,
+  currentDurationMs: number
+): MediaProgressResumeAction {
+  if (saved === null) {
+    return { action: 'play' };
   }
-  return {
-    action: 'seek',
-    positionMs: saved.positionMs
-  };
+  return resolveSavedProgressResumeAction(saved.positionMs, saved.durationMs, currentDurationMs);
 }
 
 function buildPlayerEpisodeCode(seasonNumber: number, episodeNumber: number): string {
@@ -399,18 +420,21 @@ export struct PlayerPage {
     const mediaKey = pageParam.mediaKey ?? '';
     if (mediaKey.length > 0) {
       const directStart = pageParam.startPositionMs ?? 0;
-      if (directStart > 0) {
-        this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
-          savedPositionMs: directStart,
-          resumeAction: 'seek',
-          resumePositionMs: directStart
-        });
-        this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
-          savedPositionMs: directStart,
-          resumeAction: 'seek',
-          resumePositionMs: directStart
-        });
-        this.videoPlayerController.seek(directStart).catch(() => {});
+      const directResumeAction: MediaProgressResumeAction = directStart > 0
+        ? { action: 'seek', positionMs: directStart }
+        : { action: 'play' };
+      this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
+        savedPositionMs: directStart,
+        resumeAction: directResumeAction.action,
+        resumePositionMs: directResumeAction.positionMs ?? 0
+      });
+      this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
+        savedPositionMs: directStart,
+        resumeAction: directResumeAction.action,
+        resumePositionMs: directResumeAction.positionMs ?? 0
+      });
+      if (directResumeAction.action === 'seek' && directResumeAction.positionMs !== undefined && directResumeAction.positionMs > 0) {
+        this.videoPlayerController.seek(directResumeAction.positionMs).catch(() => {});
         return;
       }
       MediaProgressStore.get(mediaKey).then((saved) => {
@@ -473,37 +497,43 @@ export struct PlayerPage {
           return;
         }
         const savedPositionMs = saved?.positionMs ?? 0;
-        if (saved !== null && saved.positionMs > 0) {
-          const dur = this.videoPlayerController.duration;
-          const isWatched = dur > 0 && saved.positionMs >= dur * 0.95;
-          this.savedPositionMs = saved.positionMs;
-          this.totalDurationMs = dur > 0 ? dur : saved.durationMs;
-          if (isWatched) {
-            this.pendingSeekMs = 0;
-          } else {
-            this.pendingSeekMs = saved.positionMs;
-          }
+        const resumeAction = resolvePlayProgressResumeAction(saved, this.videoPlayerController.duration);
+        if (resumeAction.action === 'seek' && resumeAction.positionMs !== undefined && resumeAction.positionMs > 0) {
+          this.savedPositionMs = resumeAction.positionMs;
+          this.totalDurationMs = this.videoPlayerController.duration > 0
+            ? this.videoPlayerController.duration
+            : (saved?.durationMs ?? 0);
+          this.pendingSeekMs = resumeAction.positionMs;
           this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
             savedPositionMs,
             resumeAction: 'dialog',
-            resumePositionMs: this.pendingSeekMs > 0 ? this.pendingSeekMs : 0
+            resumePositionMs: resumeAction.positionMs
           });
           this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
             savedPositionMs,
             resumeAction: 'dialog',
-            resumePositionMs: this.pendingSeekMs > 0 ? this.pendingSeekMs : 0
+            resumePositionMs: resumeAction.positionMs
           });
           this.showResumeDialog = true;
           return;
         }
+        if (resumeAction.action === 'clear_and_play') {
+          const progressContext = this.buildProgressContext(pageParam);
+          progressContext.durationMs = saved?.durationMs ?? 0;
+          progressContext.updatedAt = Date.now();
+          FileSourceDatabase.getInstance().upsertPlayProgress(progressContext).catch(() => {});
+        }
         this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
           savedPositionMs,
-          resumeAction: 'play'
+          resumeAction: resumeAction.action,
+          resumePositionMs: resumeAction.positionMs ?? 0
         });
         this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
           savedPositionMs,
-          resumeAction: 'play'
+          resumeAction: resumeAction.action,
+          resumePositionMs: resumeAction.positionMs ?? 0
         });
+        this.videoPlayerController.play().catch(() => {});
       }).catch(() => {
         this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
           resumeAction: 'play'
@@ -511,6 +541,7 @@ export struct PlayerPage {
         this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
           resumeAction: 'play'
         });
+        this.videoPlayerController.play().catch(() => {});
       });
     });
   }

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -99,6 +99,28 @@ export interface MediaProgressResumeAction {
   positionMs?: number;
 }
 
+export type ResumeDiagnosticEventName = 'page_param_received' | 'saved_progress_resolved' | 'prepared_resume_decision';
+
+export type ResumeDiagnosticAction = MediaProgressResumeActionType | 'dialog' | 'none';
+
+export interface ResumeDiagnosticLogOptions {
+  savedPositionMs?: number;
+  resumeAction?: ResumeDiagnosticAction;
+  resumePositionMs?: number;
+}
+
+export interface ResumeDiagnosticLogPayload {
+  event: ResumeDiagnosticEventName;
+  videoId: number;
+  mediaKey: string;
+  season: number;
+  episode: number;
+  startPositionMs: number;
+  savedPositionMs: number;
+  resumeAction: ResumeDiagnosticAction;
+  resumePositionMs: number;
+}
+
 export function resolveMediaProgressResumeAction(
   saved: MediaProgressEntry | null,
   currentDurationMs: number,
@@ -354,11 +376,40 @@ export struct PlayerPage {
     return ctx;
   }
 
+  private emitResumeDiagnosticLog(
+    event: ResumeDiagnosticEventName,
+    pageParam: PlayerPageParam,
+    options?: ResumeDiagnosticLogOptions
+  ): void {
+    const payload: ResumeDiagnosticLogPayload = {
+      event,
+      videoId: pageParam.videoId ?? 0,
+      mediaKey: pageParam.mediaKey ?? '',
+      season: pageParam.seasonNumber ?? 0,
+      episode: pageParam.episodeNumber ?? 0,
+      startPositionMs: pageParam.startPositionMs ?? 0,
+      savedPositionMs: options?.savedPositionMs ?? 0,
+      resumeAction: options?.resumeAction ?? 'none',
+      resumePositionMs: options?.resumePositionMs ?? 0
+    };
+    console.info(`[PlayerPage][RESUME] ${JSON.stringify(payload)}`);
+  }
+
   private resumePlaybackForParam(pageParam: PlayerPageParam): void {
     const mediaKey = pageParam.mediaKey ?? '';
     if (mediaKey.length > 0) {
       const directStart = pageParam.startPositionMs ?? 0;
       if (directStart > 0) {
+        this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
+          savedPositionMs: directStart,
+          resumeAction: 'seek',
+          resumePositionMs: directStart
+        });
+        this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
+          savedPositionMs: directStart,
+          resumeAction: 'seek',
+          resumePositionMs: directStart
+        });
         this.videoPlayerController.seek(directStart).catch(() => {});
         return;
       }
@@ -369,6 +420,18 @@ export struct PlayerPage {
           this.currentMediaSeason,
           this.currentMediaEpisode
         );
+        const savedPositionMs = saved?.positionMs ?? 0;
+        const resumePositionMs = resumeAction.positionMs ?? 0;
+        this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
+          savedPositionMs,
+          resumeAction: resumeAction.action,
+          resumePositionMs
+        });
+        this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
+          savedPositionMs,
+          resumeAction: resumeAction.action,
+          resumePositionMs
+        });
         if (resumeAction.action === 'seek' && resumeAction.positionMs !== undefined && resumeAction.positionMs > 0) {
           this.videoPlayerController.seek(resumeAction.positionMs).catch(() => {});
           return;
@@ -378,10 +441,19 @@ export struct PlayerPage {
         }
         this.videoPlayerController.play().catch(() => {});
       }).catch(() => {
+        this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
+          resumeAction: 'play'
+        });
+        this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
+          resumeAction: 'play'
+        });
         this.videoPlayerController.play().catch(() => {});
       });
       return;
     }
+    this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
+      resumeAction: 'play'
+    });
     this.videoPlayerController.play().catch(() => {});
   }
 
@@ -400,6 +472,7 @@ export struct PlayerPage {
         if (token !== this.pageParamToken) {
           return;
         }
+        const savedPositionMs = saved?.positionMs ?? 0;
         if (saved !== null && saved.positionMs > 0) {
           const dur = this.videoPlayerController.duration;
           const isWatched = dur > 0 && saved.positionMs >= dur * 0.95;
@@ -410,14 +483,41 @@ export struct PlayerPage {
           } else {
             this.pendingSeekMs = saved.positionMs;
           }
+          this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
+            savedPositionMs,
+            resumeAction: 'dialog',
+            resumePositionMs: this.pendingSeekMs > 0 ? this.pendingSeekMs : 0
+          });
+          this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
+            savedPositionMs,
+            resumeAction: 'dialog',
+            resumePositionMs: this.pendingSeekMs > 0 ? this.pendingSeekMs : 0
+          });
           this.showResumeDialog = true;
+          return;
         }
-      }).catch(() => {});
+        this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
+          savedPositionMs,
+          resumeAction: 'play'
+        });
+        this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
+          savedPositionMs,
+          resumeAction: 'play'
+        });
+      }).catch(() => {
+        this.emitResumeDiagnosticLog('saved_progress_resolved', pageParam, {
+          resumeAction: 'play'
+        });
+        this.emitResumeDiagnosticLog('prepared_resume_decision', pageParam, {
+          resumeAction: 'play'
+        });
+      });
     });
   }
 
   private applyPlayerPageParam(pageParam: PlayerPageParam): void {
     this.currentPageParam = pageParam;
+    this.emitResumeDiagnosticLog('page_param_received', pageParam);
     this.pageParamToken += 1;
     const token = this.pageParamToken;
     if (pageParam.preferredBackend) {

--- a/entry/src/test/PlayerPage.test.ets
+++ b/entry/src/test/PlayerPage.test.ets
@@ -801,6 +801,74 @@ export default function playerPageTest() {
       expect(action.positionMs ?? 0).assertEqual(0)
     })
 
+    it('重新进入同季同集且存在有效进度时会生成 seek 决策', 0, () => {
+      const savedEntry: MediaProgressEntry = {
+        mediaKey: 'media_progress_episode_tmdb_tmdb-9527_s1_e7',
+        positionMs: 420000,
+        durationMs: 1800000,
+        lastPlayedAt: 1,
+        seasonNumber: 1,
+        episodeNumber: 7
+      }
+      const action: MediaProgressResumeAction = resolveMediaProgressResumeAction(
+        savedEntry,
+        1800000,
+        1,
+        7
+      )
+
+      expect(action.action).assertEqual('seek')
+      expect(action.positionMs ?? 0).assertEqual(420000)
+    })
+
+    it('重新进入同一视频但没有有效进度时会直接播放', 0, () => {
+      const noProgressEntry: MediaProgressEntry = {
+        mediaKey: 'media_progress_episode_tmdb_tmdb-9527_s1_e7',
+        positionMs: 0,
+        durationMs: 1800000,
+        lastPlayedAt: 1,
+        seasonNumber: 1,
+        episodeNumber: 7
+      }
+      const action: MediaProgressResumeAction = resolveMediaProgressResumeAction(
+        noProgressEntry,
+        1800000,
+        1,
+        7
+      )
+
+      expect(action.action).assertEqual('play')
+      expect(action.positionMs ?? 0).assertEqual(0)
+    })
+
+    it('重新进入不同季或不同集时不会错误复用旧进度', 0, () => {
+      const savedEntry: MediaProgressEntry = {
+        mediaKey: 'media_progress_episode_tmdb_tmdb-9527_s1_e7',
+        positionMs: 420000,
+        durationMs: 1800000,
+        lastPlayedAt: 1,
+        seasonNumber: 1,
+        episodeNumber: 7
+      }
+      const actionForDifferentSeason: MediaProgressResumeAction = resolveMediaProgressResumeAction(
+        savedEntry,
+        1800000,
+        2,
+        7
+      )
+      const actionForDifferentEpisode: MediaProgressResumeAction = resolveMediaProgressResumeAction(
+        savedEntry,
+        1800000,
+        1,
+        8
+      )
+
+      expect(actionForDifferentSeason.action).assertEqual('play')
+      expect(actionForDifferentSeason.positionMs ?? 0).assertEqual(0)
+      expect(actionForDifferentEpisode.action).assertEqual('play')
+      expect(actionForDifferentEpisode.positionMs ?? 0).assertEqual(0)
+    })
+
     it('handleEpisodeSelect 会在解析新播放源前推进 pageParamToken', 0, async () => {
       const context = buildEpisodeSwitchContext(0)
       const page = new EpisodeSwitchTokenPage(context, 'https://example.com/s01e02.mkv')

--- a/entry/src/test/PlayerPage.test.ets
+++ b/entry/src/test/PlayerPage.test.ets
@@ -74,6 +74,10 @@ interface BoundRegisterPreparedResumeMethod {
   bind(target: Object): (pageParam: PlayerPageParam, token: number) => void
 }
 
+interface BoundResumePlaybackForParamMethod {
+  bind(target: Object): (pageParam: PlayerPageParam) => void
+}
+
 class TestPlayerPageController implements PlayerPageControllerAccessor {
   currentTime: number = 120000
   duration: number = 1800000
@@ -175,6 +179,32 @@ class PreparedResumeIsolationController extends TestPlayerPageController impleme
     this.playCalls += 1
     return Promise.resolve()
   }
+}
+
+interface ResumeDecisionControllerAccessor extends PlayerPageControllerPlaybackAccessor {
+  seek(timeMs: number): Promise<void>
+}
+
+class ResumeDecisionController extends TestPlayerPageController implements ResumeDecisionControllerAccessor {
+  seekCalls: number[] = []
+  playCalls: number = 0
+
+  seek(timeMs: number): Promise<void> {
+    this.seekCalls.push(timeMs)
+    return Promise.resolve()
+  }
+
+  play(): Promise<void> {
+    this.playCalls += 1
+    return Promise.resolve()
+  }
+}
+
+interface EpisodeSwitchResumeCall {
+  mediaKey: string
+  startPositionMs: number
+  seasonAtCall: number
+  episodeAtCall: number
 }
 
 class PreparedResumeListenerPage {
@@ -283,6 +313,24 @@ class EpisodeSwitchTokenPage {
   }
 }
 
+class ResumeDecisionPage {
+  currentMediaSeason: number = 0
+  currentMediaEpisode: number = 0
+  videoPlayerController: ResumeDecisionControllerAccessor
+  private readonly resumePlaybackForParamImpl: (pageParam: PlayerPageParam) => void
+
+  constructor(context: MediaLibraryContext) {
+    const page = buildPlayerPageAccessor()
+    const resumePlaybackForParam = page.resumePlaybackForParam as Object as BoundResumePlaybackForParamMethod
+    this.resumePlaybackForParamImpl = resumePlaybackForParam.bind(this as Object)
+    this.videoPlayerController = new ResumeDecisionController(context)
+  }
+
+  resumePlaybackForParam(pageParam: PlayerPageParam): void {
+    this.resumePlaybackForParamImpl(pageParam)
+  }
+}
+
 class TestEpisodeSwitchPage {
   currentPageParam?: PlayerPageParam
   episodeSwitching: boolean = false
@@ -352,6 +400,47 @@ class TestEpisodeSwitchPage {
 
   resumePlaybackForParam(_pageParam: PlayerPageParam): void {
     this.videoPlayerController.play().catch(() => {})
+  }
+}
+
+class ResumeDecisionEpisodeSwitchPage extends TestEpisodeSwitchPage {
+  resumeCalls: EpisodeSwitchResumeCall[] = []
+  private readonly resolvedStartPositionMs: number
+
+  constructor(
+    context: MediaLibraryContext,
+    calls: EpisodeSelectNoOpSideEffectCalls,
+    resolvedSourceUrl: string,
+    resolvedStartPositionMs: number
+  ) {
+    super(context, calls, resolvedSourceUrl)
+    this.resolvedStartPositionMs = resolvedStartPositionMs
+  }
+
+  async resolveEpisodePlaybackSource(item: PlaybackContextItem): Promise<ResolvedEpisodePlaybackSource | null> {
+    const resolvedSource = await super.resolveEpisodePlaybackSource(item)
+    if (resolvedSource === null) {
+      return null
+    }
+    const nextResolvedSource: ResolvedEpisodePlaybackSource = {
+      url: resolvedSource.url,
+      httpHeader: resolvedSource.httpHeader,
+      durationHintMs: resolvedSource.durationHintMs,
+      presetAudioTracks: resolvedSource.presetAudioTracks,
+      presetSubtitleTracks: resolvedSource.presetSubtitleTracks,
+      startPositionMs: this.resolvedStartPositionMs
+    }
+    return nextResolvedSource
+  }
+
+  resumePlaybackForParam(pageParam: PlayerPageParam): void {
+    const call: EpisodeSwitchResumeCall = {
+      mediaKey: pageParam.mediaKey ?? '',
+      startPositionMs: pageParam.startPositionMs ?? 0,
+      seasonAtCall: this.currentMediaSeason,
+      episodeAtCall: this.currentMediaEpisode
+    }
+    this.resumeCalls.push(call)
   }
 }
 
@@ -867,6 +956,55 @@ export default function playerPageTest() {
       expect(actionForDifferentSeason.positionMs ?? 0).assertEqual(0)
       expect(actionForDifferentEpisode.action).assertEqual('play')
       expect(actionForDifferentEpisode.positionMs ?? 0).assertEqual(0)
+    })
+
+    it('resumePlaybackForParam 会优先 seek 选集切换传入的新媒体 startPositionMs', 0, async () => {
+      const context = buildEpisodeSwitchContext(1)
+      const page = new ResumeDecisionPage(context)
+      const controller = page.videoPlayerController as ResumeDecisionController
+      const pageParam: PlayerPageParam = {
+        url: 'https://example.com/s01e02.mkv',
+        title: '长夜余火 第一季-S1:E2-突围',
+        mediaKey: 'media_progress_episode_tmdb_tmdb-9527_s1_e2',
+        seasonNumber: 1,
+        episodeNumber: 2,
+        startPositionMs: 245000
+      }
+
+      page.resumePlaybackForParam(pageParam)
+
+      expect(controller.seekCalls.length).assertEqual(1)
+      expect(controller.seekCalls[0]).assertEqual(245000)
+      expect(controller.playCalls).assertEqual(0)
+    })
+
+    it('handleEpisodeSelect 会把新媒体续播参数与新季集标识一起传给 reload 后的续播决策', 0, async () => {
+      const context = buildEpisodeSwitchContext(0)
+      const calls: EpisodeSelectNoOpSideEffectCalls = {
+        persistCurrentPlaybackState: 0,
+        reloadSource: 0,
+        resumePlaybackForParam: 0,
+        saveProgressNow: 0,
+        play: 0
+      }
+      const page = new ResumeDecisionEpisodeSwitchPage(
+        context,
+        calls,
+        'https://example.com/s01e02.mkv',
+        245000
+      )
+      page.currentPageParam = buildEpisodeSwitchParam(context)
+
+      const didSwitch = await page.handleEpisodeSelect(context.items[1])
+
+      expect(didSwitch).assertTrue()
+      expect(calls.reloadSource).assertEqual(1)
+      expect(page.resumeCalls.length).assertEqual(1)
+      expect(page.resumeCalls[0].mediaKey).assertEqual('media_progress_episode_tmdb_tmdb-9527_s1_e2')
+      expect(page.resumeCalls[0].startPositionMs).assertEqual(245000)
+      expect(page.resumeCalls[0].seasonAtCall).assertEqual(1)
+      expect(page.resumeCalls[0].episodeAtCall).assertEqual(2)
+      expect(page.currentPageParam?.episodeNumber ?? 0).assertEqual(2)
     })
 
     it('handleEpisodeSelect 会在解析新播放源前推进 pageParamToken', 0, async () => {

--- a/entry/src/test/VideoPlayerController.test.ets
+++ b/entry/src/test/VideoPlayerController.test.ets
@@ -7,6 +7,11 @@ import {
   resolveEffectivePlaybackSurfaceId
 } from '../main/ets/components/core/player/VideoPlayerController';
 import { IPlayer, SubtitleInfo, TrackInfo } from '../main/ets/components/core/player/IPlayer';
+import {
+  ISubtitleBridgeAdapter,
+  SubtitleBridgeState,
+  SubtitleTrackItem
+} from '../main/ets/components/core/player/SubtitleBridgeAdapter';
 import { VideoData } from '../main/ets/components/core/player/VideoData';
 import { VideoDataType } from '../main/ets/components/core/player/Constants';
 
@@ -23,11 +28,14 @@ interface VideoPlayerControllerAccessor {
   progress: number
   isPlaying: boolean
   isSeeking: boolean
+  activeSubtitleIndex: number
   pendingBackendResumeTimeMs: number
   pendingBackendResumePlay: boolean
+  subtitleAdapter: ISubtitleBridgeAdapter
   pendingReloadResolve?: () => void
   pendingReloadReject?: (error: Error) => void
   capturePendingResumeForFallback(): void
+  continuePendingReadyAfterSeek(): Promise<void>
   onPlayerReady(): Promise<void>
   resolvePendingReload(): void
 }
@@ -74,6 +82,110 @@ class MockFallbackPlayer implements IPlayer {
   onUnsupportedFormat(_callback: () => void): void {}
   onSeekDone(_callback: () => void): void {}
   onSubtitleUpdate(_callback: (info: SubtitleInfo) => void): void {}
+}
+
+class RecordingFallbackPlayer extends MockFallbackPlayer {
+  readonly events: string[]
+  private readonly audioTrackInfo: TrackInfo
+
+  constructor(events: string[]) {
+    super()
+    this.events = events
+    const audioTrackInfo: TrackInfo = {
+      trackIndex: 0,
+      trackType: 'audio',
+      language: 'chi',
+      mimeType: 'audio/mp4a-latm'
+    }
+    this.audioTrackInfo = audioTrackInfo
+  }
+
+  play(): Promise<void> {
+    this.events.push('player:play')
+    return super.play()
+  }
+
+  seek(timeMs: number): void {
+    this.events.push(`player:seek:${timeMs}`)
+    super.seek(timeMs)
+  }
+
+  getTrackInfos(): Promise<TrackInfo[]> {
+    this.events.push('player:getTrackInfos')
+    return Promise.resolve([this.audioTrackInfo])
+  }
+
+  selectTrack(trackIndex: number): Promise<void> {
+    this.events.push(`player:selectTrack:${trackIndex}`)
+    return Promise.resolve()
+  }
+}
+
+class RecordingSubtitleAdapter implements ISubtitleBridgeAdapter {
+  private readonly events: string[]
+  private state: SubtitleBridgeState
+
+  constructor(events: string[]) {
+    this.events = events
+    const subtitleTracks: TrackInfo[] = []
+    const allSubtitleTracks: SubtitleTrackItem[] = []
+    const state: SubtitleBridgeState = {
+      subtitleTracks,
+      allSubtitleTracks,
+      activeSubtitleIndex: -1,
+      currentSubtitleTrack: -1,
+      currentSubtitleText: '',
+      subtitleDelayMs: 0,
+      hasExternalActive: false
+    }
+    this.state = state
+  }
+
+  async init(_player: IPlayer, _videoData?: VideoData): Promise<void> {
+    this.events.push('subtitle:init')
+    const internalSubtitleTracks: SubtitleTrackItem[] = [{
+      kind: 'internal',
+      displayName: '中文',
+      internalIndex: 0,
+      language: 'chi'
+    }]
+    const nextState: SubtitleBridgeState = {
+      subtitleTracks: [],
+      allSubtitleTracks: internalSubtitleTracks,
+      activeSubtitleIndex: 0,
+      currentSubtitleTrack: 0,
+      currentSubtitleText: '',
+      subtitleDelayMs: 0,
+      hasExternalActive: false
+    }
+    this.state = nextState
+  }
+
+  onTimeUpdate(_currentTimeMs: number): void {}
+
+  onSubtitleUpdate(_info: SubtitleInfo): void {}
+
+  onEmbeddedTimedText(_text: string): void {}
+
+  async switchTrack(_allIndex: number): Promise<void> {
+    return Promise.resolve()
+  }
+
+  adjustDelay(_deltaMs: number): void {}
+
+  onSeekSync(): void {
+    this.events.push('subtitle:onSeekSync')
+  }
+
+  getState(): SubtitleBridgeState {
+    return this.state
+  }
+
+  release(): void {}
+
+  async addLocalSubtitle(_localPath: string): Promise<void> {
+    return Promise.resolve()
+  }
 }
 
 class TestVideoPlayerController extends VideoPlayerController {
@@ -268,6 +380,61 @@ export default function videoPlayerControllerTest() {
       expect(accessor.pendingBackendResumePlay).assertFalse()
       expect(accessor.currentTime).assertEqual(501626)
       expect(player.playCallCount).assertEqual(0)
+    })
+
+    it('fallback pending-resume 场景 onPlayerReady 会先进入 seek 再延后轨道初始化', 0, async () => {
+      const controller = new TestVideoPlayerController()
+      const accessor = accessController(controller)
+      const events: string[] = []
+      const player = new RecordingFallbackPlayer(events)
+      const subtitleAdapter = new RecordingSubtitleAdapter(events)
+      accessor.backend = 'ijkplayer'
+      accessor.player = player
+      accessor.subtitleAdapter = subtitleAdapter
+      accessor.currentTime = 0
+      accessor.duration = player.duration
+      accessor.progress = 0
+      accessor.isPlaying = false
+      accessor.isSeeking = false
+      accessor.pendingBackendResumeTimeMs = 501626
+      accessor.pendingBackendResumePlay = true
+
+      await accessor.onPlayerReady()
+
+      expect(events.length).assertEqual(2)
+      expect(events[0]).assertEqual('subtitle:onSeekSync')
+      expect(events[1]).assertEqual('player:seek:501626')
+    })
+
+    it('fallback pending-resume 场景 seek 完成后才补偿轨道初始化并只恢复一次播放', 0, async () => {
+      const controller = new TestVideoPlayerController()
+      const accessor = accessController(controller)
+      const events: string[] = []
+      const player = new RecordingFallbackPlayer(events)
+      const subtitleAdapter = new RecordingSubtitleAdapter(events)
+      accessor.backend = 'ijkplayer'
+      accessor.player = player
+      accessor.subtitleAdapter = subtitleAdapter
+      accessor.currentTime = 0
+      accessor.duration = player.duration
+      accessor.progress = 0
+      accessor.isPlaying = false
+      accessor.isSeeking = false
+      accessor.pendingBackendResumeTimeMs = 501626
+      accessor.pendingBackendResumePlay = true
+
+      await accessor.onPlayerReady()
+      await accessor.continuePendingReadyAfterSeek()
+
+      expect(events.length).assertEqual(6)
+      expect(events[0]).assertEqual('subtitle:onSeekSync')
+      expect(events[1]).assertEqual('player:seek:501626')
+      expect(events[2]).assertEqual('subtitle:init')
+      expect(events[3]).assertEqual('player:getTrackInfos')
+      expect(events[4]).assertEqual('player:selectTrack:0')
+      expect(events[5]).assertEqual('player:play')
+      expect(accessor.activeSubtitleIndex).assertEqual(0)
+      expect(player.playCallCount).assertEqual(1)
     })
 
   })


### PR DESCRIPTION
## Summary
- 修复真实设备续播恢复链路，覆盖重新进入视频、E-AC3 fallback 与切源/选集切换场景
- 补齐 PlayerPage / VideoPlayerController 相关回归单测，并保留续播结构化日志用于诊断
- 真机验证通过；切集后偶发不自动播放已拆分为后续 Issue #218，不阻塞 #217 收口

## Test Plan
- [x] `hvigorw.js --mode module -p module=entry@default test --no-daemon`
- [x] `hvigorw.js --mode module -p module=entry@default -p product=default assembleHap`
- [x] 真实设备人工验证：重新进入同一视频续播
- [x] 真实设备人工验证：E-AC3 / codec fallback 后续播
- [x] 真实设备人工验证：切源 / 选集切换后使用新媒体续播进度
- [x] 真实设备人工验证：#213 的 FIT / FILL / STRETCH 比例回归

Closes #217
Related #218


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive diagnostic logging for resume decisions and playback flow tracking.

* **Bug Fixes**
  * Improved resume behavior during video source transitions.
  * Enhanced subtitle synchronization during playback resume operations.
  * Refined state preservation when switching episodes or media sources.
  * Strengthened reliability of playback state management and resume decision logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaoshining/vidall-tv/pull/219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->