### PR TITLE
字幕快速菜单接线与 TV 部署规范沉淀 (#32)

### DIFF
--- a/.github/agents/qa-subagent.agent.md
+++ b/.github/agents/qa-subagent.agent.md
@@ -92,13 +92,19 @@ tools: ['vscode', 'execute', 'read', 'agent', 'edit', 'search', 'web', 'todo']
 - 将测试与私有方法名或内部状态结构等实现细节强绑定。
 - 提交“它不工作”这类无复现步骤的模糊缺陷报告。
 
+## 真机安装与工作树规则
+
+- 若任务涉及“安装到电视、真机验证、看当前分支效果、查看设备日志”，先读取 `.github/instructions/localTvDeploy.instructions.md`
+- 当前 worktree 的识别、构建、安装、启动、日志查看，以该 instructions 文件为准
+- 本 Agent 保留 QA 测试方法与验证标准，不再单独维护一套与共享 instructions 分叉的电视部署流程
+
 ## 本仓库测试环境与命令（持久记忆）
 
 以下内容用于 `VidAll_TV` 仓库（HarmonyOS 6.0.2）本地复现，后续执行测试默认先按此基线。
 
 ### 一、已验证环境基线
 
-- 工程根目录：`/Users/yaoshining/DevEcoStudioProjects/VidAll_TV`
+- 工程根目录：优先使用当前 worktree 根目录，即 `git rev-parse --show-toplevel`
 - SDK 基线：DevEco Studio 内置 SDK（优先使用 IDE 同源路径）
 - 建议执行 shell：`zsh -f`（避免 `.zshrc` 中 `neofetch` 等噪音干扰）
 - 关键环境变量：
@@ -114,7 +120,8 @@ export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/ope
 1) 同步工程
 
 ```bash
-zsh -f -c 'cd /Users/yaoshining/DevEcoStudioProjects/VidAll_TV && \
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+zsh -f -c 'cd "'"$ROOT_DIR"'" && \
 export DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk && \
 export OHOS_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
 export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
@@ -126,7 +133,8 @@ export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/ope
 2) 本地单测**真实执行**（推荐，无需设备，输出测试结果和 HTML 报告）
 
 ```bash
-zsh -f -c 'cd /Users/yaoshining/DevEcoStudioProjects/VidAll_TV && \
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+zsh -f -c 'cd "'"$ROOT_DIR"'" && \
 export DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk && \
 export OHOS_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
 export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
@@ -145,7 +153,8 @@ HTML 报告位于：`entry/.test/default/outputs/test/reports/index.html`
 2b) 本地单测**仅编译**（不执行，只验证编译链路）
 
 ```bash
-zsh -f -c 'cd /Users/yaoshining/DevEcoStudioProjects/VidAll_TV && \
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+zsh -f -c 'cd "'"$ROOT_DIR"'" && \
 export DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk && \
 export OHOS_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
 export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
@@ -160,7 +169,8 @@ export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/ope
 3) 查看模块可用任务
 
 ```bash
-zsh -f -c 'cd /Users/yaoshining/DevEcoStudioProjects/VidAll_TV && \
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+zsh -f -c 'cd "'"$ROOT_DIR"'" && \
 export DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk && \
 export OHOS_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
 export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
@@ -240,6 +250,7 @@ zsh -f -c 'set -o pipefail; your_hvigor_command 2>&1 | tail -n 40; echo HVIGOR_E
 **前置条件**：
 - 设备已连接（真机或模拟器）
 - `hdc` 可用：`/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony/toolchains/hdc`
+- 若需要先把当前功能分支版本安装到电视，先读取 `.github/instructions/localTvDeploy.instructions.md`
 
 **执行步骤**：
 
@@ -254,7 +265,8 @@ $HDC list targets
 #### 2) 编译集成测试 HAP
 
 ```bash
-cd /Users/yaoshining/DevEcoStudioProjects/VidAll_TV && \
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR" && \
 zsh -f -c '
 export DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk
 export OHOS_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony
@@ -277,7 +289,8 @@ export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/ope
 
 ```bash
 HDC=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony/toolchains/hdc
