### PR TITLE
修复: 补齐历史播放与首页续播预设轨道链路

### DIFF
--- a/entry/src/main/ets/components/media/ContinueWatchCard.ets
+++ b/entry/src/main/ets/components/media/ContinueWatchCard.ets
@@ -17,9 +17,39 @@ import { ContinueWatchingItem } from '../../db/models/MediaEntity';
 import { PlayerPageParam, PlayerPage } from '../../pages/player/index';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { MediaLibraryContext } from '../core/player/PlaybackContext';
+import { PresetAudioTrack, PresetSubtitleTrack } from '../core/player/VideoData';
 import { FileSourceType, FileSourceTypeLabels, SMBSourceConfig } from '../../db/models/FileSourceEntity';
 import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient';
 import promptAction from '@ohos.promptAction';
+import { resolvePlaybackTrackPresetFromDb } from '../../utils/PlaybackTrackPresetHelper';
+
+export interface ContinueWatchPlayerParamInput {
+  item: ContinueWatchingItem
+  fullUrl: string
+  httpHeader: Record<string, string>
+  title: string
+  durationHintMs?: number
+  presetAudioTracks?: PresetAudioTrack[]
+  presetSubtitleTracks?: PresetSubtitleTrack[]
+}
+
+export function buildContinueWatchPlayerParam(input: ContinueWatchPlayerParamInput): PlayerPageParam {
+  const param: PlayerPageParam = {
+    videoId: input.item.videoId,
+    url: input.fullUrl,
+    httpHeader: input.httpHeader,
+    title: input.title,
+    durationHintMs: input.durationHintMs,
+    mediaKey: input.item.mediaKey,
+    startPositionMs: input.item.startPositionMs,
+    seriesProviderId: input.item.seriesProviderId,
+    seasonNumber: input.item.seasonNumber,
+    episodeNumber: input.item.episodeNumber,
+    presetAudioTracks: input.presetAudioTracks,
+    presetSubtitleTracks: input.presetSubtitleTracks
+  };
+  return param;
+}
 
 // ─── 卡片尺寸常量 ────────────────────────────────
 const CARD_W = 320;
@@ -176,18 +206,20 @@ export struct ContinueWatchCard {
         return;
       }
 
