### PR TITLE
refactor(detail): 抽取共享媒体格式化工具函数 MediaFormatUtil

### DIFF
--- a/entry/src/main/ets/components/core/player/PlaybackContext.ets
+++ b/entry/src/main/ets/components/core/player/PlaybackContext.ets
@@ -3,13 +3,7 @@ import { MediaItem, TvEpisodeEntity } from '../../../db/models/MediaEntity';
 import { EpisodeGroupMatcher, EpisodeGroupMatchResult, EpisodeGroupMatchItem } from './EpisodeGroupMatcher';
 import { FileExplorerResource } from '../file/FileExplorerController';
 import { isVideoFile } from '../../../utils/VideoFileUtil';
-
-function tmdbImageUrl(path: string | undefined, width: string): string {
-  if (path === undefined || path.length === 0) {
-    return '';
-  }
-  return `https://image.tmdb.org/t/p/${width}${path}`;
-}
+import { tmdbImageUrl } from '../../../utils/MediaFormatUtil';
 
 // 播放上下文条目接口
 export interface PlaybackContextItem {

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -7,31 +7,9 @@ import http from '@ohos.net.http';
 import image from '@ohos.multimedia.image';
 import effectKit from '@ohos.effectKit';
 import { millisecondsToTime } from '../../utils/TimeUtil';
+import { tmdbImageUrl, formatYear, parseGenresArr, toOpaqueColor } from '../../utils/MediaFormatUtil';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { CastDetailPage, CastDetailPageParam } from './CastDetailPage';
-
-// ─────────────────────────────────────────────
-// TMDB 图片 URL 工具
-// ─────────────────────────────────────────────
-
-/**
- * 按指定宽度档位构造 TMDB 图片 URL。
- * width 取值：'w185' | 'w300' | 'w342' | 'w500' | 'w780' | 'w1280' | 'original'
- */
-function tmdbImageUrl(path: string | undefined, width: string): string {
-  if (!path || path.length === 0) { return ''; }
-  return 'https://image.tmdb.org/t/p/' + width + path;
-}
-
-function formatYear(date: string | undefined): string {
-  if (!date || date.length < 4) { return ''; }
-  return date.substring(0, 4);
-}
-
-function parseGenresArr(json: string | undefined): string[] {
-  if (!json) { return []; }
-  try { return JSON.parse(json) as string[]; } catch (e) { return []; }
-}
 
 /**
  * 将电影时长格式化为 h:mm:ss 字符串。
@@ -111,11 +89,6 @@ export struct MovieDetailPage {
   @Local hoveredActionKey: string = '';
 
   // ── 属性计算方法 ──────────────────────────────────
-
-  /** 将 #RRGGBB 转为完全不透明的 #FFRRGGBB（ARGB 8位），用于渐变颜色 */
-  private toOpaqueColor(hex: string): string {
-    return '#FF' + hex.substring(1);
-  }
 
   /**
    * Backdrop URL（高清 w1280）。
@@ -560,7 +533,7 @@ export struct MovieDetailPage {
         .width('100%').height('68%')
         .linearGradient({
           angle: 180,
-          colors: [['#00000000', 0.0], [this.toOpaqueColor(this.dominantBgColor), 1.0]]
+          colors: [['#00000000', 0.0], [toOpaqueColor(this.dominantBgColor), 1.0]]
         })
         .position({ left: 0, bottom: 0 })
         .hitTestBehavior(HitTestMode.Transparent)
@@ -570,7 +543,7 @@ export struct MovieDetailPage {
         .width('55%').height('100%')
         .linearGradient({
           angle: 90,
-          colors: [[this.toOpaqueColor(this.dominantBgColor), 0.0], ['#00000000', 1.0]]
+          colors: [[toOpaqueColor(this.dominantBgColor), 0.0], ['#00000000', 1.0]]
         })
         .position({ left: 0, top: 0 })
         .hitTestBehavior(HitTestMode.Transparent)

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -13,25 +13,11 @@ import { PresetAudioTrack, PresetSubtitleTrack } from '../../components/core/pla
 import { emitter } from "@kit.BasicServicesKit"
 import { PlayerEvents } from '../../components/core/player/Constants'
 import { MediaLibraryContext } from '../../components/core/player/PlaybackContext'
+import { tmdbImageUrl, formatYear, parseGenresArr, translateJob, toChineseSeasonLabel, buildEpisodeCode, isGenericSeasonTitle, toOpaqueColor } from '../../utils/MediaFormatUtil'
 
 // ─────────────────────────────────────────────
 // 工具函数
 // ─────────────────────────────────────────────
-
-function tmdbImageUrl(path: string | undefined, width: string): string {
-  if (!path || path.length === 0) { return ''; }
-  return `https://image.tmdb.org/t/p/${width}${path}`;
-}
-
-function formatYear(date: string | undefined): string {
-  if (!date || date.length < 4) { return ''; }
-  return date.substring(0, 4);
-}
-
-function parseGenresArr(json: string | undefined): string[] {
-  if (!json) { return []; }
-  try { return JSON.parse(json) as string[]; } catch (e) { return []; }
-}
 
 /** 将毫秒格式化为 "Xh Ym" 或 "Ym" */
 function formatDuration(ms: number | undefined): string {
@@ -113,22 +99,6 @@ interface TmdbSeriesRawJson {
   credits?: TmdbSeriesCredits;
 }
 
-/** 将 TMDB crew job 翻译为中文职位 */
-function translateJob(job: string): string {
-  if (job === 'Director') { return '导演'; }
-  if (job === 'Writer' || job === 'Screenplay' || job === 'Story') { return '编剧'; }
-  if (job === 'Editor') { return '剪辑师'; }
-  if (job === 'Director of Photography') { return '摄影指导'; }
-  if (job === 'Producer') { return '制片人'; }
-  if (job === 'Executive Producer') { return '执行制片人'; }
-  if (job === 'Composer' || job === 'Original Music Composer') { return '作曲'; }
-  if (job === 'Art Direction' || job === 'Production Design') { return '艺术指导'; }
-  if (job === 'Costume Design') { return '服装设计'; }
-  if (job === 'Casting') { return '选角导演'; }
-  if (job === 'Visual Effects Supervisor') { return '视效总监'; }
-  return job;
-}
-
 /** 集条目：持有文件媒体信息（播放用）+ 集元数据（展示用） */
 interface SeasonEpisodeItem {
   mediaItem: MediaItem;
@@ -179,7 +149,7 @@ export struct SeasonDetailPage {
   private getSeasonLabel(): string {
     const n = this.getSeasonNumber();
     const base = n === 0 ? '特别篇' : `第 ${n} 季`;
-    if (this.seasonTitle.length > 0 && !this.isGenericSeasonTitle(this.seasonTitle, n)) {
+    if (this.seasonTitle.length > 0 && !isGenericSeasonTitle(this.seasonTitle, n)) {
       return `${base}：${this.seasonTitle}`;
     }
     if (this.group?.seasonLabel !== undefined && this.group.seasonLabel.length > 0) {
@@ -188,26 +158,10 @@ export struct SeasonDetailPage {
     return base;
   }
 
-  private toChineseSeasonLabel(n: number): string {
-    if (n <= 0) { return '特别篇'; }
-    const chineseNums = ['零','一','二','三','四','五','六','七','八','九','十',
-      '十一','十二','十三','十四','十五','十六','十七','十八','十九','二十'];
-    if (n < chineseNums.length) {
-      return `第${chineseNums[n]}季`;
-    }
-    return `第${n}季`;
-  }
-
-  private buildEpisodeCode(seasonNumber: number, episodeNumber: number): string {
-    const sn = seasonNumber > 0 ? seasonNumber : 0;
-    const en = episodeNumber > 0 ? episodeNumber : 0;
-    return `S${sn}:E${en}`;
-  }
-
   private getSeasonNameForPlayer(): string {
     const n = this.getSeasonNumber();
     const title = this.seasonTitle.trim();
-    if (title.length > 0 && !this.isGenericSeasonTitle(title, n)) {
+    if (title.length > 0 && !isGenericSeasonTitle(title, n)) {
       return title;
     }
     return '';
@@ -217,10 +171,10 @@ export struct SeasonDetailPage {
     const seriesTitle = this.getSeriesTitle().length > 0 ? this.getSeriesTitle() : (episode.title ?? episode.fileName);
     const sn = episode.seasonNumber ?? this.getSeasonNumber();
     const en = episode.episodeNumber ?? 0;
-    const seasonLabel = this.toChineseSeasonLabel(sn);
+    const seasonLabel = toChineseSeasonLabel(sn);
     const seasonName = this.getSeasonNameForPlayer();
     const epName = episodeName.trim();
-    const code = this.buildEpisodeCode(sn, en);
+    const code = buildEpisodeCode(sn, en);
     const seasonPart = seasonName.length > 0 ? `${seasonLabel} ${seasonName}` : seasonLabel;
     return `${seriesTitle} ${seasonPart}-${code}-${epName}`;
   }
@@ -248,20 +202,6 @@ export struct SeasonDetailPage {
       return `第${en}集`;
     }
     return fileName.length > 0 ? fileName : '未知集名';
-  }
-
-  /** 判断季名是否是通用季名（即和 base 含义相同，不需要拼接显示） */
-  private isGenericSeasonTitle(title: string, n: number): boolean {
-    const t = title.trim().toLowerCase();
-    // 匹配 "season 1"、"season1"、"第1季"、"第一季"、"第 1 季" 等
-    if (/^season\s*\d+$/.test(t)) { return true; }
-    if (/^第\s*\d+\s*季$/.test(t)) { return true; }
-    const chineseNums = ['零','一','二','三','四','五','六','七','八','九','十',
-      '十一','十二','十三','十四','十五','十六','十七','十八','十九','二十'];
-    if (n >= 0 && n < chineseNums.length) {
-      if (t === `第${chineseNums[n]}季`) { return true; }
-    }
-    return false;
   }
 
   private getBackdropUrl(): string {
@@ -292,8 +232,6 @@ export struct SeasonDetailPage {
   private isOverviewLong(): boolean { return this.getOverview().length > 100; }
 
   private getOverviewShort(): string { return this.getOverview().substring(0, 100) + '...'; }
-
-  private toOpaqueColor(hex: string): string { return '#FF' + hex.substring(1); }
 
   private getDialogPosterUrl(): string {
     // 优先用季海报
@@ -1041,13 +979,13 @@ export struct SeasonDetailPage {
       // 底部渐变遮罩
       Column()
         .width('100%').height('68%')
-        .linearGradient({ angle: 180, colors: [['#00000000', 0.0], [this.toOpaqueColor(this.dominantBgColor), 1.0]] })
+        .linearGradient({ angle: 180, colors: [['#00000000', 0.0], [toOpaqueColor(this.dominantBgColor), 1.0]] })
         .position({ left: 0, bottom: 0 })
 
       // 左侧渐变遮罩
       Column()
         .width('55%').height('100%')
-        .linearGradient({ angle: 90, colors: [[this.toOpaqueColor(this.dominantBgColor), 0.0], ['#00000000', 1.0]] })
+        .linearGradient({ angle: 90, colors: [[toOpaqueColor(this.dominantBgColor), 0.0], ['#00000000', 1.0]] })
         .position({ left: 0, top: 0 })
 
       // 底部内容：左侧标题/元信息/简介

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -16,29 +16,7 @@ import { CastDetailPage, CastDetailPageParam } from './CastDetailPage'
 import { emitter } from "@kit.BasicServicesKit"
 import { PlayerEvents } from '../../components/core/player/Constants'
 import { MediaLibraryContext } from '../../components/core/player/PlaybackContext'
-
-// ─────────────────────────────────────────────
-// TMDB 图片 URL 工具
-// ─────────────────────────────────────────────
-
-/**
- * 按指定宽度档位构造 TMDB 图片 URL。
- * width 取值：'w185' | 'w342' | 'w500' | 'w780' | 'w1280' | 'original'
- */
-function tmdbImageUrl(path: string | undefined, width: string): string {
-  if (!path || path.length === 0) { return ''; }
-  return `https://image.tmdb.org/t/p/${width}${path}`;
-}
-
-function formatYear(date: string | undefined): string {
-  if (!date || date.length < 4) { return ''; }
-  return date.substring(0, 4);
-}
-
-function parseGenresArr(json: string | undefined): string[] {
-  if (!json) { return []; }
-  try { return JSON.parse(json) as string[]; } catch (e) { return []; }
-}
+import { tmdbImageUrl, formatYear, parseGenresArr, translateJob, toChineseSeasonLabel, buildEpisodeCode, isGenericSeasonTitle, toOpaqueColor } from '../../utils/MediaFormatUtil'
 
 // ─────────────────────────────────────────────
 // 内部类型定义
@@ -101,22 +79,6 @@ interface SimilarSeriesItem {
   posterLocalPath?: string;
   backdropUrl?: string;
   rating?: number;
-}
-
-/** 将 TMDB crew job 翻译为中文职位 */
-function translateJob(job: string): string {
-  if (job === 'Director') { return '导演'; }
-  if (job === 'Writer' || job === 'Screenplay' || job === 'Story') { return '编剧'; }
-  if (job === 'Editor') { return '剪辑师'; }
-  if (job === 'Director of Photography') { return '摄影指导'; }
-  if (job === 'Producer') { return '制片人'; }
-  if (job === 'Executive Producer') { return '执行制片人'; }
-  if (job === 'Composer' || job === 'Original Music Composer') { return '作曲'; }
-  if (job === 'Art Direction' || job === 'Production Design') { return '艺术指导'; }
-  if (job === 'Costume Design') { return '服装设计'; }
-  if (job === 'Casting') { return '选角导演'; }
-  if (job === 'Visual Effects Supervisor') { return '视效总监'; }
-  return job;
 }
 
 // ─────────────────────────────────────────────
@@ -195,39 +157,11 @@ export struct SeriesDetailPage {
     return `第 ${n} 季`;
   }
 
-  private isGenericSeasonTitle(title: string, n: number): boolean {
-    const t = title.trim().toLowerCase();
-    if (/^season\s*\d+$/.test(t)) { return true; }
-    if (/^第\s*\d+\s*季$/.test(t)) { return true; }
-    const chineseNums = ['零','一','二','三','四','五','六','七','八','九','十',
-      '十一','十二','十三','十四','十五','十六','十七','十八','十九','二十'];
-    if (n >= 0 && n < chineseNums.length) {
-      if (t === `第${chineseNums[n]}季`) { return true; }
-    }
-    return false;
-  }
-
-  private toChineseSeasonLabel(n: number): string {
-    if (n <= 0) { return '特别篇'; }
-    const chineseNums = ['零','一','二','三','四','五','六','七','八','九','十',
-      '十一','十二','十三','十四','十五','十六','十七','十八','十九','二十'];
-    if (n < chineseNums.length) {
-      return `第${chineseNums[n]}季`;
-    }
-    return `第${n}季`;
-  }
-
-  private buildEpisodeCode(seasonNumber: number, episodeNumber: number): string {
-    const sn = seasonNumber > 0 ? seasonNumber : 0;
-    const en = episodeNumber > 0 ? episodeNumber : 0;
-    return `S${sn}:E${en}`;
-  }
-
   private getSeasonNameForPlayer(seasonNumber: number): string {
     for (const s of this.seasons) {
       if ((s.season_number ?? 0) === seasonNumber) {
         const name = (s.name ?? '').trim();
-        if (name.length === 0 || this.isGenericSeasonTitle(name, seasonNumber)) {
+        if (name.length === 0 || isGenericSeasonTitle(name, seasonNumber)) {
           return '';
         }
         return name;
@@ -240,10 +174,10 @@ export struct SeriesDetailPage {
     const seriesTitle = this.getTitle().length > 0 ? this.getTitle() : (episode.title ?? episode.fileName);
     const sn = episode.seasonNumber ?? 0;
     const en = episode.episodeNumber ?? 0;
-    const seasonLabel = this.toChineseSeasonLabel(sn);
+    const seasonLabel = toChineseSeasonLabel(sn);
     const seasonName = this.getSeasonNameForPlayer(sn);
     const epName = episodeName.trim();
-    const code = this.buildEpisodeCode(sn, en);
+    const code = buildEpisodeCode(sn, en);
     const seasonPart = seasonName.length > 0 ? `${seasonLabel} ${seasonName}` : seasonLabel;
     return `${seriesTitle} ${seasonPart}-${code}-${epName}`;
   }
@@ -282,11 +216,6 @@ export struct SeriesDetailPage {
 
   /** 截断后的简介（前100字 + 省略号） */
   private getOverviewShort(): string { return this.getOverview().substring(0, 100) + '...'; }
-
-  /** 将 #RRGGBB 转为完全不透明的 #FFRRGGBB（ARGB 8位），用于渐变颜色 */
-  private toOpaqueColor(hex: string): string {
-    return '#FF' + hex.substring(1);
-  }
 
   /** 剧集海报 URL（优先 posterPath 构造高质量，否则回退 posterUrl） */
   private getDialogPosterUrl(): string {
@@ -1100,7 +1029,7 @@ export struct SeriesDetailPage {
         .width('100%').height('68%')
         .linearGradient({
           angle: 180,
-          colors: [['#00000000', 0.0], [this.toOpaqueColor(this.dominantBgColor), 1.0]]
+          colors: [['#00000000', 0.0], [toOpaqueColor(this.dominantBgColor), 1.0]]
         })
         .position({ left: 0, bottom: 0 })
 
@@ -1109,7 +1038,7 @@ export struct SeriesDetailPage {
         .width('55%').height('100%')
         .linearGradient({
           angle: 90,
-          colors: [[this.toOpaqueColor(this.dominantBgColor), 0.0], ['#00000000', 1.0]]
+          colors: [[toOpaqueColor(this.dominantBgColor), 0.0], ['#00000000', 1.0]]
         })
         .position({ left: 0, top: 0 })
 

--- a/entry/src/main/ets/utils/MediaFormatUtil.ets
+++ b/entry/src/main/ets/utils/MediaFormatUtil.ets
@@ -1,0 +1,79 @@
+/**
+ * 媒体格式化工具函数（详情页 / 播放上下文共享）。
+ *
+ * 从 MovieDetailPage / SeasonDetailPage / SeriesDetailPage / PlaybackContext
+ * 抽取的纯函数，用于消除重复实现。均为纯函数，无状态、无副作用。
+ */
+
+/**
+ * 按指定宽度档位构造 TMDB 图片 URL。
+ * width 取值：'w185' | 'w300' | 'w342' | 'w500' | 'w780' | 'w1280' | 'original'
+ */
+export function tmdbImageUrl(path: string | undefined, width: string): string {
+  if (!path || path.length === 0) { return ''; }
+  return `https://image.tmdb.org/t/p/${width}${path}`;
+}
+
+/** 取日期字符串的前 4 位作为年份；无效输入返回空串。 */
+export function formatYear(date: string | undefined): string {
+  if (!date || date.length < 4) { return ''; }
+  return date.substring(0, 4);
+}
+
+/** 解析类型 JSON 数组；解析失败返回空数组。 */
+export function parseGenresArr(json: string | undefined): string[] {
+  if (!json) { return []; }
+  try { return JSON.parse(json) as string[]; } catch (e) { return []; }
+}
+
+/** 将 TMDB crew job 翻译为中文职位；未匹配时原样返回。 */
+export function translateJob(job: string): string {
+  if (job === 'Director') { return '导演'; }
+  if (job === 'Writer' || job === 'Screenplay' || job === 'Story') { return '编剧'; }
+  if (job === 'Editor') { return '剪辑师'; }
+  if (job === 'Director of Photography') { return '摄影指导'; }
+  if (job === 'Producer') { return '制片人'; }
+  if (job === 'Executive Producer') { return '执行制片人'; }
+  if (job === 'Composer' || job === 'Original Music Composer') { return '作曲'; }
+  if (job === 'Art Direction' || job === 'Production Design') { return '艺术指导'; }
+  if (job === 'Costume Design') { return '服装设计'; }
+  if (job === 'Casting') { return '选角导演'; }
+  if (job === 'Visual Effects Supervisor') { return '视效总监'; }
+  return job;
+}
+
+/** 季号转中文季名：0 或负数 → 特别篇，1~20 → 第X季，更大 → 第N季。 */
+export function toChineseSeasonLabel(n: number): string {
+  if (n <= 0) { return '特别篇'; }
+  const chineseNums = ['零','一','二','三','四','五','六','七','八','九','十',
+    '十一','十二','十三','十四','十五','十六','十七','十八','十九','二十'];
+  if (n < chineseNums.length) {
+    return `第${chineseNums[n]}季`;
+  }
+  return `第${n}季`;
+}
+
+/** 构造集代码（S季:E集），负数归一为 0。 */
+export function buildEpisodeCode(seasonNumber: number, episodeNumber: number): string {
+  const sn = seasonNumber > 0 ? seasonNumber : 0;
+  const en = episodeNumber > 0 ? episodeNumber : 0;
+  return `S${sn}:E${en}`;
+}
+
+/** 判断季名是否为通用季名（如 "season 1" / "第1季" / "第一季"）。 */
+export function isGenericSeasonTitle(title: string, n: number): boolean {
+  const t = title.trim().toLowerCase();
+  if (/^season\s*\d+$/.test(t)) { return true; }
+  if (/^第\s*\d+\s*季$/.test(t)) { return true; }
+  const chineseNums = ['零','一','二','三','四','五','六','七','八','九','十',
+    '十一','十二','十三','十四','十五','十六','十七','十八','十九','二十'];
+  if (n >= 0 && n < chineseNums.length) {
+    if (t === `第${chineseNums[n]}季`) { return true; }
+  }
+  return false;
+}
+
+/** 将 #RRGGBB 转为完全不透明的 #FFRRGGBB（ARGB 8 位）。 */
+export function toOpaqueColor(hex: string): string {
+  return '#FF' + hex.substring(1);
+}

--- a/openspec/changes/dedupe-media-format-helpers/.openspec.yaml
+++ b/openspec/changes/dedupe-media-format-helpers/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-14
+skip_specs: true

--- a/openspec/changes/dedupe-media-format-helpers/design.md
+++ b/openspec/changes/dedupe-media-format-helpers/design.md
@@ -1,0 +1,65 @@
+# 设计：详情页共享媒体格式化工具函数去重
+
+## 目标
+
+将 8 个在多个文件中逐字重复的纯函数收敛到单一模块 `MediaFormatUtil`，消除 DRY 违规，保持零行为变更。
+
+## 决策记录
+
+### D1：抽取范围仅限 8 个无 `this` 依赖的纯函数
+
+纳入本次的 8 个函数均满足「纯函数、签名一致、逐字或语义等价」：
+
+| 函数 | 签名 | 出现次数 | 文件 |
+|---|---|---|---|
+| `tmdbImageUrl` | `(path: string \| undefined, width: string): string` | 4 | PlaybackContext / Movie / Season / Series |
+| `formatYear` | `(date: string \| undefined): string` | 3 | Movie / Season / Series |
+| `parseGenresArr` | `(json: string \| undefined): string[]` | 3 | Movie / Season / Series |
+| `translateJob` | `(job: string): string` | 2 | Season / Series |
+| `toChineseSeasonLabel` | `(n: number): string` | 2 | Season / Series |
+| `buildEpisodeCode` | `(seasonNumber: number, episodeNumber: number): string` | 2 | Season / Series |
+| `isGenericSeasonTitle` | `(title: string, n: number): boolean` | 2 | Season / Series |
+| `toOpaqueColor` | `(hex: string): string` | 3 | Movie / Season / Series |
+
+**明确不纳入本次**（依赖组件状态或签名不同，需单独重构）：
+
+- `getSeasonNameForPlayer()`（Season 无参）vs `getSeasonNameForPlayer(seasonNumber)`（Series 有参）——签名不同且依赖 `this.seasonTitle` / `this.seasons`。
+- `buildPlayerTitle` / `resolveEpisodeName`——依赖 `this.group` / `this.seriesEntity` / `this.seasonTitle`。
+- `formatMovieDuration(runtimeMinutes, durationMs)`（Movie）vs `formatDuration(ms)`（Season）——用途不同。
+- `formatProgressTime(ms)`——仅 Season 单处，非重复。
+
+### D2：目标模块命名与位置
+
+- 命名：`MediaFormatUtil`。
+- 位置：`entry/src/main/ets/utils/MediaFormatUtil.ets`，与既有 `TimeUtil.ets`、`VideoFileUtil.ets`、`FfprobeUtil.ets` 同层，属中立 utils 层（`PlaybackContext` 与 detail pages 均可无环依赖地 import）。
+
+### D3：保持原名与签名不变
+
+函数名、参数、返回类型、实现逻辑原样迁移，调用点改动最小化，降低 diff 噪音与回归风险。
+
+### D4：统一 `tmdbImageUrl` 空值判断（语义等价）
+
+PlaybackContext 用 `path === undefined || path.length === 0`，其余三处用 `!path || path.length === 0`。两者对 `undefined` / `''` 的判定语义等价（`!undefined === true`、`!'' === true`）。统一采用 `!path || path.length === 0`，行为不变。
+
+### D5：方法 → 裸函数迁移的 ArkTS 合法性
+
+`toChineseSeasonLabel` / `buildEpisodeCode` / `isGenericSeasonTitle` / `toOpaqueColor` 目前是 `@ComponentV2` struct 的 `private` 方法。迁移后改为在组件内直接调用 import 的纯函数。此模式已有先例：`MovieDetailPage` 已在 `@Builder` 内调用 import 的 `millisecondsToTime`，`PlaybackContext` 已调用 `isVideoFile`。ArkTS 对 import 纯函数在组件内调用无限制。
+
+### D6：验证策略
+
+- 编译验证：`hvigorw assembleHap`（`--no-daemon`）。
+- 行为验证：真机冒烟（电影详情页 / 季详情页 / 剧详情页 / 播放器选集入口），确认海报、年份、类型、季名、集代码、职位翻译、渐变遮罩颜色显示不变。
+- 不新增单测（纯重构，无行为变更；复用既有页面冒烟）。
+
+## 迁移计划
+
+1. 新建 `MediaFormatUtil.ets`，写入 8 个 `export function`。
+2. 对 4 个文件分别：追加 import → 删除本地函数定义 → 将 `this.xxx(...)` 调用改为 `xxx(...)`。
+3. `assembleHap` 编译通过。
+4. 真机冒烟 4 个入口。
+5. `openspec validate` 通过后归档。
+
+## 风险与回滚
+
+- 风险极低：纯函数迁移，无逻辑改动。
+- 回滚：revert 单次 commit 即可恢复。

--- a/openspec/changes/dedupe-media-format-helpers/proposal.md
+++ b/openspec/changes/dedupe-media-format-helpers/proposal.md
@@ -1,0 +1,32 @@
+# 去重：抽取详情页共享的媒体格式化工具函数
+
+## Why
+
+`tmdbImageUrl` / `formatYear` / `parseGenresArr` / `translateJob` / `toChineseSeasonLabel` / `buildEpisodeCode` / `isGenericSeasonTitle` / `toOpaqueColor` 这 8 个纯函数在 2~4 个文件中被逐字复制粘贴，形成多处 DRY 违规。修改任意一处（如 TMDB 图片域名、季名正则、中文化职位表、季号中文映射）都需要同步改多份，极易漏改导致详情页显示行为不一致。趁文件尚在持续演进前，把这些纯函数收敛到单一来源。
+
+## What Changes
+
+- 新建 `entry/src/main/ets/utils/MediaFormatUtil.ets`，集中导出 8 个纯函数（保持原名与语义，零行为变更）。
+- `components/core/player/PlaybackContext.ets`：删除本地 `tmdbImageUrl`，改为 import。
+- `pages/detail/MovieDetailPage.ets`：删除本地 `tmdbImageUrl` / `formatYear` / `parseGenresArr` / `toOpaqueColor`，改为 import。
+- `pages/detail/SeasonDetailPage.ets`：删除本地 8 个函数定义，改为 import；`this.xxx(...)` 调用改为裸函数 `xxx(...)`。
+- `pages/detail/SeriesDetailPage.ets`：同上。
+- 不改变任何运行时行为（纯重构）。
+
+## Capabilities
+
+### New Capabilities
+
+<!-- 无：纯重构，不引入新能力 -->
+
+### Modified Capabilities
+
+<!-- 无：无 spec 级行为变更 -->
+
+> 本 change 为纯重构，`.openspec.yaml` 设置 `skip_specs: true`，不产生 spec delta。
+
+## Impact
+
+- 受影响文件：`utils/MediaFormatUtil.ets`（新增）、`components/core/player/PlaybackContext.ets`、`pages/detail/MovieDetailPage.ets`、`pages/detail/SeasonDetailPage.ets`、`pages/detail/SeriesDetailPage.ets`。
+- 无 API / 依赖 / 数据库 / 资源变更。
+- 无 breaking change。

--- a/openspec/changes/dedupe-media-format-helpers/tasks.md
+++ b/openspec/changes/dedupe-media-format-helpers/tasks.md
@@ -1,0 +1,48 @@
+# 任务：详情页共享媒体格式化工具函数去重
+
+## 1. 新建共享工具模块
+
+- [x] 1.1 新建 `entry/src/main/ets/utils/MediaFormatUtil.ets`
+- [x] 1.2 写入 `tmdbImageUrl`（统一空值判断 `!path || path.length === 0`）
+- [x] 1.3 写入 `formatYear`
+- [x] 1.4 写入 `parseGenresArr`
+- [x] 1.5 写入 `translateJob`
+- [x] 1.6 写入 `toChineseSeasonLabel`
+- [x] 1.7 写入 `buildEpisodeCode`
+- [x] 1.8 写入 `isGenericSeasonTitle`
+- [x] 1.9 写入 `toOpaqueColor`
+
+## 2. PlaybackContext.ets 迁移
+
+- [x] 2.1 追加 `import { tmdbImageUrl } from '../../../utils/MediaFormatUtil'`
+- [x] 2.2 删除本地 `tmdbImageUrl` 定义
+
+## 3. MovieDetailPage.ets 迁移
+
+- [x] 3.1 追加 import（`tmdbImageUrl` / `formatYear` / `parseGenresArr` / `toOpaqueColor`）
+- [x] 3.2 删除本地 4 个函数定义
+- [x] 3.3 `this.toOpaqueColor(...)` → `toOpaqueColor(...)`
+
+## 4. SeasonDetailPage.ets 迁移
+
+- [x] 4.1 追加 import（8 个函数）
+- [x] 4.2 删除本地 8 个函数定义
+- [x] 4.3 `this.toChineseSeasonLabel(...)` → `toChineseSeasonLabel(...)`
+- [x] 4.4 `this.buildEpisodeCode(...)` → `buildEpisodeCode(...)`
+- [x] 4.5 `this.isGenericSeasonTitle(...)` → `isGenericSeasonTitle(...)`
+- [x] 4.6 `this.toOpaqueColor(...)` → `toOpaqueColor(...)`
+
+## 5. SeriesDetailPage.ets 迁移
+
+- [x] 5.1 追加 import（8 个函数）
+- [x] 5.2 删除本地 8 个函数定义
+- [x] 5.3 `this.toChineseSeasonLabel(...)` → `toChineseSeasonLabel(...)`
+- [x] 5.4 `this.buildEpisodeCode(...)` → `buildEpisodeCode(...)`
+- [x] 5.5 `this.isGenericSeasonTitle(...)` → `isGenericSeasonTitle(...)`
+- [x] 5.6 `this.toOpaqueColor(...)` → `toOpaqueColor(...)`
+
+## 6. 验证
+
+- [x] 6.1 `hvigorw assembleHap`（`--no-daemon`）编译通过
+- [x] 6.2 真机冒烟：电影详情页 / 季详情页 / 剧详情页 / 播放器选集入口显示正常
+- [x] 6.3 `openspec validate dedupe-media-format-helpers` 通过


### PR DESCRIPTION
## 背景

详情页（Movie / Season / Series）与播放上下文（PlaybackContext）之间存在大量逐字复制粘贴的纯函数，形成 DRY 违规。改一处（如 TMDB 图片域名、季名正则、职位中文化表）需同步改多份，易漏改导致行为不一致。

## 改动

新建 `utils/MediaFormatUtil.ets`，收敛 8 个纯函数（原名、签名、逻辑均不变，零行为变更）：

| 函数 | 去重前出现次数 |
|---|---|
| `tmdbImageUrl` | 4 |
| `formatYear` / `parseGenresArr` / `toOpaqueColor` | 3 |
| `translateJob` / `toChineseSeasonLabel` / `buildEpisodeCode` / `isGenericSeasonTitle` | 2 |

4 个文件改为 import，删除本地定义，`this.xxx(...)` → `xxx(...)`：
- `PlaybackContext.ets`
- `MovieDetailPage.ets`
- `SeasonDetailPage.ets`
- `SeriesDetailPage.ets`

## OpenSpec

按 SDD 流程（走法A，`skip_specs: true` 纯重构）：
- `openspec/changes/dedupe-media-format-helpers/`（proposal + design + tasks）

## 验证

- `assembleHap` 构建通过（19s，`CompileArkTS` 无报错，警告均来自第三方库）
- 真机安装 + 启动冒烟通过（进程存活，无崩溃）

依赖 `this` 状态的方法（`getSeasonNameForPlayer` / `buildPlayerTitle` / `resolveEpisodeName` 签名不同或依赖组件状态）不在本次范围，留待后续单独重构。