### PR TITLE
修复: #214 混合音轨文件 codec-aware 选轨防止 eac3 命中导致 AVPlayer fallback

### DIFF
--- a/entry/src/main/ets/components/core/player/VideoData.ets
+++ b/entry/src/main/ets/components/core/player/VideoData.ets
@@ -21,6 +21,12 @@ export interface PresetAudioTrack {
    * 用于同声道数下的高质量轨道优先选择（高码率优先）。
    */
   bitrate?: number;
+  /**
+   * 编解码器名称，由调用方按 ffprobe 结果注入，如 "aac"、"eac3"、"ac3"。
+   * 用于 codec-aware 音轨候选选择器，避免偏好恢复时命中 AVPlayer 不支持的 codec。
+   * 缺失时按未知 codec 处理，不视为可播放证明。
+   */
+  codecName?: string;
 }
 
 /**

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -217,6 +217,8 @@ export interface AudioTrackItem {
   language?: string;
   /** MIME 类型 */
   mimeType?: string;
+  /** 编解码器名称，如 "aac"、"eac3"、"ac3"，供 codec-aware 选轨使用 */
+  codecName?: string;
 }
 
 export type UnsupportedFormatFallback = 'ijkplayer' | 'native';
@@ -852,7 +854,8 @@ export class VideoPlayerController {
           trackIndex: p.trackIndex,
           displayName: p.displayName,
           language: p.language,
-          mimeType: p.mimeType
+          mimeType: p.mimeType,
+          codecName: p.codecName
         };
         tracks.push(item);
       }
@@ -2226,6 +2229,76 @@ export class VideoPlayerController {
     return true;
   }
 
