### PR TITLE
修复: 单测 test 步骤检测 OhmUrl 归一化冲突并显式跳过（fix #262）

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -120,17 +120,14 @@ jobs:
 
           # 执行设备端测试，带超时保护
           RESULT_TXT="$WORK_DIR/entry/.test/default/intermediates/test/coverage_data/test_result.txt"
-          # 用子进程+计时器实现超时，避免 hdc daemon 卡死无限等待
-          (
-            "$NODE_BIN" "$HVIGOR_WRAPPER" \
-              --mode module -p module=entry@default \
-              test --no-daemon -p coverage=true \
-              2>&1 | tee "$RUNNER_TEMP/unit-test.log"
-          ) &
-          # 使用 setsid 将测试命令放入独立进程组，便于超时时终止完整进程树
-          setsid bash -c '$HVIGOR_CMD 2>&1 | tee "$UNIT_TEST_LOG"' &
+          UNIT_TEST_LOG="$RUNNER_TEMP/unit-test.log"
+          # 单次启动并直接重定向到日志文件（不用 tee），使 $! 指向 hvigor 真实进程，
+          # 从而能正确采集退出码并做超时终止；macOS 无 setsid，改用 kill + pkill 清理进程树。
+          "$NODE_BIN" "$HVIGOR_WRAPPER" \
+            --mode module -p module=entry@default \
+            test --no-daemon -p coverage=true \
+            > "$UNIT_TEST_LOG" 2>&1 &
           TEST_PID=$!
-          TEST_PGID=$(ps -o pgid= -p "$TEST_PID" | tr -d ' ' || echo "$TEST_PID")
           # 最多等待 3 分钟（手动验证约 17 秒完成，超过 180s 一定异常）
           MAX_WAIT=180
           ELAPSED=0
@@ -139,12 +136,14 @@ jobs:
             ELAPSED=$((ELAPSED + 5))
           done
           if kill -0 "$TEST_PID" 2>/dev/null; then
-            echo "⚠️ 设备端测试超时（${MAX_WAIT}s），终止进程组"
-            # 先 SIGTERM 整个进程组，等待 5 秒
-            kill -- -"$TEST_PGID" 2>/dev/null || kill "$TEST_PID" 2>/dev/null || true
+            echo "⚠️ 设备端测试超时（${MAX_WAIT}s），终止进程树"
+            # 先 SIGTERM 主进程与其直接子进程，等待 5 秒
+            kill "$TEST_PID" 2>/dev/null || true
+            pkill -P "$TEST_PID" 2>/dev/null || true
             sleep 5
-            # 如果还在运行，SIGKILL 整个进程组
-            kill -9 -- -"$TEST_PGID" 2>/dev/null || kill -9 "$TEST_PID" 2>/dev/null || true
+            # 如果还在运行，SIGKILL
+            kill -9 "$TEST_PID" 2>/dev/null || true
+            pkill -9 -P "$TEST_PID" 2>/dev/null || true
             wait "$TEST_PID" 2>/dev/null || true
             # 清理可能残留的卡死 hdc 进程
             ps aux | grep -E '[h]dc' | awk '{print $2}' | xargs kill -9 2>/dev/null || true
@@ -155,9 +154,19 @@ jobs:
           HVIGOR_EXIT=$?
 
           if [ "$HVIGOR_EXIT" -ne 0 ]; then
+            # issue #262：@ohos/hypium（useNormalizedOHMUrl:false）与字节码 HAR（强制 true）互斥，
+            # 导致 test 任务编译期 OhmUrl 解析失败（错误码 10311002）。检测到该特征时显式告警并跳过，
+            # 避免与其它运行时失败混为一谈、长期静默。
+            if grep -qE 'Failed to resolve OhmUrl|10311002' "$UNIT_TEST_LOG"; then
+              echo "::warning title=issue-262::设备端单测因 OhmUrl 归一化冲突被跳过（@ohos/hypium 与字节码 HAR 互斥），详见 issue #262"
+              echo "⚠️ 检测到 OhmUrl 解析失败（issue #262），显式跳过设备端测试"
+              exit 0
+            fi
             echo "⚠️ hvigor test 退出码非零（$HVIGOR_EXIT），但不阻塞 CI"
             exit 0
           fi
