### PR TITLE
修复: 文件浏览器 WebDAV 视频播放失败

### DIFF
--- a/entry/src/main/ets/lib/WebDAVClient.ets
+++ b/entry/src/main/ets/lib/WebDAVClient.ets
@@ -234,13 +234,17 @@ export class WebDAVClient {
    * 获取完整的 WebDAV URL（用于流式播放）
    */
   public getFullUrl(path: string): string {
-    const basePath = this.baseUrl.replace(/^https?:\/\/[^:\/]+(?::\d+)?/, '');
-    const normalizedPath = this.decodeXmlEntities(path);
-    // 文件浏览器会把选中目录拼入 baseUrl，仅规整路径段，避免产生重复斜杠。
-    let fullPath = `${basePath}/${normalizedPath}`.replace(/\/{2,}/g, '/');
-    fullPath = this.encodeURIPath(fullPath);
+    return `${this.isHttps ? 'https' : 'http'}://${this.host}:${this.port}${this.buildEncodedPath(path)}`;
+  }
 
-    return `${this.isHttps ? 'https' : 'http'}://${this.host}:${this.port}${fullPath}`;
+  /**
+   * 合并服务根路径和资源路径，确保所有请求使用相同的路径规范化规则。
+   */
+  private buildEncodedPath(remotePath: string): string {
+    const basePath = this.baseUrl.replace(/^https?:\/\/[^:\/]+(?::\d+)?/, '');
+    // 文件浏览器会把选中目录拼入 baseUrl，仅规整路径段，避免产生重复斜杠。
+    const fullPath = `${basePath}/${remotePath}`.replace(/\/{2,}/g, '/');
+    return this.encodeURIPath(fullPath);
   }
 
   private getAuthHeader(): string {
@@ -903,9 +907,7 @@ export class WebDAVClient {
       throw error;
     }
 
-    let basePath = this.baseUrl.replace(/^https?:\/\/[^:\/]+(?::\d+)?/, '');
-    let fullPath = basePath + (remotePath.startsWith('/') ? remotePath : '/' + remotePath);
-    fullPath = this.encodeURIPath(fullPath);
+    const fullPath = this.buildEncodedPath(remotePath);
 
     const downloadHeaders: Record<string, string> = {
       'User-Agent': 'WebDAV-Client/1.0',
@@ -1276,10 +1278,8 @@ export class WebDAVClient {
         }
       });
 
-      // 构建完整路径并编码
-      let basePath = this.baseUrl.replace(/^https?:\/\/[^:\/]+(?::\d+)?/, '');
-      let fullPath = basePath + (remotePath.startsWith('/') ? remotePath : '/' + remotePath);
-      fullPath = this.encodeURIPath(fullPath);
+      // 与播放地址使用同一套路径规范化和编码逻辑。
+      const fullPath = this.buildEncodedPath(remotePath);
 
       console.info('Download path (encoded):', fullPath);
 

--- a/entry/src/main/ets/lib/WebDAVClient.ets
+++ b/entry/src/main/ets/lib/WebDAVClient.ets
@@ -125,6 +125,15 @@ export function sanitizeUrlForAudit(rawUrl: string): string {
   return rawUrl.replace(/:\/\/([^:@]+):([^@]+)@/, '://***:***@');
 }
 
+/** 仅在存在有效凭据时向媒体请求附加 Authorization。 */
+export function buildWebDavHttpHeader(authHeader: string): Record<string, string> {
+  if (authHeader.length === 0) {
+    return {};
+  }
+  const headers: Record<string, string> = { 'Authorization': authHeader };
+  return headers;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface WebDAVConfig {

--- a/entry/src/main/ets/lib/WebDAVClient.ets
+++ b/entry/src/main/ets/lib/WebDAVClient.ets
@@ -234,9 +234,10 @@ export class WebDAVClient {
    * 获取完整的 WebDAV URL（用于流式播放）
    */
   public getFullUrl(path: string): string {
-    let basePath = this.baseUrl.replace(/^https?:\/\/[^:\/]+(?::\d+)?/, '');
+    const basePath = this.baseUrl.replace(/^https?:\/\/[^:\/]+(?::\d+)?/, '');
     const normalizedPath = this.decodeXmlEntities(path);
-    let fullPath = basePath + (normalizedPath.startsWith('/') ? normalizedPath : '/' + normalizedPath);
+    // 文件浏览器会把选中目录拼入 baseUrl，仅规整路径段，避免产生重复斜杠。
+    let fullPath = `${basePath}/${normalizedPath}`.replace(/\/{2,}/g, '/');
     fullPath = this.encodeURIPath(fullPath);
 
     return `${this.isHttps ? 'https' : 'http'}://${this.host}:${this.port}${fullPath}`;

--- a/entry/src/main/ets/pages/files/index.ets
+++ b/entry/src/main/ets/pages/files/index.ets
@@ -2,7 +2,7 @@ import { IBestToast } from "@ibestservices/ibest-ui";
 import { WebDavFileExplorerAdapter } from "../../components/core/file/FileExplorerAdapter";
 import { FileExplorer } from "../../components/core/file/FileExplorer";
 import { FileExplorerController } from "../../components/core/file/FileExplorerController";
-import { WebDAVClient, WebDAVConfig, WebDAVResource } from "../../lib/WebDAVClient";
+import { buildWebDavHttpHeader, WebDAVClient, WebDAVConfig, WebDAVResource } from "../../lib/WebDAVClient";
 import { PlayerPage, PlayerPageParam } from "../player";
 import { common } from "@kit.AbilityKit";
 import { util } from "@kit.ArkTS";
@@ -254,7 +254,7 @@ export struct FileExplorerPage {
   private async playVideo(path: string, displayName: string) {
     const url = this.client.getFullUrl(path);
     const authHeader = this.client.getAuthHeaderPublic();
-    const httpHeader: Record<string, string> = { 'Authorization': authHeader };
+    const httpHeader = buildWebDavHttpHeader(authHeader);
 
     console.info(`[playVideo] 开始 — path="${path}" displayName="${displayName}" url="${url}"`);
 

--- a/entry/src/main/ets/services/sourceAdapter/SourceAdapterService.ets
+++ b/entry/src/main/ets/services/sourceAdapter/SourceAdapterService.ets
@@ -28,7 +28,7 @@ import {
   WebDAVSourceConfig
 } from "../../db/models/FileSourceEntity";
 import { FfprobeTrack, FfprobeUtil } from "../../utils/FfprobeUtil";
-import { WebDAVClient, WebDAVConfig } from "../../lib/WebDAVClient";
+import { buildWebDavHttpHeader, WebDAVClient, WebDAVConfig } from "../../lib/WebDAVClient";
 import buffer from '@ohos.buffer';
 import { PresetAudioTrack, PresetSubtitleTrack } from "../../components/core/player/VideoData";
 import {
@@ -236,8 +236,7 @@ export class SourceAdapterService {
     const client = new WebDAVClient(webdavConfig);
     const url = client.getFullUrl(filePath);
     const authHeader = client.getAuthHeaderPublic();
-    const httpHeader: Record<string, string> =
-      authHeader.length > 0 ? { 'Authorization': authHeader } : {};
+    const httpHeader = buildWebDavHttpHeader(authHeader);
     const result: AssembledSource = { url, httpHeader };
     return result;
   }

--- a/entry/src/test/WebDAVClientUtils.test.ets
+++ b/entry/src/test/WebDAVClientUtils.test.ets
@@ -48,6 +48,18 @@ export default function webDAVClientUtilsTest() {
 
       expect(url).assertEqual('http://dav.example.com:80/Videos/episode.mkv');
     });
+
+    it('保留资源名中已解码的 XML 实体文本', 0, () => {
+      const client = new WebDAVClient({
+        baseUrl: 'https://dav.example.com:5006/Videos',
+        username: 'user',
+        password: 'pass'
+      });
+
+      const url = client.getFullUrl('/literal &amp; name.mkv');
+
+      expect(url).assertEqual('https://dav.example.com:5006/Videos/literal%20%26amp%3B%20name.mkv');
+    });
   });
 
   // ─── classifyTlsError ────────────────────────────────────────────────────

--- a/entry/src/test/WebDAVClientUtils.test.ets
+++ b/entry/src/test/WebDAVClientUtils.test.ets
@@ -1,6 +1,7 @@
 import { describe, it, expect } from '@ohos/hypium';
 import {
   buildWebDavHttpHeader,
+  WebDAVClient,
   classifyTlsError,
   isTlsError,
   normalizeTlsCertPolicy,
@@ -20,6 +21,32 @@ export default function webDAVClientUtilsTest() {
       const headers = buildWebDavHttpHeader('Basic dXNlcjpwYXNz');
 
       expect(headers.Authorization).assertEqual('Basic dXNlcjpwYXNz');
+    });
+  });
+
+  describe('getFullUrl', () => {
+    it('合并根目录和资源路径时不保留重复斜杠', 0, () => {
+      const client = new WebDAVClient({
+        baseUrl: 'https://dav.example.com:5006//Videos/',
+        username: 'user',
+        password: 'pass'
+      });
+
+      const url = client.getFullUrl('/TV Series/episode 01.mkv');
+
+      expect(url).assertEqual('https://dav.example.com:5006/Videos/TV%20Series/episode%2001.mkv');
+    });
+
+    it('保留协议分隔符并补齐缺失的资源路径斜杠', 0, () => {
+      const client = new WebDAVClient({
+        baseUrl: 'http://dav.example.com:80/Videos',
+        username: 'user',
+        password: 'pass'
+      });
+
+      const url = client.getFullUrl('episode.mkv');
+
+      expect(url).assertEqual('http://dav.example.com:80/Videos/episode.mkv');
     });
   });
 

--- a/entry/src/test/WebDAVClientUtils.test.ets
+++ b/entry/src/test/WebDAVClientUtils.test.ets
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@ohos/hypium';
 import {
+  buildWebDavHttpHeader,
   classifyTlsError,
   isTlsError,
   normalizeTlsCertPolicy,
@@ -7,6 +8,21 @@ import {
 } from '../main/ets/lib/WebDAVClient';
 
 export default function webDAVClientUtilsTest() {
+  describe('buildWebDavHttpHeader', () => {
+    it('未配置凭据时不传 Authorization', 0, () => {
+      const headers = buildWebDavHttpHeader('');
+
+      expect(Object.keys(headers).length).assertEqual(0);
+      expect(headers.Authorization === undefined).assertTrue();
+    });
+
+    it('存在凭据时保留 Authorization', 0, () => {
+      const headers = buildWebDavHttpHeader('Basic dXNlcjpwYXNz');
+
+      expect(headers.Authorization).assertEqual('Basic dXNlcjpwYXNz');
+    });
+  });
+
   // ─── classifyTlsError ────────────────────────────────────────────────────
 
   describe('classifyTlsError', () => {


### PR DESCRIPTION
文件浏览器播放 WebDAV 视频时会生成重复斜杠路径，且未配置凭据时仍可能传递空的 Authorization 请求头，导致 MPV 无法打开部分视频。

- 统一构造 WebDAV 播放请求头，仅在存在有效凭据时附加 Authorization。
- 规范化 WebDAV URL 的路径部分，避免目录与文件路径拼接为 `//Videos/...`，同时保持协议分隔符不受影响。
- 为请求头和 URL 拼接新增回归测试，覆盖无凭据、有效 Basic Auth、重复斜杠及空格编码。

已验证：应用构建、`UnitTestBuild`、`git diff --check`，并已安装启动到真机。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 优化 WebDAV 地址拼接，统一处理路径斜杠并正确编码资源路径。
  * 改进视频播放及资源访问时的 WebDAV 认证请求头处理，无凭据时不发送空认证信息。

* **测试**
  * 增加 WebDAV 请求头生成和 URL 拼接场景的覆盖，提升访问稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->