+  /**
+   * 判断指定音轨是否可播放（AVPlayer 可解码）。
+   * 优先使用 codecName 字段；缺失时降级到 mimeType；两者均缺失时视为可播放（保持既有行为）。
+   * codecName 或 mimeType 缺失 / 未知时，不视为可播放的额外证明，但也不阻止选择。
+   */
+  private isAudioTrackPlayable(track: AudioTrackItem): boolean {
+    const codec = ((track.codecName ?? track.mimeType) ?? '').toLowerCase();
+    return this.isLikelySystemHardDecodeSupported(codec);
+  }
+
+  /**
+   * codec-aware 初始音轨候选选择器。
+   *
+   * 选择策略（优先级从高到低）：
+   * 1. 偏好轨（audioTracks[0]）可播放 → 直接使用
+   * 2. 偏好轨不可播放，存在同语言可播放轨 → 同语言降级
+   * 3. 无同语言候选，存在任意可播放轨 → 任意可播放降级
+   * 4. 全部不可播放 → 返回 0，沿用现有失败/fallback 策略
+   *
+   * @returns 应传给 switchAudioTrack 的轨道在 audioTracks 数组中的索引
+   */
+  private findInitialAudioTrackIndex(): number {
+    if (this.audioTracks.length === 0) {
+      return 0;
+    }
+
+    const preferred = this.audioTracks[0];
+    const preferredCodec = ((preferred.codecName ?? preferred.mimeType) ?? '');
+
+    // 1. 偏好轨可播放：直接选
+    if (this.isAudioTrackPlayable(preferred)) {
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        `[findInitialAudioTrackIndex] 偏好轨可播放，直接选中: index=0 lang=${preferred.language ?? 'unknown'} codec=${preferredCodec || 'unknown'}`);
+      return 0;
+    }
+
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[findInitialAudioTrackIndex] 偏好轨不可播放: index=0 lang=${preferred.language ?? 'unknown'} codec=${preferredCodec || 'unknown'}，尝试降级`);
+
+    // 2. 同语言可播放降级
+    const preferredLang = preferred.language ?? '';
+    if (preferredLang.length > 0) {
+      for (let i = 1; i < this.audioTracks.length; i++) {
+        const t = this.audioTracks[i];
+        if (t.language === preferredLang && this.isAudioTrackPlayable(t)) {
+          const tCodec = ((t.codecName ?? t.mimeType) ?? '');
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `[findInitialAudioTrackIndex] 同语言降级: index=${i} lang=${preferredLang} codec=${tCodec || 'unknown'}`);
+          return i;
+        }
+      }
+    }
+
+    // 3. 任意可播放轨降级
+    for (let i = 1; i < this.audioTracks.length; i++) {
+      const t = this.audioTracks[i];
+      if (this.isAudioTrackPlayable(t)) {
+        const tCodec = ((t.codecName ?? t.mimeType) ?? '');
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          `[findInitialAudioTrackIndex] 任意可播放降级: index=${i} lang=${t.language ?? 'unknown'} codec=${tCodec || 'unknown'}`);
+        return i;
+      }
+    }
+
+    // 4. 全部不可播放：返回 0，沿用现有失败/fallback 策略
+    hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+      `[findInitialAudioTrackIndex] 全部音轨不可播放（共 ${this.audioTracks.length} 条），返回 0 沿用现有降级策略`);
+    return 0;
+  }
+
   /** prepared 后回调：读取 duration、加载字幕轨道和音轨 */
   private async onPlayerReady(): Promise<void> {
     const readySessionId = this.playbackSessionId;
@@ -3065,7 +3138,7 @@ export class VideoPlayerController {
         if (this.backend === 'ffmpeg') {
           this.activeAudioIndex = 0;
         } else {
-          await this.switchAudioTrack(0);
+          await this.switchAudioTrack(this.findInitialAudioTrackIndex());
         }
         return;
       }
@@ -3097,7 +3170,7 @@ export class VideoPlayerController {
         if (this.backend === 'ffmpeg') {
           this.activeAudioIndex = 0;
         } else {
-          await this.switchAudioTrack(0);
+          await this.switchAudioTrack(this.findInitialAudioTrackIndex());
         }
       }
     } catch (e) {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -2233,9 +2233,14 @@ export class VideoPlayerController {
    * 判断指定音轨是否可播放（AVPlayer 可解码）。
    * 优先使用 codecName 字段；缺失时降级到 mimeType；两者均缺失时视为可播放（保持既有行为）。
    * codecName 或 mimeType 缺失 / 未知时，不视为可播放的额外证明，但也不阻止选择。
+   *
+   * mimeType 归一化：去掉 "audio/" 前缀并移除短横线，使 "audio/ac-3" → "ac3"、
+   * "audio/e-ac-3" → "eac3"，与 isLikelySystemHardDecodeSupported 的关键字列表对齐。
    */
   private isAudioTrackPlayable(track: AudioTrackItem): boolean {
-    const codec = ((track.codecName ?? track.mimeType) ?? '').toLowerCase();
+    const raw = ((track.codecName ?? track.mimeType) ?? '').toLowerCase();
+    // 归一化：去掉 "audio/" 前缀，移除短横线，使 "audio/ac-3" 匹配黑名单关键字 "ac3"
+    const codec = raw.replace('audio/', '').split('-').join('');
     return this.isLikelySystemHardDecodeSupported(codec);
   }
 

--- a/entry/src/main/ets/utils/FfprobeUtil.ets
+++ b/entry/src/main/ets/utils/FfprobeUtil.ets
@@ -854,8 +854,10 @@ export class FfprobeUtil {
         trackIndex: t.index,
         displayName: FfprobeUtil.buildAudioTrackDisplayName(t, i),
         language: t.language,
-        // codecName 是解码器名，不是 MIME type，下游用 codecName 匹配即可
-        mimeType: undefined
+        mimeType: undefined,
+        codecName: t.codecName,
+        channels: t.channels,
+        bitrate: t.bitrate
       };
       result.push(item);
     }

--- a/entry/src/test/VideoPlayerController.test.ets
+++ b/entry/src/test/VideoPlayerController.test.ets
@@ -1444,5 +1444,22 @@ export default function videoPlayerControllerTest() {
       expect(result).assertEqual(0)
     })
 
+    it('4.5 mimeType=audio/ac-3 路径：无 codecName 时通过归一化 mimeType 判定为不可播放并降级', 0, () => {
+      // 验证 getTrackInfos() 路径下 mimeType="audio/ac-3"（含短横线）能被正确识别为不可播放
+      const ctrl = new TestVideoPlayerController()
+      const accessor = accessController(ctrl)
+      const ac3Track: AudioTrackItem = {
+        trackIndex: 0, displayName: 'AC-3', language: 'chi', mimeType: 'audio/ac-3'
+        // codecName 故意不设置，模拟 getTrackInfos() 只有 mimeType 的情况
+      }
+      const aacTrack: AudioTrackItem = {
+        trackIndex: 1, displayName: 'AAC', language: 'chi', codecName: 'aac'
+      }
+      accessor.audioTracks = [ac3Track, aacTrack]
+      const result = accessor.findInitialAudioTrackIndex()
+      // audio/ac-3 归一化后为 "ac3"，命中黑名单，应降级到 index=1 的 AAC 轨
+      expect(result).assertEqual(1)
+    })
+
   })
 }

--- a/entry/src/test/VideoPlayerController.test.ets
+++ b/entry/src/test/VideoPlayerController.test.ets
@@ -58,6 +58,8 @@ interface VideoPlayerControllerAccessor {
   continuePendingReadyAfterSeek(): Promise<void>
   onPlayerReady(): Promise<void>
   resolvePendingReload(): void
+  findInitialAudioTrackIndex(): number
+  isAudioTrackPlayable(track: AudioTrackItem): boolean
 }
 
 interface PendingResumeStateSnapshot {
@@ -1371,6 +1373,75 @@ export default function videoPlayerControllerTest() {
       expect(secondSessionEvents[5]).assertEqual('player:play')
       expect(secondSessionPlayer.seekCalls.length).assertEqual(1)
       expect(secondSessionPlayer.playCallCount).assertEqual(1)
+    })
+
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // codec-aware 音轨候选选择器（#214 修复）
+  // ─────────────────────────────────────────────────────────────────────────
+  describe('findInitialAudioTrackIndex - codec-aware 音轨选择', () => {
+
+    it('4.1 可播偏好命中：偏好轨 codec 可播放时直接返回 0', 0, () => {
+      const ctrl = new TestVideoPlayerController()
+      const accessor = accessController(ctrl)
+      const aacTrack: AudioTrackItem = {
+        trackIndex: 0, displayName: '中文 (AAC)', language: 'chi', codecName: 'aac'
+      }
+      const eac3Track: AudioTrackItem = {
+        trackIndex: 1, displayName: '日语 (E-AC-3)', language: 'jpn', codecName: 'eac3'
+      }
+      accessor.audioTracks = [aacTrack, eac3Track]
+      const result = accessor.findInitialAudioTrackIndex()
+      expect(result).assertEqual(0)
+    })
+
+    it('4.2 同语言可播放降级：偏好轨 eac3 不可播，同语言 aac 轨优先', 0, () => {
+      const ctrl = new TestVideoPlayerController()
+      const accessor = accessController(ctrl)
+      const eac3Chi: AudioTrackItem = {
+        trackIndex: 0, displayName: '中文 (E-AC-3)', language: 'chi', codecName: 'eac3'
+      }
+      const aacChi: AudioTrackItem = {
+        trackIndex: 1, displayName: '中文 (AAC)', language: 'chi', codecName: 'aac'
+      }
+      const aacEng: AudioTrackItem = {
+        trackIndex: 2, displayName: '英语 (AAC)', language: 'eng', codecName: 'aac'
+      }
+      accessor.audioTracks = [eac3Chi, aacChi, aacEng]
+      const result = accessor.findInitialAudioTrackIndex()
+      expect(result).assertEqual(1)
+    })
+
+    it('4.3 任意可播放降级：偏好轨 eac3 不可播、无同语言候选时选择第一个可播放轨', 0, () => {
+      const ctrl = new TestVideoPlayerController()
+      const accessor = accessController(ctrl)
+      const eac3Chi: AudioTrackItem = {
+        trackIndex: 0, displayName: '中文 (E-AC-3)', language: 'chi', codecName: 'eac3'
+      }
+      const eac3Jpn: AudioTrackItem = {
+        trackIndex: 1, displayName: '日语 (E-AC-3)', language: 'jpn', codecName: 'eac3'
+      }
+      const aacEng: AudioTrackItem = {
+        trackIndex: 2, displayName: '英语 (AAC)', language: 'eng', codecName: 'aac'
+      }
+      accessor.audioTracks = [eac3Chi, eac3Jpn, aacEng]
+      const result = accessor.findInitialAudioTrackIndex()
+      expect(result).assertEqual(2)
+    })
+
+    it('4.4 全部不可播放：所有轨道 codec 不支持时返回 0，沿用现有降级策略', 0, () => {
+      const ctrl = new TestVideoPlayerController()
+      const accessor = accessController(ctrl)
+      const eac3Chi: AudioTrackItem = {
+        trackIndex: 0, displayName: '中文 (E-AC-3)', language: 'chi', codecName: 'eac3'
+      }
+      const ac3Eng: AudioTrackItem = {
+        trackIndex: 1, displayName: '英语 (AC-3)', language: 'eng', codecName: 'ac3'
+      }
+      accessor.audioTracks = [eac3Chi, ac3Eng]
+      const result = accessor.findInitialAudioTrackIndex()
+      expect(result).assertEqual(0)
     })
 
   })


### PR DESCRIPTION
## 问题

修复 #214：eac3/AAC 混合音轨 MKV 文件中，偏好恢复时无脑选 track 0 导致 AVPlayer 触发 5400106 错误并 fallback 到 ijkplayer。

## 根因

`loadAudioTracks` 两条路径（presetAudioTracks 路径和 getTrackInfos 路径）都无脑调用 `switchAudioTrack(0)`，不检查 codec 是否可播放。

## 解决方案

新增 `findInitialAudioTrackIndex()` codec-aware 选轨方法，按以下优先级选轨：

1. **偏好轨可播放** → 直接使用（不变）
2. **偏好轨 codec 不支持** → 优先选同语言可播放轨
3. **无同语言候选** → 选任意可播放轨
4. **全部不可播放** → 返回 0，沿用现有 fallback 策略

## 变更文件

- `VideoData.ets`：`PresetAudioTrack` 新增 `codecName?: string`
- `VideoPlayerController.ets`：`AudioTrackItem` 新增 `codecName`，新增 `isAudioTrackPlayable` + `findInitialAudioTrackIndex`，`loadAudioTracks` 两处 `switchAudioTrack(0)` 改用选择器
- `FfprobeUtil.ets`：`toPresetAudioTracks` 注入 `codecName`/`channels`/`bitrate`
- `VideoPlayerController.test.ets`：新增 4 组 codec-aware 选轨单元测试（可播命中/同语言降级/任意降级/全不可播）

## 测试

- ✅ `hvigor UnitTestBuild` 编译通过
- ✅ `hvigor test` 所有单元测试通过（含新增 4 组用例）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codec-aware audio track selection: player now picks the most compatible audio track based on codec support, with ranked fallback when preferred tracks aren’t playable.
  * Enhanced audio track metadata: tracks include codec name, channel count, and bitrate to improve compatibility detection.

* **Tests**
  * Added codec-aware unit tests validating initial-track selection and playability/fallback scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaoshining/vidall-tv/pull/221)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->