### PR TITLE
新增: 音频轨道选择持久化（Issue #223）

### DIFF
--- a/entry/src/main/ets/audio/AudioDispatcher.ets
+++ b/entry/src/main/ets/audio/AudioDispatcher.ets
@@ -1,0 +1,104 @@
+import { AppPreferences, PrefKey } from '../utils/AppPreferences';
+import { sha256Hex } from '../subtitle/SubtitleDownloader';
+import { AudioTrackItem } from '../components/core/player/VideoPlayerController';
+
+/** 用户音轨绑定记录 */
+export interface AudioBinding {
+  videoPath: string;
+  displayName: string;
+  savedAt: number;
+}
+
+/** 音轨调度结果 */
+export interface AudioResolution {
+  type: 'user-specified' | 'none';
+  trackIndex?: number;
+}
+
+/**
+ * 音频轨道优先级调度器。
+ * 在 VideoPlayerController.loadAudioTracks() 内、轨道列表填充后调用，
+ * 按用户历史绑定恢复上次选择的音轨。
+ */
+export class AudioDispatcher {
+
+  private async buildKey(videoPath: string): Promise<string> {
+    const hash = await sha256Hex(videoPath);
+    return `${PrefKey.AUDIO_BINDING_PREFIX}_${hash.slice(0, 12)}`;
+  }
+
+  async getAudioBinding(videoPath: string): Promise<AudioBinding | null> {
+    try {
+      const key = await this.buildKey(videoPath);
+      const raw = await AppPreferences.get(key, '');
+      if (raw.length === 0) {
+        return null;
+      }
+      const parsed = JSON.parse(raw) as Record<string, string | number>;
+      if (!parsed['videoPath'] || !parsed['displayName'] || !parsed['savedAt']) {
+        return null;
+      }
+      const binding: AudioBinding = {
+        videoPath: parsed['videoPath'] as string,
+        displayName: parsed['displayName'] as string,
+        savedAt: parsed['savedAt'] as number
+      };
+      return binding;
+    } catch {
+      return null;
+    }
+  }
+
+  async saveAudioBinding(videoPath: string, displayName: string): Promise<void> {
+    try {
+      const key = await this.buildKey(videoPath);
+      const binding: AudioBinding = {
+        videoPath,
+        displayName,
+        savedAt: Date.now()
+      };
+      await AppPreferences.set(key, JSON.stringify(binding));
+    } catch (e) {
+      console.error(`[AudioDispatcher] saveAudioBinding 失败: ${String(e)}`);
+    }
+  }
+
+  async clearAudioBinding(videoPath: string): Promise<void> {
+    try {
+      const key = await this.buildKey(videoPath);
+      await AppPreferences.set(key, '');
+    } catch (e) {
+      console.error(`[AudioDispatcher] clearAudioBinding 失败: ${String(e)}`);
+    }
+  }
+
+  async resolveAudioTrack(
+    videoPath: string,
+    audioTracks: AudioTrackItem[]
+  ): Promise<AudioResolution> {
+    try {
+      const binding = await this.getAudioBinding(videoPath);
+      if (binding !== null) {
+        let foundIndex = -1;
+        for (let i = 0; i < audioTracks.length; i++) {
+          if (audioTracks[i].displayName === binding.displayName) {
+            foundIndex = i;
+            break;
+          }
+        }
+        if (foundIndex >= 0) {
+          console.info(`[AudioDispatcher] 命中用户绑定: index=${foundIndex} displayName=${binding.displayName}`);
+          const resolution: AudioResolution = { type: 'user-specified', trackIndex: foundIndex };
+          return resolution;
+        } else {
+          console.warn(`[AudioDispatcher] 绑定 displayName 不在轨道列表中，自动清除: ${binding.displayName}`);
+          await this.clearAudioBinding(videoPath);
+        }
+      }
+    } catch {
+      // 安全降级
+    }
+    const none: AudioResolution = { type: 'none' };
+    return none;
+  }
+}

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -548,7 +548,7 @@ struct VideoControls {
 
   private dispatchAudioTrackSwitch(index: number): void {
     setTimeout(() => {
-      this.videoController.switchAudioTrack(index)
+      this.videoController.switchAudioTrack(index, true)
     }, 0)
   }
 

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -31,6 +31,7 @@ import {
 import { MetricsService } from "../../../services/metrics/MetricsService";
 import { MediaIdentity } from "../../../services/metrics/MetricsReporter";
 import { SubtitleDispatcher } from "../../../subtitle/SubtitleDispatcher";
+import { AudioDispatcher } from "../../../audio/AudioDispatcher";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
 
@@ -3157,6 +3158,16 @@ export class VideoPlayerController {
         if (this.backend === 'ffmpeg') {
           this.activeAudioIndex = 0;
         } else {
+          // 尝试恢复用户上次选择的音轨
+          const videoPath = this.currentVideoData?.videoSrc ?? '';
+          if (videoPath.length > 0) {
+            const audioDispatcher = new AudioDispatcher();
+            const resolution = await audioDispatcher.resolveAudioTrack(videoPath, this.audioTracks);
+            if (resolution.type === 'user-specified' && resolution.trackIndex !== undefined) {
+              await this.switchAudioTrack(resolution.trackIndex);
+              return;
+            }
+          }
           await this.switchAudioTrack(this.findInitialAudioTrackIndex());
         }
         return;
@@ -3189,6 +3200,16 @@ export class VideoPlayerController {
         if (this.backend === 'ffmpeg') {
           this.activeAudioIndex = 0;
         } else {
+          // 尝试恢复用户上次选择的音轨
+          const videoPath = this.currentVideoData?.videoSrc ?? '';
+          if (videoPath.length > 0) {
+            const audioDispatcher = new AudioDispatcher();
+            const resolution = await audioDispatcher.resolveAudioTrack(videoPath, this.audioTracks);
+            if (resolution.type === 'user-specified' && resolution.trackIndex !== undefined) {
+              await this.switchAudioTrack(resolution.trackIndex);
+              return;
+            }
+          }
           await this.switchAudioTrack(this.findInitialAudioTrackIndex());
         }
       }
@@ -3345,7 +3366,7 @@ export class VideoPlayerController {
   /**
    * 通过 audioTracks 索引切换音轨
    */
-  async switchAudioTrack(trackIndex: number): Promise<void> {
+  async switchAudioTrack(trackIndex: number, userInitiated: boolean = false): Promise<void> {
     if (trackIndex < 0 || trackIndex >= this.audioTracks.length) {
       hilog.error(CommonConstants.LOG_DOMAIN, TAG,
         `切换音轨失败: 索引越界 ${trackIndex}`);
@@ -3389,6 +3410,15 @@ export class VideoPlayerController {
       this.activeAudioIndex = trackIndex;
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `[switchAudioTrack] 音轨已切换: ${audioTrack.displayName} (trackIndex=${audioTrack.trackIndex})`);
+
+      // 用户主动切换时持久化绑定
+      if (userInitiated) {
+        const videoPath = this.currentVideoData?.videoSrc ?? '';
+        if (videoPath.length > 0) {
+          const dispatcher = new AudioDispatcher();
+          dispatcher.saveAudioBinding(videoPath, audioTrack.displayName).catch(() => {});
+        }
+      }
 
       // 3. seek 到当前位置，强制音频解码器 flush 并从正确位置开始解码
       //    这样恢复播放时新音轨与视频帧完全对齐

--- a/entry/src/main/ets/utils/AppPreferences.ets
+++ b/entry/src/main/ets/utils/AppPreferences.ets
@@ -42,6 +42,8 @@ export class PrefKey {
   static readonly OPENSUBTITLES_DEVICE_ID = 'opensubtitles_device_id';
   /** 用户字幕绑定前缀，完整 key = subtitle_binding_<sha256前12位> */
   static readonly SUBTITLE_BINDING_PREFIX = 'subtitle_binding';
+  /** 用户音轨绑定前缀，完整 key = audio_binding_<sha256前12位> */
+  static readonly AUDIO_BINDING_PREFIX = 'audio_binding';
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
实现 Issue #223：用户手动切换音轨后，重新打开视频自动恢复上次选择的音轨。新增 AudioDispatcher 模块，集成到 switchAudioTrack 和 loadAudioTracks。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- The video player now remembers your preferred audio track selection for each video and automatically restores it when you watch that video again.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaoshining/vidall-tv/pull/225)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->