-HAP=/Users/yaoshining/DevEcoStudioProjects/VidAll_TV/entry/build/default/outputs/ohosTest/entry-ohosTest-signed.hap
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+HAP="$ROOT_DIR/entry/build/default/outputs/ohosTest/entry-ohosTest-signed.hap"
 
 $HDC install "$HAP"
 # 输出示例：[Info]...msg:install bundle successfully.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,14 @@
 - `.github/instructions/githubWorkflow.instructions.md`：放 Git 提交、推分支、创建 PR、命令行执行方式等工作流规则
 - `.github/instructions/arktsGuardrails.instructions.md`：放 ArkTS 编译约束、生命周期限制、Promise/catch 书写规范等代码护栏
 - `.github/instructions/agentOrganization.instructions.md`：放 `.github/agents/*.agent.md` 的维护规则、命名稳定性和低风险改动原则
+- `.github/instructions/localTvDeploy.instructions.md`：放“当前 worktree 构建并安装到局域网电视”的共享流程、设备检查、启动与日志查看规则
 - 新增经验时优先追加到最贴近主题的 instructions 文件，避免继续把所有规则堆进一个总文件
+
+## 局域网电视部署入口规则
+
+- 只要任务涉及 **构建 HAP、安装到电视、真机看效果、设备日志、局域网 TV 验证**，必须先读取 `.github/instructions/localTvDeploy.instructions.md`
+- 默认操作对象是**当前 worktree**，不是默认主工作区
+- 部署结果必须说明：当前 worktree 路径、分支、是否有本地改动、目标电视地址、安装包路径
 
 ## Git 提交规范（重要）
 

