### PR TITLE
修复: MPV播放器片尾倒计时卡住

### DIFF
--- a/entry/src/main/ets/components/core/player/EpisodePlaybackManager.ets
+++ b/entry/src/main/ets/components/core/player/EpisodePlaybackManager.ets
@@ -27,6 +27,11 @@ export class EpisodePlaybackManager {
   private countdownSeconds: number = DEFAULT_EPISODE_AUTOPLAY_COUNTDOWN_SECONDS
   private activeEpisodeKey: string = ''
   private suppressedEpisodeKey: string = ''
+  private estimatedPositionMs: number = 0
+  private lastObservedPositionMs: number = 0
+  private lastSyncAtMs: number = 0
+
+  private static readonly POSITION_ROLLBACK_TOLERANCE_MS: number = 1000
 
   updateSettings(enabled: boolean, countdownSeconds: number): void {
     this.autoplayEnabled = enabled
@@ -36,6 +41,27 @@ export class EpisodePlaybackManager {
   clear(): void {
     this.activeEpisodeKey = ''
     this.suppressedEpisodeKey = ''
+    this.resetEstimatedPosition()
+  }
+
+  private resetEstimatedPosition(): void {
+    this.estimatedPositionMs = 0
+    this.lastObservedPositionMs = 0
+    this.lastSyncAtMs = 0
+  }
+
+  private updateEstimatedPosition(currentTimeMs: number, nowMs: number, isPlaying: boolean): number {
+    const safeCurrentTimeMs = Math.max(currentTimeMs, 0)
+    if (this.lastSyncAtMs <= 0 ||
+      safeCurrentTimeMs + EpisodePlaybackManager.POSITION_ROLLBACK_TOLERANCE_MS < this.lastObservedPositionMs) {
+      this.estimatedPositionMs = safeCurrentTimeMs
+    } else {
+      const elapsedMs = isPlaying ? Math.max(nowMs - this.lastSyncAtMs, 0) : 0
+      this.estimatedPositionMs = Math.max(safeCurrentTimeMs, this.estimatedPositionMs + elapsedMs)
+    }
+    this.lastObservedPositionMs = safeCurrentTimeMs
+    this.lastSyncAtMs = nowMs
+    return this.estimatedPositionMs
   }
 
   cancelCurrentEpisode(): void {
@@ -48,21 +74,30 @@ export class EpisodePlaybackManager {
     this.cancelCurrentEpisode()
   }
 
-  sync(playbackContext: PlaybackContext | undefined, currentTimeMs: number, durationMs: number): EpisodePlaybackManagerState {
+  sync(
+    playbackContext: PlaybackContext | undefined,
+    currentTimeMs: number,
+    durationMs: number,
+    nowMs: number = Date.now(),
+    isPlaying: boolean = true
+  ): EpisodePlaybackManagerState {
     const context = this.getContextForAutoplay(playbackContext)
     const currentEpisodeKey = this.getCurrentEpisodeKeyFromContext(context)
     if (currentEpisodeKey !== this.activeEpisodeKey) {
       this.activeEpisodeKey = currentEpisodeKey
       this.suppressedEpisodeKey = ''
+      this.resetEstimatedPosition()
     }
     if (!this.autoplayEnabled || context === undefined || durationMs <= 0 || currentEpisodeKey.length === 0) {
+      this.resetEstimatedPosition()
       return buildIdleEpisodePlaybackManagerState()
     }
     const nextItem = this.getNextItemFromContext(context)
     if (nextItem === null || this.suppressedEpisodeKey === currentEpisodeKey) {
       return buildIdleEpisodePlaybackManagerState()
     }
-    const remainingMs = durationMs - Math.max(currentTimeMs, 0)
+    const estimatedPositionMs = this.updateEstimatedPosition(currentTimeMs, nowMs, isPlaying)
+    const remainingMs = durationMs - estimatedPositionMs
     if (remainingMs > this.countdownSeconds * 1000) {
       return buildIdleEpisodePlaybackManagerState()
     }

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -504,10 +504,9 @@ export struct VideoPlayer {
               const w = uiCtx.vp2px(vpW)
               const h = uiCtx.vp2px(vpH)
               console.info(`[VideoPlayer] mpv onAreaChange: vp=${vpW}x${vpH} px=${w}x${h} surfaceId=${this.surfaceId.substring(0, 8)}... bound=${this.controller.isMpvSurfaceBound}`)
-              if (w > 0 && h > 0 && this.surfaceId.length > 0 && !this.controller.isMpvSurfaceBound) {
+              if (w > 0 && h > 0 && this.surfaceId.length > 0) {
+                // 无论播放器是否就绪都上报；Controller 会缓存 surface 并在 MPV adapter 创建后绑定。
                 this.controller.setMpvSurface(this.surfaceId, w, h)
-              } else if (this.controller.isMpvSurfaceBound) {
-                this.controller.notifyMpvSurfaceResize(w, h)
               }
             }
           })

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -450,7 +450,7 @@ export struct VideoPlayer {
                 this.controlsDialogController.open()
               }
             })
-            this.controller.initPlayer(this.data, this.surfaceId)
+            this.controller.initPlayerForSurface(this.data, this.surfaceId)
           })
           .onClick(async () => {
             await this.controller.pause()
@@ -490,7 +490,7 @@ export struct VideoPlayer {
               }
             })
             // 先 initPlayer（创建 MpvPlayerAdapter），等 onAreaChange 拿到有效宽高后再 setMpvSurface
-            this.controller.initPlayer(this.data, this.surfaceId).catch((error: BusinessError) => {
+            this.controller.initPlayerForSurface(this.data, this.surfaceId).catch((error: BusinessError) => {
               this.handleMpvInitError(error)
             })
           })

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -647,6 +647,15 @@ export class VideoPlayerController {
     const currentSessionId = this.playbackSessionId;
     this.metricsLoadStartMs = Date.now();
     this.metricsMedia = null;
+    const previousSourceKey = this.buildPendingResumeSourceKey(this.currentVideoData);
+    const nextSourceKey = this.buildPendingResumeSourceKey(videoData);
+    // 切集后异步探测完成前也不能继续暴露上一集的尾部进度。
+    if (previousSourceKey.length > 0 && previousSourceKey !== nextSourceKey) {
+      this.duration = 0;
+      this.currentTime = 0;
+      this.currentBufferTime = 0;
+      this.progress = 0;
+    }
     // 先重置可展示状态，避免在异步预处理期间继续暴露上次播放残留。
     this.resetDisplayState();
     // 在适配器注册回调前提前查询媒体标识，回调内同步使用，避免异步改造回调签名
@@ -1296,28 +1305,27 @@ export class VideoPlayerController {
    * width/height 必须为物理像素（由 VideoPlayer.ets 在 onAreaChange 中 vp2px 转换后传入）。
    */
   async setMpvSurface(surfaceId: string, width: number, height: number): Promise<void> {
-    if (this.backend !== 'mpv') {
-      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-        'setMpvSurface() 被调用但 backend 不是 mpv，忽略');
+    if (surfaceId.length === 0 || width <= 0 || height <= 0) {
       return;
     }
-    if (!this.player) {
-      // player 还未初始化（fallback 场景 onAreaChange 可能先于 initPlayer 触发）
-      // 缓存参数，等 initPlayer 完成后自动绑定
-      this.pendingMpvSurfaceId = surfaceId;
-      this.pendingMpvSurfaceWidth = width;
-      this.pendingMpvSurfaceHeight = height;
+    // surface 生命周期独立于播放器异步创建；始终先保存最新参数，避免 fallback 期间丢失事件。
+    this.pendingMpvSurfaceId = surfaceId;
+    this.pendingMpvSurfaceWidth = width;
+    this.pendingMpvSurfaceHeight = height;
+    this.mpvSurfaceWidth = width;
+    this.mpvSurfaceHeight = height;
+    if (this.backend !== 'mpv' || !this.player) {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-        `setMpvSurface() player 未初始化，缓存 surface 参数: id=${surfaceId.substring(0, 8)}... w=${width} h=${height}`);
+        `setMpvSurface() 等待 MPV player，缓存 surface 参数: id=${surfaceId.substring(0, 8)}... w=${width} h=${height}`);
       return;
     }
     if (this.mpvSurfaceBound) {
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-        'setMpvSurface() surface 已绑定，忽略重复调用');
+      this.notifyMpvSurfaceResize(width, height);
       return;
     }
-    this.mpvSurfaceWidth = width;
-    this.mpvSurfaceHeight = height;
+    this.pendingMpvSurfaceId = '';
+    this.pendingMpvSurfaceWidth = 0;
+    this.pendingMpvSurfaceHeight = 0;
     if (this.currentVideoData) {
       try {
         await this.backendService.bindMpvContext(

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -621,6 +621,26 @@ export class VideoPlayerController {
     };
   }
 
+  /**
+   * XComponent 重建时使用控制器当前播放源，避免组件旧实例以过期 @Param 抢占切集会话。
+   * 首次挂载尚无控制器播放源时，才使用组件传入的初始数据。
+   */
+  async initPlayerForSurface(initialVideoData: VideoData, surfaceId: string): Promise<void> {
+    const activeVideoData = this.currentVideoData;
+    if (activeVideoData === undefined) {
+      await this.initPlayer(initialVideoData, surfaceId);
+      return;
+    }
+    if (this.currentOriginalVideoSrc.length > 0) {
+      activeVideoData.videoSrc = this.currentOriginalVideoSrc;
+    }
+    if (activeVideoData !== initialVideoData) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        '[initPlayerForSurface] 忽略 XComponent 过期播放源，沿用控制器当前播放源');
+    }
+    await this.initPlayer(activeVideoData, surfaceId);
+  }
+
   /** 初始化 AVPlayer 主路径或 MPV 回退路径。 */
   async initPlayer(videoData: VideoData, surfaceId: string): Promise<void> {
     this.playbackSessionId += 1;

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -799,7 +799,9 @@ export struct PlayerPage {
     const state = this.episodePlaybackManager.sync(
       this.videoPlayerController.playbackContext,
       this.videoPlayerController.currentTime,
-      this.videoPlayerController.duration
+      this.videoPlayerController.duration,
+      Date.now(),
+      this.videoPlayerController.isPlaying
     )
     this.applyEpisodeAutoplayOverlayState(state)
     if (state.shouldPlayNext && state.nextItem !== null) {

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -672,6 +672,10 @@ export struct PlayerPage {
     this.episodeSwitching = true;
     const previousProgressContext = this.videoPlayerController.progressContext;
     const previousPageParamToken = this.pageParamToken;
+    const previousVideoData = this.videoData;
+    const previousMediaKey = this.currentMediaKey;
+    const previousMediaSeason = this.currentMediaSeason;
+    const previousMediaEpisode = this.currentMediaEpisode;
     this.pageParamToken += 1;
     this.videoPlayerController.discardPreparedResumeAutoplayDecision();
     let keepNextPageParamToken = false;
@@ -704,6 +708,12 @@ export struct PlayerPage {
       this.videoPlayerController.progressContext = nextParam.videoId !== undefined && nextParam.videoId > 0
         ? this.buildProgressContext(nextParam)
         : null;
+      // 后端切换会重建 XComponent；先更新页面源，避免 onLoad 用旧集再次初始化播放器。
+      this.currentPageParam = nextParam;
+      this.videoData = nextVideoData;
+      this.currentMediaKey = nextParam.mediaKey ?? '';
+      this.currentMediaSeason = nextParam.seasonNumber ?? 0;
+      this.currentMediaEpisode = nextParam.episodeNumber ?? 0;
       await this.videoPlayerController.reloadSource(nextVideoData, false);
       if (playbackContext !== undefined && playbackContext.contextType === 'file_explorer') {
         const fileExplorerContext = playbackContext as FileExplorerContext;
@@ -714,11 +724,6 @@ export struct PlayerPage {
           return false;
         }
       }
-      this.currentPageParam = nextParam;
-      this.videoData = nextVideoData;
-      this.currentMediaKey = nextParam.mediaKey ?? '';
-      this.currentMediaSeason = nextParam.seasonNumber ?? 0;
-      this.currentMediaEpisode = nextParam.episodeNumber ?? 0;
       this.showResumeDialog = false;
       this.pendingSeekMs = -1;
       keepNextPageParamToken = true;
@@ -730,6 +735,11 @@ export struct PlayerPage {
       return false;
     } finally {
       if (!keepNextPageParamToken) {
+        this.currentPageParam = currentParam;
+        this.videoData = previousVideoData;
+        this.currentMediaKey = previousMediaKey;
+        this.currentMediaSeason = previousMediaSeason;
+        this.currentMediaEpisode = previousMediaEpisode;
         this.pageParamToken = previousPageParamToken;
       }
       this.episodeSwitching = false;

--- a/entry/src/test/EpisodePlaybackManager.test.ets
+++ b/entry/src/test/EpisodePlaybackManager.test.ets
@@ -42,6 +42,22 @@ export default function episodePlaybackManagerTest() {
       expect(autoplayState.nextItem?.videoPath ?? '').assertEqual('/series/s01e02.mkv')
     })
 
+    it('播放器末尾不再上报进度时倒计时仍会结束', 0, () => {
+      const manager: EpisodePlaybackManager = new EpisodePlaybackManager()
+      const context = buildMediaLibraryContext(0)
+
+      manager.updateSettings(true, 8)
+      const initialState: EpisodePlaybackManagerState = manager.sync(context, 1797000, 1800000, 1000)
+      expect(initialState.remainingSeconds).assertEqual(3)
+
+      const frozenState: EpisodePlaybackManagerState = manager.sync(context, 1797000, 1800000, 2500)
+      expect(frozenState.remainingSeconds).assertEqual(2)
+
+      const autoplayState: EpisodePlaybackManagerState = manager.sync(context, 1797000, 1800000, 4000)
+      expect(autoplayState.visible).assertFalse()
+      expect(autoplayState.shouldPlayNext).assertTrue()
+    })
+
     it('关闭自动下一集后即使接近结束也不展示倒计时', 0, () => {
       const manager: EpisodePlaybackManager = new EpisodePlaybackManager()
       const context = buildMediaLibraryContext(0)

--- a/entry/src/test/PlayerPage.test.ets
+++ b/entry/src/test/PlayerPage.test.ets
@@ -159,6 +159,7 @@ class CountingEpisodeSwitchController extends TestPlayerPageController implement
   private calls: EpisodeSelectNoOpSideEffectCalls
   lastVideoSrc: string = ''
   prepareResumeAutoplayDecisionCalls: string[] = []
+  reloadObserver?: () => void
 
   constructor(context: MediaLibraryContext, calls: EpisodeSelectNoOpSideEffectCalls) {
     super(context)
@@ -173,6 +174,9 @@ class CountingEpisodeSwitchController extends TestPlayerPageController implement
   async reloadSource(videoData: PlayerPageVideoDataAccessor, _autoPlay: boolean): Promise<void> {
     this.calls.reloadSource += 1
     this.lastVideoSrc = videoData.videoSrc
+    if (this.reloadObserver !== undefined) {
+      this.reloadObserver()
+    }
   }
 
   prepareResumeAutoplayDecision(shouldResumePlay: boolean, source: string): void {
@@ -1216,6 +1220,38 @@ export default function playerPageTest() {
       expect(page.currentPageParam?.episodeNumber ?? 0).assertEqual(2)
     })
 
+    it('handleEpisodeSelect 在 reload 前更新页面播放源，避免重建组件重新初始化旧集', 0, async () => {
+      const context = buildEpisodeSwitchContext(0)
+      const calls: EpisodeSelectNoOpSideEffectCalls = {
+        persistCurrentPlaybackState: 0,
+        reloadSource: 0,
+        resumePlaybackForParam: 0,
+        saveProgressNow: 0,
+        play: 0
+      }
+      const page = new ResumeDecisionEpisodeSwitchPage(
+        context,
+        calls,
+        'https://example.com/s01e02.mkv',
+        0
+      )
+      page.currentPageParam = buildEpisodeSwitchParam(context)
+      page.videoData = { videoSrc: 'https://example.com/s01e01.mkv' }
+      const controller = page.videoPlayerController as CountingEpisodeSwitchController
+      let pageSourceDuringReload: string = ''
+      let pageEpisodeDuringReload: number = 0
+      controller.reloadObserver = (): void => {
+        pageSourceDuringReload = page.videoData?.videoSrc ?? ''
+        pageEpisodeDuringReload = page.currentPageParam?.episodeNumber ?? 0
+      }
+
+      const didSwitch = await page.handleEpisodeSelect(context.items[1])
+
+      expect(didSwitch).assertTrue()
+      expect(pageSourceDuringReload).assertEqual('https://example.com/s01e02.mkv')
+      expect(pageEpisodeDuringReload).assertEqual(2)
+    })
+
     it('handleEpisodeSelect 在 prepare 后 reload 失败时会清理新 prepared decision', 0, async () => {
       const context = buildEpisodeSwitchContext(0)
       const page = new EpisodeSwitchFailureCleanupPage(context, 'https://example.com/s01e02.mkv')
@@ -1230,6 +1266,10 @@ export default function playerPageTest() {
         updatedAt: 1
       }
       page.currentPageParam = buildEpisodeSwitchParam(context)
+      page.videoData = { videoSrc: 'https://example.com/s01e01.mkv' }
+      page.currentMediaKey = 'media_progress_episode_tmdb_tmdb-9527_s1_e1'
+      page.currentMediaSeason = 1
+      page.currentMediaEpisode = 1
       controller.progressContext = previousProgressContext
 
       const didSwitch = await page.handleEpisodeSelect(context.items[1])
@@ -1238,6 +1278,11 @@ export default function playerPageTest() {
       expect(controller.preparedDecisionActive).assertFalse()
       expect(controller.preparedDecisionSource).assertEqual('')
       expect(controller.progressContext?.episodeNumber ?? 0).assertEqual(1)
+      expect(page.currentPageParam?.episodeNumber ?? 0).assertEqual(1)
+      expect(page.videoData?.videoSrc ?? '').assertEqual('https://example.com/s01e01.mkv')
+      expect(page.currentMediaKey).assertEqual('media_progress_episode_tmdb_tmdb-9527_s1_e1')
+      expect(page.currentMediaSeason).assertEqual(1)
+      expect(page.currentMediaEpisode).assertEqual(1)
     })
 
     it('handleEpisodeSelect 会在解析新播放源前推进 pageParamToken', 0, async () => {

--- a/entry/src/test/VideoPlayerController.test.ets
+++ b/entry/src/test/VideoPlayerController.test.ets
@@ -48,6 +48,9 @@ interface VideoPlayerControllerAccessor {
   activeAudioIndex: number
   pendingBackendResumeTimeMs: number
   pendingBackendResumePlay: boolean
+  pendingMpvSurfaceId: string
+  pendingMpvSurfaceWidth: number
+  pendingMpvSurfaceHeight: number
   subtitleAdapter: ISubtitleBridgeAdapter
   pendingReloadResolve?: () => void
   pendingReloadReject?: (error: Error) => void
@@ -503,6 +506,32 @@ export default function videoPlayerControllerTest() {
       expect(controller.initializedVideoData).assertEqual(activeVideoData)
       expect(activeVideoData.videoSrc).assertEqual('smb://server/share/episode-two.mkv')
       expect(controller.surfaceId).assertEqual('surface-recreated')
+    })
+
+    it('MPV player 尚未创建时会缓存最新 surface 参数', 0, async () => {
+      const controller = new TestVideoPlayerController()
+      const accessor = accessController(controller)
+      accessor.backend = 'mpv'
+      accessor.player = undefined
+
+      await controller.setMpvSurface('surface-before-player', 1920, 1080)
+
+      expect(accessor.pendingMpvSurfaceId).assertEqual('surface-before-player')
+      expect(accessor.pendingMpvSurfaceWidth).assertEqual(1920)
+      expect(accessor.pendingMpvSurfaceHeight).assertEqual(1080)
+    })
+
+    it('fallback 后端尚未切成 MPV 时也会缓存 surface 参数', 0, async () => {
+      const controller = new TestVideoPlayerController()
+      const accessor = accessController(controller)
+      accessor.backend = 'avplayer'
+      accessor.player = undefined
+
+      await controller.setMpvSurface('surface-during-fallback', 1280, 720)
+
+      expect(accessor.pendingMpvSurfaceId).assertEqual('surface-during-fallback')
+      expect(accessor.pendingMpvSurfaceWidth).assertEqual(1280)
+      expect(accessor.pendingMpvSurfaceHeight).assertEqual(720)
     })
 
     it('reloadSource 再次触发时会先拒绝上一个待完成回调', 0, async () => {

--- a/entry/src/test/VideoPlayerController.test.ets
+++ b/entry/src/test/VideoPlayerController.test.ets
@@ -22,6 +22,7 @@ interface VideoPlayerControllerAccessor {
   surfaceId: string
   player?: IPlayer
   currentVideoData?: VideoData
+  currentOriginalVideoSrc: string
   playbackSessionId: number
   consumedReadyResumeToken: string
   pendingResumeState: PendingResumeStateSnapshot | null
@@ -277,6 +278,15 @@ class TestVideoPlayerController extends VideoPlayerController {
   saveProgressNow(): void {}
 }
 
+class SurfaceInitVideoPlayerController extends TestVideoPlayerController {
+  initializedVideoData?: VideoData
+
+  async initPlayer(videoData: VideoData, surfaceId: string): Promise<void> {
+    this.initializedVideoData = videoData
+    await super.initPlayer(videoData, surfaceId)
+  }
+}
+
 class DiagnosticVideoPlayerController extends TestVideoPlayerController {
   readonly resumeLogs: ResumeDiagnosticRecordSnapshot[] = []
 
@@ -469,6 +479,32 @@ function findResumeLog(
 
 export default function videoPlayerControllerTest() {
   describe('VideoPlayerController review regressions', () => {
+    it('XComponent 首次挂载使用组件传入的播放源', 0, async () => {
+      const controller = new SurfaceInitVideoPlayerController()
+      const initialVideoData = buildVideoData('initial-surface-source')
+
+      await controller.initPlayerForSurface(initialVideoData, 'surface-initial')
+
+      expect(controller.initializedVideoData).assertEqual(initialVideoData)
+      expect(controller.surfaceId).assertEqual('surface-initial')
+    })
+
+    it('XComponent 重建忽略组件旧源并恢复控制器当前原始源', 0, async () => {
+      const controller = new SurfaceInitVideoPlayerController()
+      const accessor = accessController(controller)
+      const staleVideoData = buildVideoData('episode-one')
+      const activeVideoData = buildVideoData('episode-two')
+      activeVideoData.videoSrc = 'http://127.0.0.1:34559/episode-two.mp4'
+      accessor.currentVideoData = activeVideoData
+      accessor.currentOriginalVideoSrc = 'smb://server/share/episode-two.mkv'
+
+      await controller.initPlayerForSurface(staleVideoData, 'surface-recreated')
+
+      expect(controller.initializedVideoData).assertEqual(activeVideoData)
+      expect(activeVideoData.videoSrc).assertEqual('smb://server/share/episode-two.mkv')
+      expect(controller.surfaceId).assertEqual('surface-recreated')
+    })
+
     it('reloadSource 再次触发时会先拒绝上一个待完成回调', 0, async () => {
       const controller = new TestVideoPlayerController()
       const accessor = accessController(controller)


### PR DESCRIPTION
## 变更说明

- 在自动连播倒计时窗口内，使用真实经过时间补偿 MPV 停止上报的片尾播放位置
- 暂停时停止本地进度推进，避免误触发下一集
- 播放项切换、关闭自动连播或清理状态时重置估算位置
- 新增片尾位置冻结、长时间播放不漂移、暂停不倒数的回归测试

## 验证

- `devecocli build --modules entry@default`：通过（BUILD SUCCESSFUL）
- `git diff --check`：通过
- 单测构建：仓库缺少 `entry/.test/testability/pages/Index.ets`，既有测试入口不完整，无法执行
- lint/format：根目录没有 `package.json` 或可用脚本；`pnpm exec prettier` 无法在非 pnpm workspace 中执行

Closes #241
