### PR TITLE
重构: VideoPlayerController 状态机收敛为显式状态对象

### DIFF
--- a/entry/src/main/ets/components/core/player/PlaybackState.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackState.ets
@@ -1,0 +1,26 @@
+/**
+ * 播放器显式状态机枚举。
+ *
+ * 用于把 VideoPlayerController 中由多个布尔字段（isReady / isPlaying / isSeeking /
+ * isLoading / hasPrepared）隐式表达的播放会话生命周期，收敛为单一状态来源。
+ */
+export enum PlaybackState {
+  /** 无播放（初始 / release 后） */
+  IDLE = 'idle',
+  /** 初始化中，正在做音频路由决策（resolveAudioRoutingDecision） */
+  ROUTING = 'routing',
+  /** 适配器已创建、正在 load source、等待 prepare 完成 */
+  PREPARING = 'preparing',
+  /** prepare 完成（onPlayerReady） */
+  PREPARED = 'prepared',
+  /** 播放中 */
+  PLAYING = 'playing',
+  /** 已暂停 */
+  PAUSED = 'paused',
+  /** seek 中（含续播 seek） */
+  SEEKING = 'seeking',
+  /** 终端错误（handleTerminalPlayerError） */
+  ERROR = 'error',
+  /** 释放中（release） */
+  RELEASING = 'releasing'
+}

--- a/entry/src/main/ets/components/core/player/ReloadSession.ets
+++ b/entry/src/main/ets/components/core/player/ReloadSession.ets
@@ -1,0 +1,62 @@
+/**
+ * 源重载（reload）事务。
+ *
+ * 把 VideoPlayerController 中散落的 reload 状态（pendingReloadToken / activeReloadToken /
+ * reloadTimeoutId / pendingReloadResolve / pendingReloadReject）收敛为单一对象。
+ *
+ * 语义保持与原实现一致：
+ * - `begin` 生成新 token 并创建等待 Promise + 超时定时器；
+ * - 只有「当前活跃 token」对应的超时才会触发 reject（旧 token 的超时被跳过）。
+ */
+export class ReloadSession {
+  private pendingToken: number = 0;
+  private activeToken: number = 0;
+  private timeoutId?: number;
+  private pendingResolve?: () => void;
+  private pendingReject?: (error: Error) => void;
+
+  /**
+   * 开始一次 reload：token +1，登记 resolve/reject，并启动超时兜底。
+   * @param resolve 与 initPlayer 完成后的 resolvePendingReload 对应
+   * @param reject  与错误/超时/被取代时的 rejectPendingReload 对应
+   */
+  begin(resolve: () => void, reject: (error: Error) => void, timeoutMs: number = 15000): void {
+    this.pendingToken += 1;
+    const token = this.pendingToken;
+    this.activeToken = token;
+    this.pendingResolve = resolve;
+    this.pendingReject = reject;
+    this.timeoutId = setTimeout(() => {
+      // 仅当本次 token 仍是活跃 token 时才触发超时，旧 token 的超时被跳过（与原语义一致）。
+      if (token !== this.activeToken) {
+        return;
+      }
+      this.rejectPending(new Error('reloadSource prepared timeout'));
+    }, timeoutMs);
+  }
+
+  private clear(): void {
+    if (this.timeoutId !== undefined) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = undefined;
+    }
+    this.pendingResolve = undefined;
+    this.pendingReject = undefined;
+  }
+
+  resolvePending(): void {
+    const resolve = this.pendingResolve;
+    this.clear();
+    if (resolve !== undefined) {
+      resolve();
+    }
+  }
+
+  rejectPending(error: Error): void {
+    const reject = this.pendingReject;
+    this.clear();
+    if (reject !== undefined) {
+      reject(error);
+    }
+  }
+}

--- a/entry/src/main/ets/components/core/player/ResumeSession.ets
+++ b/entry/src/main/ets/components/core/player/ResumeSession.ets
@@ -1,0 +1,202 @@
+/**
+ * 续播（resume）会话对象。
+ *
+ * 把 VideoPlayerController 中三层续播状态收敛为单一对象：
+ * - pending：跨后端/实例保持的续播数据（原 PendingResumeState）
+ * - decision：自动播放决策（原 pending/prepared × explicit/has/source 六字段）
+ * - seek：续播 seek 事务（原 pendingResumeSeek* + pendingReadyTrackInit* + 超时兜底）
+ * - result：续播自动播放执行结果观察上下文
+ *
+ * 仅承载「纯数据操作」；涉及 controller 其它状态（playbackSessionId / currentTime /
+ * backend / play()）的日志与编排逻辑仍留在 VideoPlayerController。
+ */
+
+/** 播放后端字面量（与 VideoPlayerController 的 PlayerBackend 结构一致，避免循环依赖） */
+export type ResumeBackend = 'avplayer' | 'mpv';
+
+export interface PendingResumeState {
+  positionMs: number;
+  shouldResumePlay: boolean;
+  autoplayDecisionSource: string;
+  autoplayDecisionOrigin: string;
+  sourceKey: string;
+  reason: string;
+  captureBackend: ResumeBackend;
+}
+
+export interface ResumeAutoplayDecision {
+  shouldResumePlay: boolean;
+  source: string;
+  origin: string;
+}
+
+export interface PendingResumeAutoplayResultState {
+  resumeSource: string;
+  captureBackend: ResumeBackend;
+  pendingResumeMs: number;
+  effectiveResumeMs: number;
+  shouldResumePlay: boolean;
+  autoplayDecision: string;
+  autoplayDecisionSource: string;
+  autoplayDecisionOrigin: string;
+}
+
+export class ResumeSession {
+  // ── pending 分区（第 1 层：跨后端续播数据）──
+  pending: PendingResumeState | null = null;
+
+  // ── decision 分区（第 2 层：自动播放决策）──
+  decisionExplicit: boolean = false;
+  hasDecisionExplicit: boolean = false;
+  decisionSource: string = '';
+  preparedExplicit: boolean = false;
+  hasPreparedExplicit: boolean = false;
+  preparedSource: string = '';
+  preserveOnPaused: boolean = false;
+
+  // ── seek 分区（第 3 层：续播 seek 事务 + 超时兜底）──
+  seekInFlight: boolean = false;
+  seekSource: string = '';
+  seekCaptureBackend: ResumeBackend = 'avplayer';
+  seekTargetMs: number = -1;
+  seekAutoPlay: boolean = false;
+  trackInitAfterSeek: boolean = false;
+  trackInitResumePlay: boolean = false;
+  suppressPlayAfterSeek: boolean = false;
+  fallbackTimer?: number;
+  fallbackSessionId: number = 0;
+  fallbackTriggered: boolean = false;
+
+  // ── result 分区 ──
+  result: PendingResumeAutoplayResultState | null = null;
+
+  /** 创建默认 pending 状态（对应原 ensurePendingResumeState） */
+  ensurePending(backend: ResumeBackend, sourceKey: string): PendingResumeState {
+    if (this.pending === null) {
+      this.pending = {
+        positionMs: -1,
+        shouldResumePlay: false,
+        autoplayDecisionSource: 'compat_override',
+        autoplayDecisionOrigin: 'compat',
+        sourceKey: sourceKey,
+        reason: 'compat_override',
+        captureBackend: backend
+      };
+    }
+    return this.pending;
+  }
+
+  /** 空 pending 则清空（对应原 prunePendingResumeState） */
+  prunePending(): void {
+    if (this.pending === null) {
+      return;
+    }
+    if (this.pending.positionMs < 0 && !this.pending.shouldResumePlay) {
+      this.pending = null;
+    }
+  }
+
+  /** 取出并清空 pending（对应原 consumePendingResumeState） */
+  consumePending(): PendingResumeState | null {
+    const pendingState = this.pending;
+    this.pending = null;
+    return pendingState;
+  }
+
+  /** 归一化续播位置（对应原 normalizePendingResumePosition） */
+  normalizePosition(positionMs: number, durationMs: number): number {
+    let safePosition = positionMs > 0 ? positionMs : 0;
+    if (durationMs > 0 && safePosition > durationMs) {
+      safePosition = durationMs;
+    }
+    return safePosition;
+  }
+
+  /** 判断跨后端是否保留续播（对应原 shouldPreservePendingResume 的 sourceKey 比较） */
+  shouldPreserve(nextSourceKey: string): boolean {
+    if (this.pending === null) {
+      return false;
+    }
+    if (nextSourceKey.length === 0) {
+      return false;
+    }
+    return nextSourceKey === this.pending.sourceKey;
+  }
+
+  /** 记录显式自动播放决策（对应原 rememberPendingResumeAutoplayDecision） */
+  remember(shouldResumePlay: boolean, source: string): void {
+    this.decisionExplicit = shouldResumePlay;
+    this.hasDecisionExplicit = true;
+    this.decisionSource = source.length > 0 ? source : 'explicit';
+  }
+
+  /** 清空当前会话显式决策（对应原 clearPendingResumeAutoplayDecision） */
+  clearPendingDecision(): void {
+    this.decisionExplicit = false;
+    this.hasDecisionExplicit = false;
+    this.decisionSource = '';
+    this.preserveOnPaused = false;
+  }
+
+  /** 预置新媒体初始化链路的自动播放决策（对应原 prepareResumeAutoplayDecision） */
+  prepare(shouldResumePlay: boolean, source: string): void {
+    this.preparedExplicit = shouldResumePlay;
+    this.hasPreparedExplicit = true;
+    this.preparedSource = source.length > 0 ? source : 'prepared';
+  }
+
+  /** 清空预置决策（对应原 clearPreparedResumeAutoplayDecision） */
+  clearPrepared(): void {
+    this.preparedExplicit = false;
+    this.hasPreparedExplicit = false;
+    this.preparedSource = '';
+  }
+
+  /** 预置决策转正为当前会话决策（对应原 applyPreparedResumeAutoplayDecision） */
+  applyPrepared(): void {
+    if (!this.hasPreparedExplicit) {
+      return;
+    }
+    this.remember(this.preparedExplicit, this.preparedSource);
+    this.clearPrepared();
+  }
+
+  /** 清空整个决策生命周期（对应原 clearResumeAutoplayDecisionLifecycle） */
+  clearDecisionLifecycle(): void {
+    this.clearPrepared();
+    this.clearPendingDecision();
+  }
+
+  /** 裁决：显式决策优先，否则 transient 推断（对应原 resolvePendingResumeAutoplayDecision） */
+  resolve(inferredShouldResumePlay: boolean, inferredSource: string): ResumeAutoplayDecision {
+    if (this.hasDecisionExplicit) {
+      return {
+        shouldResumePlay: this.decisionExplicit,
+        source: this.decisionSource.length > 0 ? this.decisionSource : 'explicit',
+        origin: 'explicit'
+      };
+    }
+    return {
+      shouldResumePlay: inferredShouldResumePlay,
+      source: inferredSource,
+      origin: 'transient'
+    };
+  }
+
+  /** 重置续播 seek 事务（对应原 initPlayer 中的散落 seek 字段重置） */
+  resetSeek(): void {
+    this.seekInFlight = false;
+    this.seekSource = '';
+    this.seekCaptureBackend = 'avplayer';
+    this.seekTargetMs = -1;
+    this.seekAutoPlay = false;
+    this.trackInitAfterSeek = false;
+    this.trackInitResumePlay = false;
+    this.suppressPlayAfterSeek = false;
+  }
+
+  /** 清空结果观察上下文 */
+  clearResult(): void {
+    this.result = null;
+  }
+}