--- a/.github/instructions/localTvDeploy.instructions.md
+++ b/.github/instructions/localTvDeploy.instructions.md
@@ -1,0 +1,181 @@
+---
+applyTo: "build-profile.json5,entry/build-profile.json5,entry/**,.github/agents/*.agent.md,.github/prompts/**"
+description: "局域网电视部署与当前 worktree 构建规范。用于在本地 DevEco 环境中构建当前工作树版本、安装到局域网电视、启动应用并采集日志。关键词：worktree、hdc、电视安装、assembleHap、EntryAbility、局域网 TV。"
+---
+
+# 当前 Worktree 部署到局域网电视规范
+
+## 目标
+
+- 任何 Agent 在执行“构建 HAP、安装到电视、真机验证、查看电视效果”类任务时，默认操作对象都是**当前工作树**
+- 禁止误用主工作区或其他 worktree 的旧产物
+- 构建、安装、启动、日志查看使用统一命令
+
+## 一、工作树识别规则
+
+执行任何部署命令前，先确认当前 worktree 身份：
+
+```bash
+pwd
+git rev-parse --show-toplevel
+git branch --show-current
+git worktree list
+git status --short --branch
+```
+
+**规则**：
+
+- 一律以 `git rev-parse --show-toplevel` 的输出作为当前工程根目录
+- 一律以当前工程根目录下的 `entry/build/...` 产物作为安装源
+- 不要默认使用 `/Users/yaoshining/DevEcoStudioProjects/VidAll_TV`
+- 若存在多个 worktree，必须明确说明当前使用的是哪一个路径和分支
+- 若当前 worktree 有未提交改动，默认按**当前本地状态**构建和安装，除非用户明确要求只装某个提交或远端版本
+
+## 二、已验证本地环境基线
+
+```bash
+export DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk
+export OHOS_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony
+export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony
+export NODE_BIN=/Applications/DevEco-Studio.app/Contents/tools/node/bin/node
+export HVIGOR_WRAPPER=/Applications/DevEco-Studio.app/Contents/tools/hvigor/bin/hvigorw.js
+export HDC=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony/toolchains/hdc
+```
+
+**执行 shell**：
+
+- 优先使用 `zsh -f`
+- 避免受用户 shell profile 中额外输出干扰
+
+## 三、标准部署流程
+
+### 1) 检查电视在线状态
+
+```bash
+$HDC list targets
+```
+
+**成功标志**：
+
+- 输出中存在局域网设备，例如 `192.168.3.85:5555`
+
+若未看到设备：
+
+- 先不要构建和安装
+- 先提示设备未连接，等待用户处理网络、配对或开发者模式
+
+### 2) 在当前 worktree 构建开发包
+
+先取当前工程根目录：
+
+```bash
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+```
+
+标准构建命令：
+
+```bash
+zsh -f -c '
+cd "'"$ROOT_DIR"'" && \
+export DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk && \
+export OHOS_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
+export HARMONY_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony && \
+/Applications/DevEco-Studio.app/Contents/tools/node/bin/node \
+/Applications/DevEco-Studio.app/Contents/tools/hvigor/bin/hvigorw.js \
+--mode module -p module=entry@default -p product=default \
+assembleHap --analyze=normal --parallel --incremental --daemon'
+```
+
+**规则**：
+
+- 默认构建 `product=default`
+- 真机看效果时，优先安装 `entry-default-signed.hap`
+- 不要在未确认需求前切到 `production`
+
+**成功产物**：
+
+```bash
+$ROOT_DIR/entry/build/default/outputs/default/entry-default-signed.hap
+```
+
+### 3) 安装当前 worktree 的 HAP 到电视
+
+```bash
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+HAP="$ROOT_DIR/entry/build/default/outputs/default/entry-default-signed.hap"
+
+$HDC install -r "$HAP"
+```
+
+**成功标志**：
+
+- 输出包含 `install bundle successfully`
+
+**规则**：
+
+- 安装时必须显式使用当前 worktree 路径下的 HAP
+- 不要复用其他 worktree 或主工作区残留包
+- 默认使用 `-r` 覆盖安装
+
+### 4) 启动应用
+
+```bash
+$HDC shell aa start -b com.yao.vidalltv -a EntryAbility
+```
+
+**成功标志**：
+
+- 输出 `start ability successfully`
+
+### 5) 查看日志
+
+```bash
+$HDC shell hilog | grep -i "vidall\\|error\\|fail\\|exception"
+```
+
+只看错误：
+
+```bash
+$HDC shell hilog -b E
+```
+
+## 四、校验与回报要求
+
+执行完部署后，Agent 至少应回报：
+
+- 当前 worktree 路径
+- 当前分支名
+- 是否存在本地未提交改动
+- 构建是否成功
+- 安装是否成功
+- 启动是否成功
+- 安装包路径
+- 目标设备地址
+
+推荐格式：
+
+```text
+当前 worktree: <绝对路径>
+当前分支: <branch>
+本地改动: 有 / 无
+目标设备: <ip:port>
+构建: 成功 / 失败
+安装: 成功 / 失败
+启动: 成功 / 失败
+HAP: <绝对路径>
+```
+
+## 五、常见误区
+
+- 在主工作区构建，却把结果当成 feature worktree 版本安装
+- 只说“已安装”，但没有说明安装的是哪个 worktree 和分支
+- 使用历史 `build/` 产物而不是重新构建当前 worktree
+- 设备不在线时仍继续执行安装命令
+- 部署后不启动应用，也不确认电视上是否可见
+
+## 六、与其他文档的分工
+
+- `.github/copilot-instructions.md`：只放全局入口和总规则
+- 本文件：放 worktree 到局域网电视的操作规范
+- `.github/instructions/multiEnvBuild.instructions.md`：放 product / AppEnv / Worker 的多环境构建规则
+- `.github/agents/qa-subagent.agent.md`：保留 QA 的测试策略；若涉及真机安装，引用本文件而不是重复维护整套部署命令

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -12,7 +12,6 @@ import {
   saveEpisodeAutoplayEnabled
 } from './EpisodeAutoplayPreferences'
 import { common } from '@kit.AbilityKit'
