### PR TITLE
新增: 字幕优先级调度器 SubtitleDispatcher（Closes #30）

### DIFF
--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -3327,6 +3327,9 @@ export class VideoPlayerController {
         if (track.kind === 'external' && track.url !== undefined && track.url.length > 0) {
           // 用户手动选择外置字幕 → 保存绑定
           this.subtitleDispatcher.saveUserBinding(videoPath, track.url, 'local-file').catch(() => {});
+        } else if (track.kind === 'internal') {
+          // 用户手动选择内置字幕 → 用 displayName 作为绑定 key
+          this.subtitleDispatcher.saveUserBinding(videoPath, track.displayName, 'internal').catch(() => {});
         }
       }
     }

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -30,6 +30,7 @@ import {
 } from "./EpisodeAutoplayPreferences";
 import { MetricsService } from "../../../services/metrics/MetricsService";
 import { MediaIdentity } from "../../../services/metrics/MetricsReporter";
+import { SubtitleDispatcher } from "../../../subtitle/SubtitleDispatcher";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
 
@@ -303,6 +304,7 @@ export class VideoPlayerController {
   private pendingReloadResolve?: () => void;
   private pendingReloadReject?: (error: Error) => void;
   private subtitleAdapter: ISubtitleBridgeAdapter = new NoSubtitleBridgeAdapter();
+  private readonly subtitleDispatcher: SubtitleDispatcher = new SubtitleDispatcher();
   private currentVideoData?: VideoData;
   private timeToSeek = -1
   private subtitleClearTimer?: number
@@ -3119,6 +3121,18 @@ export class VideoPlayerController {
     try {
       await this.subtitleAdapter.init(this.player, this.currentVideoData);
       this.applySubtitleBridgeState(this.subtitleAdapter.getState());
+
+      // 字幕优先级调度：步骤 1（用户指定）
+      const videoPath = this.currentVideoData?.videoSrc ?? '';
+      if (videoPath.length > 0 && this.allSubtitleTracks.length > 0) {
+        const resolution = await this.subtitleDispatcher.resolveSubtitle(videoPath, this.allSubtitleTracks);
+        if (resolution.type === 'user-specified' && resolution.trackIndex !== undefined) {
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `[loadSubtitleTracks] 调度器覆盖选轨: trackIndex=${resolution.trackIndex}`);
+          await this.subtitleAdapter.switchTrack(resolution.trackIndex);
+          this.applySubtitleBridgeState(this.subtitleAdapter.getState());
+        }
+      }
     } catch (e) {
       const err = e as BusinessError;
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
@@ -3301,7 +3315,22 @@ export class VideoPlayerController {
     this.subtitleRemainingTime = 0;
     await this.subtitleAdapter.switchTrack(allIndex);
     this.applySubtitleBridgeState(this.subtitleAdapter.getState());
-    
+
+    // 用户绑定持久化
+    const videoPath = this.currentVideoData?.videoSrc ?? '';
+    if (videoPath.length > 0) {
+      if (allIndex === -1) {
+        // 关闭字幕 → 清除绑定
+        this.subtitleDispatcher.clearUserBinding(videoPath).catch(() => {});
+      } else if (allIndex >= 0 && allIndex < this.allSubtitleTracks.length) {
+        const track = this.allSubtitleTracks[allIndex];
+        if (track.kind === 'external' && track.url !== undefined && track.url.length > 0) {
+          // 用户手动选择外置字幕 → 保存绑定
+          this.subtitleDispatcher.saveUserBinding(videoPath, track.url, 'local-file').catch(() => {});
+        }
+      }
+    }
+
     // Task 5.4: 缺陷 2 修复：此处不再调用 recordSubtitleUsage，
     // subtitle 使用计数已在 onPlayerReady 内一次性记录，此处重复调用会导致 total_playbacks 双重计数。
   }

--- a/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
+++ b/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
@@ -13,7 +13,12 @@ export type SubtitleBindingType = 'local-file' | 'cached' | 'downloaded' | 'inte
 export interface SubtitleBinding {
   /** 视频完整 URL */
   videoPath: string;
-  /** 字幕完整 URL（local-file）或本地路径（downloaded/cached） */
+  /**
+   * 字幕标识符，语义因 subtitleType 而异：
+   * - `local-file`：外置字幕的完整 URL
+   * - `downloaded` / `cached`：本地缓存文件路径
+   * - `internal`：内置轨道的 displayName（用于按名称重定位轨道索引）
+   */
   subtitlePath: string;
   /** 绑定类型 */
   subtitleType: SubtitleBindingType;
@@ -107,7 +112,7 @@ export class SubtitleDispatcher {
       };
       await AppPreferences.set(key, JSON.stringify(binding));
     } catch (e) {
-      console.error(`[SubtitleDispatcher] saveUserBinding 失败: ${JSON.stringify(e)}`);
+      console.error(`[SubtitleDispatcher] saveUserBinding 失败: ${String(e)}`);
     }
   }
 
@@ -120,7 +125,7 @@ export class SubtitleDispatcher {
       const key = await this.buildKey(videoPath);
       await AppPreferences.set(key, '');
     } catch (e) {
-      console.error(`[SubtitleDispatcher] clearUserBinding 失败: ${JSON.stringify(e)}`);
+      console.error(`[SubtitleDispatcher] clearUserBinding 失败: ${String(e)}`);
     }
   }
 