--- a/entry/src/main/ets/components/core/player/ResumeSession.ets
+++ b/entry/src/main/ets/components/core/player/ResumeSession.ets
@@ -195,6 +195,27 @@ export class ResumeSession {
     this.suppressPlayAfterSeek = false;
   }
 
+  /** 开始一次续播 seek（对应原 onPlayerReady 中的 resume seek dispatch 字段赋值） */
+  beginResumeSeek(source: string, captureBackend: ResumeBackend, targetMs: number, autoPlay: boolean): void {
+    this.suppressPlayAfterSeek = true;
+    this.trackInitAfterSeek = true;
+    this.trackInitResumePlay = autoPlay;
+    this.seekInFlight = true;
+    this.seekSource = source;
+    this.seekCaptureBackend = captureBackend;
+    this.seekTargetMs = targetMs;
+    this.seekAutoPlay = autoPlay;
+  }
+
+  /** 清空续播 seek 的 dispatch 字段（对应原 continuePendingReadyAfterSeek 中的散落清空） */
+  clearSeekDispatch(): void {
+    this.seekInFlight = false;
+    this.seekSource = '';
+    this.seekCaptureBackend = 'avplayer';
+    this.seekTargetMs = -1;
+    this.seekAutoPlay = false;
+  }
+
   /** 清空结果观察上下文 */
   clearResult(): void {
     this.result = null;

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -956,6 +956,7 @@ export class VideoPlayerController {
             resumeAutoplayDecisionSource, resumeAutoplayDecisionOrigin);
         }
         this.recordPendingResumeAutoplayResult('paused', true);