-import { KeyCode } from '@kit.InputKit'
 import {
   OpenSubtitlesClient,
   SubtitleSearchResult,

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -130,6 +130,8 @@ struct VideoControls {
                 Text(item.displayName)
                   .fontSize(16)
                   .fontColor(Color.White)
+                  .maxLines(1)
+                  .textOverflow({ overflow: TextOverflow.Ellipsis })
                 if (item.kind === 'external') {
                   Text('外部文件')
                     .fontSize(11)
@@ -137,6 +139,7 @@ struct VideoControls {
                 }
               }
               .alignItems(HorizontalAlign.Start)
+              .layoutWeight(1)
 
               if (this.videoController.activeSubtitleIndex === index) {
                 SymbolGlyph($r('sys.symbol.checkmark'))
@@ -2203,7 +2206,7 @@ export struct SubtitleSelectorDrawerDialog {
                         Text(result.fileName)
                           .fontSize(16)
                           .fontColor('#EAF0F7')
-                          .maxLines(2)
+                          .maxLines(1)
                           .textOverflow({ overflow: TextOverflow.Ellipsis })
                           .width('100%')
                         Text(`${result.languageCode}  ↓ ${this.formatDownloadCount(result.downloadCount)}`)

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -21,6 +21,7 @@ import {
   SubtitleDownloadError
 } from '../../../lib/OpenSubtitlesClient'
 import { SubtitleDownloader, SubtitleStorageContext } from '../../../subtitle/SubtitleDownloader'
+import { SubtitleCacheManager } from '../../../subtitle/SubtitleCacheManager'
 import { parseFileName, buildSearchTitles } from '../../../lib/ScrapeClient'
 import { loadSubtitleSearchPreferenceSnapshot } from '../../../subtitle/SubtitleLanguagePreference'
 
@@ -29,6 +30,7 @@ struct VideoControls {
   @Require @Param videoController: VideoPlayerController
   @Require @Param dialogController: CustomDialogController
   @Require @Param openSettings: () => void
+  @Param onOpenSubtitleSelector: () => void = () => {}
   closeTimer?: number
   seekTimer?: number
   private AUTO_CLOSE_TIMEOUT = 5000
@@ -213,6 +215,25 @@ struct VideoControls {
             .padding({ top: 8, bottom: 8 })
           }
         }
+
+        ListItem() {
+          Row({ space: 10 }) {
+            Text('🔍')
+              .fontSize(16)
+              .fontColor(Color.White)
+            Text('更多字幕配置')
+              .fontSize(16)
+              .fontColor(Color.White)
+          }
+          .width('100%')
+          .height(50)
+          .justifyContent(FlexAlign.Start)
+          .padding({ left: 20, right: 20 })
+        }
+        .onClick(() => {
+          this.showSubtitleMenu = false
+          this.onOpenSubtitleSelector()
+        })
       }
       .width('100%')
       .backgroundColor('rgba(0, 0, 0, 0.8)')
@@ -299,27 +320,25 @@ struct VideoControls {
           }
 
           // 字幕按钮
-          if (this.videoController.allSubtitleTracks.length > 0) {
-            Row({ space: 8 }) {
-              SymbolGlyph($r('sys.symbol.text_bubble_left_2'))
-                .fontColor([this.videoController.activeSubtitleIndex >= 0 ? Color.White : Color.Gray])
-                .fontSize(24)
-              Text(this.getActiveSubtitleName())
-                .fontSize(14)
-                .fontColor(this.videoController.activeSubtitleIndex >= 0 ? Color.White : Color.Gray)
-            }
-            .padding({ left: 12, right: 12, top: 8, bottom: 8 })
-            .backgroundColor(this.subtitleButtonFocused ? 'rgba(27, 120, 242, 0.35)' : 'rgba(0, 0, 0, 0.5)')
-            .borderRadius(20)
-            .border({ width: this.subtitleButtonFocused ? 2 : 1, color: this.subtitleButtonFocused ? '#66A9D8FF' : 'rgba(255, 255, 255, 0.18)' })
-            .focusable(true)
-            .onFocus(() => { this.subtitleButtonFocused = true })
-            .onBlur(() => { this.subtitleButtonFocused = false })
-            .onClick(() => {
-              this.showSubtitleMenu = !this.showSubtitleMenu
-              clearTimeout(this.closeTimer)
-            })
+          Row({ space: 8 }) {
+            SymbolGlyph($r('sys.symbol.text_bubble_left_2'))
+              .fontColor([this.videoController.activeSubtitleIndex >= 0 ? Color.White : Color.Gray])
+              .fontSize(24)
+            Text(this.getActiveSubtitleName())
+              .fontSize(14)
+              .fontColor(this.videoController.activeSubtitleIndex >= 0 ? Color.White : Color.Gray)
           }
+          .padding({ left: 12, right: 12, top: 8, bottom: 8 })
+          .backgroundColor(this.subtitleButtonFocused ? 'rgba(27, 120, 242, 0.35)' : 'rgba(0, 0, 0, 0.5)')
+          .borderRadius(20)
+          .border({ width: this.subtitleButtonFocused ? 2 : 1, color: this.subtitleButtonFocused ? '#66A9D8FF' : 'rgba(255, 255, 255, 0.18)' })
+          .focusable(true)
+          .onFocus(() => { this.subtitleButtonFocused = true })
+          .onBlur(() => { this.subtitleButtonFocused = false })
+          .onClick(() => {
+            this.showSubtitleMenu = !this.showSubtitleMenu
+            clearTimeout(this.closeTimer)
+          })
 
           Row({ space: 8 }) {
             SymbolGlyph($r('sys.symbol.gearshape'))
@@ -576,6 +595,7 @@ export struct VideoControlsDialog {
   controller: CustomDialogController
   @Require videoController: VideoPlayerController
   @Require onOpenSettings: () => void
+  onOpenSubtitleSelector: () => void = () => {}
   @State opacityValue: number = 0;
 
   aboutToAppear(): void {
@@ -592,7 +612,8 @@ export struct VideoControlsDialog {
     VideoControls({
       videoController: this.videoController,
       dialogController: this.controller,
-      openSettings: this.onOpenSettings
+      openSettings: this.onOpenSettings,
+      onOpenSubtitleSelector: this.onOpenSubtitleSelector
     })
       .opacity(this.opacityValue)
   }
@@ -1864,6 +1885,15 @@ export struct SubtitleSelectorDrawerDialog {
 
       await this.videoController.addExternalSubtitle(downloadResult.localPath)
 
+      const cacheManager = new SubtitleCacheManager()
+      await cacheManager.setLastUsedSubtitle(
+        hostCtx.filesDir,
+        this.sourceType,
+        this.sourceId,
+        this.videoController.stableVideoSrcForCache,
+        downloadResult.fileName
+      )
+
       this.showSearchResults = false
     } catch (e) {
       const errMsg = (e as object as Record<string, string>)['message'] ?? JSON.stringify(e)
@@ -2138,7 +2168,7 @@ export struct SubtitleSelectorDrawerDialog {
 
               Scroll() {
                 Column({ space: 8 }) {
-                  ForEach(this.searchResults, (result: SubtitleSearchResult) => {
+                  ForEach(this.searchResults, (result: SubtitleSearchResult, index: number) => {
                     Row({ space: 10 }) {
                       Row() {
                         Text(this.getResultLanguageTag(result.languageCode))
@@ -2181,6 +2211,7 @@ export struct SubtitleSelectorDrawerDialog {
                     .alignItems(VerticalAlign.Center)
                     .backgroundColor('rgba(255, 255, 255, 0.05)')
                     .borderRadius(14)
+                    .defaultFocus(index === 0)
                     .focusable(true)
                     .enabled(!this.isDownloading)
                     .onClick(() => {
@@ -2211,5 +2242,13 @@ export struct SubtitleSelectorDrawerDialog {
     }
     .width('100%')
     .height('100%')
+    .onKeyEvent((event: KeyEvent) => {
+      if (event.type === KeyType.Down &&
+          event.keyCode === KeyCode.KEYCODE_BACK &&
+          this.showSearchResults) {
+        this.showSearchResults = false
+        event.stopPropagation()
+      }
+    })
   }
 }

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -1904,6 +1904,12 @@ export struct SubtitleSelectorDrawerDialog {
 
       await this.videoController.addExternalSubtitle(downloadResult.localPath)
 
+      // 下载成功后自动切换到该字幕轨道（新增轨道总是追加到列表末尾）
+      const newSubtitleIndex = this.videoController.allSubtitleTracks.length - 1
+      if (newSubtitleIndex >= 0) {
+        await this.videoController.switchSubtitleTrack(newSubtitleIndex)
+      }
+
       const cacheManager = new SubtitleCacheManager()
       await cacheManager.setLastUsedSubtitle(
         hostCtx.filesDir,

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -12,6 +12,7 @@ import {
   saveEpisodeAutoplayEnabled
 } from './EpisodeAutoplayPreferences'
 import { common } from '@kit.AbilityKit'
+import { KeyCode } from '@kit.InputKit'
 import {
   OpenSubtitlesClient,
   SubtitleSearchResult,

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -1634,6 +1634,13 @@ export struct SubtitleSelectorDrawerDialog {
   scrapeOriginalTitle: string = ''
   /** TMDB ID（可选），用于 OpenSubtitles tmdb_id 精准匹配 */
   tmdbId: string = ''
+  /**
+   * 由 VideoPlayer 注入：注册一个「尝试退出搜索结果」的回调。
+   * 当 VideoPlayer 的 onWillDismiss 拦截到返回键时，调用此处注册的函数：
+   *   - 若当前处于搜索结果视图：将 showSearchResults 置 false 并返回 true（dialog 保持打开）
+   *   - 若当前处于轨道列表视图：返回 false（交由 VideoPlayer 调用 action.dismiss()）
+   */
+  onRegisterResetSearch?: (fn: () => boolean) => void
 
   @State panelOffsetX: number = 72
   @State panelOpacity: number = 0
@@ -1656,6 +1663,14 @@ export struct SubtitleSelectorDrawerDialog {
     this.getUIContext().animateTo({ duration: 220, curve: Curve.EaseOut }, () => {
       this.panelOffsetX = 0
       this.panelOpacity = 1
+    })
+    // 向 VideoPlayer 注册「退出搜索结果」回调，供 onWillDismiss 拦截返回键时调用
+    this.onRegisterResetSearch?.(() => {
+      if (this.showSearchResults) {
+        this.showSearchResults = false
+        return true
+      }
+      return false
     })
   }
 
@@ -2243,13 +2258,5 @@ export struct SubtitleSelectorDrawerDialog {
     }
     .width('100%')
     .height('100%')
-    .onKeyEvent((event: KeyEvent) => {
-      if (event.type === KeyType.Down &&
-          event.keyCode === KeyCode.KEYCODE_BACK &&
-          this.showSearchResults) {
-        this.showSearchResults = false
-        event.stopPropagation()
-      }
-    })
   }
 }

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -60,6 +60,12 @@ export struct VideoPlayer {
   @Local ijkVideoRatio: number = 0
   @Local ijkViewportWidth: number = 0
   @Local ijkViewportHeight: number = 0
+  /**
+   * 字幕选择器抽屉「退出搜索结果」回调。
+   * 由 SubtitleSelectorDrawerDialog.aboutToAppear 注册；
+   * onWillDismiss 拦截返回键时调用：若处于搜索结果视图则退回轨道列表（返回 true），否则返回 false。
+   */
+  private subtitleTryHideSearch: (() => boolean) | undefined = undefined
 
   // ASS 解析结果缓存：相同 raw 文本不重复解析（#17 AC）
   private _lastRawText: string = ''
@@ -215,7 +221,11 @@ export struct VideoPlayer {
       sourceType: this.resolveSubtitleSourceType(),
       sourceId: this.data.fileSourceId ?? '0',
       scrapeOriginalTitle: this.data.scrapeOriginalTitle,
-      tmdbId: this.data.tmdbId
+      tmdbId: this.data.tmdbId,
+      // 注册回调：onWillDismiss 拦截返回键时，先调用此函数尝试退出搜索结果视图
+      onRegisterResetSearch: (fn: () => boolean) => {
+        this.subtitleTryHideSearch = fn
+      }
     }),
     customStyle: true,
     backgroundColor: Color.Transparent,
@@ -223,8 +233,13 @@ export struct VideoPlayer {
     width: '100%',
     height: '100%',
     cornerRadius: 0,
-    onWillDismiss: () => {
-      this.subtitleSelectorDialogController.close()
+    onWillDismiss: (action: DismissDialogAction) => {
+      // 若处于搜索结果视图，退回轨道列表而不关闭 Dialog
+      if (this.subtitleTryHideSearch?.()) {
+        // subtitleTryHideSearch 已将 showSearchResults 置 false，不调用 action.dismiss()
+      } else {
+        action.dismiss()
+      }
     },
     openAnimation: {
       duration: 0

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -147,6 +147,10 @@ export struct VideoPlayer {
       onOpenSettings: () => {
         this.controlsDialogController.close()
         this.settingsDialogController.open()
+      },
+      onOpenSubtitleSelector: () => {
+        this.controlsDialogController.close()
+        this.subtitleSelectorDialogController.open()
       }
     }),
     customStyle: true,

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -237,9 +237,10 @@ export struct VideoPlayer {
       // 若处于搜索结果视图，退回轨道列表而不关闭 Dialog
       if (this.subtitleTryHideSearch?.()) {
         // subtitleTryHideSearch 已将 showSearchResults 置 false，不调用 action.dismiss()
-      } else {
-        action.dismiss()
+        return
       }
+      action.dismiss()
+      this.subtitleSelectorDialogController.close()
     },
     openAnimation: {
       duration: 0

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -3145,15 +3145,20 @@ export class VideoPlayerController {
       const videoPath = this.smbOriginalSrc.length > 0 ? this.smbOriginalSrc : rawVideoSrc;
       if (videoPath.length > 0) {
         // 构建缓存上下文：filesDir 由外部注入，sourceType/sourceId 来自 VideoData
+        // Bug 修复：fileSourceType/fileSourceId 仅在 SMB/WebDAV 源时才存在，
+        // 本地文件（FILE_URI）不设置这两个字段，需要用与 VideoPlayer.resolveSubtitleSourceType()
+        // 相同的降级逻辑补全，否则缓存上下文无法构建，重开视频后已下载字幕消失。
         let cacheCtx: SubtitleCacheContext | undefined = undefined;
         const cachedFilesDir = this.subtitleCacheContext?.filesDir;
-        const cachedSourceType = this.currentVideoData?.fileSourceType;
-        const cachedSourceId = this.currentVideoData?.fileSourceId;
-        if (cachedFilesDir !== undefined && cachedSourceType !== undefined && cachedSourceId !== undefined) {
+        if (cachedFilesDir !== undefined) {
+          const rawSourceType = this.currentVideoData?.fileSourceType;
+          const resolvedSourceType = rawSourceType !== undefined ? rawSourceType :
+            (this.currentVideoData?.type === VideoDataType.FILE_URI ? 'local' : 'network');
+          const resolvedSourceId = this.currentVideoData?.fileSourceId ?? '0';
           const ctx: SubtitleCacheContext = {
             filesDir: cachedFilesDir,
-            sourceType: cachedSourceType,
-            sourceId: cachedSourceId
+            sourceType: resolvedSourceType,
+            sourceId: resolvedSourceId
           };
           cacheCtx = ctx;
         }


### PR DESCRIPTION
## 概要

推进 Issue #32「字幕快速菜单接线」相关的修复与文档沉淀，覆盖 5 项 ArkTS 修复 + 1 项文档规范。

## 改动文件

| 文件 | 说明 |
|---|---|
| `entry/src/main/ets/components/core/player/VideoControls.ets` | 字幕快速菜单 / 抽屉交互修复 |
| `entry/src/main/ets/components/core/player/VideoPlayer.ets` | 视频播放器入口接线 |
| `entry/src/main/ets/components/core/player/VideoPlayerController.ets` | 播放器控制器协调字幕 |
| `.github/agents/qa-subagent.agent.md` | QA 流程补充 |
| `.github/copilot-instructions.md` | 入口规则 |
| `.github/instructions/localTvDeploy.instructions.md` | 新增：局域网电视部署规范 |

## 提交列表

- 新增: 字幕快速菜单「更多字幕配置」入口接线
- 修复: 补充 KeyCode import（onKeyEvent 编译缺失）
- 修复: 物理返回键错误关闭字幕抽屉
- 修复: 字幕文件名截断，防止长文件名挤压布局
- 修复: 字幕缓存恢复、快捷菜单截断、下载后自动选择
- 文档: 沉淀当前工作树电视部署规范

## 验证

- 当前 worktree（`VidAll_TV-subtitle-wiring`）已 `assembleHap` 成功
- 安装到 `192.168.3.85:5555` 局域网电视：install bundle successfully + start ability successfully
- hilog ERROR 级别无 vidall/fail/error/exception/crash 命中
- 进程 PID 持续存活，无强制重启

## 关联

- Issue: #32
- Project: https://github.com/users/yaoshining/projects/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 字幕选择器新增“更多字幕配置”入口，入口点击后关闭当前字幕菜单并打开配置入口
  * 在线字幕下载成功后自动切换到新增字幕轨道
  * 新增字幕使用记录：自动保存并记住最后一次使用的字幕
  * 优化在线字幕搜索：结果列表更易读（单行展示）、首条默认聚焦；支持在关闭时仅退出搜索结果视图而不直接关闭字幕选择器
* **体验优化**
  * 从视频控制弹窗进入字幕选择器时，先关闭字幕控制弹窗再打开字幕选择器
<!-- end of auto-generated comment: release notes by coderabbit.ai -->