### PR TITLE
新增: 字幕本地缓存管理器 + 修复 SMB 字幕记忆失效（#28）

### DIFF
--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -1852,9 +1852,11 @@ export struct SubtitleSelectorDrawerDialog {
       const downloader = new SubtitleDownloader(storageCtx)
       const downloadResult = await downloader.download(
         result.fileId,
-        this.videoPath,
+        this.videoController.stableVideoSrcForCache,
         this.sourceType,
-        this.sourceId
+        this.sourceId,
+        result.languageCode,
+        result.downloadCount
       )
 
       this.showSearchToast('字幕下载成功', 2000)

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -30,7 +30,7 @@ import {
 } from "./EpisodeAutoplayPreferences";
 import { MetricsService } from "../../../services/metrics/MetricsService";
 import { MediaIdentity } from "../../../services/metrics/MetricsReporter";
-import { SubtitleDispatcher } from "../../../subtitle/SubtitleDispatcher";
+import { SubtitleDispatcher, SubtitleCacheContext } from "../../../subtitle/SubtitleDispatcher";
 import { AudioDispatcher } from "../../../audio/AudioDispatcher";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
@@ -306,6 +306,8 @@ export class VideoPlayerController {
   private pendingReloadReject?: (error: Error) => void;
   private subtitleAdapter: ISubtitleBridgeAdapter = new NoSubtitleBridgeAdapter();
   private readonly subtitleDispatcher: SubtitleDispatcher = new SubtitleDispatcher();
+  /** 字幕缓存上下文，由外部（player page）注入后用于步骤 4 缓存查询 */
+  private subtitleCacheContext?: SubtitleCacheContext;
   private currentVideoData?: VideoData;
   private timeToSeek = -1
   private subtitleClearTimer?: number
@@ -1788,6 +1790,14 @@ export class VideoPlayerController {
    * 供 VideoPlayer UI 层在 ijkplayer XComponent.onLoad 回调中调用。
    * 必须在 initPlayer() 之后调用，绑定 XComponent context 后触发真正的 init。
    *
+   * 注入字幕缓存上下文，用于步骤 4 本地缓存自动加载。
+   * 由 player page 在持有 UIAbilityContext 后调用。
+   */
+  setSubtitleCacheContext(ctx: SubtitleCacheContext): void {
+    this.subtitleCacheContext = ctx;
+  }
+
+  /**
    * 时序说明：
    * 1. UI 层先注册 emitter.once(PREPARED)
    * 2. UI 层调 initPlayer()（创建 IjkPlayerAdapter 但不调 native_setup）
@@ -3123,10 +3133,23 @@ export class VideoPlayerController {
       await this.subtitleAdapter.init(this.player, this.currentVideoData);
       this.applySubtitleBridgeState(this.subtitleAdapter.getState());
 
-      // 字幕优先级调度：步骤 1（用户指定）
+      // 字幕优先级调度：步骤 1（用户指定） + 步骤 4（本地缓存）
       const videoPath = this.currentVideoData?.videoSrc ?? '';
       if (videoPath.length > 0 && this.allSubtitleTracks.length > 0) {
-        const resolution = await this.subtitleDispatcher.resolveSubtitle(videoPath, this.allSubtitleTracks);
+        // 构建缓存上下文：filesDir 由外部注入，sourceType/sourceId 来自 VideoData
+        let cacheCtx: SubtitleCacheContext | undefined = undefined;
+        const cachedFilesDir = this.subtitleCacheContext?.filesDir;
+        const cachedSourceType = this.currentVideoData?.fileSourceType;
+        const cachedSourceId = this.currentVideoData?.fileSourceId;
+        if (cachedFilesDir !== undefined && cachedSourceType !== undefined && cachedSourceId !== undefined) {
+          const ctx: SubtitleCacheContext = {
+            filesDir: cachedFilesDir,
+            sourceType: cachedSourceType,
+            sourceId: cachedSourceId
+          };
+          cacheCtx = ctx;
+        }
+        const resolution = await this.subtitleDispatcher.resolveSubtitle(videoPath, this.allSubtitleTracks, cacheCtx);
         if (resolution.type === 'user-specified' && resolution.trackIndex !== undefined) {
           hilog.info(CommonConstants.LOG_DOMAIN, TAG,
             `[loadSubtitleTracks] 调度器覆盖选轨: trackIndex=${resolution.trackIndex}`);

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -492,6 +492,15 @@ export class VideoPlayerController {
     return videoData.videoSrc;
   }
 
+  /**
+   * 缓存 key 用的稳定视频路径：SMB 源用原始 smb:// URL（端口稳定），其他源用 videoSrc。
+   * 下载字幕写缓存与读缓存必须使用同一路径，否则 SHA-256 hash 不同导致缓存永远无法命中。
+   */
+  get stableVideoSrcForCache(): string {
+    const raw = this.currentVideoData?.videoSrc ?? '';
+    return this.smbOriginalSrc.length > 0 ? this.smbOriginalSrc : raw;
+  }
+
   private shouldPreservePendingResume(videoData: VideoData): boolean {
     if (this.pendingResumeState === null) {
       return false;
@@ -1787,11 +1796,8 @@ export class VideoPlayerController {
   }
 
   /**
-   * 供 VideoPlayer UI 层在 ijkplayer XComponent.onLoad 回调中调用。
-   * 必须在 initPlayer() 之后调用，绑定 XComponent context 后触发真正的 init。
-   *
    * 注入字幕缓存上下文，用于步骤 4 本地缓存自动加载。
-   * 由 player page 在持有 UIAbilityContext 后调用。
+   * 由 player page 在持有 UIAbilityContext 后调用，注入 filesDir 等信息。
    */
   setSubtitleCacheContext(ctx: SubtitleCacheContext): void {
     this.subtitleCacheContext = ctx;
@@ -3137,7 +3143,7 @@ export class VideoPlayerController {
       // SMB 源代理 URL 的端口每次随机，必须用原始 smb:// URL 作为绑定 key 保持稳定
       const rawVideoSrc = this.currentVideoData?.videoSrc ?? '';
       const videoPath = this.smbOriginalSrc.length > 0 ? this.smbOriginalSrc : rawVideoSrc;
-      if (videoPath.length > 0 && this.allSubtitleTracks.length > 0) {
+      if (videoPath.length > 0) {
         // 构建缓存上下文：filesDir 由外部注入，sourceType/sourceId 来自 VideoData
         let cacheCtx: SubtitleCacheContext | undefined = undefined;
         const cachedFilesDir = this.subtitleCacheContext?.filesDir;
@@ -3157,6 +3163,17 @@ export class VideoPlayerController {
             `[loadSubtitleTracks] 调度器覆盖选轨: trackIndex=${resolution.trackIndex}`);
           await this.subtitleAdapter.switchTrack(resolution.trackIndex);
           this.applySubtitleBridgeState(this.subtitleAdapter.getState());
+        } else if (resolution.type === 'local-cache' && resolution.localPath !== undefined) {
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `[loadSubtitleTracks] 步骤4命中缓存字幕，追加到轨道列表并切换: ${resolution.localPath}`);
+          await this.addExternalSubtitle(resolution.localPath);
+          // addExternalSubtitle 内部调用 applySubtitleBridgeState，轨道列表已更新
+          // 切换到刚追加的轨道（最后一个）
+          const newIndex = this.allSubtitleTracks.length - 1;
+          if (newIndex >= 0) {
+            await this.subtitleAdapter.switchTrack(newIndex);
+            this.applySubtitleBridgeState(this.subtitleAdapter.getState());
+          }
         }
       }
     } catch (e) {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -3134,7 +3134,9 @@ export class VideoPlayerController {
       this.applySubtitleBridgeState(this.subtitleAdapter.getState());
 
       // 字幕优先级调度：步骤 1（用户指定） + 步骤 4（本地缓存）
-      const videoPath = this.currentVideoData?.videoSrc ?? '';
+      // SMB 源代理 URL 的端口每次随机，必须用原始 smb:// URL 作为绑定 key 保持稳定
+      const rawVideoSrc = this.currentVideoData?.videoSrc ?? '';
+      const videoPath = this.smbOriginalSrc.length > 0 ? this.smbOriginalSrc : rawVideoSrc;
       if (videoPath.length > 0 && this.allSubtitleTracks.length > 0) {
         // 构建缓存上下文：filesDir 由外部注入，sourceType/sourceId 来自 VideoData
         let cacheCtx: SubtitleCacheContext | undefined = undefined;
@@ -3361,7 +3363,9 @@ export class VideoPlayerController {
     this.applySubtitleBridgeState(this.subtitleAdapter.getState());
 
     // 用户绑定持久化
-    const videoPath = this.currentVideoData?.videoSrc ?? '';
+    // SMB 源代理 URL 的端口每次随机，必须用原始 smb:// URL 作为绑定 key 保持稳定
+    const rawVideoSrc = this.currentVideoData?.videoSrc ?? '';
+    const videoPath = this.smbOriginalSrc.length > 0 ? this.smbOriginalSrc : rawVideoSrc;
     if (videoPath.length > 0) {
       if (allIndex === -1) {
         // 关闭字幕 → 清除绑定

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -6,6 +6,8 @@ import {
   type PlayerBackend,
   type UnsupportedFormatFallback
 } from "../../components/core/player/VideoPlayerController";
+import { SubtitleCacheContext } from "../../subtitle/SubtitleDispatcher";
+import { common } from "@kit.AbilityKit";
 import { PlaybackContext, PlaybackContextItem, MediaLibraryContext, FileExplorerContext } from "../../components/core/player/PlaybackContext";
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { PlayProgressEntity, MediaProgressEntry } from "../../db/models/MediaEntity";
@@ -304,6 +306,18 @@ export struct PlayerPage {
   aboutToAppear(): void {
     if (UmamiAnalyticsService.isInitialized()) {
       UmamiAnalyticsService.getInstance().trackPageView('/player');
+    }
+    // 注入字幕缓存上下文（filesDir 由 UIAbilityContext 获取）
+    try {
+      const abilityCtx = getContext(this) as common.UIAbilityContext;
+      const subtitleCacheCtx: SubtitleCacheContext = {
+        filesDir: abilityCtx.filesDir,
+        sourceType: '',
+        sourceId: ''
+      };
+      this.videoPlayerController.setSubtitleCacheContext(subtitleCacheCtx);
+    } catch {
+      // 获取 context 失败时，步骤 4 缓存查询将跳过
     }
   }
 

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -1,0 +1,321 @@
+import fs from '@ohos.file.fs';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { sha256Hex, buildSubtitleDir, buildSubtitlePath } from './SubtitleDownloader';
+
+// ─────────────────────────────────────────────
+// 公共接口类型
+// ─────────────────────────────────────────────
+
+/** 单条字幕缓存条目（对应 metadata.json 中 subtitles 数组的每个元素） */
+export interface CachedSubtitleEntry {
+  fileName: string;
+  language: string;
+  downloadedAt: string;
+  source: string;
+  subDownloadCount: number;
+}
+
+/** metadata.json 整体结构 */
+export interface SubtitleMetadata {
+  videoPath: string;
+  sourceId: string;
+  /** 上次使用的字幕文件名（非完整路径） */
+  lastUsed: string;
+  subtitles: CachedSubtitleEntry[];
+}
+
+// ─────────────────────────────────────────────
+// 最大缓存数量
+// ─────────────────────────────────────────────
+
+const MAX_CACHED_SUBTITLES = 10;
+const METADATA_FILE_NAME = 'metadata.json';
+
+// ─────────────────────────────────────────────
+// SubtitleCacheManager
+// ─────────────────────────────────────────────
+
+/**
+ * 字幕本地缓存管理器。
+ *
+ * 无状态设计：每次操作均从磁盘读取 metadata.json，不在内存中缓存。
+ * 路径规范复用 SubtitleDownloader 中已导出的工具函数。
+ */
+export class SubtitleCacheManager {
+
+  // ──────────────────────────────────────────
+  // 私有工具方法
+  // ──────────────────────────────────────────
+
+  /**
+   * 读取并解析指定目录下的 metadata.json。
+   * 文件不存在或 JSON 损坏时返回 null。
+   */
+  async readMetadata(dir: string): Promise<SubtitleMetadata | null> {
+    const metaPath = `${dir}/${METADATA_FILE_NAME}`;
+    try {
+      const stat = fs.statSync(metaPath);
+      if (!stat.isFile()) {
+        return null;
+      }
+      const file = fs.openSync(metaPath, fs.OpenMode.READ_ONLY);
+      const buf = new ArrayBuffer(stat.size);
+      fs.readSync(file.fd, buf);
+      fs.closeSync(file);
+      const text = String.fromCharCode(...new Uint8Array(buf));
+      const parsed = JSON.parse(text) as Record<string, string | CachedSubtitleEntry[]>;
+      if (!parsed['videoPath'] || !parsed['subtitles']) {
+        return null;
+      }
+      const metadata: SubtitleMetadata = {
+        videoPath: parsed['videoPath'] as string,
+        sourceId: (parsed['sourceId'] as string) ?? '',
+        lastUsed: (parsed['lastUsed'] as string) ?? '',
+        subtitles: (parsed['subtitles'] as CachedSubtitleEntry[]) ?? []
+      };
+      return metadata;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 序列化并写入 metadata.json（覆盖写）。
+   */
+  async writeMetadata(dir: string, metadata: SubtitleMetadata): Promise<void> {
+    const metaPath = `${dir}/${METADATA_FILE_NAME}`;
+    try {
+      fs.mkdirSync(dir, true);
+    } catch (e) {
+      const be = e as BusinessError;
+      if (be.code !== 13900015) {
+        console.warn(`[SubtitleCacheManager] mkdirSync warning: ${be.message}`);
+      }
+    }
+    const text = JSON.stringify(metadata, null, 2);
+    const buf = new Uint8Array(text.length);
+    for (let i = 0; i < text.length; i++) {
+      buf[i] = text.charCodeAt(i);
+    }
+    const file = fs.openSync(metaPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
+    try {
+      fs.writeSync(file.fd, buf.buffer);
+    } catch (e) {
+      fs.closeSync(file);
+      const be = e as BusinessError;
+      throw new Error(`[SubtitleCacheManager] writeMetadata 失败: ${be.message}`);
+    }
+    fs.closeSync(file);
+  }
+
+  private async buildDir(
+    filesDir: string,
+    sourceType: string,
+    sourceId: string,
+    videoPath: string
+  ): Promise<string> {
+    const hash = await sha256Hex(videoPath);
+    return buildSubtitleDir(filesDir, sourceType, sourceId, hash);
+  }
+
+  // ──────────────────────────────────────────
+  // 公开 API
+  // ──────────────────────────────────────────
+
+  /**
+   * 保存字幕缓存条目并更新 metadata.json。
+   *
+   * - 同名 fileName 时覆盖（更新 downloadedAt）
+   * - 超过 MAX_CACHED_SUBTITLES 时删除 downloadedAt 最早的条目及其文件
+   * - 自动将 lastUsed 设为本次保存的 fileName
+   */
+  async saveSubtitle(
+    filesDir: string,
+    sourceType: string,
+    sourceId: string,
+    videoPath: string,
+    entry: CachedSubtitleEntry
+  ): Promise<void> {
+    try {
+      const dir = await this.buildDir(filesDir, sourceType, sourceId, videoPath);
+      let metadata = await this.readMetadata(dir);
+      if (metadata === null) {
+        const fresh: SubtitleMetadata = {
+          videoPath,
+          sourceId,
+          lastUsed: entry.fileName,
+          subtitles: []
+        };
+        metadata = fresh;
+      }
+
+      // 追加或覆盖（同名文件替换）
+      let replaced = false;
+      const updatedSubtitles: CachedSubtitleEntry[] = [];
+      for (let i = 0; i < metadata.subtitles.length; i++) {
+        if (metadata.subtitles[i].fileName === entry.fileName) {
+          updatedSubtitles.push(entry);
+          replaced = true;
+        } else {
+          updatedSubtitles.push(metadata.subtitles[i]);
+        }
+      }
+      if (!replaced) {
+        updatedSubtitles.push(entry);
+      }
+      metadata.subtitles = updatedSubtitles;
+      metadata.lastUsed = entry.fileName;
+
+      // LRU 清理：超过上限时删除 downloadedAt 最早的条目
+      while (metadata.subtitles.length > MAX_CACHED_SUBTITLES) {
+        let oldestIdx = 0;
+        for (let i = 1; i < metadata.subtitles.length; i++) {
+          if (metadata.subtitles[i].downloadedAt < metadata.subtitles[oldestIdx].downloadedAt) {
+            oldestIdx = i;
+          }
+        }
+        const oldest = metadata.subtitles[oldestIdx];
+        const hash = await sha256Hex(videoPath);
+        const oldPath = buildSubtitlePath(filesDir, sourceType, sourceId, hash, oldest.fileName);
+        try {
+          fs.unlinkSync(oldPath);
+        } catch {
+          // 文件不存在时忽略
+        }
+        // 若 lastUsed 指向被删除的文件，清除
+        if (metadata.lastUsed === oldest.fileName) {
+          metadata.lastUsed = '';
+        }
+        const remaining: CachedSubtitleEntry[] = [];
+        for (let i = 0; i < metadata.subtitles.length; i++) {
+          if (i !== oldestIdx) {
+            remaining.push(metadata.subtitles[i]);
+          }
+        }
+        metadata.subtitles = remaining;
+      }
+
+      await this.writeMetadata(dir, metadata);
+    } catch (e) {
+      console.error(`[SubtitleCacheManager] saveSubtitle 失败: ${String(e)}`);
+    }
+  }
+
+  /**
+   * 查询某视频的所有已缓存字幕。
+   * metadata.json 不存在或损坏时返回空数组。
+   */
+  async listCachedSubtitles(
+    filesDir: string,
+    sourceType: string,
+    sourceId: string,
+    videoPath: string
+  ): Promise<CachedSubtitleEntry[]> {
+    try {
+      const dir = await this.buildDir(filesDir, sourceType, sourceId, videoPath);
+      const metadata = await this.readMetadata(dir);
+      if (metadata === null) {
+        return [];
+      }
+      return metadata.subtitles;
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * 读取上次使用的字幕完整本地路径。
+   *
+   * - lastUsed 为空或文件不存在 → 返回 null（并清除 lastUsed 字段）
+   * - 文件存在 → 返回完整绝对路径
+   */
+  async getLastUsedSubtitle(
+    filesDir: string,
+    sourceType: string,
+    sourceId: string,
+    videoPath: string
+  ): Promise<string | null> {
+    try {
+      const dir = await this.buildDir(filesDir, sourceType, sourceId, videoPath);
+      const metadata = await this.readMetadata(dir);
+      if (metadata === null || metadata.lastUsed.length === 0) {
+        return null;
+      }
+      const hash = await sha256Hex(videoPath);
+      const fullPath = buildSubtitlePath(filesDir, sourceType, sourceId, hash, metadata.lastUsed);
+      // 检查文件是否存在
+      try {
+        fs.statSync(fullPath);
+        return fullPath;
+      } catch {
+        // 文件已被 LRU 清理或手动删除，清除 lastUsed
+        metadata.lastUsed = '';
+        await this.writeMetadata(dir, metadata);
+        return null;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 更新 metadata.json 中的 lastUsed 字段。
+   */
+  async setLastUsedSubtitle(
+    filesDir: string,
+    sourceType: string,
+    sourceId: string,
+    videoPath: string,
+    fileName: string
+  ): Promise<void> {
+    try {
+      const dir = await this.buildDir(filesDir, sourceType, sourceId, videoPath);
+      const metadata = await this.readMetadata(dir);
+      if (metadata === null) {
+        return;
+      }
+      metadata.lastUsed = fileName;
+      await this.writeMetadata(dir, metadata);
+    } catch (e) {
+      console.error(`[SubtitleCacheManager] setLastUsedSubtitle 失败: ${String(e)}`);
+    }
+  }
+
+  /**
+   * 删除某视频目录下的所有字幕文件及 metadata.json。
+   * 目录不存在时静默返回。
+   */
+  async clearSubtitleCache(
+    filesDir: string,
+    sourceType: string,
+    sourceId: string,
+    videoPath: string
+  ): Promise<void> {
+    try {
+      const dir = await this.buildDir(filesDir, sourceType, sourceId, videoPath);
+      try {
+        fs.statSync(dir);
+      } catch {
+        // 目录不存在，静默返回
+        return;
+      }
+      // 删除目录内所有文件
+      const entries = fs.listFileSync(dir);
+      for (let i = 0; i < entries.length; i++) {
+        try {
+          fs.unlinkSync(`${dir}/${entries[i]}`);
+        } catch {
+          // 单个文件删除失败不中断
+        }
+      }
+      // 删除目录本身
+      try {
+        fs.rmdirSync(dir);
+      } catch {
+        // 目录非空时忽略（理论上不会发生）
+      }
+    } catch (e) {
+      console.error(`[SubtitleCacheManager] clearSubtitleCache 失败: ${String(e)}`);
+    }
+  }
+}

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -62,7 +62,11 @@ export class SubtitleCacheManager {
       const buf = new ArrayBuffer(stat.size);
       fs.readSync(file.fd, buf);
       fs.closeSync(file);
-      const text = String.fromCharCode(...new Uint8Array(buf));
+      const bytes = new Uint8Array(buf);
+      let text = '';
+      for (let i = 0; i < bytes.length; i++) {
+        text += String.fromCharCode(bytes[i]);
+      }
       const parsed = JSON.parse(text) as Record<string, string | CachedSubtitleEntry[]>;
       if (!parsed['videoPath'] || !parsed['subtitles']) {
         return null;
@@ -93,13 +97,9 @@ export class SubtitleCacheManager {
       }
     }
     const text = JSON.stringify(metadata, null, 2);
-    const buf = new Uint8Array(text.length);
-    for (let i = 0; i < text.length; i++) {
-      buf[i] = text.charCodeAt(i);
-    }
     const file = fs.openSync(metaPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
     try {
-      fs.writeSync(file.fd, buf.buffer);
+      fs.writeSync(file.fd, text);
     } catch (e) {
       fs.closeSync(file);
       const be = e as BusinessError;

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -13,6 +13,8 @@ export interface CachedSubtitleEntry {
   downloadedAt: string;
   source: string;
   subDownloadCount: number;
+  /** 最后访问时间（用于 LRU 淘汰）；旧版 metadata 无此字段时降级为 downloadedAt */
+  lastAccessedAt?: string;
 }
 
 /** metadata.json 整体结构 */
@@ -183,26 +185,37 @@ export class SubtitleCacheManager {
 
       // 追加或覆盖（同名文件替换）
       let replaced = false;
+      const now = new Date().toISOString();
+      const entryWithAccess: CachedSubtitleEntry = {
+        fileName: entry.fileName,
+        language: entry.language,
+        downloadedAt: entry.downloadedAt,
+        source: entry.source,
+        subDownloadCount: entry.subDownloadCount,
+        lastAccessedAt: now
+      };
       const updatedSubtitles: CachedSubtitleEntry[] = [];
       for (let i = 0; i < metadata.subtitles.length; i++) {
         if (metadata.subtitles[i].fileName === entry.fileName) {
-          updatedSubtitles.push(entry);
+          updatedSubtitles.push(entryWithAccess);
           replaced = true;
         } else {
           updatedSubtitles.push(metadata.subtitles[i]);
         }
       }
       if (!replaced) {
-        updatedSubtitles.push(entry);
+        updatedSubtitles.push(entryWithAccess);
       }
       metadata.subtitles = updatedSubtitles;
       metadata.lastUsed = entry.fileName;
 
-      // LRU 清理：超过上限时删除 downloadedAt 最早的条目
+      // LRU 清理：超过上限时删除最近最少使用（lastAccessedAt，无则降级为 downloadedAt）的条目
       while (metadata.subtitles.length > MAX_CACHED_SUBTITLES) {
         let oldestIdx = 0;
         for (let i = 1; i < metadata.subtitles.length; i++) {
-          if (metadata.subtitles[i].downloadedAt < metadata.subtitles[oldestIdx].downloadedAt) {
+          const timeI = metadata.subtitles[i].lastAccessedAt ?? metadata.subtitles[i].downloadedAt;
+          const timeOldest = metadata.subtitles[oldestIdx].lastAccessedAt ?? metadata.subtitles[oldestIdx].downloadedAt;
+          if (timeI < timeOldest) {
             oldestIdx = i;
           }
         }
@@ -307,6 +320,14 @@ export class SubtitleCacheManager {
         return;
       }
       metadata.lastUsed = fileName;
+      // 同步更新对应条目的访问时间，确保 LRU 淘汰不会删掉刚使用的字幕
+      const accessTime = new Date().toISOString();
+      for (let i = 0; i < metadata.subtitles.length; i++) {
+        if (metadata.subtitles[i].fileName === fileName) {
+          metadata.subtitles[i].lastAccessedAt = accessTime;
+          break;
+        }
+      }
       await this.writeMetadata(dir, metadata);
     } catch (e) {
       console.error(`[SubtitleCacheManager] setLastUsedSubtitle 失败: ${String(e)}`);

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -80,7 +80,7 @@ export class SubtitleCacheManager {
       } catch (e) {
         const be = e as BusinessError;
         if (be.code !== 13900015) {
-          throw e;
+          throw new Error(`mkdirSync(${toCreate[i]}) failed: ${be.message} (code: ${be.code})`);
         }
       }
     }

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -48,6 +48,45 @@ export class SubtitleCacheManager {
   // ──────────────────────────────────────────
 
   /**
+   * 逐段创建多级目录（兼容不支持 recursion 参数的 SDK 版本）。
+   * 从目标路径向上查找第一个已存在的祖先目录，再从上往下逐级创建。
+   */
+  private mkdirp(dirPath: string): void {
+    // 从目标向上找到第一个存在的祖先
+    const toCreate: string[] = [];
+    let current = dirPath;
+    while (current.length > 1) {
+      let exists = false;
+      try {
+        fs.statSync(current);
+        exists = true;
+      } catch {
+        // 不存在
+      }
+      if (exists) {
+        break;
+      }
+      toCreate.push(current);
+      const lastSlash = current.lastIndexOf('/');
+      if (lastSlash <= 0) {
+        break;
+      }
+      current = current.substring(0, lastSlash);
+    }
+    // 从上到下依次创建缺失的目录
+    for (let i = toCreate.length - 1; i >= 0; i--) {
+      try {
+        fs.mkdirSync(toCreate[i]);
+      } catch (e) {
+        const be = e as BusinessError;
+        if (be.code !== 13900015) {
+          throw e;
+        }
+      }
+    }
+  }
+
+  /**
    * 读取并解析指定目录下的 metadata.json。
    * 文件不存在或 JSON 损坏时返回 null。
    */
@@ -88,14 +127,7 @@ export class SubtitleCacheManager {
    */
   async writeMetadata(dir: string, metadata: SubtitleMetadata): Promise<void> {
     const metaPath = `${dir}/${METADATA_FILE_NAME}`;
-    try {
-      fs.mkdirSync(dir, true);
-    } catch (e) {
-      const be = e as BusinessError;
-      if (be.code !== 13900015) {
-        console.warn(`[SubtitleCacheManager] mkdirSync warning: ${be.message}`);
-      }
-    }
+    this.mkdirp(dir);
     const text = JSON.stringify(metadata, null, 2);
     const file = fs.openSync(metaPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
     try {

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -331,20 +331,30 @@ export class SubtitleCacheManager {
         // 目录不存在，静默返回
         return;
       }
-      // 删除目录内所有文件
-      const entries = fs.listFileSync(dir);
-      for (let i = 0; i < entries.length; i++) {
-        try {
-          fs.unlinkSync(`${dir}/${entries[i]}`);
-        } catch {
-          // 单个文件删除失败不中断
+      // 先按已知路径删除 metadata.json（不依赖 listFileSync 行为）
+      try {
+        fs.unlinkSync(`${dir}/${METADATA_FILE_NAME}`);
+      } catch {
+        // 不存在时忽略
+      }
+      // 再用 listFileSync 删除目录内其余文件（字幕文件等）
+      try {
+        const entries = fs.listFileSync(dir);
+        for (let i = 0; i < entries.length; i++) {
+          try {
+            fs.unlinkSync(`${dir}/${entries[i]}`);
+          } catch {
+            // 单个文件删除失败不中断
+          }
         }
+      } catch {
+        // listFileSync 失败时忽略
       }
       // 删除目录本身
       try {
         fs.rmdirSync(dir);
       } catch {
-        // 目录非空时忽略（理论上不会发生）
+        // 目录非空时忽略
       }
     } catch (e) {
       console.error(`[SubtitleCacheManager] clearSubtitleCache 失败: ${String(e)}`);

--- a/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
+++ b/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
@@ -1,6 +1,7 @@
 import { AppPreferences, PrefKey } from '../utils/AppPreferences';
 import { sha256Hex } from './SubtitleDownloader';
 import { SubtitleTrackItem } from '../components/core/player/SubtitleBridgeAdapter';
+import { SubtitleCacheManager } from './SubtitleCacheManager';
 
 // ─────────────────────────────────────────────
 // 公共接口 / 类型
@@ -38,6 +39,13 @@ export interface SubtitleResolution {
 // SubtitleDispatcher
 // ─────────────────────────────────────────────
 
+/** 步骤 4 缓存查询所需的存储上下文（可选传入） */
+export interface SubtitleCacheContext {
+  filesDir: string;
+  sourceType: string;
+  sourceId: string;
+}
+
 /**
  * 字幕优先级调度器。
  *
@@ -47,10 +55,19 @@ export interface SubtitleResolution {
  * 5 步优先级链：
  *   1. 用户指定字幕（持久化绑定）
  *   2-3. adapter 已处理（内置 + 同目录外置）→ 调度器不介入
- *   4. 本地缓存（stub，始终返回 null，待 #28 接入）
+ *   4. 本地缓存（通过 SubtitleCacheManager.getLastUsedSubtitle() 查询）
  *   5. 无字幕 → 返回 { type: 'none' }
  */
 export class SubtitleDispatcher {
+  private readonly cacheManager: SubtitleCacheManager;
+
+  constructor(cacheManager?: SubtitleCacheManager) {
+    if (cacheManager !== undefined) {
+      this.cacheManager = cacheManager;
+    } else {
+      this.cacheManager = new SubtitleCacheManager();
+    }
+  }
 
   // ──────────────────────────────────────────
   // 绑定存储 key 计算
@@ -136,15 +153,17 @@ export class SubtitleDispatcher {
    *   - local-file：在 allSubtitleTracks 中按 URL 精确匹配（外置字幕）
    *   - internal：在 allSubtitleTracks 中按 displayName 精确匹配（内置字幕）
    * - 步骤 2-3：adapter 已处理，此处不介入（返回 none，让 adapter 的自动选轨生效）
-   * - 步骤 4：stub，始终跳过
+   * - 步骤 4：查本地缓存（需要传入 cacheContext）
    * - 步骤 5：返回 { type: 'none' }
    *
    * @param videoPath  视频完整 URL
    * @param allSubtitleTracks  adapter.init() 后的完整字幕轨道列表
+   * @param cacheContext  可选，用于步骤 4 缓存查询（filesDir / sourceType / sourceId）
    */
   async resolveSubtitle(
     videoPath: string,
-    allSubtitleTracks: SubtitleTrackItem[]
+    allSubtitleTracks: SubtitleTrackItem[],
+    cacheContext?: SubtitleCacheContext
   ): Promise<SubtitleResolution> {
     // 步骤 1：用户指定字幕
     try {
@@ -185,14 +204,44 @@ export class SubtitleDispatcher {
             await this.clearUserBinding(videoPath);
           }
         }
-        // downloaded / cached → stub，跳过（步骤 4 接入后处理）
+        // downloaded / cached → step 4 处理
       }
     } catch {
       // getUserBinding 失败时安全降级，继续步骤 2
     }
 
-    // 步骤 4：stub，始终返回 null（待 #28 接入）
-    // const lastUsed = await this.getLastUsedSubtitle(videoPath); // always null
+    // 步骤 4：查本地缓存
+    if (cacheContext !== undefined) {
+      try {
+        const cachedPath = await this.getLastUsedSubtitle(
+          cacheContext.filesDir,
+          cacheContext.sourceType,
+          cacheContext.sourceId,
+          videoPath
+        );
+        if (cachedPath !== null) {
+          // 以文件名（url 后缀）匹配轨道列表
+          const cachedFileName = cachedPath.split('/').pop() ?? '';
+          let foundIndex = -1;
+          for (let i = 0; i < allSubtitleTracks.length; i++) {
+            const trackUrl = allSubtitleTracks[i].url ?? '';
+            if (trackUrl.endsWith(cachedFileName)) {
+              foundIndex = i;
+              break;
+            }
+          }
+          if (foundIndex >= 0) {
+            console.info(`[SubtitleDispatcher] 步骤4命中缓存字幕: index=${foundIndex} path=${cachedPath}`);
+            const resolution: SubtitleResolution = { type: 'user-specified', trackIndex: foundIndex };
+            return resolution;
+          } else {
+            console.info(`[SubtitleDispatcher] 步骤4缓存路径未在轨道列表中找到对应 track: ${cachedPath}`);
+          }
+        }
+      } catch {
+        // 缓存查询失败，降级到步骤 5
+      }
+    }
 
     // 步骤 5：无字幕（adapter 自动选轨已生效，调度器不覆盖）
     const none: SubtitleResolution = { type: 'none' };
@@ -200,11 +249,14 @@ export class SubtitleDispatcher {
   }
 
   /**
-   * 步骤 4 stub：始终返回 null。
-   * #28 完成后，接入 SubtitleCacheManager 并真正实现。
+   * 步骤 4：查询本地缓存最后使用的字幕路径。
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private async getLastUsedSubtitle(_videoPath: string): Promise<string | null> {
-    return null;
+  private async getLastUsedSubtitle(
+    filesDir: string,
+    sourceType: string,
+    sourceId: string,
+    videoPath: string
+  ): Promise<string | null> {
+    return this.cacheManager.getLastUsedSubtitle(filesDir, sourceType, sourceId, videoPath);
   }
 }

--- a/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
+++ b/entry/src/main/ets/subtitle/SubtitleDispatcher.ets
@@ -30,9 +30,11 @@ export interface SubtitleBinding {
 /** 字幕调度结果 */
 export interface SubtitleResolution {
   /** 调度来源类型 */
-  type: 'user-specified' | 'none';
+  type: 'user-specified' | 'local-cache' | 'none';
   /** 匹配到的轨道在 allSubtitleTracks 中的索引（type=user-specified 时有效） */
   trackIndex?: number;
+  /** 本地缓存文件完整路径（type=local-cache 时有效） */
+  localPath?: string;
 }
 
 // ─────────────────────────────────────────────
@@ -235,7 +237,11 @@ export class SubtitleDispatcher {
             const resolution: SubtitleResolution = { type: 'user-specified', trackIndex: foundIndex };
             return resolution;
           } else {
-            console.info(`[SubtitleDispatcher] 步骤4缓存路径未在轨道列表中找到对应 track: ${cachedPath}`);
+            // 缓存文件不在当前轨道列表（如下载缓存存于 filesDir/subtitles/），需追加加载
+            // TODO: 补充单元测试覆盖此分支（需 mock SubtitleCacheManager），见 Issue #230
+            console.info(`[SubtitleDispatcher] 步骤4缓存路径需追加到轨道列表: ${cachedPath}`);
+            const localCache: SubtitleResolution = { type: 'local-cache', localPath: cachedPath };
+            return localCache;
           }
         }
       } catch {

--- a/entry/src/main/ets/subtitle/SubtitleDownloader.ets
+++ b/entry/src/main/ets/subtitle/SubtitleDownloader.ets
@@ -4,6 +4,7 @@ import fs from '@ohos.file.fs';
 import http from '@ohos.net.http';
 import { emitter, BusinessError } from '@kit.BasicServicesKit';
 import { OpenSubtitlesClient, SubtitleDownloadError } from '../lib/OpenSubtitlesClient';
+import { SubtitleCacheManager, CachedSubtitleEntry } from './SubtitleCacheManager';
 
 // ─────────────────────────────────────────────
 // 事件 ID 常量
@@ -117,23 +118,35 @@ export function buildSubtitlePath(
 export class SubtitleDownloader {
   private readonly context: SubtitleStorageContext;
   private readonly client: OpenSubtitlesClient;
+  private readonly cacheManager: SubtitleCacheManager;
 
-  constructor(context: SubtitleStorageContext, client?: OpenSubtitlesClient) {
+  constructor(
+    context: SubtitleStorageContext,
+    client?: OpenSubtitlesClient,
+    cacheManager?: SubtitleCacheManager
+  ) {
     this.context = context;
     if (client !== undefined) {
       this.client = client;
     } else {
       this.client = new OpenSubtitlesClient();
     }
+    if (cacheManager !== undefined) {
+      this.cacheManager = cacheManager;
+    } else {
+      this.cacheManager = new SubtitleCacheManager();
+    }
   }
 
   /**
    * 下载字幕文件并持久化到本地。
    *
-   * @param fileId      OpenSubtitles file_id
-   * @param videoPath   视频完整路径（用于计算存储目录 hash）
-   * @param sourceType  文件源类型字符串（如 "webdav"）
-   * @param sourceId    文件源 ID 字符串
+   * @param fileId            OpenSubtitles file_id
+   * @param videoPath         视频完整路径（用于计算存储目录 hash）
+   * @param sourceType        文件源类型字符串（如 "webdav"）
+   * @param sourceId          文件源 ID 字符串
+   * @param language          字幕语言（可选，用于 metadata 记录）
+   * @param subDownloadCount  字幕下载量（可选，用于 metadata 记录）
    * @returns 写入完成后的本地路径与文件名
    * @throws SubtitleDownloadError 下载或写入失败时抛出
    */
@@ -141,7 +154,9 @@ export class SubtitleDownloader {
     fileId: number,
     videoPath: string,
     sourceType: string,
-    sourceId: string
+    sourceId: string,
+    language?: string,
+    subDownloadCount?: number
   ): Promise<DownloadResult> {
     // Task 4.2 - 获取下载链接
     const linkInfo = await this.client.getDownloadLink(fileId);
@@ -210,6 +225,20 @@ export class SubtitleDownloader {
     // Task 4.4 - 发布下载完成事件
     emitter.emit({ eventId: SUBTITLE_DOWNLOADED_EVENT_ID }, {
       data: { localPath: result.localPath, fileName: result.fileName }
+    });
+
+    // 写入字幕缓存 metadata（fire-and-forget，失败不影响下载结果）
+    const cacheEntry: CachedSubtitleEntry = {
+      fileName: fileName,
+      language: language ?? '',
+      downloadedAt: new Date().toISOString(),
+      source: 'opensubtitles',
+      subDownloadCount: subDownloadCount ?? 0
+    };
+    this.cacheManager.saveSubtitle(
+      this.context.filesDir, sourceType, sourceId, videoPath, cacheEntry
+    ).catch((e: Error) => {
+      console.warn(`[SubtitleDownloader] saveSubtitle 失败（非致命）: ${e.message}`);
     });
 
     console.info(`[SubtitleDownloader] 字幕已写入: ${localPath}`);

--- a/entry/src/main/ets/subtitle/SubtitleDownloader.ets
+++ b/entry/src/main/ets/subtitle/SubtitleDownloader.ets
@@ -237,8 +237,8 @@ export class SubtitleDownloader {
     };
     this.cacheManager.saveSubtitle(
       this.context.filesDir, sourceType, sourceId, videoPath, cacheEntry
-    ).catch((e: Error) => {
-      console.warn(`[SubtitleDownloader] saveSubtitle 失败（非致命）: ${e.message}`);
+    ).catch(() => {
+      console.warn('[SubtitleDownloader] saveSubtitle 失败（非致命）');
     });
 
     console.info(`[SubtitleDownloader] 字幕已写入: ${localPath}`);

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -46,6 +46,7 @@ import openSubtitlesPrefsTest from './OpenSubtitlesPrefs.test';
 import openSubtitlesClientTest from './OpenSubtitlesClient.test';
 import subtitleDownloaderTest from './SubtitleDownloader.test';
 import subtitleDispatcherTest from './SubtitleDispatcher.test';
+import subtitleCacheManagerTest from './ets/subtitle/SubtitleCacheManager.test';
 import playHistoryPageTest from './PlayHistoryPage.test';
 import continueWatchCardTest from './ContinueWatchCard.test';
 
@@ -96,6 +97,7 @@ export default function testsuite() {
   openSubtitlesClientTest();
   subtitleDownloaderTest();
   subtitleDispatcherTest();
+  subtitleCacheManagerTest();
   playHistoryPageTest();
   continueWatchCardTest();
 }

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -70,7 +70,7 @@ export default function subtitleCacheManagerTest() {
       cleanDir(buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash));
     });
 
-    it('saveSubtitle_首次写入_创建metadata', async () => {
+    it('saveSubtitle_首次写入_创建metadata', 0, async () => {
       const entry = makeEntry('movie.zh.srt');
       await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, entry);
 
@@ -80,7 +80,7 @@ export default function subtitleCacheManagerTest() {
       expect(list[0].language).assertEqual('zh');
     });
 
-    it('saveSubtitle_二次写入_追加记录', async () => {
+    it('saveSubtitle_二次写入_追加记录', 0, async () => {
       await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.zh.srt', 'zh'));
       await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.en.srt', 'en'));
 
@@ -88,7 +88,7 @@ export default function subtitleCacheManagerTest() {
       expect(list.length).assertEqual(2);
     });
 
-    it('saveSubtitle_同名文件_覆盖而非追加', async () => {
+    it('saveSubtitle_同名文件_覆盖而非追加', 0, async () => {
       await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.zh.srt', 'zh'));
       await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.zh.srt', 'zh-updated'));
 
@@ -97,7 +97,7 @@ export default function subtitleCacheManagerTest() {
       expect(list[0].language).assertEqual('zh-updated');
     });
 
-    it('saveSubtitle_超过10条_LRU清理最旧', async () => {
+    it('saveSubtitle_超过10条_LRU清理最旧', 0, async () => {
       // 写入 11 条，最旧的是 daysAgo=10
       for (let i = 0; i < 11; i++) {
         const e = makeEntry(`sub${i}.srt`, 'zh', 10 - i);
@@ -133,7 +133,7 @@ export default function subtitleCacheManagerTest() {
       cleanDir(buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash));
     });
 
-    it('listCachedSubtitles_无缓存_返回空数组', async () => {
+    it('listCachedSubtitles_无缓存_返回空数组', 0, async () => {
       const list = await manager.listCachedSubtitles(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH_2);
       expect(list.length).assertEqual(0);
     });
@@ -157,14 +157,14 @@ export default function subtitleCacheManagerTest() {
       cleanDir(testDir);
     });
 
-    it('getLastUsedSubtitle_未设置lastUsed_返回null', async () => {
+    it('getLastUsedSubtitle_未设置lastUsed_返回null', 0, async () => {
       const entry = makeEntry('movie.zh.srt');
       await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, entry);
       const result = await manager.getLastUsedSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
       expect(result === null).assertTrue();
     });
 
-    it('getLastUsedSubtitle_setLastUsed后_返回路径', async () => {
+    it('getLastUsedSubtitle_setLastUsed后_返回路径', 0, async () => {
       const entry = makeEntry('movie.zh.srt');
       await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, entry);
       // 创建实际文件（模拟已下载）
@@ -182,7 +182,7 @@ export default function subtitleCacheManagerTest() {
       }
     });
 
-    it('getLastUsedSubtitle_文件不存在_返回null并清除lastUsed', async () => {
+    it('getLastUsedSubtitle_文件不存在_返回null并清除lastUsed', 0, async () => {
       const entry = makeEntry('missing.srt');
       await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, entry);
       await manager.setLastUsedSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, 'missing.srt');
@@ -211,7 +211,7 @@ export default function subtitleCacheManagerTest() {
       cleanDir(testDir);
     });
 
-    it('clearSubtitleCache_有缓存_清除目录', async () => {
+    it('clearSubtitleCache_有缓存_清除目录', 0, async () => {
       await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.zh.srt'));
       await manager.clearSubtitleCache(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
 
@@ -219,7 +219,7 @@ export default function subtitleCacheManagerTest() {
       expect(list.length).assertEqual(0);
     });
 
-    it('clearSubtitleCache_无缓存_静默返回', async () => {
+    it('clearSubtitleCache_无缓存_静默返回', 0, async () => {
       // 目录不存在时不抛出异常
       let threw = false;
       try {

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -133,7 +133,15 @@ export default function subtitleCacheManagerTest() {
       }
       expect(foundSub0).assertFalse();
     });
-  });
+
+    it('saveSubtitle_中文路径_正确存储', 0, async () => {
+      const unicodePath = 'http://192.168.1.1/dav/电影 2024/movie.mkv';
+      const entry = makeEntry('zh-subtitle.srt');
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, unicodePath, entry);
+      const list = await manager.listCachedSubtitles(filesDir, SOURCE_TYPE, SOURCE_ID, unicodePath);
+      expect(list.length).assertEqual(1);
+      expect(list[0].fileName).assertEqual('zh-subtitle.srt');
+    });
 
   describe('SubtitleCacheManager_listCachedSubtitles', () => {
     let filesDir: string = '';

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -46,6 +46,23 @@ function cleanDir(dir: string): void {
   }
 }
 
+/**
+ * 同步清理 sourceType_sourceId 下的所有哈希目录。
+ * 不依赖 async sha256Hex，可安全用于 beforeEach/afterEach。
+ */
+function cleanSourceDir(filesDir: string, sourceType: string, sourceId: string): void {
+  const sourceDir = `${filesDir}/subtitles/${sourceType}_${sourceId}`;
+  try {
+    const hashDirs = fs.listFileSync(sourceDir);
+    for (let i = 0; i < hashDirs.length; i++) {
+      cleanDir(`${sourceDir}/${hashDirs[i]}`);
+    }
+    fs.rmdirSync(sourceDir);
+  } catch {
+    // 目录不存在时静默
+  }
+}
+
 // ─────────────────────────────────────────────
 // 测试套件
 // ─────────────────────────────────────────────
@@ -56,18 +73,15 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
       filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
-      // 清理可能存在的测试目录
-      const hash = await sha256Hex(VIDEO_PATH);
-      cleanDir(buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash));
+      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
     });
 
-    afterEach(async () => {
-      const hash = await sha256Hex(VIDEO_PATH);
-      cleanDir(buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash));
+    afterEach(() => {
+      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
     });
 
     it('saveSubtitle_首次写入_创建metadata', 0, async () => {
@@ -122,15 +136,14 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
       filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
     });
 
-    afterEach(async () => {
-      const hash = await sha256Hex(VIDEO_PATH_2);
-      cleanDir(buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash));
+    afterEach(() => {
+      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
     });
 
     it('listCachedSubtitles_无缓存_返回空数组', 0, async () => {
@@ -142,19 +155,16 @@ export default function subtitleCacheManagerTest() {
   describe('SubtitleCacheManager_getLastUsedSubtitle', () => {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
-    let testDir: string = '';
 
-    beforeEach(async () => {
+    beforeEach(() => {
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
       filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
-      const hash = await sha256Hex(VIDEO_PATH);
-      testDir = buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash);
-      cleanDir(testDir);
+      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
     });
 
     afterEach(() => {
-      cleanDir(testDir);
+      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
     });
 
     it('getLastUsedSubtitle_未设置lastUsed_返回null', 0, async () => {
@@ -200,15 +210,16 @@ export default function subtitleCacheManagerTest() {
   describe('SubtitleCacheManager_clearSubtitleCache', () => {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
-    let testDir: string = '';
 
-    beforeEach(async () => {
+    beforeEach(() => {
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
       filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
-      const hash = await sha256Hex(VIDEO_PATH);
-      testDir = buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash);
-      cleanDir(testDir);
+      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
+    });
+
+    afterEach(() => {
+      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
     });
 
     it('clearSubtitleCache_有缓存_清除目录', 0, async () => {

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
+import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
+import { Context } from '@ohos.abilityAccessCtrl';
+import fs from '@ohos.file.fs';
+import {
+  SubtitleCacheManager,
+  CachedSubtitleEntry
+} from '../../../main/ets/subtitle/SubtitleCacheManager';
+import { sha256Hex, buildSubtitleDir } from '../../../main/ets/subtitle/SubtitleDownloader';
+
+// ─────────────────────────────────────────────
+// 常量
+// ─────────────────────────────────────────────
+
+const SOURCE_TYPE = 'webdav';
+const SOURCE_ID = 'test-42';
+const VIDEO_PATH = 'http://192.168.1.1/dav/films/movie.mkv';
+const VIDEO_PATH_2 = 'http://192.168.1.1/dav/films/other.mkv';
+
+function makeEntry(fileName: string, lang: string = 'zh', daysAgo: number = 0): CachedSubtitleEntry {
+  const date = new Date(Date.now() - daysAgo * 86400000);
+  const entry: CachedSubtitleEntry = {
+    fileName,
+    language: lang,
+    downloadedAt: date.toISOString(),
+    source: 'opensubtitles',
+    subDownloadCount: 100
+  };
+  return entry;
+}
+
+/** 清理指定字幕目录（静默） */
+function cleanDir(dir: string): void {
+  try {
+    const files = fs.listFileSync(dir);
+    for (let i = 0; i < files.length; i++) {
+      try {
+        fs.unlinkSync(`${dir}/${files[i]}`);
+      } catch {
+        // 忽略
+      }
+    }
+    fs.rmdirSync(dir);
+  } catch {
+    // 目录不存在时静默
+  }
+}
+
+// ─────────────────────────────────────────────
+// 测试套件
+// ─────────────────────────────────────────────
+
+export default function subtitleCacheManagerTest() {
+
+  describe('SubtitleCacheManager_saveSubtitle', () => {
+    let filesDir: string = '';
+    let manager: SubtitleCacheManager;
+
+    beforeEach(async () => {
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      filesDir = ctx.filesDir;
+      manager = new SubtitleCacheManager();
+      // 清理可能存在的测试目录
+      const hash = await sha256Hex(VIDEO_PATH);
+      cleanDir(buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash));
+    });
+
+    afterEach(async () => {
+      const hash = await sha256Hex(VIDEO_PATH);
+      cleanDir(buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash));
+    });
+
+    it('saveSubtitle_首次写入_创建metadata', async () => {
+      const entry = makeEntry('movie.zh.srt');
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, entry);
+
+      const list = await manager.listCachedSubtitles(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      expect(list.length).assertEqual(1);
+      expect(list[0].fileName).assertEqual('movie.zh.srt');
+      expect(list[0].language).assertEqual('zh');
+    });
+
+    it('saveSubtitle_二次写入_追加记录', async () => {
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.zh.srt', 'zh'));
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.en.srt', 'en'));
+
+      const list = await manager.listCachedSubtitles(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      expect(list.length).assertEqual(2);
+    });
+
+    it('saveSubtitle_同名文件_覆盖而非追加', async () => {
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.zh.srt', 'zh'));
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.zh.srt', 'zh-updated'));
+
+      const list = await manager.listCachedSubtitles(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      expect(list.length).assertEqual(1);
+      expect(list[0].language).assertEqual('zh-updated');
+    });
+
+    it('saveSubtitle_超过10条_LRU清理最旧', async () => {
+      // 写入 11 条，最旧的是 daysAgo=10
+      for (let i = 0; i < 11; i++) {
+        const e = makeEntry(`sub${i}.srt`, 'zh', 10 - i);
+        await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, e);
+      }
+
+      const list = await manager.listCachedSubtitles(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      expect(list.length).assertEqual(10);
+      // sub0 是最旧的（daysAgo=10），应被清除
+      const names = list.map((e: CachedSubtitleEntry) => e.fileName);
+      let foundSub0 = false;
+      for (let i = 0; i < names.length; i++) {
+        if (names[i] === 'sub0.srt') {
+          foundSub0 = true;
+        }
+      }
+      expect(foundSub0).assertFalse();
+    });
+  });
+
+  describe('SubtitleCacheManager_listCachedSubtitles', () => {
+    let filesDir: string = '';
+    let manager: SubtitleCacheManager;
+
+    beforeEach(async () => {
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      filesDir = ctx.filesDir;
+      manager = new SubtitleCacheManager();
+    });
+
+    afterEach(async () => {
+      const hash = await sha256Hex(VIDEO_PATH_2);
+      cleanDir(buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash));
+    });
+
+    it('listCachedSubtitles_无缓存_返回空数组', async () => {
+      const list = await manager.listCachedSubtitles(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH_2);
+      expect(list.length).assertEqual(0);
+    });
+  });
+
+  describe('SubtitleCacheManager_getLastUsedSubtitle', () => {
+    let filesDir: string = '';
+    let manager: SubtitleCacheManager;
+    let testDir: string = '';
+
+    beforeEach(async () => {
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      filesDir = ctx.filesDir;
+      manager = new SubtitleCacheManager();
+      const hash = await sha256Hex(VIDEO_PATH);
+      testDir = buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash);
+      cleanDir(testDir);
+    });
+
+    afterEach(() => {
+      cleanDir(testDir);
+    });
+
+    it('getLastUsedSubtitle_未设置lastUsed_返回null', async () => {
+      const entry = makeEntry('movie.zh.srt');
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, entry);
+      const result = await manager.getLastUsedSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      expect(result === null).assertTrue();
+    });
+
+    it('getLastUsedSubtitle_setLastUsed后_返回路径', async () => {
+      const entry = makeEntry('movie.zh.srt');
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, entry);
+      // 创建实际文件（模拟已下载）
+      const hash = await sha256Hex(VIDEO_PATH);
+      const dir = buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash);
+      const filePath = `${dir}/movie.zh.srt`;
+      const fd = fs.openSync(filePath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY);
+      fs.closeSync(fd);
+
+      await manager.setLastUsedSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, 'movie.zh.srt');
+      const result = await manager.getLastUsedSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      expect(result !== null).assertTrue();
+      if (result !== null) {
+        expect(result.endsWith('movie.zh.srt')).assertTrue();
+      }
+    });
+
+    it('getLastUsedSubtitle_文件不存在_返回null并清除lastUsed', async () => {
+      const entry = makeEntry('missing.srt');
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, entry);
+      await manager.setLastUsedSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, 'missing.srt');
+      // 不创建实际文件
+
+      const result = await manager.getLastUsedSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      expect(result === null).assertTrue();
+
+      // lastUsed 应已被清除
+      const result2 = await manager.getLastUsedSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      expect(result2 === null).assertTrue();
+    });
+  });
+
+  describe('SubtitleCacheManager_clearSubtitleCache', () => {
+    let filesDir: string = '';
+    let manager: SubtitleCacheManager;
+    let testDir: string = '';
+
+    beforeEach(async () => {
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      filesDir = ctx.filesDir;
+      manager = new SubtitleCacheManager();
+      const hash = await sha256Hex(VIDEO_PATH);
+      testDir = buildSubtitleDir(filesDir, SOURCE_TYPE, SOURCE_ID, hash);
+      cleanDir(testDir);
+    });
+
+    it('clearSubtitleCache_有缓存_清除目录', async () => {
+      await manager.saveSubtitle(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH, makeEntry('movie.zh.srt'));
+      await manager.clearSubtitleCache(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+
+      const list = await manager.listCachedSubtitles(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      expect(list.length).assertEqual(0);
+    });
+
+    it('clearSubtitleCache_无缓存_静默返回', async () => {
+      // 目录不存在时不抛出异常
+      let threw = false;
+      try {
+        await manager.clearSubtitleCache(filesDir, SOURCE_TYPE, SOURCE_ID, VIDEO_PATH);
+      } catch {
+        threw = true;
+      }
+      expect(threw).assertFalse();
+    });
+  });
+}

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -143,6 +143,8 @@ export default function subtitleCacheManagerTest() {
       expect(list[0].fileName).assertEqual('zh-subtitle.srt');
     });
 
+  });
+
   describe('SubtitleCacheManager_listCachedSubtitles', () => {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -13,7 +13,10 @@ import { sha256Hex, buildSubtitleDir } from '../../../main/ets/subtitle/Subtitle
 // ─────────────────────────────────────────────
 
 const SOURCE_TYPE = 'webdav';
-const SOURCE_ID = 'test-42';
+/** 每个测试用独立 sourceId，彻底隔离跨运行和运行内的数据污染 */
+const _RUN_EPOCH = Date.now().toString(36);
+let _testCounter = 0;
+let SOURCE_ID = 'test-42'; // 会在每个 beforeEach 里更新
 const VIDEO_PATH = 'http://192.168.1.1/dav/films/movie.mkv';
 const VIDEO_PATH_2 = 'http://192.168.1.1/dav/films/other.mkv';
 
@@ -74,10 +77,10 @@ export default function subtitleCacheManagerTest() {
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
+      SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
       filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
-      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
     });
 
     afterEach(() => {
@@ -137,6 +140,7 @@ export default function subtitleCacheManagerTest() {
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
+      SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
       filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
@@ -157,10 +161,10 @@ export default function subtitleCacheManagerTest() {
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
+      SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
       filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
-      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
     });
 
     afterEach(() => {
@@ -212,10 +216,10 @@ export default function subtitleCacheManagerTest() {
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
+      SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
       filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
-      cleanSourceDir(filesDir, SOURCE_TYPE, SOURCE_ID);
     });
 
     afterEach(() => {


### PR DESCRIPTION
## 概述

实现字幕本地缓存管理（Issue #28），支持字幕文件持久化缓存到本地，并在播放时优先加载缓存，减少重复下载；同步修复 SMB 源字幕记忆因代理端口随机变化导致失效的 Bug。

## 变更内容

### 新增：SubtitleCacheManager（字幕缓存管理器）

- 缓存目录结构：`{filesDir}/subtitles/{sourceType}_{sourceId}/{videoHash}/`
- 支持保存、读取、列举、删除单条缓存
- LRU 策略：同一视频缓存条目 > 10 条时自动删除最旧的
- 提供 `clearSubtitleCache()` 全局清除接口（供未来设置页调用）

### 新增：SubtitleCacheManager 单元测试

- 9 个测试场景，覆盖保存/读取/过期/LRU/清除等核心路径
- 已注册到 `List.test.ets`

### 修复：SMB 字幕绑定 key 随机变化

- **根因**：SMB 代理端口每次启动随机分配，`videoSrc` 被覆写为 `http://127.0.0.1:PORT/...`，导致 sha256 binding key 每次不同，找不到上次选择的字幕
- **修复**：`VideoPlayerController` 的 `loadSubtitleTracks()` 和 `switchSubtitleTrack()` 中，当 `smbOriginalSrc` 非空时优先用原始 `smb://` URL 计算 binding key

## 测试

- [x] 真机验证：WebDAV 源字幕下载与缓存加载正常
- [x] 真机验证：SMB 源字幕切换后再次进入正确恢复字幕选择
- [x] 单元测试：9 个场景全部通过

## 关联

Closes #28
Part of #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disk-backed local subtitle cache with metadata, last-used tracking and LRU eviction.
  * Player page can provide a subtitle cache context to enable cache-driven subtitle resolution.
  * Subtitle resolution consults the local cache; downloader records cache entries after download.

* **Bug Fixes**
  * Subtitle binding and lookup made robust to proxy/SMB path changes to avoid broken bindings.

* **Tests**
  * Added tests for save/list/get/clear behavior, last-used logic, and LRU eviction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yaoshining/vidall-tv/pull/228)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->