-      const param: PlayerPageParam = {
-        videoId: this.item.videoId,
-        url: fullUrl,
+      const presetResult = await resolvePlaybackTrackPresetFromDb(
+        this.item.filePath,
+        this.item.durationMs,
+        async (filePath: string) => db.getVideoByPath(filePath)
+      );
+      const param = buildContinueWatchPlayerParam({
+        item: this.item,
+        fullUrl,
         httpHeader,
         title: this.buildPlayerTitle(),
-        durationHintMs: this.item.durationMs > 0 ? this.item.durationMs : undefined,
-        mediaKey: this.item.mediaKey,
-        startPositionMs: this.item.startPositionMs,
-        seriesProviderId: this.item.seriesProviderId,
-        seasonNumber: this.item.seasonNumber,
-        episodeNumber: this.item.episodeNumber
-      };
+        durationHintMs: presetResult.durationHintMs,
+        presetAudioTracks: presetResult.presetAudioTracks,
+        presetSubtitleTracks: presetResult.presetSubtitleTracks
+      });
       if (this.item.kind === 'series' && this.item.tvSeriesId > 0 && this.item.seasonNumber > 0) {
         try {
           const playbackCtx = await MediaLibraryContext.build(

--- a/entry/src/main/ets/pages/history/PlayHistoryPage.ets
+++ b/entry/src/main/ets/pages/history/PlayHistoryPage.ets
@@ -1,15 +1,13 @@
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { MediaProgressEntry, MediaItem, MovieEntity, TvSeriesEntity } from '../../db/models/MediaEntity';
-import { VideoEntity } from '../../db/models/MediaEntity';
 import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntity';
 import { MediaProgressStore } from '../../db/MediaProgressStore';
 import { PlayerPage, PlayerPageParam } from '../player/index';
-import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData';
 import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient';
 import promptAction from '@ohos.promptAction';
 import { BusinessError, emitter } from '@kit.BasicServicesKit';
 import { PlayerEvents } from '../../components/core/player/Constants';
-import { FfprobeUtil, FfprobeTrack } from '../../utils/FfprobeUtil';
+import { resolvePlaybackTrackPresetFromDb } from '../../utils/PlaybackTrackPresetHelper';
 
 
 // ─────────────────────────────────────────────
@@ -47,14 +45,6 @@ interface PlayUrlResult {
   url: string;
   httpHeader: Record<string, string>;
 }
-
-export interface PlayHistoryTrackPresetResult {
-  durationHintMs?: number;
-  presetAudioTracks?: PresetAudioTrack[];
-  presetSubtitleTracks?: PresetSubtitleTrack[];
-}
-
-type PlayHistoryVideoLoader = (filePath: string) => Promise<VideoEntity | null>;
 
 /** showActionMenu 回调数据结构（仅需 index 字段） */
 interface ActionMenuSuccessResult {
@@ -106,54 +96,6 @@ function parseMediaKey(mediaKey: string): ParsedMediaKey {
     }
   }
   return { kind: 'unknown', providerId: '' };
-}
-
-export async function resolvePlayHistoryTrackPreset(
-  filePath: string,
-  fallbackDurationMs: number,
-  loadVideoByPath: PlayHistoryVideoLoader
-): Promise<PlayHistoryTrackPresetResult> {
-  let durationHintMs: number | undefined = fallbackDurationMs > 0 ? fallbackDurationMs : undefined;
-  let presetAudioTracks: PresetAudioTrack[] | undefined = undefined;
-  let presetSubtitleTracks: PresetSubtitleTrack[] | undefined = undefined;
-
-  try {
-    const videoEntity = await loadVideoByPath(filePath);
-    if (videoEntity !== null) {
-      if (videoEntity.durationMs !== undefined && videoEntity.durationMs !== null && videoEntity.durationMs > 0) {
-        durationHintMs = videoEntity.durationMs;
-      }
-      if (videoEntity.audioTracksJson !== undefined && videoEntity.audioTracksJson !== null && videoEntity.audioTracksJson.length > 0) {
-        const tracks = JSON.parse(videoEntity.audioTracksJson) as FfprobeTrack[];
-        const resolvedTracks = FfprobeUtil.toPresetAudioTracks(tracks);
-        if (resolvedTracks.length > 0) {
-          presetAudioTracks = resolvedTracks;
-        }
-      }
-      if (videoEntity.subtitleTracksJson !== undefined &&
-        videoEntity.subtitleTracksJson !== null &&
-        videoEntity.subtitleTracksJson.length > 0) {
-        const tracks = JSON.parse(videoEntity.subtitleTracksJson) as FfprobeTrack[];
-        const resolvedTracks = FfprobeUtil.toPresetSubtitleTracks(tracks);
-        if (resolvedTracks.length > 0) {
-          presetSubtitleTracks = resolvedTracks;
-        }
-      }
-    }
-  } catch (_e) {
-  }
-
-  const result: PlayHistoryTrackPresetResult = {};
-  if (durationHintMs !== undefined && durationHintMs > 0) {
-    result.durationHintMs = durationHintMs;
-  }
-  if (presetAudioTracks !== undefined && presetAudioTracks.length > 0) {
-    result.presetAudioTracks = presetAudioTracks;
-  }
-  if (presetSubtitleTracks !== undefined && presetSubtitleTracks.length > 0) {
-    result.presetSubtitleTracks = presetSubtitleTracks;
-  }
-  return result;
 }
 
 // ─────────────────────────────────────────────
@@ -421,10 +363,10 @@ export struct PlayHistoryPage {
       try { this.getUIContext().getPromptAction().showToast({ message: '无法构建播放地址' }); } catch (_e) {}
       return;
     }
-    const presetResult = await resolvePlayHistoryTrackPreset(
+    const presetResult = await resolvePlaybackTrackPresetFromDb(
       item.filePath,
       item.durationMs,
-      async (filePath: string): Promise<VideoEntity | null> => db.getVideoByPath(filePath)
+      async (filePath: string) => db.getVideoByPath(filePath)
     );
     const param: PlayerPageParam = {
       url: urlResult.url.length > 0 ? urlResult.url : undefined,

--- a/entry/src/main/ets/pages/history/PlayHistoryPage.ets
+++ b/entry/src/main/ets/pages/history/PlayHistoryPage.ets
@@ -1,12 +1,15 @@
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { MediaProgressEntry, MediaItem, MovieEntity, TvSeriesEntity } from '../../db/models/MediaEntity';
+import { VideoEntity } from '../../db/models/MediaEntity';
 import { FileSourceType, SMBSourceConfig } from '../../db/models/FileSourceEntity';
 import { MediaProgressStore } from '../../db/MediaProgressStore';
 import { PlayerPage, PlayerPageParam } from '../player/index';
+import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/player/VideoData';
 import { WebDAVClient, WebDAVConfig } from '../../lib/WebDAVClient';
 import promptAction from '@ohos.promptAction';
 import { BusinessError, emitter } from '@kit.BasicServicesKit';
 import { PlayerEvents } from '../../components/core/player/Constants';
+import { FfprobeUtil, FfprobeTrack } from '../../utils/FfprobeUtil';
 
 
 // ─────────────────────────────────────────────
@@ -44,6 +47,14 @@ interface PlayUrlResult {
   url: string;
   httpHeader: Record<string, string>;
 }
+
+export interface PlayHistoryTrackPresetResult {
+  durationHintMs?: number;
+  presetAudioTracks?: PresetAudioTrack[];
+  presetSubtitleTracks?: PresetSubtitleTrack[];
+}
+
+type PlayHistoryVideoLoader = (filePath: string) => Promise<VideoEntity | null>;
 
 /** showActionMenu 回调数据结构（仅需 index 字段） */
 interface ActionMenuSuccessResult {
@@ -95,6 +106,54 @@ function parseMediaKey(mediaKey: string): ParsedMediaKey {
     }
   }
   return { kind: 'unknown', providerId: '' };
+}
+
+export async function resolvePlayHistoryTrackPreset(
+  filePath: string,
+  fallbackDurationMs: number,
+  loadVideoByPath: PlayHistoryVideoLoader
+): Promise<PlayHistoryTrackPresetResult> {
+  let durationHintMs: number | undefined = fallbackDurationMs > 0 ? fallbackDurationMs : undefined;
+  let presetAudioTracks: PresetAudioTrack[] | undefined = undefined;
+  let presetSubtitleTracks: PresetSubtitleTrack[] | undefined = undefined;
+
+  try {
+    const videoEntity = await loadVideoByPath(filePath);
+    if (videoEntity !== null) {
+      if (videoEntity.durationMs !== undefined && videoEntity.durationMs !== null && videoEntity.durationMs > 0) {
+        durationHintMs = videoEntity.durationMs;
+      }
+      if (videoEntity.audioTracksJson !== undefined && videoEntity.audioTracksJson !== null && videoEntity.audioTracksJson.length > 0) {
+        const tracks = JSON.parse(videoEntity.audioTracksJson) as FfprobeTrack[];
+        const resolvedTracks = FfprobeUtil.toPresetAudioTracks(tracks);
+        if (resolvedTracks.length > 0) {
+          presetAudioTracks = resolvedTracks;
+        }
+      }
+      if (videoEntity.subtitleTracksJson !== undefined &&
+        videoEntity.subtitleTracksJson !== null &&
+        videoEntity.subtitleTracksJson.length > 0) {
+        const tracks = JSON.parse(videoEntity.subtitleTracksJson) as FfprobeTrack[];
+        const resolvedTracks = FfprobeUtil.toPresetSubtitleTracks(tracks);
+        if (resolvedTracks.length > 0) {
+          presetSubtitleTracks = resolvedTracks;
+        }
+      }
+    }
+  } catch (_e) {
+  }
+
+  const result: PlayHistoryTrackPresetResult = {};
+  if (durationHintMs !== undefined && durationHintMs > 0) {
+    result.durationHintMs = durationHintMs;
+  }
+  if (presetAudioTracks !== undefined && presetAudioTracks.length > 0) {
+    result.presetAudioTracks = presetAudioTracks;
+  }
+  if (presetSubtitleTracks !== undefined && presetSubtitleTracks.length > 0) {
+    result.presetSubtitleTracks = presetSubtitleTracks;
+  }
+  return result;
 }
 
 // ─────────────────────────────────────────────
@@ -356,20 +415,29 @@ export struct PlayHistoryPage {
       try { this.getUIContext().getPromptAction().showToast({ message: '无法找到对应视频文件' }); } catch (_e) {}
       return;
     }
+    const db = FileSourceDatabase.getInstance();
     const urlResult = await this.buildPlayUrl(item.sourceId, item.filePath);
     if (urlResult === null) {
       try { this.getUIContext().getPromptAction().showToast({ message: '无法构建播放地址' }); } catch (_e) {}
       return;
     }
+    const presetResult = await resolvePlayHistoryTrackPreset(
+      item.filePath,
+      item.durationMs,
+      async (filePath: string): Promise<VideoEntity | null> => db.getVideoByPath(filePath)
+    );
     const param: PlayerPageParam = {
       url: urlResult.url.length > 0 ? urlResult.url : undefined,
       fileUrl: urlResult.fileUrl.length > 0 ? urlResult.fileUrl : undefined,
       httpHeader: urlResult.httpHeader,
       title: item.title,
+      durationHintMs: presetResult.durationHintMs,
       videoId: item.videoId,
       seriesProviderId: item.seriesProviderId,
       seasonNumber: item.episodeNumber > 0 ? item.seasonNumber : 0,
       episodeNumber: item.episodeNumber > 0 ? item.episodeNumber : 0,
+      presetAudioTracks: presetResult.presetAudioTracks,
+      presetSubtitleTracks: presetResult.presetSubtitleTracks,
       mediaKey: fromStart ? undefined : item.mediaKey,
       startPositionMs: fromStart ? 0 : (item.positionMs > 0 ? item.positionMs : undefined),
     };

--- a/entry/src/main/ets/utils/PlaybackTrackPresetHelper.ets
+++ b/entry/src/main/ets/utils/PlaybackTrackPresetHelper.ets
@@ -1,0 +1,59 @@
+import { VideoEntity } from '../db/models/MediaEntity'
+import { PresetAudioTrack, PresetSubtitleTrack } from '../components/core/player/VideoData'
+import { FfprobeUtil, FfprobeTrack } from './FfprobeUtil'
+
+export interface PlaybackTrackPresetResult {
+  durationHintMs?: number
+  presetAudioTracks?: PresetAudioTrack[]
+  presetSubtitleTracks?: PresetSubtitleTrack[]
+}
+
+export type PlaybackTrackVideoLoader = (filePath: string) => Promise<VideoEntity | null>
+
+export async function resolvePlaybackTrackPresetFromDb(
+  filePath: string,
+  fallbackDurationMs: number,
+  loadVideoByPath: PlaybackTrackVideoLoader
+): Promise<PlaybackTrackPresetResult> {
+  let durationHintMs: number | undefined = fallbackDurationMs > 0 ? fallbackDurationMs : undefined
+  let presetAudioTracks: PresetAudioTrack[] | undefined = undefined
+  let presetSubtitleTracks: PresetSubtitleTrack[] | undefined = undefined
+
+  try {
+    const videoEntity = await loadVideoByPath(filePath)
+    if (videoEntity !== null) {
+      if (videoEntity.durationMs !== undefined && videoEntity.durationMs !== null && videoEntity.durationMs > 0) {
+        durationHintMs = videoEntity.durationMs
+      }
+      if (videoEntity.audioTracksJson !== undefined && videoEntity.audioTracksJson !== null &&
+        videoEntity.audioTracksJson.length > 0) {
+        const tracks = JSON.parse(videoEntity.audioTracksJson) as FfprobeTrack[]
+        const resolvedTracks = FfprobeUtil.toPresetAudioTracks(tracks)
+        if (resolvedTracks.length > 0) {
+          presetAudioTracks = resolvedTracks
+        }
+      }
+      if (videoEntity.subtitleTracksJson !== undefined && videoEntity.subtitleTracksJson !== null &&
+        videoEntity.subtitleTracksJson.length > 0) {
+        const tracks = JSON.parse(videoEntity.subtitleTracksJson) as FfprobeTrack[]
+        const resolvedTracks = FfprobeUtil.toPresetSubtitleTracks(tracks)
+        if (resolvedTracks.length > 0) {
+          presetSubtitleTracks = resolvedTracks
+        }
+      }
+    }
+  } catch (_e) {
+  }
+
+  const result: PlaybackTrackPresetResult = {}
+  if (durationHintMs !== undefined && durationHintMs > 0) {
+    result.durationHintMs = durationHintMs
+  }
+  if (presetAudioTracks !== undefined && presetAudioTracks.length > 0) {
+    result.presetAudioTracks = presetAudioTracks
+  }
+  if (presetSubtitleTracks !== undefined && presetSubtitleTracks.length > 0) {
+    result.presetSubtitleTracks = presetSubtitleTracks
+  }
+  return result
+}

--- a/entry/src/main/ets/utils/PlaybackTrackPresetHelper.ets
+++ b/entry/src/main/ets/utils/PlaybackTrackPresetHelper.ets
@@ -18,31 +18,39 @@ export async function resolvePlaybackTrackPresetFromDb(
   let durationHintMs: number | undefined = fallbackDurationMs > 0 ? fallbackDurationMs : undefined
   let presetAudioTracks: PresetAudioTrack[] | undefined = undefined
   let presetSubtitleTracks: PresetSubtitleTrack[] | undefined = undefined
+  let videoEntity: VideoEntity | null = null
 
   try {
-    const videoEntity = await loadVideoByPath(filePath)
-    if (videoEntity !== null) {
-      if (videoEntity.durationMs !== undefined && videoEntity.durationMs !== null && videoEntity.durationMs > 0) {
-        durationHintMs = videoEntity.durationMs
-      }
-      if (videoEntity.audioTracksJson !== undefined && videoEntity.audioTracksJson !== null &&
-        videoEntity.audioTracksJson.length > 0) {
+    videoEntity = await loadVideoByPath(filePath)
+  } catch (_e) {
+  }
+
+  if (videoEntity !== null) {
+    if (videoEntity.durationMs !== undefined && videoEntity.durationMs !== null && videoEntity.durationMs > 0) {
+      durationHintMs = videoEntity.durationMs
+    }
+    if (videoEntity.audioTracksJson !== undefined && videoEntity.audioTracksJson !== null &&
+      videoEntity.audioTracksJson.length > 0) {
+      try {
         const tracks = JSON.parse(videoEntity.audioTracksJson) as FfprobeTrack[]
         const resolvedTracks = FfprobeUtil.toPresetAudioTracks(tracks)
         if (resolvedTracks.length > 0) {
           presetAudioTracks = resolvedTracks
         }
+      } catch (_e) {
       }
-      if (videoEntity.subtitleTracksJson !== undefined && videoEntity.subtitleTracksJson !== null &&
-        videoEntity.subtitleTracksJson.length > 0) {
+    }
+    if (videoEntity.subtitleTracksJson !== undefined && videoEntity.subtitleTracksJson !== null &&
+      videoEntity.subtitleTracksJson.length > 0) {
+      try {
         const tracks = JSON.parse(videoEntity.subtitleTracksJson) as FfprobeTrack[]
         const resolvedTracks = FfprobeUtil.toPresetSubtitleTracks(tracks)
         if (resolvedTracks.length > 0) {
           presetSubtitleTracks = resolvedTracks
         }
+      } catch (_e) {
       }
     }
-  } catch (_e) {
   }
 
   const result: PlaybackTrackPresetResult = {}

--- a/entry/src/test/ContinueWatchCard.test.ets
+++ b/entry/src/test/ContinueWatchCard.test.ets
@@ -1,0 +1,80 @@
+import { describe, it, expect } from '@ohos/hypium'
+import {
+  buildContinueWatchPlayerParam,
+  ContinueWatchPlayerParamInput
+} from '../main/ets/components/media/ContinueWatchCard'
+import { ContinueWatchingItem } from '../main/ets/db/models/MediaEntity'
+import { PresetAudioTrack, PresetSubtitleTrack } from '../main/ets/components/core/player/VideoData'
+import { PlayerPageParam } from '../main/ets/pages/player/index'
+
+function buildContinueWatchingItem(): ContinueWatchingItem {
+  return {
+    mediaKey: 'media_progress_movie_tmdb_1',
+    title: 'Demo Movie',
+    posterLocalPath: '',
+    posterUrl: '',
+    backdropLocalPath: '',
+    backdropUrl: '',
+    kind: 'movie',
+    progressRatio: 0.5,
+    positionFormatted: '00:10:00',
+    durationFormatted: '00:20:00',
+    lastPlayedAt: 123456789,
+    seasonNumber: 0,
+    episodeNumber: 0,
+    episodeTitle: '',
+    videoId: 99,
+    tvSeriesId: 0,
+    startPositionMs: 600000,
+    sourceId: 7,
+    filePath: '/library/demo.mkv',
+    durationMs: 1000,
+    seriesProviderId: ''
+  }
+}
+
+function buildAudioTracks(): PresetAudioTrack[] {
+  return [{
+    trackIndex: 2,
+    displayName: '国语 (E-AC-3)',
+    language: 'chi',
+    channels: 6
+  }]
+}
+
+function buildSubtitleTracks(): PresetSubtitleTrack[] {
+  return [{
+    trackIndex: 5,
+    displayName: 'English (SRT)',
+    codecName: 'subrip'
+  }]
+}
+
+export default function continueWatchCardTest(): void {
+  describe('ContinueWatchCard_player_param', () => {
+    it('首页继续播放会把数据库缓存的轨道与时长写入播放器参数', 0, () => {
+      const httpHeader: Record<string, string> = {
+        'Authorization': 'Basic xxx'
+      }
+      const input: ContinueWatchPlayerParamInput = {
+        item: buildContinueWatchingItem(),
+        fullUrl: 'https://dav.example.com/media/library/demo.mkv',
+        httpHeader,
+        title: 'Demo Movie',
+        durationHintMs: 543210,
+        presetAudioTracks: buildAudioTracks(),
+        presetSubtitleTracks: buildSubtitleTracks()
+      }
+
+      const param: PlayerPageParam = buildContinueWatchPlayerParam(input)
+
+      expect(param.durationHintMs ?? 0).assertEqual(543210)
+      expect(param.presetAudioTracks?.length ?? 0).assertEqual(1)
+      expect(param.presetSubtitleTracks?.length ?? 0).assertEqual(1)
+      expect(param.presetAudioTracks?.[0].trackIndex ?? -1).assertEqual(2)
+      expect(param.presetSubtitleTracks?.[0].trackIndex ?? -1).assertEqual(5)
+      expect(param.startPositionMs ?? 0).assertEqual(600000)
+      expect(param.mediaKey ?? '').assertEqual('media_progress_movie_tmdb_1')
+    })
+  })
+}

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -47,6 +47,7 @@ import openSubtitlesClientTest from './OpenSubtitlesClient.test';
 import subtitleDownloaderTest from './SubtitleDownloader.test';
 import subtitleDispatcherTest from './SubtitleDispatcher.test';
 import playHistoryPageTest from './PlayHistoryPage.test';
+import continueWatchCardTest from './ContinueWatchCard.test';
 
 export default function testsuite() {
   timeUtilTest();
@@ -96,4 +97,5 @@ export default function testsuite() {
   subtitleDownloaderTest();
   subtitleDispatcherTest();
   playHistoryPageTest();
+  continueWatchCardTest();
 }

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -46,6 +46,7 @@ import openSubtitlesPrefsTest from './OpenSubtitlesPrefs.test';
 import openSubtitlesClientTest from './OpenSubtitlesClient.test';
 import subtitleDownloaderTest from './SubtitleDownloader.test';
 import subtitleDispatcherTest from './SubtitleDispatcher.test';
+import playHistoryPageTest from './PlayHistoryPage.test';
 
 export default function testsuite() {
   timeUtilTest();
@@ -94,4 +95,5 @@ export default function testsuite() {
   openSubtitlesClientTest();
   subtitleDownloaderTest();
   subtitleDispatcherTest();
+  playHistoryPageTest();
 }

--- a/entry/src/test/PlayHistoryPage.test.ets
+++ b/entry/src/test/PlayHistoryPage.test.ets
@@ -1,0 +1,75 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { resolvePlayHistoryTrackPreset } from '../main/ets/pages/history/PlayHistoryPage'
+import { FfprobeTrack } from '../main/ets/utils/FfprobeUtil'
+import { VideoEntity } from '../main/ets/db/models/MediaEntity'
+
+function buildAudioTrackFixture(): FfprobeTrack[] {
+  const track: FfprobeTrack = {
+    index: 2,
+    type: 'audio',
+    codecName: 'eac3',
+    codecLongName: 'E-AC-3',
+    language: 'chi',
+    title: '国语',
+    channels: 6,
+    channelLayout: '5.1'
+  }
+  return [track]
+}
+
+function buildSubtitleTrackFixture(): FfprobeTrack[] {
+  const track: FfprobeTrack = {
+    index: 5,
+    type: 'subtitle',
+    codecName: 'subrip',
+    codecLongName: 'SubRip subtitle',
+    language: 'eng',
+    title: 'English'
+  }
+  return [track]
+}
+
+function buildVideoEntity(): VideoEntity {
+  return {
+    sourceId: 7,
+    directoryPath: '/video',
+    filePath: '/video/demo.mkv',
+    fileName: 'demo.mkv',
+    durationMs: 543210,
+    audioTracksJson: JSON.stringify(buildAudioTrackFixture()),
+    subtitleTracksJson: JSON.stringify(buildSubtitleTrackFixture()),
+    scannedAt: 123456789
+  }
+}
+
+export default function playHistoryPageTest(): void {
+  describe('PlayHistoryPage_track_preset_resolution', () => {
+    it('fills player presets from database cached tracks', 0, async () => {
+      const result = await resolvePlayHistoryTrackPreset(
+        '/video/demo.mkv',
+        120000,
+        async (_filePath: string): Promise<VideoEntity | null> => buildVideoEntity()
+      )
+
+      expect(result.durationHintMs ?? 0).assertEqual(543210)
+      expect(result.presetAudioTracks?.length ?? 0).assertEqual(1)
+      expect(result.presetSubtitleTracks?.length ?? 0).assertEqual(1)
+      expect(result.presetAudioTracks?.[0].trackIndex ?? -1).assertEqual(2)
+      expect(result.presetSubtitleTracks?.[0].trackIndex ?? -1).assertEqual(5)
+    })
+
+    it('keeps playback fallback when database lookup fails', 0, async () => {
+      const result = await resolvePlayHistoryTrackPreset(
+        '/video/demo.mkv',
+        246800,
+        async (_filePath: string): Promise<VideoEntity | null> => {
+          throw new Error('db failed')
+        }
+      )
+
+      expect(result.durationHintMs ?? 0).assertEqual(246800)
+      expect(result.presetAudioTracks === undefined).assertTrue()
+      expect(result.presetSubtitleTracks === undefined).assertTrue()
+    })
+  })
+}

--- a/entry/src/test/PlayHistoryPage.test.ets
+++ b/entry/src/test/PlayHistoryPage.test.ets
@@ -42,6 +42,16 @@ function buildVideoEntity(): VideoEntity {
   }
 }
 
+function buildVideoEntityWithTrackJson(
+  audioTracksJson: string | undefined,
+  subtitleTracksJson: string | undefined
+): VideoEntity {
+  const videoEntity: VideoEntity = buildVideoEntity()
+  videoEntity.audioTracksJson = audioTracksJson
+  videoEntity.subtitleTracksJson = subtitleTracksJson
+  return videoEntity
+}
+
 export default function playHistoryPageTest(): void {
   describe('PlayHistoryPage_track_preset_resolution', () => {
     it('fills player presets from database cached tracks', 0, async () => {
@@ -70,6 +80,38 @@ export default function playHistoryPageTest(): void {
       expect(result.durationHintMs ?? 0).assertEqual(246800)
       expect(result.presetAudioTracks === undefined).assertTrue()
       expect(result.presetSubtitleTracks === undefined).assertTrue()
+    })
+
+    it('keeps duration and subtitle presets when audio track json is malformed', 0, async () => {
+      const result = await resolvePlaybackTrackPresetFromDb(
+        '/video/demo.mkv',
+        120000,
+        async (_filePath: string): Promise<VideoEntity | null> => buildVideoEntityWithTrackJson(
+          '{broken-audio-json',
+          JSON.stringify(buildSubtitleTrackFixture())
+        )
+      )
+
+      expect(result.durationHintMs ?? 0).assertEqual(543210)
+      expect(result.presetAudioTracks === undefined).assertTrue()
+      expect(result.presetSubtitleTracks?.length ?? 0).assertEqual(1)
+      expect(result.presetSubtitleTracks?.[0].trackIndex ?? -1).assertEqual(5)
+    })
+
+    it('keeps duration and audio presets when subtitle track json is malformed', 0, async () => {
+      const result = await resolvePlaybackTrackPresetFromDb(
+        '/video/demo.mkv',
+        120000,
+        async (_filePath: string): Promise<VideoEntity | null> => buildVideoEntityWithTrackJson(
+          JSON.stringify(buildAudioTrackFixture()),
+          '{broken-subtitle-json'
+        )
+      )
+
+      expect(result.durationHintMs ?? 0).assertEqual(543210)
+      expect(result.presetSubtitleTracks === undefined).assertTrue()
+      expect(result.presetAudioTracks?.length ?? 0).assertEqual(1)
+      expect(result.presetAudioTracks?.[0].trackIndex ?? -1).assertEqual(2)
     })
   })
 }

--- a/entry/src/test/PlayHistoryPage.test.ets
+++ b/entry/src/test/PlayHistoryPage.test.ets
@@ -1,7 +1,7 @@
 import { describe, it, expect } from '@ohos/hypium'
-import { resolvePlayHistoryTrackPreset } from '../main/ets/pages/history/PlayHistoryPage'
 import { FfprobeTrack } from '../main/ets/utils/FfprobeUtil'
 import { VideoEntity } from '../main/ets/db/models/MediaEntity'
+import { resolvePlaybackTrackPresetFromDb } from '../main/ets/utils/PlaybackTrackPresetHelper'
 
 function buildAudioTrackFixture(): FfprobeTrack[] {
   const track: FfprobeTrack = {
@@ -45,7 +45,7 @@ function buildVideoEntity(): VideoEntity {
 export default function playHistoryPageTest(): void {
   describe('PlayHistoryPage_track_preset_resolution', () => {
     it('fills player presets from database cached tracks', 0, async () => {
-      const result = await resolvePlayHistoryTrackPreset(
+      const result = await resolvePlaybackTrackPresetFromDb(
         '/video/demo.mkv',
         120000,
         async (_filePath: string): Promise<VideoEntity | null> => buildVideoEntity()
@@ -59,7 +59,7 @@ export default function playHistoryPageTest(): void {
     })
 
     it('keeps playback fallback when database lookup fails', 0, async () => {
-      const result = await resolvePlayHistoryTrackPreset(
+      const result = await resolvePlaybackTrackPresetFromDb(
         '/video/demo.mkv',
         246800,
         async (_filePath: string): Promise<VideoEntity | null> => {


### PR DESCRIPTION
## 关联 Issue
Closes #226

## 变更背景
- Issue #226 暴露的问题是从播放历史/首页继续观看进入播放器时，预设音轨链路不完整。
- 第一轮修复只覆盖 `PlayHistoryPage`，补齐播放历史入口的 `presetAudioTracks`、`presetSubtitleTracks`、`durationHintMs`。
- 第二轮基于复盘抽取共享 `PlaybackTrackPresetHelper`，统一数据库缓存轨道解析逻辑，并补齐 `ContinueWatchCard` 首页续播链路。

## 变更内容
- 在 `PlayHistoryPage` 进入播放器前统一解析数据库缓存的音轨、字幕轨与时长提示。
- 新增 `PlaybackTrackPresetHelper`，封装 DB 轨道/字幕/时长解析与失败降级逻辑。
- `ContinueWatchCard` 接入共享 helper，并通过 `buildContinueWatchPlayerParam` 补齐首页继续观看到播放器的预设参数传递。
- 补充 `PlayHistoryPage.test.ets`、`ContinueWatchCard.test.ets`，并更新测试注册，覆盖轨道恢复与降级场景。

## 验证结果
- 自动化测试：已补充历史播放/首页续播播放器参数构建相关单元测试，覆盖预设音轨、字幕轨、时长提示与 DB 失败降级。
- 编译验证：`./hvigorw assembleHap --no-daemon` 已通过。
- QA / 真机验收：已通过。

## 风险与回滚
- 风险：无接口变更；DB 查询失败时保持静默降级，不阻断播放。
- 回滚：直接回退本 PR 对应提交即可。

## 其他
- OpenSpec：`fix-history-audio-tracks`
- 不适用项：无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Continue/resume playback now restores previously selected audio and subtitle presets and uses stored duration hints when launching the player.
  * Play actions from history and continue-watching now include resolved track presets and duration hints for more accurate resume behavior.

* **Tests**
  * Added tests covering preset resolution from cache and player-parameter generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaoshining/vidall-tv/pull/227)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->