--- a/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
+++ b/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
@@ -7,7 +7,7 @@ import { SubtitleTrackItem } from '../components/core/player/SubtitleBridgeAdapt
 // ─────────────────────────────────────────────
 
 /** 用户字幕绑定类型 */
-export type SubtitleBindingType = 'local-file' | 'cached' | 'downloaded';
+export type SubtitleBindingType = 'local-file' | 'cached' | 'downloaded' | 'internal';
 
 /** 用户字幕绑定记录（存储在 AppPreferences 中） */
 export interface SubtitleBinding {
@@ -127,7 +127,9 @@ export class SubtitleDispatcher {
   /**
    * 按 5 步优先级链裁决字幕来源。
    *
-   * - 步骤 1：查用户绑定 → 在 allSubtitleTracks 中按 URL 精确匹配
+   * - 步骤 1：查用户绑定
+   *   - local-file：在 allSubtitleTracks 中按 URL 精确匹配（外置字幕）
+   *   - internal：在 allSubtitleTracks 中按 displayName 精确匹配（内置字幕）
    * - 步骤 2-3：adapter 已处理，此处不介入（返回 none，让 adapter 的自动选轨生效）
    * - 步骤 4：stub，始终跳过
    * - 步骤 5：返回 { type: 'none' }
@@ -144,7 +146,7 @@ export class SubtitleDispatcher {
       const binding = await this.getUserBinding(videoPath);
       if (binding !== null) {
         if (binding.subtitleType === 'local-file') {
-          // 在轨道列表中按 URL 精确匹配
+          // 外置字幕：按 URL 精确匹配
           let foundIndex = -1;
           for (let i = 0; i < allSubtitleTracks.length; i++) {
             if (allSubtitleTracks[i].url === binding.subtitlePath) {
@@ -153,12 +155,28 @@ export class SubtitleDispatcher {
             }
           }
           if (foundIndex >= 0) {
-            console.info(`[SubtitleDispatcher] 步骤1命中用户绑定: index=${foundIndex} url=${binding.subtitlePath}`);
+            console.info(`[SubtitleDispatcher] 步骤1命中用户绑定(external): index=${foundIndex} url=${binding.subtitlePath}`);
             const resolution: SubtitleResolution = { type: 'user-specified', trackIndex: foundIndex };
             return resolution;
           } else {
-            // URL 已失效，自动清除绑定
             console.warn(`[SubtitleDispatcher] 绑定 URL 不在轨道列表中，自动清除: ${binding.subtitlePath}`);
+            await this.clearUserBinding(videoPath);
+          }
+        } else if (binding.subtitleType === 'internal') {
+          // 内置字幕：按 displayName 精确匹配
+          let foundIndex = -1;
+          for (let i = 0; i < allSubtitleTracks.length; i++) {
+            if (allSubtitleTracks[i].kind === 'internal' && allSubtitleTracks[i].displayName === binding.subtitlePath) {
+              foundIndex = i;
+              break;
+            }
+          }
+          if (foundIndex >= 0) {
+            console.info(`[SubtitleDispatcher] 步骤1命中用户绑定(internal): index=${foundIndex} displayName=${binding.subtitlePath}`);
+            const resolution: SubtitleResolution = { type: 'user-specified', trackIndex: foundIndex };
+            return resolution;
+          } else {
+            console.warn(`[SubtitleDispatcher] 绑定 displayName 不在轨道列表中，自动清除: ${binding.subtitlePath}`);
             await this.clearUserBinding(videoPath);
           }
         }

--- a/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
+++ b/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
@@ -1,0 +1,187 @@
+import { AppPreferences, PrefKey } from '../utils/AppPreferences';
+import { sha256Hex } from './SubtitleDownloader';
+import { SubtitleTrackItem } from '../components/core/player/SubtitleBridgeAdapter';
+
+// ─────────────────────────────────────────────
+// 公共接口 / 类型
+// ─────────────────────────────────────────────
+
+/** 用户字幕绑定类型 */
+export type SubtitleBindingType = 'local-file' | 'cached' | 'downloaded';
+
+/** 用户字幕绑定记录（存储在 AppPreferences 中） */
+export interface SubtitleBinding {
+  /** 视频完整 URL */
+  videoPath: string;
+  /** 字幕完整 URL（local-file）或本地路径（downloaded/cached） */
+  subtitlePath: string;
+  /** 绑定类型 */
+  subtitleType: SubtitleBindingType;
+  /** 写入时的 Unix 时间戳（毫秒） */
+  savedAt: number;
+}
+
+/** 字幕调度结果 */
+export interface SubtitleResolution {
+  /** 调度来源类型 */
+  type: 'user-specified' | 'none';
+  /** 匹配到的轨道在 allSubtitleTracks 中的索引（type=user-specified 时有效） */
+  trackIndex?: number;
+}
+
+// ─────────────────────────────────────────────
+// SubtitleDispatcher
+// ─────────────────────────────────────────────
+
+/**
+ * 字幕优先级调度器。
+ *
+ * 在 `VideoPlayerController.loadSubtitleTracks()` 内、`subtitleAdapter.init()` 返回后调用，
+ * 覆盖 adapter 的自动选轨结果。
+ *
+ * 5 步优先级链：
+ *   1. 用户指定字幕（持久化绑定）
+ *   2-3. adapter 已处理（内置 + 同目录外置）→ 调度器不介入
+ *   4. 本地缓存（stub，始终返回 null，待 #28 接入）
+ *   5. 无字幕 → 返回 { type: 'none' }
+ */
+export class SubtitleDispatcher {
+
+  // ──────────────────────────────────────────
+  // 绑定存储 key 计算
+  // ──────────────────────────────────────────
+
+  private async buildKey(videoPath: string): Promise<string> {
+    const hash = await sha256Hex(videoPath);
+    return `${PrefKey.SUBTITLE_BINDING_PREFIX}_${hash.slice(0, 12)}`;
+  }
+
+  // ──────────────────────────────────────────
+  // 公开 API
+  // ──────────────────────────────────────────
+
+  /**
+   * 读取用户字幕绑定。
+   * - key 存在且合法 JSON → 返回 SubtitleBinding
+   * - key 不存在或 JSON 损坏 → 返回 null（不抛异常）
+   */
+  async getUserBinding(videoPath: string): Promise<SubtitleBinding | null> {
+    try {
+      const key = await this.buildKey(videoPath);
+      const raw = await AppPreferences.get(key, '');
+      if (raw.length === 0) {
+        return null;
+      }
+      const parsed = JSON.parse(raw) as Record<string, string | number>;
+      if (!parsed['videoPath'] || !parsed['subtitlePath'] || !parsed['subtitleType'] || !parsed['savedAt']) {
+        return null;
+      }
+      const binding: SubtitleBinding = {
+        videoPath: parsed['videoPath'] as string,
+        subtitlePath: parsed['subtitlePath'] as string,
+        subtitleType: parsed['subtitleType'] as SubtitleBindingType,
+        savedAt: parsed['savedAt'] as number
+      };
+      return binding;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 保存用户字幕绑定。
+   * 在用户手动选择外置字幕时调用。
+   */
+  async saveUserBinding(
+    videoPath: string,
+    subtitlePath: string,
+    type: SubtitleBindingType
+  ): Promise<void> {
+    try {
+      const key = await this.buildKey(videoPath);
+      const binding: SubtitleBinding = {
+        videoPath,
+        subtitlePath,
+        subtitleType: type,
+        savedAt: Date.now()
+      };
+      await AppPreferences.set(key, JSON.stringify(binding));
+    } catch (e) {
+      console.error(`[SubtitleDispatcher] saveUserBinding 失败: ${JSON.stringify(e)}`);
+    }
+  }
+
+  /**
+   * 清除用户字幕绑定。
+   * 在用户关闭字幕或绑定 URL 匹配失败时调用。
+   */
+  async clearUserBinding(videoPath: string): Promise<void> {
+    try {
+      const key = await this.buildKey(videoPath);
+      await AppPreferences.set(key, '');
+    } catch (e) {
+      console.error(`[SubtitleDispatcher] clearUserBinding 失败: ${JSON.stringify(e)}`);
+    }
+  }
+
+  /**
+   * 按 5 步优先级链裁决字幕来源。
+   *
+   * - 步骤 1：查用户绑定 → 在 allSubtitleTracks 中按 URL 精确匹配
+   * - 步骤 2-3：adapter 已处理，此处不介入（返回 none，让 adapter 的自动选轨生效）
+   * - 步骤 4：stub，始终跳过
+   * - 步骤 5：返回 { type: 'none' }
+   *
+   * @param videoPath  视频完整 URL
+   * @param allSubtitleTracks  adapter.init() 后的完整字幕轨道列表
+   */
+  async resolveSubtitle(
+    videoPath: string,
+    allSubtitleTracks: SubtitleTrackItem[]
+  ): Promise<SubtitleResolution> {
+    // 步骤 1：用户指定字幕
+    try {
+      const binding = await this.getUserBinding(videoPath);
+      if (binding !== null) {
+        if (binding.subtitleType === 'local-file') {
+          // 在轨道列表中按 URL 精确匹配
+          let foundIndex = -1;
+          for (let i = 0; i < allSubtitleTracks.length; i++) {
+            if (allSubtitleTracks[i].url === binding.subtitlePath) {
+              foundIndex = i;
+              break;
+            }
+          }
+          if (foundIndex >= 0) {
+            console.info(`[SubtitleDispatcher] 步骤1命中用户绑定: index=${foundIndex} url=${binding.subtitlePath}`);
+            const resolution: SubtitleResolution = { type: 'user-specified', trackIndex: foundIndex };
+            return resolution;
+          } else {
+            // URL 已失效，自动清除绑定
+            console.warn(`[SubtitleDispatcher] 绑定 URL 不在轨道列表中，自动清除: ${binding.subtitlePath}`);
+            await this.clearUserBinding(videoPath);
+          }
+        }
+        // downloaded / cached → stub，跳过（步骤 4 接入后处理）
+      }
+    } catch {
+      // getUserBinding 失败时安全降级，继续步骤 2
+    }
+
+    // 步骤 4：stub，始终返回 null（待 #28 接入）
+    // const lastUsed = await this.getLastUsedSubtitle(videoPath); // always null
+
+    // 步骤 5：无字幕（adapter 自动选轨已生效，调度器不覆盖）
+    const none: SubtitleResolution = { type: 'none' };
+    return none;
+  }
+
+  /**
+   * 步骤 4 stub：始终返回 null。
+   * #28 完成后，接入 SubtitleCacheManager 并真正实现。
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private async getLastUsedSubtitle(_videoPath: string): Promise<string | null> {
+    return null;
+  }
+}

--- a/entry/src/main/ets/utils/AppPreferences.ets
+++ b/entry/src/main/ets/utils/AppPreferences.ets
@@ -40,6 +40,8 @@ export class PrefKey {
   static readonly OPENSUBTITLES_API_KEY = 'opensubtitles_api_key';
   /** OpenSubtitles 设备 ID（代理通道身份标识，首次启动自动生成） */
   static readonly OPENSUBTITLES_DEVICE_ID = 'opensubtitles_device_id';
+  /** 用户字幕绑定前缀，完整 key = subtitle_binding_<sha256前12位> */
+  static readonly SUBTITLE_BINDING_PREFIX = 'subtitle_binding';
 }
 
 // ─────────────────────────────────────────────

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -45,6 +45,7 @@ import compositeMetricsReporterTest from './ets/services/metrics/CompositeMetric
 import openSubtitlesPrefsTest from './OpenSubtitlesPrefs.test';
 import openSubtitlesClientTest from './OpenSubtitlesClient.test';
 import subtitleDownloaderTest from './SubtitleDownloader.test';
+import subtitleDispatcherTest from './SubtitleDispatcher.test';
 
 export default function testsuite() {
   timeUtilTest();
@@ -92,4 +93,5 @@ export default function testsuite() {
   openSubtitlesPrefsTest();
   openSubtitlesClientTest();
   subtitleDownloaderTest();
+  subtitleDispatcherTest();
 }

--- a/entry/src/test/SubtitleDispatcher.test.ets
+++ b/entry/src/test/SubtitleDispatcher.test.ets
@@ -134,6 +134,36 @@ export default function subtitleDispatcherTest() {
       expect(resolution.type).assertEqual('none');
     });
 
+    it('resolveSubtitle_internalBindingMatches_returnsUserSpecified', 0, async () => {
+      const setup = await makeSetup();
+      await setup.dispatcher.saveUserBinding(VIDEO_PATH, '简体中文', 'internal');
+
+      const track: SubtitleTrackItem = {
+        kind: 'internal',
+        displayName: '简体中文'
+      };
+      const tracks: SubtitleTrackItem[] = [track];
+      const resolution: SubtitleResolution = await setup.dispatcher.resolveSubtitle(VIDEO_PATH, tracks);
+      expect(resolution.type).assertEqual('user-specified');
+      expect(resolution.trackIndex).assertEqual(0);
+    });
+
+    it('resolveSubtitle_internalBindingNotInTracks_clearsBindingAndReturnsNone', 0, async () => {
+      const setup = await makeSetup();
+      await setup.dispatcher.saveUserBinding(VIDEO_PATH, '简体中文', 'internal');
+
+      const track: SubtitleTrackItem = {
+        kind: 'internal',
+        displayName: 'English'
+      };
+      const tracks: SubtitleTrackItem[] = [track];
+      const resolution: SubtitleResolution = await setup.dispatcher.resolveSubtitle(VIDEO_PATH, tracks);
+      expect(resolution.type).assertEqual('none');
+
+      const binding: SubtitleBinding | null = await setup.dispatcher.getUserBinding(VIDEO_PATH);
+      expect(binding).assertNull();
+    });
+
     it('clearUserBinding_removesExistingBinding', 0, async () => {
       const setup = await makeSetup();
       await setup.dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');

--- a/entry/src/test/SubtitleDispatcher.test.ets
+++ b/entry/src/test/SubtitleDispatcher.test.ets
@@ -1,115 +1,104 @@
-import { describe, it, expect, beforeEach } from '@ohos/hypium';
+import { describe, it, expect } from '@ohos/hypium';
+import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
+import { Context } from '@ohos.abilityAccessCtrl';
 import {
   AppPreferences,
   AppPreferencesLoader,
-  AppPreferencesStore
-} from '../../main/ets/utils/AppPreferences';
-import { SubtitleDispatcher, SubtitleBinding } from '../../main/ets/subtitle/SubtitleDispatcher';
-import { SubtitleTrackItem } from '../../main/ets/components/core/player/SubtitleBridgeAdapter';
+  AppPreferencesStore,
+  AppPreferenceValue
+} from '../main/ets/utils/AppPreferences';
+import { SubtitleDispatcher, SubtitleBinding, SubtitleResolution } from '../main/ets/subtitle/SubtitleDispatcher';
+import { SubtitleTrackItem } from '../main/ets/components/core/player/SubtitleBridgeAdapter';
 
 // ──────────────────────────────────────────
 // 内存 store mock
 // ──────────────────────────────────────────
 
 class InMemoryStore implements AppPreferencesStore {
-  private readonly values: Map<string, string | number> = new Map<string, string | number>();
+  private readonly values: Map<string, AppPreferenceValue> = new Map<string, AppPreferenceValue>();
 
-  seed(key: string, value: string | number): void {
+  seed(key: string, value: AppPreferenceValue): void {
     this.values.set(key, value);
   }
 
-  async get(key: string, defaultValue: string | number): Promise<string | number> {
+  corruptFirstKey(prefix: string): void {
+    this.values.forEach((_v: AppPreferenceValue, k: string) => {
+      if (k.startsWith(prefix)) {
+        this.values.set(k, 'not-valid-json{{{');
+      }
+    });
+  }
+
+  async get(key: string, defaultValue: AppPreferenceValue): Promise<AppPreferenceValue> {
     const v = this.values.get(key);
     return v === undefined ? defaultValue : v;
   }
 
-  async put(key: string, value: string | number): Promise<void> {
+  async put(key: string, value: AppPreferenceValue): Promise<void> {
     this.values.set(key, value);
   }
 
   async flush(): Promise<void> {}
 }
 
-function makeLoader(store: InMemoryStore): AppPreferencesLoader {
-  return async (): Promise<AppPreferencesStore> => store;
+interface DispatcherSetup {
+  store: InMemoryStore;
+  dispatcher: SubtitleDispatcher;
 }
 
-// ──────────────────────────────────────────
-// 测试套件
-// ──────────────────────────────────────────
+async function makeSetup(): Promise<DispatcherSetup> {
+  const store = new InMemoryStore();
+  const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+  const loader: AppPreferencesLoader = async () => store;
+  AppPreferences.setStoreLoaderForTesting(loader);
+  await AppPreferences.init(ctx);
+  const dispatcher = new SubtitleDispatcher();
+  const setup: DispatcherSetup = { store, dispatcher };
+  return setup;
+}
+
+const VIDEO_PATH = 'http://192.168.1.1/dav/test/movie.mkv';
+const SUBTITLE_URL = 'http://192.168.1.1/dav/test/movie.srt';
 
 export default function subtitleDispatcherTest() {
   describe('SubtitleDispatcher', () => {
-    let store: InMemoryStore;
-    let dispatcher: SubtitleDispatcher;
-    const VIDEO_PATH = 'http://192.168.1.1/dav/test/movie.mkv';
-    const SUBTITLE_URL = 'http://192.168.1.1/dav/test/movie.srt';
 
-    beforeEach(async () => {
-      store = new InMemoryStore();
-      AppPreferences.setStoreLoaderForTesting(makeLoader(store));
-      // 触发初始化（传空 Context，loader 不需要它）
-      await AppPreferences.init({} as Parameters<typeof AppPreferences.init>[0]);
-      dispatcher = new SubtitleDispatcher();
+    it('getUserBinding_keyNotExist_returnsNull', 0, async () => {
+      const setup = await makeSetup();
+      const result: SubtitleBinding | null = await setup.dispatcher.getUserBinding(VIDEO_PATH);
+      expect(result).assertNull();
     });
 
-    // ──────────────────────────────────────────
-    // getUserBinding
-    // ──────────────────────────────────────────
-
-    it('getUserBinding_keyNotExist_returnsNull', async () => {
-      const result = await dispatcher.getUserBinding(VIDEO_PATH);
-      expect(result).toBeNull();
-    });
-
-    it('getUserBinding_validJson_returnsBinding', async () => {
-      const binding: SubtitleBinding = {
-        videoPath: VIDEO_PATH,
-        subtitlePath: SUBTITLE_URL,
-        subtitleType: 'local-file',
-        savedAt: 1000000
-      };
-      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
-      const result = await dispatcher.getUserBinding(VIDEO_PATH);
-      expect(result).not().toBeNull();
+    it('getUserBinding_validJson_returnsBinding', 0, async () => {
+      const setup = await makeSetup();
+      await setup.dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+      const result: SubtitleBinding | null = await setup.dispatcher.getUserBinding(VIDEO_PATH);
+      expect(result).not().assertNull();
       if (result !== null) {
         expect(result.subtitlePath).assertEqual(SUBTITLE_URL);
         expect(result.subtitleType).assertEqual('local-file');
         expect(result.videoPath).assertEqual(VIDEO_PATH);
         expect(result.savedAt).assertLarger(0);
       }
-      void binding;
     });
 
-    it('getUserBinding_corruptedJson_returnsNull', async () => {
-      // 直接在 store 写入损坏 JSON，key 通过已知前缀手动模拟
-      // 由于 key 是 hash 计算的，先 save 一次再手动覆盖
-      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
-      // 找到已写入的 key，覆盖为损坏值
-      const allKeys: string[] = [];
-      store['values'].forEach((_v: string | number, k: string) => {
-        if (k.startsWith('subtitle_binding_')) {
-          allKeys.push(k);
-        }
-      });
-      if (allKeys.length > 0) {
-        store.seed(allKeys[0], 'not-valid-json{{{');
-      }
-      const result = await dispatcher.getUserBinding(VIDEO_PATH);
-      expect(result).toBeNull();
+    it('getUserBinding_corruptedJson_returnsNull', 0, async () => {
+      const setup = await makeSetup();
+      await setup.dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+      setup.store.corruptFirstKey('subtitle_binding_');
+      const result: SubtitleBinding | null = await setup.dispatcher.getUserBinding(VIDEO_PATH);
+      expect(result).assertNull();
     });
 
-    // ──────────────────────────────────────────
-    // resolveSubtitle
-    // ──────────────────────────────────────────
-
-    it('resolveSubtitle_emptyTracks_returnsNone', async () => {
-      const resolution = await dispatcher.resolveSubtitle(VIDEO_PATH, []);
+    it('resolveSubtitle_emptyTracks_returnsNone', 0, async () => {
+      const setup = await makeSetup();
+      const resolution: SubtitleResolution = await setup.dispatcher.resolveSubtitle(VIDEO_PATH, []);
       expect(resolution.type).assertEqual('none');
     });
 
-    it('resolveSubtitle_bindingUrlMatches_returnsUserSpecified', async () => {
-      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+    it('resolveSubtitle_bindingUrlMatches_returnsUserSpecified', 0, async () => {
+      const setup = await makeSetup();
+      await setup.dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
 
       const track: SubtitleTrackItem = {
         kind: 'external',
@@ -117,43 +106,40 @@ export default function subtitleDispatcherTest() {
         url: SUBTITLE_URL
       };
       const tracks: SubtitleTrackItem[] = [track];
-      const resolution = await dispatcher.resolveSubtitle(VIDEO_PATH, tracks);
+      const resolution: SubtitleResolution = await setup.dispatcher.resolveSubtitle(VIDEO_PATH, tracks);
       expect(resolution.type).assertEqual('user-specified');
       expect(resolution.trackIndex).assertEqual(0);
     });
 
-    it('resolveSubtitle_bindingUrlNotInTracks_clearsBindingAndReturnsNone', async () => {
-      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+    it('resolveSubtitle_bindingUrlNotInTracks_clearsBindingAndReturnsNone', 0, async () => {
+      const setup = await makeSetup();
+      await setup.dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
 
-      // 传入轨道列表中不含 SUBTITLE_URL
       const track: SubtitleTrackItem = {
         kind: 'external',
         displayName: 'other.srt',
         url: 'http://192.168.1.1/dav/test/other.srt'
       };
       const tracks: SubtitleTrackItem[] = [track];
-      const resolution = await dispatcher.resolveSubtitle(VIDEO_PATH, tracks);
+      const resolution: SubtitleResolution = await setup.dispatcher.resolveSubtitle(VIDEO_PATH, tracks);
       expect(resolution.type).assertEqual('none');
 
-      // 绑定应已被清除
-      const binding = await dispatcher.getUserBinding(VIDEO_PATH);
-      expect(binding).toBeNull();
+      const binding: SubtitleBinding | null = await setup.dispatcher.getUserBinding(VIDEO_PATH);
+      expect(binding).assertNull();
     });
 
-    it('resolveSubtitle_noBindingNoTracks_returnsNone', async () => {
-      const resolution = await dispatcher.resolveSubtitle(VIDEO_PATH, []);
+    it('resolveSubtitle_noBindingNoTracks_returnsNone', 0, async () => {
+      const setup = await makeSetup();
+      const resolution: SubtitleResolution = await setup.dispatcher.resolveSubtitle(VIDEO_PATH, []);
       expect(resolution.type).assertEqual('none');
     });
 
-    // ──────────────────────────────────────────
-    // clearUserBinding
-    // ──────────────────────────────────────────
-
-    it('clearUserBinding_removesExistingBinding', async () => {
-      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
-      await dispatcher.clearUserBinding(VIDEO_PATH);
-      const result = await dispatcher.getUserBinding(VIDEO_PATH);
-      expect(result).toBeNull();
+    it('clearUserBinding_removesExistingBinding', 0, async () => {
+      const setup = await makeSetup();
+      await setup.dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+      await setup.dispatcher.clearUserBinding(VIDEO_PATH);
+      const result: SubtitleBinding | null = await setup.dispatcher.getUserBinding(VIDEO_PATH);
+      expect(result).assertNull();
     });
   });
 }

--- a/entry/src/test/SubtitleDispatcher.test.ets
+++ b/entry/src/test/SubtitleDispatcher.test.ets
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach } from '@ohos/hypium';
+import {
+  AppPreferences,
+  AppPreferencesLoader,
+  AppPreferencesStore
+} from '../../main/ets/utils/AppPreferences';
+import { SubtitleDispatcher, SubtitleBinding } from '../../main/ets/subtitle/SubtitleDispatcher';
+import { SubtitleTrackItem } from '../../main/ets/components/core/player/SubtitleBridgeAdapter';
+
+// ──────────────────────────────────────────
+// 内存 store mock
+// ──────────────────────────────────────────
+
+class InMemoryStore implements AppPreferencesStore {
+  private readonly values: Map<string, string | number> = new Map<string, string | number>();
+
+  seed(key: string, value: string | number): void {
+    this.values.set(key, value);
+  }
+
+  async get(key: string, defaultValue: string | number): Promise<string | number> {
+    const v = this.values.get(key);
+    return v === undefined ? defaultValue : v;
+  }
+
+  async put(key: string, value: string | number): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async flush(): Promise<void> {}
+}
+
+function makeLoader(store: InMemoryStore): AppPreferencesLoader {
+  return async (): Promise<AppPreferencesStore> => store;
+}
+
+// ──────────────────────────────────────────
+// 测试套件
+// ──────────────────────────────────────────
+
+export default function subtitleDispatcherTest() {
+  describe('SubtitleDispatcher', () => {
+    let store: InMemoryStore;
+    let dispatcher: SubtitleDispatcher;
+    const VIDEO_PATH = 'http://192.168.1.1/dav/test/movie.mkv';
+    const SUBTITLE_URL = 'http://192.168.1.1/dav/test/movie.srt';
+
+    beforeEach(async () => {
+      store = new InMemoryStore();
+      AppPreferences.setStoreLoaderForTesting(makeLoader(store));
+      // 触发初始化（传空 Context，loader 不需要它）
+      await AppPreferences.init({} as Parameters<typeof AppPreferences.init>[0]);
+      dispatcher = new SubtitleDispatcher();
+    });
+
+    // ──────────────────────────────────────────
+    // getUserBinding
+    // ──────────────────────────────────────────
+
+    it('getUserBinding_keyNotExist_returnsNull', async () => {
+      const result = await dispatcher.getUserBinding(VIDEO_PATH);
+      expect(result).toBeNull();
+    });
+
+    it('getUserBinding_validJson_returnsBinding', async () => {
+      const binding: SubtitleBinding = {
+        videoPath: VIDEO_PATH,
+        subtitlePath: SUBTITLE_URL,
+        subtitleType: 'local-file',
+        savedAt: 1000000
+      };
+      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+      const result = await dispatcher.getUserBinding(VIDEO_PATH);
+      expect(result).not().toBeNull();
+      if (result !== null) {
+        expect(result.subtitlePath).assertEqual(SUBTITLE_URL);
+        expect(result.subtitleType).assertEqual('local-file');
+        expect(result.videoPath).assertEqual(VIDEO_PATH);
+        expect(result.savedAt).assertLarger(0);
+      }
+      void binding;
+    });
+
+    it('getUserBinding_corruptedJson_returnsNull', async () => {
+      // 直接在 store 写入损坏 JSON，key 通过已知前缀手动模拟
+      // 由于 key 是 hash 计算的，先 save 一次再手动覆盖
+      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+      // 找到已写入的 key，覆盖为损坏值
+      const allKeys: string[] = [];
+      store['values'].forEach((_v: string | number, k: string) => {
+        if (k.startsWith('subtitle_binding_')) {
+          allKeys.push(k);
+        }
+      });
+      if (allKeys.length > 0) {
+        store.seed(allKeys[0], 'not-valid-json{{{');
+      }
+      const result = await dispatcher.getUserBinding(VIDEO_PATH);
+      expect(result).toBeNull();
+    });
+
+    // ──────────────────────────────────────────
+    // resolveSubtitle
+    // ──────────────────────────────────────────
+
+    it('resolveSubtitle_emptyTracks_returnsNone', async () => {
+      const resolution = await dispatcher.resolveSubtitle(VIDEO_PATH, []);
+      expect(resolution.type).assertEqual('none');
+    });
+
+    it('resolveSubtitle_bindingUrlMatches_returnsUserSpecified', async () => {
+      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+
+      const track: SubtitleTrackItem = {
+        kind: 'external',
+        displayName: 'movie.srt',
+        url: SUBTITLE_URL
+      };
+      const tracks: SubtitleTrackItem[] = [track];
+      const resolution = await dispatcher.resolveSubtitle(VIDEO_PATH, tracks);
+      expect(resolution.type).assertEqual('user-specified');
+      expect(resolution.trackIndex).assertEqual(0);
+    });
+
+    it('resolveSubtitle_bindingUrlNotInTracks_clearsBindingAndReturnsNone', async () => {
+      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+
+      // 传入轨道列表中不含 SUBTITLE_URL
+      const track: SubtitleTrackItem = {
+        kind: 'external',
+        displayName: 'other.srt',
+        url: 'http://192.168.1.1/dav/test/other.srt'
+      };
+      const tracks: SubtitleTrackItem[] = [track];
+      const resolution = await dispatcher.resolveSubtitle(VIDEO_PATH, tracks);
+      expect(resolution.type).assertEqual('none');
+
+      // 绑定应已被清除
+      const binding = await dispatcher.getUserBinding(VIDEO_PATH);
+      expect(binding).toBeNull();
+    });
+
+    it('resolveSubtitle_noBindingNoTracks_returnsNone', async () => {
+      const resolution = await dispatcher.resolveSubtitle(VIDEO_PATH, []);
+      expect(resolution.type).assertEqual('none');
+    });
+
+    // ──────────────────────────────────────────
+    // clearUserBinding
+    // ──────────────────────────────────────────
+
+    it('clearUserBinding_removesExistingBinding', async () => {
+      await dispatcher.saveUserBinding(VIDEO_PATH, SUBTITLE_URL, 'local-file');
+      await dispatcher.clearUserBinding(VIDEO_PATH);
+      const result = await dispatcher.getUserBinding(VIDEO_PATH);
+      expect(result).toBeNull();
+    });
+  });
+}


### PR DESCRIPTION
## 概述

实现 Issue #30 字幕加载优先级调度策略，新增 `SubtitleDispatcher` 类，支持用户字幕选择的持久化绑定（步骤 1），并修复内置字幕轨道切换后重开视频回退默认轨道的 bug。

Closes #30

## 变更内容

### 新增文件
- `entry/src/main/ets/subtitle/SubtitleDispatcher.ets`
  - 5 步优先级链调度器（步骤 1 用户绑定 + 步骤 4 stub）
  - 支持外置字幕（按 URL 匹配）与内置字幕（按 displayName 匹配）的绑定持久化
  - 绑定 key：`subtitle_binding_<sha256(videoPath).slice(0,12)>`
- `entry/src/test/SubtitleDispatcher.test.ets` — 7 条 Hypium 单元测试

### 修改文件
- `entry/src/main/ets/utils/AppPreferences.ets` — 新增 `SUBTITLE_BINDING_PREFIX` PrefKey
- `entry/src/main/ets/components/core/player/VideoPlayerController.ets`
  - `loadSubtitleTracks()`：adapter init 后调用调度器覆盖选轨
  - `switchSubtitleTrack()`：用户切换时保存/清除绑定（支持 internal + external）
- `entry/src/test/List.test.ets` — 注册新测试

## Bug 修复

**问题**：MKV 内置多语言字幕轨（`kind='internal'`）用户手动切换后，重开视频回退到默认轨道。

**原因**：原实现仅对 `kind='external'` 轨道保存绑定，内置轨道被跳过。

**修复**：
- `SubtitleBindingType` 新增 `'internal'` 类型
- `switchSubtitleTrack()` 对内置轨道用 `displayName` 作为绑定 key
- `resolveSubtitle()` 步骤 1 新增按 `displayName` 匹配内置字幕分支

## 测试

- ✅ UnitTestBuild 编译通过
- ✅ 真机验证（TV 192.168.3.85）：切换中文字幕 → 退出 → 重开 → 恢复中文字幕 ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remember and restore subtitle choices per video; preferences persist across sessions.
  * Automatic selection of the best matching subtitle track when a saved preference exists.

* **Bug Fixes**
  * Safely clears invalid or missing subtitle preferences to avoid stale selections.

* **Tests**
  * Added tests covering save, load, clear, and resolution behavior for subtitle preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaoshining/vidall-tv/pull/224)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->