### PR TITLE
修复 SMB 文件修改日期显示异常

### DIFF
--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -4178,10 +4178,8 @@ struct SmbListDirContext {
     std::string errorMessage;
 };
 
-// Windows FILETIME（100ns intervals since 1601-01-01）转为 POSIX 秒
-static inline int64_t WinTimeToUnix(uint64_t winTime) {
-    if (winTime == 0) return 0;
-    return (int64_t)(winTime / 10000000ULL) - (int64_t)11644473600LL;
+static inline uint64_t SmbTimeToUnixMilliseconds(uint64_t seconds, uint64_t nanoseconds) {
+    return seconds * 1000ULL + nanoseconds / 1000000ULL;
 }
 
 static void ExecuteSmbListDirectory(napi_env /*env*/, void *data) {
@@ -4228,7 +4226,7 @@ static void ExecuteSmbListDirectory(napi_env /*env*/, void *data) {
         }
         entry.isDirectory = (ent->st.smb2_type == SMB2_TYPE_DIRECTORY);
         entry.size = ent->st.smb2_size;
-        entry.lastModified = (uint64_t)WinTimeToUnix(ent->st.smb2_mtime) * 1000ULL;  // 转毫秒
+        entry.lastModified = SmbTimeToUnixMilliseconds(ent->st.smb2_mtime, ent->st.smb2_mtime_nsec);
         ctx->files.push_back(std::move(entry));
     }
     smb2_closedir(smb2, dir);

--- a/entry/src/main/cpp/vidall_core_player_napi.cpp
+++ b/entry/src/main/cpp/vidall_core_player_napi.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cctype>
 #include <climits>
+#include <limits>
 #include <thread>
 #include <atomic>
 
@@ -4179,7 +4180,14 @@ struct SmbListDirContext {
 };
 
 static inline uint64_t SmbTimeToUnixMilliseconds(uint64_t seconds, uint64_t nanoseconds) {
-    return seconds * 1000ULL + nanoseconds / 1000000ULL;
+    constexpr uint64_t NANOSECONDS_PER_SECOND = 1000000000ULL;
+    constexpr uint64_t NANOSECONDS_PER_MILLISECOND = 1000000ULL;
+    const uint64_t fractionalMilliseconds = nanoseconds / NANOSECONDS_PER_MILLISECOND;
+    if (nanoseconds >= NANOSECONDS_PER_SECOND ||
+        seconds > (std::numeric_limits<uint64_t>::max() - fractionalMilliseconds) / 1000ULL) {
+        return 0;
+    }
+    return seconds * 1000ULL + fractionalMilliseconds;
 }
 
 static void ExecuteSmbListDirectory(napi_env /*env*/, void *data) {

--- a/entry/src/main/ets/components/core/file/FileExplorerController.ets
+++ b/entry/src/main/ets/components/core/file/FileExplorerController.ets
@@ -194,7 +194,7 @@ export function createFileExplorerResourceFromSmb(file: SmbFileInfo): FileExplor
     path: file.path,
     isDirectory: file.isDirectory,
     size: file.size,
-    lastModifiedMs: file.lastModifiedMs,
+    lastModifiedMs: file.lastModifiedMs > 0 ? file.lastModifiedMs : undefined,
     isHidden: file.name.startsWith('.'),
     sourceType: 'smb'
   };

--- a/entry/src/test/FileExplorerController.test.ets
+++ b/entry/src/test/FileExplorerController.test.ets
@@ -58,6 +58,14 @@ export default function fileExplorerControllerTest() {
       expect(resource.isHidden).assertFalse()
       expect(resource.lastModifiedMs).assertEqual(1714000000123)
     })
+
+    it('SMB 资源缺少有效修改时间时不显示 Unix 起始日期', 0, () => {
+      const resource: FileExplorerResource = createFileExplorerResourceFromSmb(
+        makeSmbFileInfo('share', '/share', true, 0)
+      )
+
+      expect(resource.lastModifiedMs === undefined).assertTrue()
+    })
   })
 
   describe('FileExplorerController unified resources', () => {


### PR DESCRIPTION
## 背景

SMB 文件浏览器把 libsmb2 已返回的 Unix 时间误按 Windows FILETIME 再次转换，导致修改日期显示为 1601 年。

## 改动

- 直接将 SMB 修改时间的 Unix 秒和纳秒转换为毫秒，保留毫秒精度。
- 对零值等无效时间戳映射为未提供时间，界面显示 `-`，避免展示伪日期。
- 新增 SMB 零时间戳映射回归测试。

## 验证

- `devecocli build --modules entry@default` 构建成功。
- 已安装并启动到华为智慧屏 MateTV Pro 真机。
- `git diff --check` 通过。

Fixes: #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复 SMB 目录时间戳转换问题，确保修改时间正确显示。
  - 对无效或缺失的目录修改时间不再显示为 Unix 起始日期。

- **Tests**
  - 新增 SMB 目录无有效修改时间时的验证用例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->