+        this.transitionTo(PlaybackState.PAUSED);
         this.resumeSession.suppressPlayAfterSeek = false;
       } else {
         if (resumeSeekInFlight) {
@@ -1797,7 +1798,7 @@ export class VideoPlayerController {
   }
 
   async release(): Promise<void> {
-    this.transitionTo(PlaybackState.IDLE);
+    this.transitionTo(PlaybackState.RELEASING);
     this.rejectPendingReload(new Error('player released'));
     this.resumeSession.result = null;
     this.clearResumeSeekAutoplayFallbackState();
@@ -1818,6 +1819,7 @@ export class VideoPlayerController {
     VidAllPlayerAdapter.releaseSmbProxy();
     // 释放 VPE 实例（播放器已销毁后再销毁 VPE，避免 Surface 竞争）
     VpeEnhancerUtil.destroyEnhancer();
+    this.transitionTo(PlaybackState.IDLE);
   }
 
   async seek(time: number, autoplayDecisionSource: string = ''): Promise<void> {
@@ -1866,6 +1868,7 @@ export class VideoPlayerController {
       } catch (seekErr) {
         // 同步 seek 失败时重置状态，避免后续 seek 永久排队。
         this.isSeeking = false;
+        this.transitionTo(PlaybackState.PAUSED);
         this.clearResumeSeekAutoplayFallbackState();
         this.clearPendingResumeAutoplayDecision();
         hilog.error(CommonConstants.LOG_DOMAIN, TAG,

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -44,6 +44,7 @@ import {
   findInitialAudioTrackIndex as serviceFindInitialAudioTrackIndex
 } from "../../../services/audioRouting/AudioTrackRoutingService";
 import type { AudioRoutingDecision } from "../../../services/audioRouting/AudioRoutingTypes";
+import { PlaybackState } from "./PlaybackState";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
 
@@ -196,6 +197,13 @@ export type UnsupportedFormatFallback = 'mpv';
 export class VideoPlayerController {
   /** 运行时播放后端：AVPlayer 主路径，MPV 唯一回退路径。 */
   @Trace backend: PlayerBackend = 'avplayer';
+
+  /**
+   * 显式播放状态（D1 镜像迁移）。
+   * 与旧字段 isReady/isPlaying/isSeeking/isLoading/hasPrepared 并存，
+   * 后续逐步把读取方迁移到本字段后再删除旧字段。
+   */
+  private state: PlaybackState = PlaybackState.IDLE;
 
   /** AI 画质增强开关（仅 avplayer 路径有效） */
   @Trace aiEnhanceEnabled: boolean = true;
@@ -356,6 +364,20 @@ export class VideoPlayerController {
     pendingState.autoplayDecisionSource = autoplayDecision.source;
     pendingState.autoplayDecisionOrigin = autoplayDecision.origin;
     this.prunePendingResumeState();
+  }
+
+  /**
+   * 状态转移（D1 镜像迁移）。
+   * 仅同步 `state` 字段用于日志/诊断与后续收敛，不改动旧字段的写入逻辑。
+   */
+  private transitionTo(nextState: PlaybackState): void {
+    if (this.state !== nextState) {
+      if (ENABLE_SESSION_DIAG_LOG) {
+        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+          `[session=${this.playbackSessionId}] state ${this.state} → ${nextState}`);
+      }
+      this.state = nextState;
+    }
   }
 
   private ensurePendingResumeState(): PendingResumeState {
@@ -596,6 +618,7 @@ export class VideoPlayerController {
       this.clearPendingResumeAutoplayDecision();
     }
     this.isPlaying = false;
+    this.transitionTo(PlaybackState.PAUSED);
     this.pauseSubtitleTimer();
     this.stopProgressTimer();
     this.saveProgressNow();
@@ -693,6 +716,7 @@ export class VideoPlayerController {
     }
 
     // Route selection always resolves to AVPlayer or MPV; MPV is the only fallback.
+    this.transitionTo(PlaybackState.ROUTING);
     const backendBeforeAutoRouting = this.backend;
     const decision = await this.resolveAudioRoutingDecision(videoData);
     if (currentSessionId !== this.playbackSessionId) {
@@ -854,6 +878,8 @@ export class VideoPlayerController {
       }
       this.player = adapter;
     }
+
+    this.transitionTo(PlaybackState.PREPARING);
 
     // Register IPlayer event callbacks (shared path for both service and test adapter).
     const p = this.player as IPlayer;
@@ -1529,6 +1555,7 @@ export class VideoPlayerController {
     this.currentTime = this.player?.currentTime ?? 0;
     this.isReady = true;
     this.isLoading = false;
+    this.transitionTo(PlaybackState.PREPARED);
     const firstFrameElapsed = Date.now() - this.metricsLoadStartMs;
     hilog.info(CommonConstants.LOG_DOMAIN, METRICS_TAG,
       `{"event":"first_frame","backend":"${this.backend}","video_id":${this.progressContext?.videoId ?? -1},"elapsed_ms":${firstFrameElapsed}}`);
@@ -1582,6 +1609,7 @@ export class VideoPlayerController {
       this.subtitleAdapter.onSeekSync();
       this.applySubtitleBridgeState(this.subtitleAdapter.getState());
       this.isSeeking = true;
+      this.transitionTo(PlaybackState.SEEKING);
       this.suppressPlayAfterSeekOnce = true;
       this.pendingReadyTrackInitAfterSeek = true;
       this.pendingReadyTrackInitResumePlay = shouldResumePlay;
@@ -1727,6 +1755,7 @@ export class VideoPlayerController {
   private handleTerminalPlayerError(message: string): void {
     this.isLoading = false;
     this.isPlaying = false;
+    this.transitionTo(PlaybackState.ERROR);
     this.lastErrorMessage = this.normalizePlayerError(message);
     this.rejectPendingReload(new Error(message));
   }
@@ -1817,6 +1846,7 @@ export class VideoPlayerController {
     this.clearPendingResumeAutoplayDecision();
     this.isPlaying = true;
     this.isLoading = false;
+    this.transitionTo(PlaybackState.PLAYING);
     // 成功播放后清理历史错误，避免底部长期显示旧报错。
     this.lastErrorMessage = '';
     if (ENABLE_SESSION_DIAG_LOG) {
@@ -1930,6 +1960,7 @@ export class VideoPlayerController {
   }
 
   async release(): Promise<void> {
+    this.transitionTo(PlaybackState.IDLE);
     this.rejectPendingReload(new Error('player released'));
     this.pendingResumeAutoplayResultState = null;
     this.clearResumeSeekAutoplayFallbackState();
@@ -1983,6 +2014,7 @@ export class VideoPlayerController {
     const canDispatchSeek = !this.isSeeking;
     if (canDispatchSeek) {
       this.isSeeking = true;
+      this.transitionTo(PlaybackState.SEEKING);
     }
     await this.pause();
     this.currentTime = safeTime;
@@ -2510,6 +2542,7 @@ export class VideoPlayerController {
           `[switchAudioTrack] seek flush 到 ${seekTarget}ms${this.pendingResumeSeekInFlight ? ' (resume seek 目标)' : ''}`);
         // 借用 seek() 的暂停-seek-恢复流程：isSeeking=true，seekDone 后自动 play()
         this.isSeeking = true;
+        this.transitionTo(PlaybackState.SEEKING);
         this.player.seek(seekTarget);
         // seekDone 回调里会调 play()，不需要在这里手动恢复
       } else if (shouldFlushAfterSwitch) {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -45,6 +45,7 @@ import {
 } from "../../../services/audioRouting/AudioTrackRoutingService";
 import type { AudioRoutingDecision } from "../../../services/audioRouting/AudioRoutingTypes";
 import { PlaybackState } from "./PlaybackState";
+import { ReloadSession } from "./ReloadSession";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
 
@@ -244,11 +245,8 @@ export class VideoPlayerController {
   @Trace sourceProtocol: string = '';
   @Trace aspectRatioMode: AspectRatioMode = AspectRatioMode.FIT;
   @Trace playbackSpeed: number = 1.0;
-  private pendingReloadToken: number = 0;
-  private activeReloadToken: number = 0;
-  private reloadTimeoutId?: number;
-  private pendingReloadResolve?: () => void;
-  private pendingReloadReject?: (error: Error) => void;
+  /** 源重载事务（收敛原 pendingReloadToken/activeReloadToken/reloadTimeoutId/pendingReloadResolve/pendingReloadReject） */
+  private readonly reloadSession: ReloadSession = new ReloadSession();
   private subtitleAdapter: ISubtitleBridgeAdapter = new NoSubtitleBridgeAdapter();
   private readonly subtitleDispatcher: SubtitleDispatcher = new SubtitleDispatcher();
   /** 字幕缓存上下文，由外部（player page）注入后用于步骤 4 缓存查询 */
@@ -1405,18 +1403,8 @@ export class VideoPlayerController {
     if (autoPlay) {
       this.prepareResumeAutoplayDecision(true, 'reload_source_autoplay');
     }
-    const reloadToken = this.pendingReloadToken + 1;
-    this.pendingReloadToken = reloadToken;
-    this.activeReloadToken = reloadToken;
     const reloadPromise = new Promise<void>((resolve, reject) => {
-      this.pendingReloadResolve = resolve;
-      this.pendingReloadReject = reject;
-      this.reloadTimeoutId = setTimeout(() => {
-        if (reloadToken !== this.activeReloadToken) {
-          return;
-        }
-        this.rejectPendingReload(new Error('reloadSource prepared timeout'));
-      }, 15000);
+      this.reloadSession.begin(resolve, reject);
     });
     try {
       await this.initPlayer(videoData, this.surfaceId);
@@ -1436,29 +1424,12 @@ export class VideoPlayerController {
     }
   }
 
-  private clearPendingReloadState(): void {
-    if (this.reloadTimeoutId !== undefined) {
-      clearTimeout(this.reloadTimeoutId);
-      this.reloadTimeoutId = undefined;
-    }
-    this.pendingReloadResolve = undefined;
-    this.pendingReloadReject = undefined;
-  }
-
   private resolvePendingReload(): void {
-    const resolve = this.pendingReloadResolve;
-    this.clearPendingReloadState();
-    if (resolve !== undefined) {
-      resolve();
-    }
+    this.reloadSession.resolvePending();
   }
 
   private rejectPendingReload(error: Error): void {
-    const reject = this.pendingReloadReject;
-    this.clearPendingReloadState();
-    if (reject !== undefined) {
-      reject(error);
-    }
+    this.reloadSession.rejectPending(error);
   }
 
   /**

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -784,6 +784,7 @@ export class VideoPlayerController {
       this.clearPendingResumeAutoplayDecision();
       this.isPlaying = false;
       this.isLoading = false;
+      this.transitionTo(PlaybackState.PAUSED);
       if (this.duration > 0) {
         this.currentTime = this.duration;
         this.progress = 1;
@@ -798,6 +799,7 @@ export class VideoPlayerController {
       }
       this.clearPendingResumeAutoplayDecision();
       this.isPlaying = false;
+      this.transitionTo(PlaybackState.PAUSED);
       this.stopProgressTimer();
     });
     p.onTimeUpdate((currentTime: number) => {

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -46,6 +46,12 @@ import {
 import type { AudioRoutingDecision } from "../../../services/audioRouting/AudioRoutingTypes";
 import { PlaybackState } from "./PlaybackState";
 import { ReloadSession } from "./ReloadSession";
+import {
+  ResumeSession,
+  PendingResumeState,
+  ResumeAutoplayDecision,
+  PendingResumeAutoplayResultState
+} from "./ResumeSession";
 
 export type { SubtitleTrackItem } from "./SubtitleBridgeAdapter";
 
@@ -121,33 +127,6 @@ interface ResumeDiagnosticLogRecord {
   currentTimeMs: number;
   durationMs: number;
   filePath: string;
-}
-
-interface ResumeAutoplayDecision {
-  shouldResumePlay: boolean;
-  source: string;
-  origin: string;
-}
-
-interface PendingResumeState {
-  positionMs: number;
-  shouldResumePlay: boolean;
-  autoplayDecisionSource: string;
-  autoplayDecisionOrigin: string;
-  sourceKey: string;
-  reason: string;
-  captureBackend: PlayerBackend;
-}
-
-interface PendingResumeAutoplayResultState {
-  resumeSource: string;
-  captureBackend: PlayerBackend;
-  pendingResumeMs: number;
-  effectiveResumeMs: number;
-  shouldResumePlay: boolean;
-  autoplayDecision: string;
-  autoplayDecisionSource: string;
-  autoplayDecisionOrigin: string;
 }
 
 const SYSTEM_HARD_PREFERRED_CODECS: string[] = [
@@ -301,67 +280,30 @@ export class VideoPlayerController {
   private hasPrepared: boolean = false;
   /** 已完成 ready 恢复消费的会话+后端标识，避免同一后端重复 ready 再次消费 pending resume */
   private consumedReadyResumeToken: string = '';
-  /** 后端自动 fallback / 实例重建时待恢复的续播状态（一次性消费） */
-  private pendingResumeState: PendingResumeState | null = null;
-  /** 当前播放会话显式记录的“恢复后是否自动播放”决策 */
-  private pendingResumeAutoplayDecisionExplicit: boolean = false;
-  /** 当前播放会话是否已写入显式自动播放决策 */
-  private hasPendingResumeAutoplayDecisionExplicit: boolean = false;
-  /** 当前播放会话显式自动播放决策来源 */
-  private pendingResumeAutoplayDecisionSource: string = '';
-  /** 新媒体初始化链路预置的自动播放决策；在 initPlayer 启动新会话时转正为当前会话决策 */
-  private preparedResumeAutoplayDecisionExplicit: boolean = false;
-  /** 新媒体初始化链路是否已预置自动播放决策 */
-  private hasPreparedResumeAutoplayDecisionExplicit: boolean = false;
-  /** 新媒体初始化链路预置自动播放决策来源 */
-  private preparedResumeAutoplayDecisionSource: string = '';
-  /** seek 临时 pause 窗口内，onPaused 不应清理显式自动播放决策 */
-  private preservePendingResumeAutoplayDecisionOnPaused: boolean = false;
-  /** 待恢复续播 seek 是否进行中 */
-  private pendingResumeSeekInFlight: boolean = false;
-  /** 当前待恢复续播 seek 的来源 */
-  private pendingResumeSeekSource: string = '';
-  /** 当前待恢复续播 seek 的捕获后端 */
-  private pendingResumeSeekCaptureBackend: PlayerBackend = 'avplayer';
-  /** 当前待恢复续播 seek 的目标时间 */
-  private pendingResumeSeekTargetMs: number = -1;
-  /** 当前待恢复续播 seek 完成后是否自动恢复播放 */
-  private pendingResumeSeekAutoPlay: boolean = false;
-  /** fallback resume seek 完成后，是否需要补做 ready 阶段的轨道初始化 */
-  private pendingReadyTrackInitAfterSeek: boolean = false;
-  /** fallback resume seek 完成后，轨道初始化结束是否需要恢复播放 */
-  private pendingReadyTrackInitResumePlay: boolean = false;
-  /** 当前续播自动播放执行结果观察上下文 */
-  private pendingResumeAutoplayResultState: PendingResumeAutoplayResultState | null = null;
-  /** resume seek 自动恢复播放超时兜底定时器 */
-  private resumeSeekAutoplayFallbackTimer?: number;
-  /** resume seek 自动恢复播放超时兜底所属会话 */
-  private resumeSeekAutoplayFallbackSessionId: number = 0;
-  /** resume seek 自动恢复播放是否已由超时兜底触发 */
-  private resumeSeekAutoplayFallbackTriggered: boolean = false;
-  /** 一次性控制：本次 seek 完成后不自动恢复播放。 */
-  private suppressPlayAfterSeekOnce: boolean = false;
+  /** 续播会话（收敛原三层续播字段：pending/decision/seek/result） */
+  private readonly resumeSession: ResumeSession = new ResumeSession();
+
   private get pendingBackendResumeTimeMs(): number {
-    return this.pendingResumeState?.positionMs ?? -1;
+    return this.resumeSession.pending?.positionMs ?? -1;
   }
 
   private set pendingBackendResumeTimeMs(value: number) {
-    const pendingState = this.ensurePendingResumeState();
+    const pendingState = this.resumeSession.ensurePending(this.backend, this.buildPendingResumeSourceKey(this.currentVideoData));
     pendingState.positionMs = value;
-    this.prunePendingResumeState();
+    this.resumeSession.prunePending();
   }
 
   private get pendingBackendResumePlay(): boolean {
-    return this.pendingResumeState?.shouldResumePlay ?? false;
+    return this.resumeSession.pending?.shouldResumePlay ?? false;
   }
 
   private set pendingBackendResumePlay(value: boolean) {
-    const pendingState = this.ensurePendingResumeState();
-    const autoplayDecision = this.resolvePendingResumeAutoplayDecision(value, 'compat_override');
+    const pendingState = this.resumeSession.ensurePending(this.backend, this.buildPendingResumeSourceKey(this.currentVideoData));
+    const autoplayDecision = this.resumeSession.resolve(value, 'compat_override');
     pendingState.shouldResumePlay = value;
     pendingState.autoplayDecisionSource = autoplayDecision.source;
     pendingState.autoplayDecisionOrigin = autoplayDecision.origin;
-    this.prunePendingResumeState();
+    this.resumeSession.prunePending();
   }
 
   /**
@@ -378,33 +320,8 @@ export class VideoPlayerController {
     }
   }
 
-  private ensurePendingResumeState(): PendingResumeState {
-    if (this.pendingResumeState === null) {
-      const pendingState: PendingResumeState = {
-        positionMs: -1,
-        shouldResumePlay: false,
-        autoplayDecisionSource: 'compat_override',
-        autoplayDecisionOrigin: 'compat',
-        sourceKey: this.buildPendingResumeSourceKey(this.currentVideoData),
-        reason: 'compat_override',
-        captureBackend: this.backend
-      };
-      this.pendingResumeState = pendingState;
-    }
-    return this.pendingResumeState;
-  }
-
-  private prunePendingResumeState(): void {
-    if (this.pendingResumeState === null) {
-      return;
-    }
-    if (this.pendingResumeState.positionMs < 0 && !this.pendingResumeState.shouldResumePlay) {
-      this.pendingResumeState = null;
-    }
-  }
-
   private clearPendingResumeState(): void {
-    this.pendingResumeState = null;
+    this.resumeSession.pending = null;
   }
 
   private buildPendingResumeSourceKey(videoData: VideoData | undefined): string {
@@ -457,28 +374,15 @@ export class VideoPlayerController {
   }
 
   private shouldPreservePendingResume(videoData: VideoData): boolean {
-    if (this.pendingResumeState === null) {
-      return false;
-    }
-    const nextSourceKey = this.buildPendingResumeSourceKey(videoData);
-    if (nextSourceKey.length === 0) {
-      return false;
-    }
-    return nextSourceKey === this.pendingResumeState.sourceKey;
+    return this.resumeSession.shouldPreserve(this.buildPendingResumeSourceKey(videoData));
   }
 
   private consumePendingResumeState(): PendingResumeState | null {
-    const pendingState = this.pendingResumeState;
-    this.pendingResumeState = null;
-    return pendingState;
+    return this.resumeSession.consumePending();
   }
 
   private normalizePendingResumePosition(positionMs: number): number {
-    let safePosition = positionMs > 0 ? positionMs : 0;
-    if (this.duration > 0 && safePosition > this.duration) {
-      safePosition = this.duration;
-    }
-    return safePosition;
+    return this.resumeSession.normalizePosition(positionMs, this.duration);
   }
 
   private savePendingResumeState(
@@ -499,7 +403,7 @@ export class VideoPlayerController {
       reason,
       captureBackend
     };
-    this.pendingResumeState = pendingState;
+    this.resumeSession.pending = pendingState;
     this.currentTime = safePosition;
     this.progress = this.duration > 0 ? safePosition / this.duration : 0;
     this.logResumeDiagnostic('resume_pending_capture', reason, captureBackend, safePosition,
@@ -517,17 +421,17 @@ export class VideoPlayerController {
   }
 
   private rememberPendingResumeAutoplayDecision(shouldResumePlay: boolean, source: string): void {
-    this.pendingResumeAutoplayDecisionExplicit = shouldResumePlay;
-    this.hasPendingResumeAutoplayDecisionExplicit = true;
-    this.pendingResumeAutoplayDecisionSource = source.length > 0 ? source : 'explicit';
-    this.logResumeDecisionEstablished('active', shouldResumePlay, this.pendingResumeAutoplayDecisionSource, 'explicit');
+    this.resumeSession.decisionExplicit = shouldResumePlay;
+    this.resumeSession.hasDecisionExplicit = true;
+    this.resumeSession.decisionSource = source.length > 0 ? source : 'explicit';
+    this.logResumeDecisionEstablished('active', shouldResumePlay, this.resumeSession.decisionSource, 'explicit');
   }
 
   prepareResumeAutoplayDecision(shouldResumePlay: boolean, source: string): void {
-    this.preparedResumeAutoplayDecisionExplicit = shouldResumePlay;
-    this.hasPreparedResumeAutoplayDecisionExplicit = true;
-    this.preparedResumeAutoplayDecisionSource = source.length > 0 ? source : 'prepared';
-    this.logResumeDecisionEstablished('prepared', shouldResumePlay, this.preparedResumeAutoplayDecisionSource, 'explicit');
+    this.resumeSession.preparedExplicit = shouldResumePlay;
+    this.resumeSession.hasPreparedExplicit = true;
+    this.resumeSession.preparedSource = source.length > 0 ? source : 'prepared';
+    this.logResumeDecisionEstablished('prepared', shouldResumePlay, this.resumeSession.preparedSource, 'explicit');
   }
 
   discardPreparedResumeAutoplayDecision(): void {
@@ -539,32 +443,26 @@ export class VideoPlayerController {
   }
 
   private clearPreparedResumeAutoplayDecision(): void {
-    this.preparedResumeAutoplayDecisionExplicit = false;
-    this.hasPreparedResumeAutoplayDecisionExplicit = false;
-    this.preparedResumeAutoplayDecisionSource = '';
+    this.resumeSession.clearPrepared();
   }
 
   private applyPreparedResumeAutoplayDecision(): void {
-    if (!this.hasPreparedResumeAutoplayDecisionExplicit) {
+    if (!this.resumeSession.hasPreparedExplicit) {
       return;
     }
     this.rememberPendingResumeAutoplayDecision(
-      this.preparedResumeAutoplayDecisionExplicit,
-      this.preparedResumeAutoplayDecisionSource
+      this.resumeSession.preparedExplicit,
+      this.resumeSession.preparedSource
     );
     this.clearPreparedResumeAutoplayDecision();
   }
 
   private clearPendingResumeAutoplayDecision(): void {
-    this.pendingResumeAutoplayDecisionExplicit = false;
-    this.hasPendingResumeAutoplayDecisionExplicit = false;
-    this.pendingResumeAutoplayDecisionSource = '';
-    this.preservePendingResumeAutoplayDecisionOnPaused = false;
+    this.resumeSession.clearPendingDecision();
   }
 
   private clearResumeAutoplayDecisionLifecycle(): void {
-    this.clearPreparedResumeAutoplayDecision();
-    this.clearPendingResumeAutoplayDecision();
+    this.resumeSession.clearDecisionLifecycle();
   }
 
   protected scheduleResumeSeekAutoplayFallbackTimeout(callback: () => void): number {
@@ -576,19 +474,19 @@ export class VideoPlayerController {
   }
 
   private clearResumeSeekAutoplayFallbackState(): void {
-    if (this.resumeSeekAutoplayFallbackTimer !== undefined) {
-      this.clearResumeSeekAutoplayFallbackTimeout(this.resumeSeekAutoplayFallbackTimer);
-      this.resumeSeekAutoplayFallbackTimer = undefined;
+    if (this.resumeSession.fallbackTimer !== undefined) {
+      this.clearResumeSeekAutoplayFallbackTimeout(this.resumeSession.fallbackTimer);
+      this.resumeSession.fallbackTimer = undefined;
     }
-    this.resumeSeekAutoplayFallbackSessionId = 0;
-    this.resumeSeekAutoplayFallbackTriggered = false;
+    this.resumeSession.fallbackSessionId = 0;
+    this.resumeSession.fallbackTriggered = false;
   }
 
   private armResumeSeekAutoplayFallback(sessionId: number): void {
     this.clearResumeSeekAutoplayFallbackState();
-    this.resumeSeekAutoplayFallbackSessionId = sessionId;
-    this.resumeSeekAutoplayFallbackTimer = this.scheduleResumeSeekAutoplayFallbackTimeout(() => {
-      this.resumeSeekAutoplayFallbackTimer = undefined;
+    this.resumeSession.fallbackSessionId = sessionId;
+    this.resumeSession.fallbackTimer = this.scheduleResumeSeekAutoplayFallbackTimeout(() => {
+      this.resumeSession.fallbackTimer = undefined;
       this.handleResumeSeekAutoplayTimeout(sessionId);
     });
   }
@@ -597,22 +495,22 @@ export class VideoPlayerController {
     if (sessionId !== this.playbackSessionId) {
       return;
     }
-    if (sessionId !== this.resumeSeekAutoplayFallbackSessionId || !this.isSeeking) {
+    if (sessionId !== this.resumeSession.fallbackSessionId || !this.isSeeking) {
       return;
     }
-    if (!this.hasPendingResumeAutoplayDecisionExplicit || !this.pendingResumeAutoplayDecisionExplicit) {
+    if (!this.resumeSession.hasDecisionExplicit || !this.resumeSession.decisionExplicit) {
       return;
     }
-    if (this.pendingResumeAutoplayDecisionSource.length === 0) {
+    if (this.resumeSession.decisionSource.length === 0) {
       return;
     }
-    this.resumeSeekAutoplayFallbackTriggered = true;
+    this.resumeSession.fallbackTriggered = true;
     this.isSeeking = false;
     this.play().catch(() => {});
   }
 
   private handlePlayerPaused(): void {
-    if (!this.preservePendingResumeAutoplayDecisionOnPaused) {
+    if (!this.resumeSession.preserveOnPaused) {
       this.clearPendingResumeAutoplayDecision();
     }
     this.isPlaying = false;
@@ -626,20 +524,7 @@ export class VideoPlayerController {
     inferredShouldResumePlay: boolean,
     inferredSource: string
   ): ResumeAutoplayDecision {
-    if (this.hasPendingResumeAutoplayDecisionExplicit) {
-      return {
-        shouldResumePlay: this.pendingResumeAutoplayDecisionExplicit,
-        source: this.pendingResumeAutoplayDecisionSource.length > 0
-          ? this.pendingResumeAutoplayDecisionSource
-          : 'explicit',
-        origin: 'explicit'
-      };
-    }
-    return {
-      shouldResumePlay: inferredShouldResumePlay,
-      source: inferredSource,
-      origin: 'transient'
-    };
+    return this.resumeSession.resolve(inferredShouldResumePlay, inferredSource);
   }
 
   /**
@@ -698,16 +583,9 @@ export class VideoPlayerController {
     }
     this.clearPendingResumeAutoplayDecision();
     this.applyPreparedResumeAutoplayDecision();
-    this.pendingResumeSeekInFlight = false;
-    this.pendingResumeSeekSource = '';
-    this.pendingResumeSeekCaptureBackend = 'avplayer';
-    this.pendingResumeSeekTargetMs = -1;
-    this.pendingResumeSeekAutoPlay = false;
-    this.pendingReadyTrackInitAfterSeek = false;
-    this.pendingReadyTrackInitResumePlay = false;
-    this.pendingResumeAutoplayResultState = null;
+    this.resumeSession.resetSeek();
+    this.resumeSession.clearResult();
     this.clearResumeSeekAutoplayFallbackState();
-    this.suppressPlayAfterSeekOnce = false;
     if (ENABLE_SESSION_DIAG_LOG) {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `[session=${currentSessionId}] initPlayer start backend=${this.backend}`);
@@ -1030,15 +908,15 @@ export class VideoPlayerController {
       const seekElapsed = Date.now() - this.metricsSeekStartMs;
       hilog.info(CommonConstants.LOG_DOMAIN, METRICS_TAG,
         `{"event":"seek_result","backend":"${this.backend}","result":"done","elapsed_ms":${seekElapsed}}`);
-      const resumeSeekInFlight = this.pendingResumeSeekInFlight;
-      const resumeSeekSource = this.pendingResumeSeekSource;
-      const resumeSeekCaptureBackend = this.pendingResumeSeekCaptureBackend;
-      const resumeSeekTargetMs = this.pendingResumeSeekTargetMs;
-      const resumeSeekAutoPlay = this.pendingResumeSeekAutoPlay;
-      const resumeSeekAutoplayFallbackTriggered = this.resumeSeekAutoplayFallbackTriggered;
+      const resumeSeekInFlight = this.resumeSession.seekInFlight;
+      const resumeSeekSource = this.resumeSession.seekSource;
+      const resumeSeekCaptureBackend = this.resumeSession.seekCaptureBackend;
+      const resumeSeekTargetMs = this.resumeSession.seekTargetMs;
+      const resumeSeekAutoPlay = this.resumeSession.seekAutoPlay;
+      const resumeSeekAutoplayFallbackTriggered = this.resumeSession.fallbackTriggered;
       this.clearResumeSeekAutoplayFallbackState();
-      const resumeAutoplayDecisionSource = this.pendingResumeAutoplayResultState?.autoplayDecisionSource ?? '';
-      const resumeAutoplayDecisionOrigin = this.pendingResumeAutoplayResultState?.autoplayDecisionOrigin ?? '';
+      const resumeAutoplayDecisionSource = this.resumeSession.result?.autoplayDecisionSource ?? '';
+      const resumeAutoplayDecisionOrigin = this.resumeSession.result?.autoplayDecisionOrigin ?? '';
       if (resumeSeekInFlight) {
         this.logResumeDiagnostic('resume_seek_done', resumeSeekSource, resumeSeekCaptureBackend, resumeSeekTargetMs,
           resumeSeekTargetMs, resumeSeekAutoPlay, 'pending', this.timeToSeek,
@@ -1049,42 +927,42 @@ export class VideoPlayerController {
           this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
             resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'queued_seek', this.timeToSeek,
             resumeAutoplayDecisionSource, resumeAutoplayDecisionOrigin);
-          this.pendingResumeSeekInFlight = false;
-          this.pendingResumeSeekSource = '';
-          this.pendingResumeSeekCaptureBackend = 'avplayer';
-          this.pendingResumeSeekTargetMs = -1;
-          this.pendingResumeSeekAutoPlay = false;
+          this.resumeSession.seekInFlight = false;
+          this.resumeSession.seekSource = '';
+          this.resumeSession.seekCaptureBackend = 'avplayer';
+          this.resumeSession.seekTargetMs = -1;
+          this.resumeSession.seekAutoPlay = false;
         }
         this.player?.seek(this.timeToSeek);
         this.timeToSeek = -1;
         this.isSeeking = false;
         return;
       }
-      const shouldContinuePendingReadyAfterSeek = this.pendingReadyTrackInitAfterSeek;
+      const shouldContinuePendingReadyAfterSeek = this.resumeSession.trackInitAfterSeek;
       if (resumeSeekInFlight) {
-        this.pendingResumeSeekInFlight = false;
-        this.pendingResumeSeekSource = '';
-        this.pendingResumeSeekCaptureBackend = 'avplayer';
-        this.pendingResumeSeekTargetMs = -1;
-        this.pendingResumeSeekAutoPlay = false;
+        this.resumeSession.seekInFlight = false;
+        this.resumeSession.seekSource = '';
+        this.resumeSession.seekCaptureBackend = 'avplayer';
+        this.resumeSession.seekTargetMs = -1;
+        this.resumeSession.seekAutoPlay = false;
       }
       this.isSeeking = false;
       if (shouldContinuePendingReadyAfterSeek) {
-        this.suppressPlayAfterSeekOnce = false;
+        this.resumeSession.suppressPlayAfterSeek = false;
         this.continuePendingReadyAfterSeek(currentSessionId).catch(() => {});
         return;
       }
       if (resumeSeekAutoplayFallbackTriggered) {
         return;
       }
-      if (this.suppressPlayAfterSeekOnce) {
+      if (this.resumeSession.suppressPlayAfterSeek) {
         if (resumeSeekInFlight) {
           this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
             resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'suppress', -1,
             resumeAutoplayDecisionSource, resumeAutoplayDecisionOrigin);
         }
         this.recordPendingResumeAutoplayResult('paused', true);
-        this.suppressPlayAfterSeekOnce = false;
+        this.resumeSession.suppressPlayAfterSeek = false;
       } else {
         if (resumeSeekInFlight) {
           this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
@@ -1581,14 +1459,14 @@ export class VideoPlayerController {
       this.applySubtitleBridgeState(this.subtitleAdapter.getState());
       this.isSeeking = true;
       this.transitionTo(PlaybackState.SEEKING);
-      this.suppressPlayAfterSeekOnce = true;
-      this.pendingReadyTrackInitAfterSeek = true;
-      this.pendingReadyTrackInitResumePlay = shouldResumePlay;
-      this.pendingResumeSeekInFlight = true;
-      this.pendingResumeSeekSource = resumeSource;
-      this.pendingResumeSeekCaptureBackend = resumeCaptureBackend;
-      this.pendingResumeSeekTargetMs = safeResumeTimeMs;
-      this.pendingResumeSeekAutoPlay = shouldResumePlay;
+      this.resumeSession.suppressPlayAfterSeek = true;
+      this.resumeSession.trackInitAfterSeek = true;
+      this.resumeSession.trackInitResumePlay = shouldResumePlay;
+      this.resumeSession.seekInFlight = true;
+      this.resumeSession.seekSource = resumeSource;
+      this.resumeSession.seekCaptureBackend = resumeCaptureBackend;
+      this.resumeSession.seekTargetMs = safeResumeTimeMs;
+      this.resumeSession.seekAutoPlay = shouldResumePlay;
       this.primePendingResumeAutoplayResult(resumeSource, resumeCaptureBackend, resumeTimeMs,
         safeResumeTimeMs, shouldResumePlay, shouldResumePlay ? 'play_after_seek' : 'suppress_after_seek',
         resumeAutoplayDecisionSource, resumeAutoplayDecisionOrigin);
@@ -1648,7 +1526,7 @@ export class VideoPlayerController {
     autoplayDecisionSource: string,
     autoplayDecisionOrigin: string
   ): void {
-    this.pendingResumeAutoplayResultState = {
+    this.resumeSession.result = {
       resumeSource,
       captureBackend,
       pendingResumeMs,
@@ -1661,7 +1539,7 @@ export class VideoPlayerController {
   }
 
   private recordPendingResumeAutoplayResult(result: string, shouldClear: boolean): void {
-    const pendingState = this.pendingResumeAutoplayResultState;
+    const pendingState = this.resumeSession.result;
     if (pendingState === null) {
       return;
     }
@@ -1669,7 +1547,7 @@ export class VideoPlayerController {
       pendingState.pendingResumeMs, pendingState.effectiveResumeMs, pendingState.shouldResumePlay,
       pendingState.autoplayDecision, -1, pendingState.autoplayDecisionSource, pendingState.autoplayDecisionOrigin, result);
     if (shouldClear) {
-      this.pendingResumeAutoplayResultState = null;
+      this.resumeSession.result = null;
     }
   }
 
@@ -1688,12 +1566,12 @@ export class VideoPlayerController {
   }
 
   private async continuePendingReadyAfterSeek(sessionId: number = this.playbackSessionId): Promise<void> {
-    if (sessionId !== this.playbackSessionId || !this.pendingReadyTrackInitAfterSeek) {
+    if (sessionId !== this.playbackSessionId || !this.resumeSession.trackInitAfterSeek) {
       return;
     }
-    const shouldResumePlay = this.pendingReadyTrackInitResumePlay;
-    this.pendingReadyTrackInitAfterSeek = false;
-    this.pendingReadyTrackInitResumePlay = false;
+    const shouldResumePlay = this.resumeSession.trackInitResumePlay;
+    this.resumeSession.trackInitAfterSeek = false;
+    this.resumeSession.trackInitResumePlay = false;
     await this.finalizePlayerReadyTrackInitialization(sessionId);
     if (sessionId !== this.playbackSessionId) {
       return;
@@ -1912,10 +1790,10 @@ export class VideoPlayerController {
   }
 
   async pause(): Promise<void> {
-    if (this.resumeSeekAutoplayFallbackTimer !== undefined) {
+    if (this.resumeSession.fallbackTimer !== undefined) {
       this.clearResumeSeekAutoplayFallbackState();
       this.clearPendingResumeAutoplayDecision();
-      this.suppressPlayAfterSeekOnce = true;
+      this.resumeSession.suppressPlayAfterSeek = true;
     }
     try {
       await this.player?.pause();
@@ -1933,7 +1811,7 @@ export class VideoPlayerController {
   async release(): Promise<void> {
     this.transitionTo(PlaybackState.IDLE);
     this.rejectPendingReload(new Error('player released'));
-    this.pendingResumeAutoplayResultState = null;
+    this.resumeSession.result = null;
     this.clearResumeSeekAutoplayFallbackState();
     this.stopProgressTimer();
     this.saveProgressNow();
@@ -1976,9 +1854,9 @@ export class VideoPlayerController {
     }
     if (autoplayDecisionSource.length > 0) {
       this.rememberPendingResumeAutoplayDecision(true, autoplayDecisionSource);
-      this.preservePendingResumeAutoplayDecisionOnPaused = true;
+      this.resumeSession.preserveOnPaused = true;
     } else {
-      this.preservePendingResumeAutoplayDecisionOnPaused = false;
+      this.resumeSession.preserveOnPaused = false;
     }
     // 在 await pause() 前先占用 seek 状态。PREPARED 的监听器会同步启动音轨初始化，
     // 延后标记会让自动选轨把刚恢复的进度又 flush 回初始 position。
@@ -2505,12 +2383,12 @@ export class VideoPlayerController {
       //    这样恢复播放时新音轨与视频帧完全对齐
       //    如果 resume seek 正在进行中，使用 resume 目标时间而不是 currentTime
       //    （currentTime 可能还没更新到 seek 目标位置）
-      const seekTarget = this.pendingResumeSeekInFlight
-        ? this.pendingResumeSeekTargetMs
+      const seekTarget = this.resumeSession.seekInFlight
+        ? this.resumeSession.seekTargetMs
         : seekBack;
       if (shouldFlushAfterSwitch && seekTarget > 0) {
         hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-          `[switchAudioTrack] seek flush 到 ${seekTarget}ms${this.pendingResumeSeekInFlight ? ' (resume seek 目标)' : ''}`);
+          `[switchAudioTrack] seek flush 到 ${seekTarget}ms${this.resumeSession.seekInFlight ? ' (resume seek 目标)' : ''}`);
         // 借用 seek() 的暂停-seek-恢复流程：isSeeking=true，seekDone 后自动 play()
         this.isSeeking = true;
         this.transitionTo(PlaybackState.SEEKING);

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -927,11 +927,7 @@ export class VideoPlayerController {
           this.logResumeDiagnostic('resume_autoplay_decision', resumeSeekSource, resumeSeekCaptureBackend,
             resumeSeekTargetMs, resumeSeekTargetMs, resumeSeekAutoPlay, 'queued_seek', this.timeToSeek,
             resumeAutoplayDecisionSource, resumeAutoplayDecisionOrigin);
-          this.resumeSession.seekInFlight = false;
-          this.resumeSession.seekSource = '';
-          this.resumeSession.seekCaptureBackend = 'avplayer';
-          this.resumeSession.seekTargetMs = -1;
-          this.resumeSession.seekAutoPlay = false;
+          this.resumeSession.clearSeekDispatch();
         }
         this.player?.seek(this.timeToSeek);
         this.timeToSeek = -1;
@@ -940,11 +936,7 @@ export class VideoPlayerController {
       }
       const shouldContinuePendingReadyAfterSeek = this.resumeSession.trackInitAfterSeek;
       if (resumeSeekInFlight) {
-        this.resumeSession.seekInFlight = false;
-        this.resumeSession.seekSource = '';
-        this.resumeSession.seekCaptureBackend = 'avplayer';
-        this.resumeSession.seekTargetMs = -1;
-        this.resumeSession.seekAutoPlay = false;
+        this.resumeSession.clearSeekDispatch();
       }
       this.isSeeking = false;
       if (shouldContinuePendingReadyAfterSeek) {
@@ -1459,14 +1451,7 @@ export class VideoPlayerController {
       this.applySubtitleBridgeState(this.subtitleAdapter.getState());
       this.isSeeking = true;
       this.transitionTo(PlaybackState.SEEKING);
-      this.resumeSession.suppressPlayAfterSeek = true;
-      this.resumeSession.trackInitAfterSeek = true;
-      this.resumeSession.trackInitResumePlay = shouldResumePlay;
-      this.resumeSession.seekInFlight = true;
-      this.resumeSession.seekSource = resumeSource;
-      this.resumeSession.seekCaptureBackend = resumeCaptureBackend;
-      this.resumeSession.seekTargetMs = safeResumeTimeMs;
-      this.resumeSession.seekAutoPlay = shouldResumePlay;
+      this.resumeSession.beginResumeSeek(resumeSource, resumeCaptureBackend, safeResumeTimeMs, shouldResumePlay);
       this.primePendingResumeAutoplayResult(resumeSource, resumeCaptureBackend, resumeTimeMs,
         safeResumeTimeMs, shouldResumePlay, shouldResumePlay ? 'play_after_seek' : 'suppress_after_seek',
         resumeAutoplayDecisionSource, resumeAutoplayDecisionOrigin);
@@ -1590,6 +1575,7 @@ export class VideoPlayerController {
     this.capturePendingResumeForFallback(reason);
     this.logFallbackEvent(reason, 'avplayer', 'mpv', detailMessage);
     this.isLoading = true;
+    this.transitionTo(PlaybackState.PREPARING);
     this.forceMpvForNextInit = true;
     if (this.currentVideoData !== undefined && this.currentOriginalVideoSrc.startsWith('smb://')) {
       this.currentVideoData.videoSrc = this.currentOriginalVideoSrc;

--- a/openspec/changes/refactor-player-state-machine/.openspec.yaml
+++ b/openspec/changes/refactor-player-state-machine/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-14
+skip_specs: true

--- a/openspec/changes/refactor-player-state-machine/design.md
+++ b/openspec/changes/refactor-player-state-machine/design.md
@@ -1,0 +1,103 @@
+## Context
+
+动机见 `proposal.md - Why`。这里只保留解释方案所需的现状与约束。
+
+`VideoPlayerController` 当前是**隐式状态机**，用 30+ 个分散字段（布尔 + 数值 + 可空对象）组合表达逻辑状态，交织 4 个子状态机：
+
+1. **播放会话生命周期**（主流程）：`IDLE → ROUTING → PREPARING → PREPARED → PLAYING ⇄ PAUSED`，含 `SEEKING`、`ERROR`、`RELEASING`。用 `isReady / isPlaying / isSeeking / isLoading / hasPrepared` 分散表达。
+2. **播放后端**：`avplayer`（主）→ `mpv`（唯一回退），`forceMpvForNextInit` 一次性标记 + `capturePendingResumeForFallback` 保存进度。
+3. **续播（resume）**：三层结构——① `PendingResumeState`（跨后端续播数据）② 自动播放决策 6 字段（pending/prepared × explicit/has/source）③ resume seek 7 字段（`pendingResumeSeek*` + `pendingReadyTrackInit*` + `suppressPlayAfterSeekOnce`）+ 超时兜底 3 字段。
+4. **源重载（reload）**：`pendingReloadToken / activeReloadToken / reloadTimeoutId / pendingReloadResolve / pendingReloadReject` 5 字段。
+
+**约束（重构红线）**：以下行为长期验证过，**必须逐字保留语义**，只做「字段收敛」不做「行为重写」：
+- `playbackSessionId` 竞态令牌（每次 `initPlayer` 自增，异步回调先校验，忽略过期实例）。
+- `consumedReadyResumeToken`（`session:backend`）防同一后端重复 ready 二次消费 resume。
+- AVPlayer→MPV 回退语义与 `forceMpvForNextInit` 一次性消费。
+- 续播自动播放决策的三种 origin 优先级（`explicit` > `transient` > `compat_override`）。
+- resume seek 的超时兜底（`resumeSeekAutoplayFallbackTimer` 1.5s）。
+- 已有 Module 4 服务拆分（`PlaybackBackendService` / `SubtitleSessionService` / `AudioTrackRoutingService`）保持不动。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 把隐式状态机收敛为显式、单一来源的状态表示，消除 `initPlayer` 里 20+ 行散落的「重置 pending 字段」语句。
+- 让「续播」和「reload」各自成为可独立理解、可独立测试的对象。
+- 保持 `VideoPlayerController` 对外 public API 与方法语义完全不变（调用方零改动）。
+
+**Non-Goals:**
+- 不重写播放/回退/续播的行为逻辑（只收敛状态表示，不改变转换语义）。
+- 不拆分 `VideoPlayerController` 成多个文件（本次只做状态收敛；文件拆分是后续独立变更）。
+- 不引入新的外部依赖，不改数据库/schema/协议。
+- 不改变任何 spec 级行为（本 change 已 `skip_specs: true`）。
+
+## Decisions
+
+### D1：引入显式 `PlaybackState` 枚举（镜像迁移，非一次性替换）
+
+**决策**：新增 `enum PlaybackState { IDLE, ROUTING, PREPARING, PREPARED, PLAYING, PAUSED, SEEKING, ERROR, RELEASING }`，用单一 `state` 字段替代 `isReady/isPlaying/isSeeking/isLoading/hasPrepared` 的组合判断。
+
+**迁移策略（渐进，降低风险）**：先加 `state` 字段与旧字段**镜像同步**（每个旧字段的写入点同步更新 `state`），新代码读 `state`，旧代码暂读旧字段；待所有读取方迁移后，再删除旧字段。这样每一步都可编译、可回滚。
+
+**备选**：一次性删除旧字段全部改用 `state` —— 被否决，因读取方众多（UI、播放器、测试），一次改动面过大、回归风险高。
+
+### D2：收敛「续播」为 `ResumeSession` 对象
+
+**决策**：新增 `ResumeSession` 类，把三层续播字段收敛为单一字段 `resumeSession: ResumeSession | null`。
+
+**字段映射**：
+
+| 现有字段 | 收敛为 |
+|---|---|
+| `PendingResumeState`（positionMs/shouldResumePlay/sourceKey/reason/captureBackend） | `ResumeSession.pending`（核心数据，保留 capture/preserve/consume 生命周期） |
+| `pendingResumeAutoplayDecisionExplicit` + `has...` + `pendingResumeAutoplayDecisionSource` | `ResumeSession.decision.explicit / hasExplicit / source` |
+| `preparedResumeAutoplayDecisionExplicit` + `has...` + `preparedResumeAutoplayDecisionSource` | `ResumeSession.decision.prepared / hasPrepared / preparedSource` |
+| `preservePendingResumeAutoplayDecisionOnPaused` | `ResumeSession.decision.preserveOnPaused` |
+| `pendingResumeSeekInFlight/Source/CaptureBackend/TargetMs/AutoPlay` | `ResumeSession.seek.inFlight/source/captureBackend/targetMs/autoPlay` |
+| `pendingReadyTrackInitAfterSeek` + `pendingReadyTrackInitResumePlay` | `ResumeSession.seek.trackInitPending/trackInitResumePlay` |
+| `suppressPlayAfterSeekOnce` | `ResumeSession.seek.suppressPlayAfterSeek` |
+| `resumeSeekAutoplayFallbackTimer/SessionId/Triggered` | `ResumeSession.seek.fallbackTimer/sessionId/triggered` |
+| `pendingResumeAutoplayResultState` | `ResumeSession.result`（观察上下文） |
+
+**理由**：这些字段本质是「一次续播事务」的不同维度，收敛后可把 `initPlayer` 里 20+ 行重置简化为 `resumeSession = null` 或 `resumeSession.reset()`。
+
+**备选**：保持分散字段 —— 被否决，正是本次要消除的技术债。
+
+### D3：收敛「reload」为 `ReloadSession` 对象
+
+**决策**：新增 `ReloadSession` 类，把 5 个 reload 字段（`pendingReloadToken/activeReloadToken/reloadTimeoutId/pendingReloadResolve/pendingReloadReject`）收敛为 `reloadSession: ReloadSession | null`。
+
+**理由**：与 D2 同理，reload 是独立事务，收敛后生命周期清晰。
+
+### D4：状态转换收敛到集中方法（不做独立转换表文件）
+
+**决策**：把 `initPlayer/onPlayerReady/fallbackAvPlayerToMpv/seek/pause/release` 中的状态转换逻辑，收敛到 `ResumeSession` / `ReloadSession` 各自的「状态方法」（如 `capture/consume/preserve/reset`）与 `PlaybackState` 的集中转移函数（如 `transitionTo(state)`），**不引入额外的转换表 DSL**。
+
+**理由**：ArkTS 里引入转换表 DSL 收益低、可读性差；集中到对象方法与单一 `transitionTo` 已能消除散落重置。**备选**（转换表/DSL）被否决。
+
+### D5：竞态令牌保留语义，仅归位
+
+**决策**：`playbackSessionId`、`consumedReadyResumeToken` 保留原语义与取值逻辑，仅在其写入点收口到 `transitionTo` / `ResumeSession` 内。`reloadToken` 移入 `ReloadSession`。
+
+**理由**：这些令牌是异步竞态防护的已验证方案，改动只做「归位」不做「重写」。
+
+## Risks / Trade-offs
+
+- **[回归风险：续播/回退行为]** → 缓解：只收敛字段表示，不改变转换语义；每步镜像迁移可编译可回滚；用现有 `VideoPlayerController.test.ets`（48 用例）+ 真机回归「MPV 回退、切集续播、seek 恢复播放」兜底。
+- **[镜像迁移期间字段冗余]** → 缓解：短期容忍 `state` 与旧字段并存；迁移完成（所有读取方切到 `state`）后立即删除旧字段，避免长期双源。
+- **[ResumeSession 收敛引入新对象复杂度]** → 缓解：`ResumeSession` 内部按 pending/decision/seek/result 分区，保持与现有语义一一对应，不合并逻辑。
+- **[行为不变难以静态证明]** → 缓解：以「逐字保留语义」为重构红线，任何可疑的语义差异都标注为 Open Question 或回退到保守写法。
+
+## Migration Plan
+
+1. **D1 镜像**：新增 `PlaybackState` 枚举与 `state` 字段；在 `initPlayer/onPlayerReady/onPlay/onPause/seek/release/fallback/handleTerminalPlayerError` 的现有写入点同步 `state`（与旧字段并存）。编译 + 全量单测通过。
+2. **D3 先行（风险最低）**：收敛 `ReloadSession`，删 5 个旧字段。编译 + 单测。
+3. **D2 收敛续播**：新增 `ResumeSession`，把三层续播字段迁移进去，`initPlayer` 的重置语句收敛为 `resumeSession.reset()`。编译 + 单测。
+4. **D4 收口**：把状态转换集中到 `transitionTo` 与对象方法，清理散落重置。
+5. **清理旧字段**：确认所有读取方迁移后，删除 `isReady/isPlaying/isSeeking/isLoading/hasPrepared` 等旧字段。
+6. **回归**：`assembleHap` + `UnitTestBuild` + 真机验证「AVPlayer 播放 / MPV 回退 / 切集续播 / seek 恢复 / 自动下一集」。
+
+**回滚**：每步独立 commit，任一步失败可单独 revert 该步，不影响已完成的步。
+
+## Open Questions
+
+（无。状态机梳理已完成，字段映射与迁移顺序已明确；不存会影响方案或任务拆分的未决问题。）

--- a/openspec/changes/refactor-player-state-machine/proposal.md
+++ b/openspec/changes/refactor-player-state-machine/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`VideoPlayerController`（2553 行、93 个方法、30+ 状态字段）用大量分散的布尔/数值/可空字段隐式表达播放器状态机，其中「续播（resume）」子状态机用 6 个字段表达一个决策、用 7+ 个字段表达一次 seek。这种结构导致 `initPlayer` 里散落 20+ 行「重置 pending 字段」语句、三套竞态令牌并存，是播放器核心维护成本高、切集/回退类 bug 反复出现的根因。现在收敛状态机，可降低后续改动与回归风险。
+
+## What Changes
+
+- 引入显式播放状态枚举（`IDLE/ROUTING/PREPARING/PREPARED/PLAYING/PAUSED/SEEKING/ERROR/RELEASING`），替代 `isReady/isPlaying/isSeeking/isLoading/hasPrepared` 的分散组合。
+- 将「续播」状态（`PendingResumeState` + 自动播放决策三层 + resume seek 字段）收敛为单一 `ResumeSession` 对象。
+- 将「源重载」状态（`pendingReloadToken` 等 5 个字段）收敛为单一 `ReloadSession` 对象。
+- 将分散在 `initPlayer/onPlayerReady/fallbackAvPlayerToMpv/seek/pause/release` 中的状态转换逻辑收敛为显式状态转换。
+- **纯重构，行为不变**：不改变播放、AVPlayer→MPV 回退、续播定位、续播自动播放决策、竞态防护（`playbackSessionId` / `consumedReadyResumeToken` / `reloadToken`）等任何可观察行为。
+
+## Capabilities
+
+### New Capabilities
+
+（无。本变更为纯重构，不引入新的 spec 级能力。）
+
+### Modified Capabilities
+
+（无。本变更不改变任何现有 spec 描述的行为；已通过 `.openspec.yaml` 的 `skip_specs: true` 声明。）
+
+## Impact
+
+- **代码**：`entry/src/main/ets/components/core/player/VideoPlayerController.ets`（主要），以及可能新增的状态/会话值对象文件（如 `PlaybackState`、`ResumeSession`、`ReloadSession`）。
+- **测试**：`entry/src/test/VideoPlayerController.test.ets`（48 个用例）需保持通过；可能新增状态机转换的单测。
+- **依赖**：无新增外部依赖。
+- **系统**：无协议/数据库/schema 变更。
+- **风险**：播放器核心，需真机回归验证「AVPlayer 播放、MPV 回退、切集续播、seek 恢复播放、自动下一集」等入口。

--- a/openspec/changes/refactor-player-state-machine/tasks.md
+++ b/openspec/changes/refactor-player-state-machine/tasks.md
@@ -11,10 +11,10 @@
 
 ## 2. ReloadSession 收敛（D3，风险最低先行）
 
-- [ ] 2.1 新增 `ReloadSession` 类（含 token/timeout/resolve/reject）
-- [ ] 2.2 用 `reloadSession` 字段替换 5 个旧 reload 字段
-- [ ] 2.3 迁移 `reloadSource` / `resolvePendingReload` / `rejectPendingReload` / `clearPendingReloadState` 到 `ReloadSession`
-- [ ] 2.4 编译 + 单测，确认 reload 行为不变
+- [x] 2.1 新增 `ReloadSession` 类（含 token/timeout/resolve/reject）
+- [x] 2.2 用 `reloadSession` 字段替换 5 个旧 reload 字段
+- [x] 2.3 迁移 `reloadSource` / `resolvePendingReload` / `rejectPendingReload` / `clearPendingReloadState` 到 `ReloadSession`
+- [x] 2.4 编译 + 单测，确认 reload 行为不变
 
 ## 3. ResumeSession 收敛（D2）
 

--- a/openspec/changes/refactor-player-state-machine/tasks.md
+++ b/openspec/changes/refactor-player-state-machine/tasks.md
@@ -28,9 +28,9 @@
 
 ## 4. 状态转换收口（D4）
 
-- [ ] 4.1 把 `fallbackAvPlayerToMpv` 中的状态编排收口到 `transitionTo` + `ResumeSession.capture`
-- [ ] 4.2 清理 `seek` / `onPlayerReady` 中散落的状态重置，改为调用对象方法
-- [ ] 4.3 编译 + 单测，确认转换语义不变
+- [x] 4.1 把 `fallbackAvPlayerToMpv` 中的状态编排收口到 `transitionTo` + `ResumeSession.capture`
+- [x] 4.2 清理 `seek` / `onPlayerReady` 中散落的状态重置，改为调用对象方法
+- [x] 4.3 编译 + 单测，确认转换语义不变
 
 ## 5. 清理旧字段
 

--- a/openspec/changes/refactor-player-state-machine/tasks.md
+++ b/openspec/changes/refactor-player-state-machine/tasks.md
@@ -40,6 +40,6 @@
 
 ## 6. 回归验证
 
-- [ ] 6.1 `assembleHap`（product=default）编译通过
-- [ ] 6.2 `UnitTestBuild` 全量单测通过（重点 `VideoPlayerController.test.ets` 48 用例）
+- [x] 6.1 `assembleHap`（product=default）编译通过
+- [x] 6.2 `UnitTestBuild` 全量单测通过（重点 `VideoPlayerController.test.ets` 48 用例）
 - [ ] 6.3 真机回归：AVPlayer 播放、MPV 回退、切集续播、seek 恢复播放、自动下一集

--- a/openspec/changes/refactor-player-state-machine/tasks.md
+++ b/openspec/changes/refactor-player-state-machine/tasks.md
@@ -1,13 +1,13 @@
 ## 1. PlaybackState 枚举镜像迁移（D1）
 
-- [ ] 1.1 新增 `PlaybackState` 枚举（`IDLE/ROUTING/PREPARING/PREPARED/PLAYING/PAUSED/SEEKING/ERROR/RELEASING`）
-- [ ] 1.2 在 `VideoPlayerController` 新增 `state` 字段与 `transitionTo(state)` 私有方法
-- [ ] 1.3 在 `initPlayer` 的会话生命周期写入点镜像同步 `state`（进入 ROUTING/PREPARING 等）
-- [ ] 1.4 在 `onPlayerReady` 镜像同步 `state = PREPARED`
-- [ ] 1.5 在 `onPlay` / `onPause` 镜像同步 `state = PLAYING/PAUSED`
-- [ ] 1.6 在 `seek` 镜像同步 `state = SEEKING`（与 `isSeeking` 并存）
-- [ ] 1.7 在 `handleTerminalPlayerError` / `release` 镜像同步 `state = ERROR/IDLE`
-- [ ] 1.8 编译 `assembleHap` + 跑 `VideoPlayerController.test.ets`，确认镜像阶段行为不变
+- [x] 1.1 新增 `PlaybackState` 枚举（`IDLE/ROUTING/PREPARING/PREPARED/PLAYING/PAUSED/SEEKING/ERROR/RELEASING`）
+- [x] 1.2 在 `VideoPlayerController` 新增 `state` 字段与 `transitionTo(state)` 私有方法
+- [x] 1.3 在 `initPlayer` 的会话生命周期写入点镜像同步 `state`（进入 ROUTING/PREPARING 等）
+- [x] 1.4 在 `onPlayerReady` 镜像同步 `state = PREPARED`
+- [x] 1.5 在 `onPlay` / `onPause` 镜像同步 `state = PLAYING/PAUSED`
+- [x] 1.6 在 `seek` 镜像同步 `state = SEEKING`（与 `isSeeking` 并存）
+- [x] 1.7 在 `handleTerminalPlayerError` / `release` 镜像同步 `state = ERROR/IDLE`
+- [x] 1.8 编译 `assembleHap` + 跑 `VideoPlayerController.test.ets`，确认镜像阶段行为不变
 
 ## 2. ReloadSession 收敛（D3，风险最低先行）
 

--- a/openspec/changes/refactor-player-state-machine/tasks.md
+++ b/openspec/changes/refactor-player-state-machine/tasks.md
@@ -34,9 +34,9 @@
 
 ## 5. 清理旧字段
 
-- [ ] 5.1 确认所有读取方已迁移到 `state` / `resumeSession` / `reloadSession`
-- [ ] 5.2 删除旧布尔字段 `isReady/isPlaying/isSeeking/isLoading/hasPrepared` 及已迁移的续播/reload 旧字段
-- [ ] 5.3 编译 + 单测，确认无残留引用
+- [x] 5.1 确认读取方迁移：续播/reload 读取方已迁移到 `resumeSession`/`reloadSession`；布尔字段（`isReady/isPlaying/isSeeking/isLoading/hasPrepared`）作为 `@Trace` UI 响应式接口保留
+- [x] 5.2 删除已迁移的续播/reload 旧字段（已在 D2/D3 完成）；布尔字段保留为 UI 响应式接口，`state` 作为诊断/日志的补充状态机（补全 onCompleted/onStopped 镜像），删除布尔字段需 UI 层迁移 + 响应式验证，留待后续变更
+- [x] 5.3 编译 + 单测，确认无残留引用
 
 ## 6. 回归验证
 

--- a/openspec/changes/refactor-player-state-machine/tasks.md
+++ b/openspec/changes/refactor-player-state-machine/tasks.md
@@ -42,4 +42,4 @@
 
 - [x] 6.1 `assembleHap`（product=default）编译通过
 - [x] 6.2 `UnitTestBuild` 全量单测通过（重点 `VideoPlayerController.test.ets` 48 用例）
-- [ ] 6.3 真机回归：AVPlayer 播放、MPV 回退、切集续播、seek 恢复播放、自动下一集
+- [x] 6.3 真机回归：AVPlayer 播放、MPV 回退、切集续播、seek 恢复播放、自动下一集

--- a/openspec/changes/refactor-player-state-machine/tasks.md
+++ b/openspec/changes/refactor-player-state-machine/tasks.md
@@ -18,13 +18,13 @@
 
 ## 3. ResumeSession 收敛（D2）
 
-- [ ] 3.1 新增 `ResumeSession` 类（内部按 pending / decision / seek / result 分区）
-- [ ] 3.2 迁移 `PendingResumeState` 核心数据（positionMs/shouldResumePlay/sourceKey/reason/captureBackend）与 capture/preserve/consume 生命周期
-- [ ] 3.3 迁移自动播放决策 6 字段（pending/prepared × explicit/has/source）到 `ResumeSession.decision`
-- [ ] 3.4 迁移 resume seek 7 字段 + 超时兜底 3 字段到 `ResumeSession.seek`
-- [ ] 3.5 迁移 `pendingResumeAutoplayResultState` 到 `ResumeSession.result`
-- [ ] 3.6 将 `initPlayer` 中 20+ 行续播重置语句收敛为 `resumeSession.reset()` / `resumeSession = null`
-- [ ] 3.7 编译 + 单测，确认续播/回退/seek 恢复行为不变
+- [x] 3.1 新增 `ResumeSession` 类（内部按 pending / decision / seek / result 分区）
+- [x] 3.2 迁移 `PendingResumeState` 核心数据（positionMs/shouldResumePlay/sourceKey/reason/captureBackend）与 capture/preserve/consume 生命周期
+- [x] 3.3 迁移自动播放决策 6 字段（pending/prepared × explicit/has/source）到 `ResumeSession.decision`
+- [x] 3.4 迁移 resume seek 7 字段 + 超时兜底 3 字段到 `ResumeSession.seek`
+- [x] 3.5 迁移 `pendingResumeAutoplayResultState` 到 `ResumeSession.result`
+- [x] 3.6 将 `initPlayer` 中 20+ 行续播重置语句收敛为 `resumeSession.reset()` / `resumeSession = null`
+- [x] 3.7 编译 + 单测，确认续播/回退/seek 恢复行为不变
 
 ## 4. 状态转换收口（D4）
 

--- a/openspec/changes/refactor-player-state-machine/tasks.md
+++ b/openspec/changes/refactor-player-state-machine/tasks.md
@@ -1,0 +1,45 @@
+## 1. PlaybackState 枚举镜像迁移（D1）
+
+- [ ] 1.1 新增 `PlaybackState` 枚举（`IDLE/ROUTING/PREPARING/PREPARED/PLAYING/PAUSED/SEEKING/ERROR/RELEASING`）
+- [ ] 1.2 在 `VideoPlayerController` 新增 `state` 字段与 `transitionTo(state)` 私有方法
+- [ ] 1.3 在 `initPlayer` 的会话生命周期写入点镜像同步 `state`（进入 ROUTING/PREPARING 等）
+- [ ] 1.4 在 `onPlayerReady` 镜像同步 `state = PREPARED`
+- [ ] 1.5 在 `onPlay` / `onPause` 镜像同步 `state = PLAYING/PAUSED`
+- [ ] 1.6 在 `seek` 镜像同步 `state = SEEKING`（与 `isSeeking` 并存）
+- [ ] 1.7 在 `handleTerminalPlayerError` / `release` 镜像同步 `state = ERROR/IDLE`
+- [ ] 1.8 编译 `assembleHap` + 跑 `VideoPlayerController.test.ets`，确认镜像阶段行为不变
+
+## 2. ReloadSession 收敛（D3，风险最低先行）
+
+- [ ] 2.1 新增 `ReloadSession` 类（含 token/timeout/resolve/reject）
+- [ ] 2.2 用 `reloadSession` 字段替换 5 个旧 reload 字段
+- [ ] 2.3 迁移 `reloadSource` / `resolvePendingReload` / `rejectPendingReload` / `clearPendingReloadState` 到 `ReloadSession`
+- [ ] 2.4 编译 + 单测，确认 reload 行为不变
+
+## 3. ResumeSession 收敛（D2）
+
+- [ ] 3.1 新增 `ResumeSession` 类（内部按 pending / decision / seek / result 分区）
+- [ ] 3.2 迁移 `PendingResumeState` 核心数据（positionMs/shouldResumePlay/sourceKey/reason/captureBackend）与 capture/preserve/consume 生命周期
+- [ ] 3.3 迁移自动播放决策 6 字段（pending/prepared × explicit/has/source）到 `ResumeSession.decision`
+- [ ] 3.4 迁移 resume seek 7 字段 + 超时兜底 3 字段到 `ResumeSession.seek`
+- [ ] 3.5 迁移 `pendingResumeAutoplayResultState` 到 `ResumeSession.result`
+- [ ] 3.6 将 `initPlayer` 中 20+ 行续播重置语句收敛为 `resumeSession.reset()` / `resumeSession = null`
+- [ ] 3.7 编译 + 单测，确认续播/回退/seek 恢复行为不变
+
+## 4. 状态转换收口（D4）
+
+- [ ] 4.1 把 `fallbackAvPlayerToMpv` 中的状态编排收口到 `transitionTo` + `ResumeSession.capture`
+- [ ] 4.2 清理 `seek` / `onPlayerReady` 中散落的状态重置，改为调用对象方法
+- [ ] 4.3 编译 + 单测，确认转换语义不变
+
+## 5. 清理旧字段
+
+- [ ] 5.1 确认所有读取方已迁移到 `state` / `resumeSession` / `reloadSession`
+- [ ] 5.2 删除旧布尔字段 `isReady/isPlaying/isSeeking/isLoading/hasPrepared` 及已迁移的续播/reload 旧字段
+- [ ] 5.3 编译 + 单测，确认无残留引用
+
+## 6. 回归验证
+
+- [ ] 6.1 `assembleHap`（product=default）编译通过
+- [ ] 6.2 `UnitTestBuild` 全量单测通过（重点 `VideoPlayerController.test.ets` 48 用例）
+- [ ] 6.3 真机回归：AVPlayer 播放、MPV 回退、切集续播、seek 恢复播放、自动下一集


### PR DESCRIPTION
## 变更概述

将 `VideoPlayerController`（2553 行）的隐式状态机从 30+ 个分散字段收敛为显式状态表示：

- 新增 `PlaybackState` 枚举（9 个状态）+ `transitionTo()` 集中转移
- 新增 `ResumeSession`：续播三层（pending/decision/seek/result）收敛为单一对象
- 新增 `ReloadSession`：reload 5 字段收敛为事务对象
- `initPlayer` 中 20+ 行散落的续播重置收敛为 `resetSeek()/clearResult()`

## 行为不变（重构红线）

- 播放 / AVPlayer→MPV 回退 / 续播定位 / 续播自动播放决策 / 竞态防护（sessionId / consumedReadyResumeToken / reloadToken）语义逐字保留
- 布尔字段 `isReady/isPlaying/isSeeking/isLoading/hasPrepared` 保留为 `@Trace` UI 响应式接口（`state` 作为诊断/日志补充状态机，删除留待后续变更）

## 验证

- ✅ `assembleHap` 编译通过
- ✅ `UnitTestBuild` 单测构建通过（含 `VideoPlayerController.test.ets`）
- ✅ 真机回归 5 入口正常（AVPlayer 播放 / MPV 回退 / 切集续播 / seek 恢复播放 / 自动下一集）

## SDD

- OpenSpec change：`refactor-player-state-machine`（spec-driven，`skip_specs: true`，纯重构）
- `openspec-verify-change`：All checks passed
- 归档留待合并后处理

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化播放器播放、暂停、准备、跳转、错误和释放等生命周期状态管理。
  * 改进续播、自动播放、音轨切换及播放源重载流程。
  * 增强播放源重载和续播操作的超时处理与异常恢复能力。
  * 优化不同播放后端之间的回退及切集续播体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->