+          # 输出测试日志尾部便于排查
+          tail -n 40 "$UNIT_TEST_LOG" || true
 
           if [ -f "$RESULT_TXT" ]; then
             TESTS_LINE=$(grep "Tests run:" "$RESULT_TXT" | tail -1 || true)

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -30,7 +30,7 @@ jobs:
       - self-hosted
       - macOS
       - harmonyos-tv-test
-    timeout-minutes: 12
+    timeout-minutes: 20
 
     env:
       DEVECO_SDK_HOME: /Applications/DevEco-Studio.app/Contents/sdk
@@ -52,8 +52,11 @@ jobs:
           cd "$WORK_DIR"
           REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           # macOS LibreSSL 下 GitHub HTTP/2 偶发 RPC 中断（curl 92 / early EOF），
-          # 改用 HTTP/1.1 并带重试，避免瞬态网络错误导致 CI 假失败。
+          # 改用 HTTP/1.1 并带重试，避免瞬态网络错误导致 CI 假失败；
+          # lowSpeed 限制让卡死的 fetch 在 ~20s 内快速失败，而不是挂满整段 job 时间预算。
           git config --global http.version HTTP/1.1
+          git config --global http.lowSpeedLimit 1000
+          git config --global http.lowSpeedTime 20
           FETCHED=false
           for attempt in 1 2 3; do
             if git fetch --no-tags "$REPO_URL" "$TARGET_SHA"; then
@@ -145,7 +148,7 @@ jobs:
             > "$UNIT_TEST_LOG" 2>&1 &
           TEST_PID=$!
           # 最多等待 8 分钟：CI 冷构建（实测 UnitTestArkTS 单步 ~37s）+ 打包 + 部署设备 + 跑 500+ 用例，
-          # 原 180s 会误杀正常构建；job 仍有 timeout-minutes: 12 兜底，设备真卡死也不会无限等待。
+          # 原 180s 会误杀正常构建；job 仍有 timeout-minutes: 20 兜底，设备真卡死也不会无限等待。
           MAX_WAIT=480
           ELAPSED=0
           while kill -0 "$TEST_PID" 2>/dev/null && [ "$ELAPSED" -lt "$MAX_WAIT" ]; do

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -122,7 +122,7 @@ jobs:
           RESULT_TXT="$WORK_DIR/entry/.test/default/intermediates/test/coverage_data/test_result.txt"
           UNIT_TEST_LOG="$RUNNER_TEMP/unit-test.log"
           # 单次启动并直接重定向到日志文件（不用 tee），使 $! 指向 hvigor 真实进程，
-          # 从而能正确采集退出码并做超时终止；macOS 无 setsid，改用 kill + pkill 清理进程树。
+          # 从而能正确采集退出码并做超时终止；macOS 无 setsid，改用 kill + pgrep 递归清理进程树。
           "$NODE_BIN" "$HVIGOR_WRAPPER" \
             --mode module -p module=entry@default \
             test --no-daemon -p coverage=true \

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -51,7 +51,23 @@ jobs:
           set -euo pipefail
           cd "$WORK_DIR"
           REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git fetch --no-tags "$REPO_URL" "$TARGET_SHA"
+          # macOS LibreSSL 下 GitHub HTTP/2 偶发 RPC 中断（curl 92 / early EOF），
+          # 改用 HTTP/1.1 并带重试，避免瞬态网络错误导致 CI 假失败。
+          git config --global http.version HTTP/1.1
+          FETCHED=false
+          for attempt in 1 2 3; do
+            if git fetch --no-tags "$REPO_URL" "$TARGET_SHA"; then
+              echo "git fetch 成功（第 $attempt 次尝试）"
+              FETCHED=true
+              break
+            fi
+            echo "git fetch 第 $attempt 次失败，${attempt}0 秒后重试..."
+            sleep $((attempt * 10))
+          done
+          if [ "$FETCHED" != "true" ]; then
+            echo "错误：git fetch 重试 3 次仍失败"
+            exit 1
+          fi
           git checkout --force --detach FETCH_HEAD
           git clean -fdx
           echo "checked out sha: $(git rev-parse HEAD)"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -136,15 +136,26 @@ jobs:
             sleep 5
             ELAPSED=$((ELAPSED + 5))
           done
+          # 递归收集指定 PID 的全部后代（后序遍历：最深后代先输出）。
+          # 必须先收集再杀：若先杀父进程，macOS 会把其后代重托管给 launchd，pgrep -P 就再也找不到它们。
+          collect_descendants() {
+            local pid="$1" child
+            for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+              collect_descendants "$child"
+              printf '%s\n' "$child"
+            done
+          }
+
           if kill -0 "$TEST_PID" 2>/dev/null; then
             echo "⚠️ 设备端测试超时（${MAX_WAIT}s），终止进程树"
