### PR TITLE
修复: 按路径标题和年份筛选剧集刮削结果

### DIFF
--- a/entry/src/main/ets/lib/ScrapeClient.ets
+++ b/entry/src/main/ets/lib/ScrapeClient.ets
@@ -1,7 +1,6 @@
 import http from '@ohos.net.http';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { AppPreferences, PrefKey } from '../utils/AppPreferences';
-import { isWeakSemanticTitleText } from './MediaTypeClassifier';
 
 // ─────────────────────────────────────────────
 // 公共数据结构
@@ -184,9 +183,9 @@ function isUsefulEnglishTerm(term: string): boolean {
  * 策略：
  * - 纯中文标题（无英文）：中文 → 完整标题
  * - 纯英文标题（无中文）：英文 → 完整标题
- * - 中英混合：优先英文（精度高），但若英文部分不足（冠词/太短），回退到中文
+ * - 中英混合：优先英文，同时保留中文，避免只用英文别名时产生歧义
  *
- * 例："权力的游戏 Game of Thrones" → ["Game of Thrones"]
+ * 例："权力的游戏 Game of Thrones" → ["Game of Thrones", "权力的游戏"]
  * 例："The 庆余年"                 → ["庆余年"]（英文仅为冠词，无意义）
  * 例："权力的游戏" → ["权力的游戏"]
  * 例："Game of Thrones" → ["Game of Thrones"]
@@ -202,15 +201,10 @@ export function buildSearchTitles(title: string): string[] {
 
   if (hasChinese && hasEnglish) {
     if (isUsefulEnglishTerm(englishPart)) {
-      // 英文部分有意义，优先用英文（精度高、不歧义）
       candidates.push(englishPart);
-    } else {
-      // 英文部分无意义（如冠词 "The"、单字母等），回退到中文
-      if (chinesePart.length >= 1) {
-        candidates.push(chinesePart);
-      } else {
-        candidates.push(title.trim());
-      }
+    }
+    if (chinesePart.length >= 1 && !candidates.includes(chinesePart)) {
+      candidates.push(chinesePart);
     }
   } else if (hasEnglish) {
     if (englishPart.length >= 2) { candidates.push(englishPart); }
@@ -222,6 +216,57 @@ export function buildSearchTitles(title: string): string[] {
     candidates.push(title.trim());
   }
   return candidates;
+}
+
+interface TvSearchCandidate {
+  title: string;
+  year?: number;
+}
+
+function extractSearchYear(title: string): number | undefined {
+  const match = title.match(/(?:^|[^0-9])((?:19|20)\d{2})(?:[^0-9]|$)/);
+  return match ? parseInt(match[1]) : undefined;
+}
+
+function removeSearchYear(title: string): string {
+  return title.replace(/[\[（(]\s*(?:19|20)\d{2}\s*[\]）)]/g, ' ').replace(/\s{2,}/g, ' ').trim();
+}
+
+function buildTvSearchCandidates(parsedTitle: string, parsedYear: number | undefined, seriesHint?: string): TvSearchCandidate[] {
+  const candidates: TvSearchCandidate[] = [];
+  const appendTitle = (title: string, year?: number): void => {
+    const normalizedTitle = removeSearchYear(title);
+    if (normalizedTitle.length === 0 || candidates.some((candidate: TvSearchCandidate) => candidate.title === normalizedTitle)) {
+      return;
+    }
+    const candidate: TvSearchCandidate = { title: normalizedTitle, year };
+    candidates.push(candidate);
+  };
+
+  if (seriesHint !== undefined && seriesHint.trim().length > 0) {
+    appendTitle(seriesHint, extractSearchYear(seriesHint));
+  }
+  const fileTitleYear = parsedYear;
+  for (const title of buildSearchTitles(parsedTitle)) {
+    appendTitle(title, fileTitleYear);
+  }
+  return candidates;
+}
+
+function selectTvSearchResult(
+  results: TvSeriesScrapeResult[],
+  expectedYear: number | undefined
+): TvSeriesScrapeResult | null {
+  if (expectedYear === undefined) {
+    return results.length > 0 ? results[0] : null;
+  }
+  for (const result of results) {
+    const resultYear = extractSearchYear(result.firstAirDate ?? '');
+    if (resultYear === expectedYear) {
+      return result;
+    }
+  }
+  return null;
 }
 
 // ─────────────────────────────────────────────
@@ -677,17 +722,10 @@ export class ScrapeClient {
       console.warn(`[ScrapeClient] autoScrapeTvEpisode 跳过: mediaType=${effectiveMediaType} title="${parsed.title}" file=${fileName}`);
       return empty;
     }
-    const shouldUseSeriesHint = seriesHint !== undefined && seriesHint.length > 0 &&
-      (parsed.title.length === 0 || isWeakSemanticTitleText(parsed.title));
-    const effectiveTitle = shouldUseSeriesHint
-      ? seriesHint
-      : parsed.title;
-    if (effectiveTitle.length === 0) {
+    const searchCandidates = buildTvSearchCandidates(parsed.title, parsed.year, seriesHint);
+    if (searchCandidates.length === 0) {
       console.warn(`[ScrapeClient] autoScrapeTvEpisode 标题为空且无 seriesHint，跳过 file=${fileName}`);
       return empty;
-    }
-    if (effectiveTitle !== parsed.title) {
-      console.info(`[ScrapeClient] autoScrapeTvEpisode 使用 seriesHint="${seriesHint}" 作为搜索标题（文件名无剧名）: file="${fileName}"`);
     }
 
     // #191 支持显式季集号：优先使用显式参数，回退到 parseFileName 结果
@@ -695,28 +733,32 @@ export class ScrapeClient {
     const effectiveEpisodeNumber = explicitEpisodeNumber ?? parsed.episodeNumber;
     const effectiveSeasonNumber = explicitSeasonNumber ?? (explicitEpisodeNumber !== undefined ? 1 : parsed.seasonNumber);
 
-    console.info(`[ScrapeClient] autoScrapeTvEpisode 开始: file="${fileName}" → title="${effectiveTitle}" S${effectiveSeasonNumber ?? '?'}E${effectiveEpisodeNumber ?? '?'} year=${parsed.year ?? '?'}`);
-    const searchTitlesLog = buildSearchTitles(effectiveTitle);
-    console.info(`[ScrapeClient] autoScrapeTvEpisode 候选标题: ${JSON.stringify(searchTitlesLog)}`);
+    console.info(`[ScrapeClient] autoScrapeTvEpisode 开始: file="${fileName}" S${effectiveSeasonNumber ?? '?'}E${effectiveEpisodeNumber ?? '?'}`);
+    console.info(`[ScrapeClient] autoScrapeTvEpisode 候选标题: ${JSON.stringify(searchCandidates)}`);
 
     await this.acquire();
     try {
       for (const provider of this.getActiveProviders()) {
         try {
-          const searchTitles = buildSearchTitles(effectiveTitle);
           let topSearch: TvSeriesScrapeResult | null = null;
-          for (const candidate of searchTitles) {
-            // 第一轮：带年份搜索（year= 参数，过滤精确）
-            let results = await provider.searchTv(candidate, parsed.year, 'zh-CN');
-            console.info(`[ScrapeClient] searchTv("${candidate}" year=${parsed.year ?? 'none'}) → ${results.length} 条结果${results.length > 0 ? ' 首条: ' + results[0].title + '(id=' + results[0].providerId + ')' : ''}`);
-            // 第二轮：带年份无结果时，降级为只用剧名搜索
-            if (results.length === 0 && parsed.year !== undefined) {
-              results = await provider.searchTv(candidate, undefined, 'zh-CN');
-              console.info(`[ScrapeClient] searchTv("${candidate}" 无年份降级) → ${results.length} 条结果${results.length > 0 ? ' 首条: ' + results[0].title + '(id=' + results[0].providerId + ')' : ''}`);
+          for (const candidate of searchCandidates) {
+            let results = await provider.searchTv(candidate.title, candidate.year, 'zh-CN');
+            topSearch = selectTvSearchResult(results, candidate.year);
+            console.info(
+              `[ScrapeClient] searchTv("${candidate.title}" year=${candidate.year ?? 'none'}) → ${results.length} 条结果` +
+              `${topSearch ? '，选中: ' + topSearch.title + '(id=' + topSearch.providerId + ')' : ''}`
+            );
+            // 带年份搜索没有精确年份候选时，允许降级查询，但仍拒绝年份冲突的条目。
+            if (!topSearch && candidate.year !== undefined) {
+              results = await provider.searchTv(candidate.title, undefined, 'zh-CN');
+              topSearch = selectTvSearchResult(results, candidate.year);
+              console.info(
+                `[ScrapeClient] searchTv("${candidate.title}" 无年份降级) → ${results.length} 条结果` +
+                `${topSearch ? '，选中: ' + topSearch.title + '(id=' + topSearch.providerId + ')' : ''}`
+              );
             }
-            if (results.length > 0) {
-              topSearch = results[0];
-              console.info(`[ScrapeClient] autoScrapeTvEpisode 命中候选标题="${candidate}" providerId=${topSearch.providerId}`);
+            if (topSearch) {
+              console.info(`[ScrapeClient] autoScrapeTvEpisode 命中候选标题="${candidate.title}" providerId=${topSearch.providerId}`);
               break;
             }
           }
@@ -735,16 +777,20 @@ export class ScrapeClient {
           let episode: TvEpisodeScrapeResult | null = null;
 
           if (effectiveSeasonNumber !== undefined) {
-            season = await provider.fetchSeason(series.providerId, effectiveSeasonNumber, 'zh-CN').catch((e: BusinessError) => {
-              console.warn(`[ScrapeClient] fetchSeason(${series.providerId}, ${effectiveSeasonNumber}) 失败: ${JSON.stringify(e)}`);
-              return null;
-            });
+            try {
+              season = await provider.fetchSeason(series.providerId, effectiveSeasonNumber, 'zh-CN');
+            } catch (e) {
+              const err = e as BusinessError;
+              console.warn(`[ScrapeClient] fetchSeason(${series.providerId}, ${effectiveSeasonNumber}) 失败: ${err.message}`);
+            }
             console.info(`[ScrapeClient] fetchSeason S${effectiveSeasonNumber} → ${season ? 'OK posterUrl=' + (season.posterUrl ? 'Y' : 'N') : 'null'}`);
             if (effectiveEpisodeNumber !== undefined) {
-              episode = await provider.fetchEpisode(series.providerId, effectiveSeasonNumber, effectiveEpisodeNumber, 'zh-CN').catch((e: BusinessError) => {
-                console.warn(`[ScrapeClient] fetchEpisode(${series.providerId}, S${effectiveSeasonNumber}E${effectiveEpisodeNumber}) 失败: ${JSON.stringify(e)}`);
-                return null;
-              });
+              try {
+                episode = await provider.fetchEpisode(series.providerId, effectiveSeasonNumber, effectiveEpisodeNumber, 'zh-CN');
+              } catch (e) {
+                const err = e as BusinessError;
+                console.warn(`[ScrapeClient] fetchEpisode(${series.providerId}, S${effectiveSeasonNumber}E${effectiveEpisodeNumber}) 失败: ${err.message}`);
+              }
               console.info(`[ScrapeClient] fetchEpisode E${effectiveEpisodeNumber} → ${episode ? 'OK title="' + (episode.title ?? '') + '"' : 'null'}`);
             }
           }

--- a/entry/src/main/ets/lib/ScrapeClient.ets
+++ b/entry/src/main/ets/lib/ScrapeClient.ets
@@ -229,14 +229,29 @@ function extractSearchYear(title: string): number | undefined {
 }
 
 function removeSearchYear(title: string): string {
-  return title.replace(/[\[（(]\s*(?:19|20)\d{2}\s*[\]）)]/g, ' ').replace(/\s{2,}/g, ' ').trim();
+  return title
+    .replace(/[\[【（(]\s*(?:19|20)\d{2}\s*[\]】）)]/g, ' ')
+    .replace(/(^|[^0-9])(?:19|20)\d{2}(?=$|[^0-9])/g, '$1')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
 }
 
 function buildTvSearchCandidates(parsedTitle: string, parsedYear: number | undefined, seriesHint?: string): TvSearchCandidate[] {
   const candidates: TvSearchCandidate[] = [];
   const appendTitle = (title: string, year?: number): void => {
     const normalizedTitle = removeSearchYear(title);
-    if (normalizedTitle.length === 0 || candidates.some((candidate: TvSearchCandidate) => candidate.title === normalizedTitle)) {
+    if (normalizedTitle.length === 0) {
+      return;
+    }
+    const existingCandidate = candidates.find((candidate: TvSearchCandidate) => candidate.title === normalizedTitle);
+    if (existingCandidate !== undefined) {
+      // 保留路径标题优先级，但不要因去重而丢失文件名提供的年份约束。
+      if (existingCandidate.year === undefined && year !== undefined) {
+        existingCandidate.year = year;
+      } else if (existingCandidate.year !== year && year !== undefined) {
+        const candidate: TvSearchCandidate = { title: normalizedTitle, year };
+        candidates.push(candidate);
+      }
       return;
     }
     const candidate: TvSearchCandidate = { title: normalizedTitle, year };

--- a/entry/src/test/ScrapeClient.test.ets
+++ b/entry/src/test/ScrapeClient.test.ets
@@ -294,6 +294,61 @@ export default function scrapeClientTest() {
       }
     });
 
+    it('应使用文件名年份约束同名路径剧集候选', 0, async () => {
+      const fake = new ScriptedFakeScrapeProvider('fake-issue-234-file-year');
+      const incorrect = createTvSeriesScrapeResult('fake-issue-234-file-year', 'Climax!', 'tv-1954');
+      incorrect.firstAirDate = '1954-10-01';
+      const expected = createTvSeriesScrapeResult('fake-issue-234-file-year', 'Climax', 'tv-2026');
+      expected.firstAirDate = '2026-01-01';
+      fake.enqueueSearchTvResults([incorrect, expected]);
+      fake.enqueueFetchTvSeriesDetailResult(expected);
+
+      const client = new ScrapeClient({});
+      client.registerProvider(fake);
+
+      const result = await client.autoScrapeTvEpisode('Climax.(2026).S01E01.mkv', 'Climax', 'tv');
+
+      expect(result.series !== null).assertTrue();
+      if (result.series !== null) {
+        expect(result.series.providerId).assertEqual('tv-2026');
+      }
+      const searchCall = fake.getLastCall('searchTv');
+      expect(searchCall !== null).assertTrue();
+      if (searchCall !== null) {
+        expect(searchCall.title).assertEqual('Climax');
+        expect(searchCall.year).assertEqual(2026);
+      }
+    });
+
+    it('应清理未加括号和方括号包裹的路径年份', 0, async () => {
+      const fake = new ScriptedFakeScrapeProvider('fake-issue-234-normalize-year');
+      const show = createTvSeriesScrapeResult('fake-issue-234-normalize-year', 'Show', 'show-2026');
+      show.firstAirDate = '2026-01-01';
+      fake.enqueueSearchTvResults([show]);
+      fake.enqueueFetchTvSeriesDetailResult(show);
+      fake.enqueueSearchTvResults([show]);
+      fake.enqueueFetchTvSeriesDetailResult(show);
+
+      const client = new ScrapeClient({});
+      client.registerProvider(fake);
+
+      await client.autoScrapeTvEpisode('Episode S01E01.mkv', 'Show 2026', 'tv');
+      const firstSearchCall = fake.getLastCall('searchTv');
+      expect(firstSearchCall !== null).assertTrue();
+      if (firstSearchCall !== null) {
+        expect(firstSearchCall.title).assertEqual('Show');
+        expect(firstSearchCall.year).assertEqual(2026);
+      }
+
+      await client.autoScrapeTvEpisode('Episode S01E02.mkv', 'Show【2026】', 'tv');
+      const secondSearchCall = fake.getLastCall('searchTv');
+      expect(secondSearchCall !== null).assertTrue();
+      if (secondSearchCall !== null) {
+        expect(secondSearchCall.title).assertEqual('Show');
+        expect(secondSearchCall.year).assertEqual(2026);
+      }
+    });
+
     it('应拒绝与路径年份不一致的电视剧候选', 0, async () => {
       const fake = new ScriptedFakeScrapeProvider('fake-issue-234-year-mismatch');
       const incorrect = createTvSeriesScrapeResult('fake-issue-234-year-mismatch', 'Climax!', 'tv-1954');

--- a/entry/src/test/ScrapeClient.test.ets
+++ b/entry/src/test/ScrapeClient.test.ets
@@ -259,6 +259,61 @@ export default function scrapeClientTest() {
       }
     });
 
+    it('应按路径剧名和年份选择正确的电视剧候选', 0, async () => {
+      const fake = new ScriptedFakeScrapeProvider('fake-issue-234');
+      const incorrect = createTvSeriesScrapeResult('fake-issue-234', 'Climax!', 'tv-1954');
+      incorrect.firstAirDate = '1954-10-01';
+      const expected = createTvSeriesScrapeResult('fake-issue-234', '权欲之巅', 'tv-2026');
+      expected.firstAirDate = '2026-01-01';
+      fake.enqueueSearchTvResults([incorrect, expected]);
+      fake.enqueueFetchTvSeriesDetailResult(expected);
+      fake.enqueueFetchSeasonResult(null);
+      fake.enqueueFetchEpisodeResult(null);
+
+      const client = new ScrapeClient({});
+      client.registerProvider(fake);
+
+      const result = await client.autoScrapeTvEpisode(
+        'Climax S01E01 - 第 1 集 - 1080p WEB-DL H264 AAC 2.0.mkv',
+        '权欲之巅(2026)',
+        'tv'
+      );
+
+      expect(result.series !== null).assertTrue();
+      if (result.series !== null) {
+        expect(result.series.providerId).assertEqual('tv-2026');
+        expect(result.series.title).assertEqual('权欲之巅');
+      }
+      expect(fake.getCallCount('searchTv')).assertEqual(1);
+      expect(fake.getCallCount('fetchTvSeriesDetail')).assertEqual(1);
+      const searchCall = fake.getLastCall('searchTv');
+      expect(searchCall !== null).assertTrue();
+      if (searchCall !== null) {
+        expect(searchCall.title).assertEqual('权欲之巅');
+        expect(searchCall.year).assertEqual(2026);
+      }
+    });
+
+    it('应拒绝与路径年份不一致的电视剧候选', 0, async () => {
+      const fake = new ScriptedFakeScrapeProvider('fake-issue-234-year-mismatch');
+      const incorrect = createTvSeriesScrapeResult('fake-issue-234-year-mismatch', 'Climax!', 'tv-1954');
+      incorrect.firstAirDate = '1954-10-01';
+      fake.enqueueSearchTvResults([incorrect]);
+      fake.enqueueSearchTvResults([incorrect]);
+      fake.enqueueSearchTvResults([]);
+      fake.enqueueSearchTvResults([]);
+
+      const client = new ScrapeClient({});
+      client.registerProvider(fake);
+
+      const result = await client.autoScrapeTvEpisode('Climax S01E01.mkv', '权欲之巅(2026)', 'tv');
+
+      expect(result.series).assertEqual(null);
+      expect(result.season).assertEqual(null);
+      expect(result.episode).assertEqual(null);
+      expect(fake.getCallCount('fetchTvSeriesDetail')).assertEqual(0);
+    });
+
     /**
      * 测试用例 14：测试文件名解析 - 剧集编号识别
      */
@@ -354,10 +409,11 @@ export default function scrapeClientTest() {
   });
 
   describe('buildSearchTitles', () => {
-    it('中英混合标题只返回英文部分', 0, () => {
+    it('中英混合标题保留中英文候选', 0, () => {
       const titles: string[] = buildSearchTitles('流浪地球 The Wandering Earth');
-      expect(titles.length).assertLarger(0);
+      expect(titles.length).assertEqual(2);
       expect(titles[0].trim()).assertEqual('The Wandering Earth');
+      expect(titles[1].trim()).assertEqual('流浪地球');
     });
 
     it('纯中文标题返回中文', 0, () => {


### PR DESCRIPTION
修复电视剧文件名中的英文别名导致错误关联的问题。此前 `Climax S01E01` 会直接采用 TMDB 首条结果，从而误匹配到 1954 年的《Climax!》。

## 改动
- 优先使用扫描路径中的剧名提示，并保留文件名的中英文标题候选。
- 当路径或文件名提供年份时，仅接受首播年份一致的候选；无匹配项则不写入错误关联。
- 无年份时维持既有的 Provider 首条结果回退行为。
- 新增 #234 的正确命中与年份冲突拒绝回归测试。

## 验证
- `git diff --check`
- `devecocli build --product default --modules entry@default --build-mode debug` (`BUILD SUCCESSFUL`)
- 本地 `UnitTestBuild` 因当前 worktree 缺少 `.test` 测试替换工程及 hvigor 缓存依赖，未能启动。

Fixes: #234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化电视剧自动刮削的候选匹配逻辑，支持结合标题与年份选择更准确的结果。
  * 增强中英混合剧名的搜索候选生成。
  * 当带年份搜索未找到匹配结果时，自动进行无年份降级搜索。
  * 改善剧集详情获取失败时的容错处理，避免影响整体刮削流程。

* **测试**
  * 新增并调整多项测试，覆盖年份匹配、错误候选排除及中英混合标题搜索场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->