-            # 先 SIGTERM 主进程与其直接子进程，等待 5 秒
+            DESC_PIDS=$(collect_descendants "$TEST_PID")
+            # 先 SIGTERM：从最深后代 → 父进程，等待 5 秒
+            for pid in $DESC_PIDS; do kill "$pid" 2>/dev/null || true; done
             kill "$TEST_PID" 2>/dev/null || true
-            pkill -P "$TEST_PID" 2>/dev/null || true
             sleep 5
-            # 如果还在运行，SIGKILL
+            # 再 SIGKILL：从最深后代 → 父进程
+            for pid in $DESC_PIDS; do kill -9 "$pid" 2>/dev/null || true; done
             kill -9 "$TEST_PID" 2>/dev/null || true
-            pkill -9 -P "$TEST_PID" 2>/dev/null || true
             wait "$TEST_PID" 2>/dev/null || true
             # 清理可能残留的卡死 hdc 进程
             ps aux | grep -E '[h]dc' | awk '{print $2}' | xargs kill -9 2>/dev/null || true

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -128,8 +128,9 @@ jobs:
             test --no-daemon -p coverage=true \
             > "$UNIT_TEST_LOG" 2>&1 &
           TEST_PID=$!
-          # 最多等待 3 分钟（手动验证约 17 秒完成，超过 180s 一定异常）
-          MAX_WAIT=180
+          # 最多等待 8 分钟：CI 冷构建（实测 UnitTestArkTS 单步 ~37s）+ 打包 + 部署设备 + 跑 500+ 用例，
+          # 原 180s 会误杀正常构建；job 仍有 timeout-minutes: 12 兜底，设备真卡死也不会无限等待。
+          MAX_WAIT=480
           ELAPSED=0
           while kill -0 "$TEST_PID" 2>/dev/null && [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
             sleep 5
@@ -150,13 +151,15 @@ jobs:
             echo "⚠️ 设备端测试未在规定时间内完成，但不阻塞 CI"
             exit 0
           fi
-          wait "$TEST_PID" || true
+          # 注意：不能用 `wait ... || true`，否则 `$?` 恒为 0，hvigor 真实退出码被吞掉
+          set +e
+          wait "$TEST_PID"
           HVIGOR_EXIT=$?
+          set -e
 
           if [ "$HVIGOR_EXIT" -ne 0 ]; then
-            # issue #262：@ohos/hypium（useNormalizedOHMUrl:false）与字节码 HAR（强制 true）互斥，
-            # 导致 test 任务编译期 OhmUrl 解析失败（错误码 10311002）。检测到该特征时显式告警并跳过，
-            # 避免与其它运行时失败混为一谈、长期静默。
+            # 防御性检测（issue #262 曾在部分环境出现）：@ohos/hypium 与字节码 HAR 的归一化 OhmUrl
+            # 冲突会以「Failed to resolve OhmUrl（10311002）」呈现；命中即显式告警跳过，避免静默。
             if grep -qE 'Failed to resolve OhmUrl|10311002' "$UNIT_TEST_LOG"; then
               echo "::warning title=issue-262::设备端单测因 OhmUrl 归一化冲突被跳过（@ohos/hypium 与字节码 HAR 互斥），详见 issue #262"
               echo "⚠️ 检测到 OhmUrl 解析失败（issue #262），显式跳过设备端测试"

--- a/openspec/specs/unit-test-workflow/spec.md
+++ b/openspec/specs/unit-test-workflow/spec.md
@@ -38,17 +38,21 @@
 
 ---
 
-### Requirement: 设备端 test 步骤检测 OhmUrl 归一化冲突并显式跳过
-`unit-test.yml` 的「执行设备端单测（test）」步骤 SHALL 在 `hvigor test` 编译失败且日志命中 `Failed to resolve OhmUrl` 或 `10311002` 时，输出引用 issue #262 的 `::warning::` 注解与「显式跳过」日志，并以退出码 0 结束（不阻塞 CI）。
+### Requirement: 设备端 test 步骤正确采集退出码并防御性检测 OhmUrl 冲突
+`unit-test.yml` 的「执行设备端单测（test）」步骤 SHALL 通过 `set +e; wait "$TEST_PID"; HVIGOR_EXIT=$?; set -e` 采集 hvigor 真实退出码（不得用 `wait ... || true` 吞掉），并在日志命中 `Failed to resolve OhmUrl` 或 `10311002` 时输出引用 issue #262 的 `::warning::` 注解与「显式跳过」日志、以退出码 0 结束（不阻塞 CI）。
 
 #### Scenario: 命中 OhmUrl 冲突时显式跳过
-- **WHEN** `hvigor test` 因 `@ohos/hypium`（`useNormalizedOHMUrl: false`）与字节码 HAR（强制 `true`）的归一化 OhmUrl 配置互斥而编译失败（日志含 `Failed to resolve OhmUrl` 或 `10311002`）
+- **WHEN** `hvigor test` 以非零退出码结束且日志含 `Failed to resolve OhmUrl` 或 `10311002`（issue #262 曾报告 `@ohos/hypium` 与字节码 HAR 的归一化 OhmUrl 冲突）
 - **THEN** 步骤输出 `::warning title=issue-262::` 注解与「显式跳过设备端测试」日志
-- **AND** 步骤以退出码 0 结束，CI job 仍为 `success`（状态记为 `build_only`，不误报 `passed`）
+- **AND** 步骤以退出码 0 结束，CI job 仍为 `success`
 
 #### Scenario: 非 OhmUrl 的编译/运行失败仍按非阻塞处理
 - **WHEN** `hvigor test` 退出码非零但日志未命中 OhmUrl 特征
 - **THEN** 步骤输出「hvigor test 退出码非零，但不阻塞 CI」并退出码 0
+
+#### Scenario: 设备端测试超时保护
+- **WHEN** 设备端 `test` 在 `MAX_WAIT=480` 秒内未完成（CI 冷构建 + 打包 + 部署 + 跑用例耗时超过原 180s）
+- **THEN** 步骤终止测试进程树、清理 hdc 进程，输出「设备端测试未在规定时间内完成」并退出码 0（不阻塞 CI）
 
 ---
 
@@ -74,8 +78,8 @@
 
 #### Scenario: test 步骤经后台进程采集真实退出码
 - **WHEN** 设备端 `test` 步骤以 `> "$UNIT_TEST_LOG" 2>&1 &` 后台启动 hvigor（不经管道/`tee`）
-- **THEN** `$!` 指向 hvigor 真实进程，`wait "$TEST_PID"` 返回 hvigor 真实退出码
-- **AND** 不得再以未定义变量（`HVIGOR_CMD`/`UNIT_TEST_LOG`）启动第二份测试命令或依赖 macOS 不存在的 `setsid`
+- **THEN** `$!` 指向 hvigor 真实进程，`set +e; wait "$TEST_PID"; HVIGOR_EXIT=$?; set -e` 返回 hvigor 真实退出码
+- **AND** 不得使用 `wait "$TEST_PID" || true`（会令 `$?` 恒为 0），也不得以未定义变量（`HVIGOR_CMD`/`UNIT_TEST_LOG`）启动第二份测试命令或依赖 macOS 不存在的 `setsid`
 
 ---
 

--- a/openspec/specs/unit-test-workflow/spec.md
+++ b/openspec/specs/unit-test-workflow/spec.md
@@ -38,6 +38,20 @@
 
 ---
 
+### Requirement: 设备端 test 步骤检测 OhmUrl 归一化冲突并显式跳过
+`unit-test.yml` 的「执行设备端单测（test）」步骤 SHALL 在 `hvigor test` 编译失败且日志命中 `Failed to resolve OhmUrl` 或 `10311002` 时，输出引用 issue #262 的 `::warning::` 注解与「显式跳过」日志，并以退出码 0 结束（不阻塞 CI）。
+
+#### Scenario: 命中 OhmUrl 冲突时显式跳过
+- **WHEN** `hvigor test` 因 `@ohos/hypium`（`useNormalizedOHMUrl: false`）与字节码 HAR（强制 `true`）的归一化 OhmUrl 配置互斥而编译失败（日志含 `Failed to resolve OhmUrl` 或 `10311002`）
+- **THEN** 步骤输出 `::warning title=issue-262::` 注解与「显式跳过设备端测试」日志
+- **AND** 步骤以退出码 0 结束，CI job 仍为 `success`（状态记为 `build_only`，不误报 `passed`）
+
+#### Scenario: 非 OhmUrl 的编译/运行失败仍按非阻塞处理
+- **WHEN** `hvigor test` 退出码非零但日志未命中 OhmUrl 特征
+- **THEN** 步骤输出「hvigor test 退出码非零，但不阻塞 CI」并退出码 0
+
+---
+
 ### Requirement: 工程代码在构建前通过 git pull 同步至最新
 `unit-test.yml` SHALL 在执行 `UnitTestBuild` 前，在 iMac 工程路径执行 `git pull`，确保构建使用触发 CI 的最新提交代码。
 
@@ -57,6 +71,11 @@
 #### Scenario: hvigor 失败但管道末端命令成功
 - **WHEN** hvigor 以非零退出码结束，输出通过管道传给 `tee`
 - **THEN** CI 采集到 hvigor 的非零退出码，job 正确标记为失败
+
+#### Scenario: test 步骤经后台进程采集真实退出码
+- **WHEN** 设备端 `test` 步骤以 `> "$UNIT_TEST_LOG" 2>&1 &` 后台启动 hvigor（不经管道/`tee`）
+- **THEN** `$!` 指向 hvigor 真实进程，`wait "$TEST_PID"` 返回 hvigor 真实退出码
+- **AND** 不得再以未定义变量（`HVIGOR_CMD`/`UNIT_TEST_LOG`）启动第二份测试命令或依赖 macOS 不存在的 `setsid`
 
 ---
 


### PR DESCRIPTION
## 结论（已本地复现 + CI 日志核对，修正了 issue #262 的原假设）

**设备端单测其实可以编译并跑起来**，issue #262 最初把根因归结为「`@ohos/hypium` 与字节码 HAR 的归一化 OhmUrl 冲突」并不准确——本地在 `useNormalizedOHMUrl: true` + hypium + 三个字节码 HAR 下，`hvigorw test` 正常编译并在设备上跑完 **556 个用例**（535 通过 / 20 失败 / 1 错误），全程约 33s，**无任何 OhmUrl 报错**；CI 实盘日志同样未见 OhmUrl。

真正的 CI 故障是 workflow `test` 步骤的两个既有 bug：

1. **`setsid` 在 macOS 不存在**（CI 日志：`setsid: command not found`），且原脚本用未定义变量 `$HVIGOR_CMD`/`$UNIT_TEST_LOG` 重复启动第二份测试命令，导致真实测试进程被孤儿化、结果从未被采集；
2. **`wait "$TEST_PID" || true` 令 `$?` 恒为 0**，hvigor 真实退出码被吞掉，步骤长期「静默成功」；
3. 修复前两点后，测试真正开始跑，但原 **180s 超时太短**（CI 冷构建 `UnitTestArkTS` 单步 ~37s + 打包 + 部署 + 跑 556 用例 >180s），被超时误杀。

## 本 PR 改动

`.github/workflows/unit-test.yml` 的 `test` 步骤：

- 移除 `setsid` 与重复启动，改为单次 `> "$UNIT_TEST_LOG" 2>&1 &` 后台启动，`$!` 指向 hvigor 真实进程；
- 用 `set +e; wait "$TEST_PID"; HVIGOR_EXIT=$?; set -e` 采集真实退出码（修正 `wait ... || true` 吞退出码的 bug）；
- 超时从 180s 放宽到 **480s**（job 仍有 `timeout-minutes: 12` 兜底）；
- 保留 OhmUrl 检测作为**防御性兜底**：若未来某环境复现 `Failed to resolve OhmUrl|10311002`，输出 `::warning title=issue-262::` 并显式跳过，不再静默。

`openspec/specs/unit-test-workflow/spec.md` 同步上述契约。

## 验证

- 本地：`hvigorw UnitTestBuild` 通过；`hvigorw test` 在设备 192.168.3.85 上跑完 556 用例（生成 `test_result.txt`）。
- CI 日志核对：修复前 `setsid: command not found` + `wait || true` 吞码 + 180s 超时误杀，均已定位。
- `unit-test.yml` 通过 YAML 解析与全部 `run:` 块 `bash -n` 校验。

## 相关

- issue #262
- PR #260


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化设备端自动化测试流程，提升代码同步和测试启动的稳定性。
  * 增加失败重试与超时进程清理机制，减少测试任务卡死情况。
  * 改进测试日志收集与错误提示，便于快速定位问题。
  * 针对已知 OhmUrl 冲突自动跳过相关测试，并提供明确警告，不影响持续集成流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->