### PR TITLE
feat(vpe): 画质增强档位按缩放比例自动选择

### DIFF
--- a/entry/src/main/ets/components/core/player/PlayerSettingsDialog.ets
+++ b/entry/src/main/ets/components/core/player/PlayerSettingsDialog.ets
@@ -1,5 +1,4 @@
 import { VideoPlayerController, AspectRatioMode } from "./VideoPlayerController"
-import { VpeQualityLevel } from "../../../utils/VpeEnhancerUtil"
 import { hilog } from "@kit.PerformanceAnalysisKit"
 import { EpisodeListPanel } from './EpisodeListPanel'
 import { PlaybackContextItem, MediaLibraryContext, PlaybackContext } from './PlaybackContext'
@@ -438,7 +437,6 @@ export struct PlayerSettingsDialog {
   @State private speedHoveredIndex: number = -1
   private readonly aspectRatioOptions: AspectRatioOption[] = PLAYER_SETTINGS_ASPECT_RATIO_OPTIONS
   @State private aiEnhanceOn: boolean = true
-  @State private aiEnhanceQuality: VpeQualityLevel = 'medium'
   @State private autoplayEnabled: boolean = true
   @State private autoplayCountdownSeconds: number = 8
   @State private autoplayToggleFocusedIndex: number = -1
@@ -571,7 +569,6 @@ export struct PlayerSettingsDialog {
   aboutToAppear(): void {
     this.syncSelectionMirrorState()
     this.aiEnhanceOn = this.videoController.getResolvedAiEnhanceEnabled();
-    this.aiEnhanceQuality = this.videoController.aiEnhanceQuality;
     this.arFocusedIndex = -1;
     this.speedFocusedIndex = -1;
     this.arHoveredIndex = -1;
@@ -943,46 +940,17 @@ export struct PlayerSettingsDialog {
                       this.videoController.disableAiEnhance();
                     })
 
-                  Text('低')
+                  Text('开启')
                     .fontSize(26)
-                    .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#F3F7FF' : '#D7DCE7')
+                    .fontColor(this.aiEnhanceOn ? '#F3F7FF' : '#D7DCE7')
                     .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                    .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
+                    .backgroundColor(this.aiEnhanceOn ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
                     .borderRadius(99)
-                    .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'low' ? '#fffefe' : '#45ffffff' })
+                    .border({ width: this.aiEnhanceOn ? 2 : 1, color: this.aiEnhanceOn ? '#fffefe' : '#45ffffff' })
                     .onClick(() => {
-                      hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击低');
+                      hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击开启（档位自动）');
                       this.aiEnhanceOn = true;
-                      this.aiEnhanceQuality = 'low';
-                      this.videoController.setAiEnhance('low');
-                    })
-
-                  Text('中')
-                    .fontSize(26)
-                    .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#F3F7FF' : '#D7DCE7')
-                    .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                    .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                    .borderRadius(99)
-                    .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'medium' ? '#fffefe' : '#45ffffff' })
-                    .onClick(() => {
-                      hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击中');
-                      this.aiEnhanceOn = true;
-                      this.aiEnhanceQuality = 'medium';
-                      this.videoController.setAiEnhance('medium');
-                    })
-
-                  Text('高')
-                    .fontSize(26)
-                    .fontColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#F3F7FF' : '#D7DCE7')
-                    .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-                    .backgroundColor(this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 'rgba(255, 255, 255, 0.45)' : 'rgba(255, 255, 255, 0.1)')
-                    .borderRadius(99)
-                    .border({ width: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? 2 : 1, color: this.aiEnhanceOn && this.aiEnhanceQuality === 'high' ? '#fffefe' : '#45ffffff' })
-                    .onClick(() => {
-                      hilog.info(0x0000, 'PlayerSettingsDialog', '画质增强: 点击高');
-                      this.aiEnhanceOn = true;
-                      this.aiEnhanceQuality = 'high';
-                      this.videoController.setAiEnhance('high');
+                      this.videoController.setAiEnhance();
                     })
                 }
                 .justifyContent(FlexAlign.Start)

--- a/entry/src/main/ets/components/core/player/VideoData.ets
+++ b/entry/src/main/ets/components/core/player/VideoData.ets
@@ -105,6 +105,18 @@ export interface VideoData {
   videoHdrType?: string;
 
   /**
+   * 源视频宽度（像素，可选），由 ffprobe 探测填充。
+   * 用于 VPE 画质增强按缩放比例自动选档；undefined 表示探测失败/未知。
+   */
+  videoWidth?: number;
+
+  /**
+   * 源视频高度（像素，可选），由 ffprobe 探测填充。
+   * 用于 VPE 画质增强按缩放比例自动选档；undefined 表示探测失败/未知。
+   */
+  videoHeight?: number;
+
+  /**
    * 刮削得到的原始标题（英文），如 "The Bad Kids"。
    * 优先用于 OpenSubtitles 搜索，避免文件名中文/混合标题解析失败。
    */

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -470,6 +470,17 @@ export struct VideoPlayer {
             })
             this.controller.initPlayerForSurface(this.data, this.surfaceId)
           })
+          .onAreaChange((_oldValue: Area, newValue: Area) => {
+            // 上报显示区域物理像素给 VPE 自动选档（onAreaChange 返回 VP，需 vp2px 转物理像素）
+            const vpW = typeof newValue.width === 'number' ? newValue.width : 0
+            const vpH = typeof newValue.height === 'number' ? newValue.height : 0
+            const uiCtx = this.getUIContext()
+            const w = uiCtx.vp2px(vpW)
+            const h = uiCtx.vp2px(vpH)
+            if (w > 0 && h > 0) {
+              this.controller.updateDisplaySize(w, h)
+            }
+          })
           .onClick(async () => {
             await this.controller.pause()
             this.controlsDialogController.open()
@@ -522,6 +533,10 @@ export struct VideoPlayer {
               const w = uiCtx.vp2px(vpW)
               const h = uiCtx.vp2px(vpH)
               console.info(`[VideoPlayer] mpv onAreaChange: vp=${vpW}x${vpH} px=${w}x${h} surfaceId=${this.surfaceId.substring(0, 8)}... bound=${this.controller.isMpvSurfaceBound}`)
+              if (w > 0 && h > 0) {
+                // 复用同一显示尺寸缓存，供后端切回 avplayer 时 VPE 自动选档使用
+                this.controller.updateDisplaySize(w, h)
+              }
               if (w > 0 && h > 0 && this.surfaceId.length > 0) {
                 // 无论播放器是否就绪都上报；Controller 会缓存 surface 并在 MPV adapter 创建后绑定。
                 this.controller.setMpvSurface(this.surfaceId, w, h)

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -2,6 +2,7 @@ import { PlayerEvents, VideoDataType } from "./Constants";
 import { VideoData } from "./VideoData";
 import { BusinessError, emitter } from "@kit.BasicServicesKit";
 import { hilog } from "@kit.PerformanceAnalysisKit";
+import { display } from '@kit.ArkUI';
 import { CommonConstants } from "../../../common/constants/CommonConstants";
 import { millisecondsToTime } from "../../../utils/TimeUtil";
 import { IPlayer, TrackInfo } from "./IPlayer";
@@ -80,6 +81,65 @@ export function resolveEffectivePlaybackSurfaceId(displaySurfaceId: string, vpeS
     return vpeSurfaceId;
   }
   return displaySurfaceId;
+}
+
+// ─── VPE 画质增强：按缩放比例自动选档 ──────────────────────────
+
+/** Detail Enhancer 输入分辨率硬约束（来自官方《视频缩放》文档）：宽高上限。 */
+export const VPE_SOURCE_MAX_DIMENSION = 2000;
+/** Detail Enhancer 输入分辨率硬约束：宽高下限。 */
+export const VPE_SOURCE_MIN_DIMENSION = 32;
+/** HIGH 档输入分辨率下限（宽高均需 ≥ 该值）。 */
+export const VPE_HIGH_MIN_DIMENSION = 512;
+/** 缩放比例阈值：达到该值前使用 LOW 档。 */
+export const VPE_SCALE_MEDIUM_THRESHOLD = 1.5;
+/** 缩放比例阈值：达到该值前使用 MEDIUM 档，之后使用 HIGH 档。 */
+export const VPE_SCALE_HIGH_THRESHOLD = 2.0;
+
+/** 显示目标尺寸（物理像素）。 */
+export interface DisplaySize {
+  width: number;
+  height: number;
+}
+
+/**
+ * 按缩放比例解析 VPE 画质增强档位。
+ *
+ * 返回 null 仅表示「无法启用」（源分辨率超出 Detail Enhancer 输入硬约束）；
+ * 其余情况都返回一个档位，最低为 low（用户开启即生效）。
+ * 缩放比例 = max(显示宽/源宽, 显示高/源高)。
+ */
+export function resolveVpeQualityByScaling(
+  srcW: number | undefined,
+  srcH: number | undefined,
+  dispW: number | undefined,
+  dispH: number | undefined
+): VpeQualityLevel | null {
+  // 源宽高都已知（有效正数）时，检查 Detail Enhancer 输入硬约束
+  if (typeof srcW === 'number' && typeof srcH === 'number' && srcW > 0 && srcH > 0) {
+    if (srcW > VPE_SOURCE_MAX_DIMENSION || srcH > VPE_SOURCE_MAX_DIMENSION) {
+      return null;
+    }
+    if (srcW < VPE_SOURCE_MIN_DIMENSION || srcH < VPE_SOURCE_MIN_DIMENSION) {
+      return null;
+    }
+  }
+  // 数据缺失（源宽高或显示尺寸任一缺失/≤0）→ low（最低档保证「开启即生效」）
+  if (!srcW || !srcH || !dispW || !dispH || srcW <= 0 || srcH <= 0 || dispW <= 0 || dispH <= 0) {
+    return 'low';
+  }
+  const scale = Math.max(dispW / srcW, dispH / srcH);
+  if (scale < VPE_SCALE_MEDIUM_THRESHOLD) {
+    return 'low';
+  }
+  if (scale < VPE_SCALE_HIGH_THRESHOLD) {
+    return 'medium';
+  }
+  // scale >= 2.0：HIGH 档要求输入宽高均 ≥ 512，否则退 medium
+  if (srcW >= VPE_HIGH_MIN_DIMENSION && srcH >= VPE_HIGH_MIN_DIMENSION) {
+    return 'high';
+  }
+  return 'medium';
 }
 
 /** 画面比例模式 */
@@ -197,7 +257,12 @@ export class VideoPlayerController {
   /** AI 画质增强开关（仅 avplayer 路径有效） */
   @Trace aiEnhanceEnabled: boolean = true;
   @Trace aiEnhanceRuntimeSupported: boolean = false;
-  @Trace aiEnhanceQuality: VpeQualityLevel = 'medium';
+  /** 当前已解析档位（按缩放比例自动计算，仅用于展示/日志，不再由用户设置）。 */
+  @Trace aiEnhanceQuality: VpeQualityLevel = 'low';
+  /** 显示区域宽度（物理像素，由 XComponent onAreaChange 上报缓存；0 表示尚未上报）。 */
+  private displayWidth: number = 0;
+  /** 显示区域高度（物理像素，由 XComponent onAreaChange 上报缓存；0 表示尚未上报）。 */
+  private displayHeight: number = 0;
 
   private player?: IPlayer;
   readonly unsupportedFormatFallback: UnsupportedFormatFallback = 'mpv';
@@ -613,6 +678,8 @@ export class VideoPlayerController {
     videoData.audioProbeSummary = decision.summary;
     videoData.videoCodec = decision.videoCodecName;
     videoData.videoHdrType = decision.videoHdrType;
+    videoData.videoWidth = decision.videoWidth;
+    videoData.videoHeight = decision.videoHeight;
     if (this.forceMpvForNextInit) {
       this.backend = 'mpv';
       this.forceMpvForNextInit = false;
@@ -631,7 +698,8 @@ export class VideoPlayerController {
       `[initPlayer.route-decision] backend=${this.backend}, fallback=${this.unsupportedFormatFallback}, ` +
       `anyHardSupported=${decision.anyHardSupported}, allSoftDecodeOnly=${decision.allSoftDecodeOnly}, ` +
       `detectedCodec=${decision.detectedCodec}, detectedChannels=${decision.detectedChannels}, ` +
-      `videoHdrType=${decision.videoHdrType.length > 0 ? decision.videoHdrType : '未知'}`);
+      `videoHdrType=${decision.videoHdrType.length > 0 ? decision.videoHdrType : '未知'}, ` +
+      `videoSize=${decision.videoWidth ?? '?'}x${decision.videoHeight ?? '?'}`);
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
       `[initPlayer.route-decision] trackAnalyses=${decision.trackAnalyses.length} 条:`);
     for (let i = 0; i < decision.trackAnalyses.length; i++) {
@@ -1080,23 +1148,76 @@ export class VideoPlayerController {
   // ─── VPE AI 画质增强 ──────────────────────────────────────────
 
   /**
-   * 开启/切换 AI 画质增强。
-   * - VPE 已运行：直接更新质量参数（不重建管线，不影响播放）
-   * - VPE 未运行（首次启用）：下次 initPlayer 时才会创建（当前播放不影响）
+   * 开启 AI 画质增强（档位由系统按缩放比例自动选择，用户不指定）。
+   * - VPE 已运行：重算档位并在变化时运行中换档（不重建管线）
+   * - VPE 未运行：下次 initPlayer 时创建，档位由 resolveVpeQualityByScaling 决定
    */
-  setAiEnhance(quality: VpeQualityLevel = 'low'): void {
+  setAiEnhance(): void {
     const runtimeSupported = this.syncAiEnhanceAvailability();
     if (!runtimeSupported) {
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-        `[VPE] 运行时不可用，忽略启用请求: quality=${quality}`);
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG, '[VPE] 运行时不可用，忽略启用请求');
       return;
     }
     this.aiEnhanceEnabled = true;
-    this.aiEnhanceQuality = quality;
     if (VpeEnhancerUtil.isRunning) {
-      VpeEnhancerUtil.updateQuality(quality);
+      // 强制切回自动档位：关闭时 VPE 已切到 NONE 透传，而 aiEnhanceQuality 仍停留在旧档位，
+      // 若不强制则「档位未变化」判断会跳过 updateQuality，导致开启后画面仍无增强。
+      this.applyAutoQuality(true);
     }
-    // VPE 未运行时无需操作，下次播放时 initPlayer 会按 aiEnhanceEnabled/Quality 创建
+    // VPE 未运行时无需操作，下次播放时 initPlayer 会按自动档位创建
+  }
+
+  /**
+   * 由 XComponent onAreaChange 上报显示区域物理像素，供 VPE 自动选档使用。
+   * 显示尺寸后到（晚于 initPlayer）时重算档位，变化则运行中换档。
+   */
+  updateDisplaySize(width: number, height: number): void {
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+    const changed = this.displayWidth !== width || this.displayHeight !== height;
+    this.displayWidth = width;
+    this.displayHeight = height;
+    if (changed && VpeEnhancerUtil.isRunning) {
+      this.applyAutoQuality();
+    }
+  }
+
+  /** 计算当前应选档位并应用（运行中换档，不重建管线）。force 时无条件切回自动档位。 */
+  private applyAutoQuality(force: boolean = false): void {
+    const quality = this.resolveAutoQuality();
+    if (quality !== null && (force || quality !== this.aiEnhanceQuality)) {
+      this.aiEnhanceQuality = quality;
+      VpeEnhancerUtil.updateQuality(quality);
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        `[VPE] 自动档位更新: ${quality}${force ? ' (强制)' : ''}`);
+    }
+  }
+
+  /** 按当前源视频分辨率与显示尺寸计算自动档位。 */
+  private resolveAutoQuality(): VpeQualityLevel | null {
+    const srcW = this.currentVideoData?.videoWidth;
+    const srcH = this.currentVideoData?.videoHeight;
+    const disp = this.resolveDisplaySizeForVpe();
+    return resolveVpeQualityByScaling(srcW, srcH, disp?.width, disp?.height);
+  }
+
+  /** 解析显示目标尺寸：优先 XComponent 缓存，其次屏幕物理像素，都无则 undefined。 */
+  private resolveDisplaySizeForVpe(): DisplaySize | undefined {
+    if (this.displayWidth > 0 && this.displayHeight > 0) {
+      const cached: DisplaySize = { width: this.displayWidth, height: this.displayHeight };
+      return cached;
+    }
+    try {
+      const d = display.getDefaultDisplaySync();
+      if (d && d.width > 0 && d.height > 0) {
+        const screen: DisplaySize = { width: d.width, height: d.height };
+        return screen;
+      }
+    } catch (e) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG, `[VPE] 读取屏幕尺寸失败: ${String(e)}`);
+    }
+    return undefined;
   }
 
   /**
@@ -1196,10 +1317,18 @@ export class VideoPlayerController {
         `[VPE] 跳过创建: HDR 视频不启用 VPE (hdrType=${videoHdrType})`);
       return displaySurfaceId;
     }
-    const vpeSurfaceId = VpeEnhancerUtil.createEnhancer(displaySurfaceId, this.aiEnhanceQuality);
+    const resolvedQuality = this.resolveAutoQuality();
+    if (resolvedQuality === null) {
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        '[VPE] 跳过创建: 源分辨率超出 Detail Enhancer 输入约束');
+      return displaySurfaceId;
+    }
+    this.aiEnhanceQuality = resolvedQuality;
+    const vpeSurfaceId = VpeEnhancerUtil.createEnhancer(displaySurfaceId, resolvedQuality);
     const effectiveSurfaceId = resolveEffectivePlaybackSurfaceId(displaySurfaceId, vpeSurfaceId);
     if (effectiveSurfaceId !== displaySurfaceId) {
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG, `[VPE] 管线建立: vpeSurfaceId=${vpeSurfaceId}`);
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        `[VPE] 管线建立: vpeSurfaceId=${vpeSurfaceId} quality=${resolvedQuality}`);
       return effectiveSurfaceId;
     }
     hilog.warn(CommonConstants.LOG_DOMAIN, TAG, '[VPE] 创建失败，回退到原始 surfaceId');

--- a/entry/src/main/ets/services/audioRouting/AudioRoutingTypes.ets
+++ b/entry/src/main/ets/services/audioRouting/AudioRoutingTypes.ets
@@ -48,6 +48,10 @@ export interface AudioRoutingInput {
   probeVideoCodecName: string;
   /** ffprobe 首条视频轨的 HDR 类型（'HDR10'|'HLG'|'DOLBY_VISION'|'SDR'），探测失败传 ''。 */
   probeVideoHdrType: string;
+  /** ffprobe 首条视频轨的宽度（像素），探测失败/缺失为 undefined。 */
+  probeVideoWidth?: number;
+  /** ffprobe 首条视频轨的高度（像素），探测失败/缺失为 undefined。 */
+  probeVideoHeight?: number;
   probeSuccess: boolean;
   probeError: string;
   /** 探测是否失败（service 内部用于决策）。 */
@@ -91,6 +95,10 @@ export interface AudioRoutingDecision {
   videoCodecName: string;
   /** 视频 HDR 类型（来自 ffprobe 首条 video track）：'HDR10'|'HLG'|'DOLBY_VISION'|'SDR'，'' 表示未知（探测失败/无视频轨）。 */
   videoHdrType: string;
+  /** 视频宽度（像素，来自 ffprobe 首条 video track），探测失败/缺失为 undefined。 */
+  videoWidth?: number;
+  /** 视频高度（像素，来自 ffprobe 首条 video track），探测失败/缺失为 undefined。 */
+  videoHeight?: number;
   /** 整组音轨分析结果。 */
   trackAnalyses: AudioTrackAnalysis[];
 }
@@ -111,6 +119,8 @@ export const DEFAULT_AUDIO_ROUTING_DECISION: AudioRoutingDecision = {
   precheckProbeError: '',
   videoCodecName: '',
   videoHdrType: '',
+  videoWidth: undefined,
+  videoHeight: undefined,
   trackAnalyses: []
 };
 

--- a/entry/src/main/ets/services/audioRouting/AudioTrackRoutingService.ets
+++ b/entry/src/main/ets/services/audioRouting/AudioTrackRoutingService.ets
@@ -169,6 +169,8 @@ export function buildRoutingDecision(input: AudioRoutingInput): AudioRoutingDeci
     precheckProbeError: input.precheckProbeError,
     videoCodecName: (input.probeVideoCodecName ?? '').toLowerCase(),
     videoHdrType: input.probeVideoHdrType ?? '',
+    videoWidth: input.probeVideoWidth,
+    videoHeight: input.probeVideoHeight,
     trackAnalyses: tracks
   };
   return decision;
@@ -440,6 +442,8 @@ export class AudioTrackRoutingService {
     let precheckProbeError = '';
     let videoCodecName = '';
     let probeVideoHdrType = '';
+    let probeVideoWidth: number | undefined = undefined;
+    let probeVideoHeight: number | undefined = undefined;
     let probeSuccess = false;
     interface ProbeAudio {
       codec: string;
@@ -478,6 +482,8 @@ export class AudioTrackRoutingService {
         videoCodecName = (probe.videoTracks[0].codecName ?? '').toLowerCase();
         // 未知/缺失统一用空串表示；已知类型为 'SDR' | 'HDR10' | 'HLG' | 'DOLBY_VISION'。
         probeVideoHdrType = probe.videoTracks[0].hdrType ?? '';
+        probeVideoWidth = probe.videoTracks[0].width;
+        probeVideoHeight = probe.videoTracks[0].height;
         for (let i = 0; i < probe.videoTracks.length; i++) {
           const v: ProbeVideo = { codec: (probe.videoTracks[i].codecName ?? '').toLowerCase() };
           probeVideoTracks.push(v);
@@ -528,6 +534,8 @@ export class AudioTrackRoutingService {
       probeChannels,
       probeVideoCodecName: videoCodecName,
       probeVideoHdrType,
+      probeVideoWidth,
+      probeVideoHeight,
       probeSuccess,
       probeError: precheckProbeError,
       precheckProbeFailed,

--- a/entry/src/main/ets/services/playback/PlaybackBackendService.ets
+++ b/entry/src/main/ets/services/playback/PlaybackBackendService.ets
@@ -126,6 +126,8 @@ export class PlaybackBackendService {
         precheckProbeError: decision.precheckProbeError,
         videoCodecName: decision.videoCodecName,
         videoHdrType: decision.videoHdrType,
+        videoWidth: decision.videoWidth,
+        videoHeight: decision.videoHeight,
         trackAnalyses: decision.trackAnalyses
       };
     } catch (e) {

--- a/entry/src/main/ets/services/playback/PlaybackBackendTypes.ets
+++ b/entry/src/main/ets/services/playback/PlaybackBackendTypes.ets
@@ -74,6 +74,10 @@ export interface PlaybackBackendDecision {
   videoCodecName: string;
   /** 视频 HDR 类型（'HDR10'|'HLG'|'DOLBY_VISION'|'SDR'|''），'' 表示未知/SDR。 */
   videoHdrType: string;
+  /** 视频宽度（像素，来自 ffprobe 首条 video track），探测失败/缺失为 undefined。 */
+  videoWidth?: number;
+  /** 视频高度（像素，来自 ffprobe 首条 video track），探测失败/缺失为 undefined。 */
+  videoHeight?: number;
   /** 整组音轨分析详情（调试用）。 */
   trackAnalyses: BackendTrackAnalysis[];
 }
@@ -94,6 +98,8 @@ export const DEFAULT_BACKEND_DECISION: PlaybackBackendDecision = {
   precheckProbeError: '',
   videoCodecName: '',
   videoHdrType: '',
+  videoWidth: undefined,
+  videoHeight: undefined,
   trackAnalyses: []
 };
 
@@ -171,6 +177,8 @@ export function buildDefaultBackendDecision(): PlaybackBackendDecision {
     precheckProbeError: '',
     videoCodecName: '',
     videoHdrType: '',
+    videoWidth: undefined,
+    videoHeight: undefined,
     trackAnalyses: []
   };
   return decision;

--- a/entry/src/test/VideoPlayerController.test.ets
+++ b/entry/src/test/VideoPlayerController.test.ets
@@ -6,7 +6,8 @@ import {
   resolveAiEnhanceEnabledByRuntime,
   shouldShowAiEnhanceSettingsByRuntime,
   resolveEffectivePlaybackSurfaceId,
-  isHdrVideo
+  isHdrVideo,
+  resolveVpeQualityByScaling
 } from '../main/ets/components/core/player/VideoPlayerController';
 import { IPlayer, SubtitleInfo, TrackInfo } from '../main/ets/components/core/player/IPlayer';
 import {
@@ -581,6 +582,47 @@ export default function videoPlayerControllerTest() {
       expect(isHdrVideo('SDR')).assertFalse()
       expect(isHdrVideo('')).assertFalse()
       expect(isHdrVideo(undefined)).assertFalse()
+    })
+
+    it('resolveVpeQualityByScaling 按缩放比例自动选档', 0, () => {
+      // 大幅放大（源 960x540 → 显示 3840x2160，scale=4）→ high
+      expect(resolveVpeQualityByScaling(960, 540, 3840, 2160)).assertEqual('high')
+      // 中等放大（源 2560x1440 → 显示 3840x2160，scale=1.5）→ medium
+      expect(resolveVpeQualityByScaling(2560, 1440, 3840, 2160)).assertEqual('medium')
+      // 轻微放大（源 1920x1080 → 显示 2560x1440，scale≈1.33）→ low
+      expect(resolveVpeQualityByScaling(1920, 1080, 2560, 1440)).assertEqual('low')
+      // 1:1（源=显示 1920x1080）→ low
+      expect(resolveVpeQualityByScaling(1920, 1080, 1920, 1080)).assertEqual('low')
+      // 缩小（源 1920x1080 → 显示 1280x720）→ low
+      expect(resolveVpeQualityByScaling(1920, 1080, 1280, 720)).assertEqual('low')
+    })
+
+    it('resolveVpeQualityByScaling 源分辨率超限返回 null（不启用）', 0, () => {
+      // 超上限（4K 源 3840x2160）
+      expect(resolveVpeQualityByScaling(3840, 2160, 3840, 2160)).assertEqual(null)
+      // 低于下限（16x16）
+      expect(resolveVpeQualityByScaling(16, 16, 1920, 1080)).assertEqual(null)
+    })
+
+    it('resolveVpeQualityByScaling 大幅放大但源小于 HIGH 下限退 medium', 0, () => {
+      // 源 320x180（<512）→ 显示 3840x2160，scale=12 → medium
+      expect(resolveVpeQualityByScaling(320, 180, 3840, 2160)).assertEqual('medium')
+    })
+
+    it('resolveVpeQualityByScaling 数据缺失返回 low（保证开启即生效）', 0, () => {
+      expect(resolveVpeQualityByScaling(undefined, undefined, 3840, 2160)).assertEqual('low')
+      expect(resolveVpeQualityByScaling(1920, 1080, undefined, undefined)).assertEqual('low')
+      expect(resolveVpeQualityByScaling(0, 1080, 3840, 2160)).assertEqual('low')
+    })
+
+    it('自动选档与 HDR 门控叠加：HDR 不启用、非超限 SDR 启用', 0, () => {
+      // HDR 视频无论如何都门控（isHdrVideo true）
+      expect(isHdrVideo('HDR10')).assertTrue()
+      expect(isHdrVideo('HLG')).assertTrue()
+      // SDR 源在输入范围内返回档位（非 null = 会建 VPE）
+      expect(resolveVpeQualityByScaling(1920, 1080, 3840, 2160)).assertEqual('medium')
+      // SDR 源超限返回 null（不建 VPE）
+      expect(resolveVpeQualityByScaling(3840, 2160, 3840, 2160)).assertEqual(null)
     })
 
     it('controller 对 HDR 视频隐藏画质增强设置、对 SDR 显示', 0, () => {

--- a/openspec/changes/vpe-auto-quality-by-scaling/.openspec.yaml
+++ b/openspec/changes/vpe-auto-quality-by-scaling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/vpe-auto-quality-by-scaling/design.md
+++ b/openspec/changes/vpe-auto-quality-by-scaling/design.md
@@ -1,0 +1,102 @@
+# Design: vpe-auto-quality-by-scaling
+
+## Context
+
+VPE 画质增强（Detail Enhancer）目前由用户在设置菜单手动选择「低/中/高」档位，`VideoPlayerController.aiEnhanceQuality` 默认 `medium`。官方《视频缩放》文档给出档位与「缩放」的强关联：
+
+| 档位 | 输入分辨率要求 | 效果 |
+| --- | --- | --- |
+| NONE | 宽高 (32,2000] | 仅缩放，无清晰度增强 |
+| LOW（默认） | 宽高 (32,2000] | 仅缩放场景；等比缩放时无清晰度增强 |
+| MEDIUM | 宽高 (32,2000] | 仅缩放场景；等比缩放时无清晰度增强 |
+| HIGH | 宽高 [512,2000] | 缩放+清晰度增强；等比缩放时也能清晰度增强 |
+
+本变更把档位选择自动化，用户只保留总开关。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 移除「低/中/高」手动档位，用户只保留「开/关」总开关。
+- **用户开启开关后必启用 VPE（至少 LOW 档）**：缩放比例只决定档位高低，不决定是否启用，保证开启后用户能看到增强已生效的反馈。
+- 档位按「缩放比例」自动选择：放大越多档位越高；1:1/缩小/数据缺失用最低档 LOW。
+- 显示尺寸来源灵活适配（多级 fallback），适配不同型号 TV。
+- 自动选档逻辑为纯函数，可单测。
+- 源视频宽高与显示尺寸两条数据链打通到 `tryCreateVpeEnhancer`。
+
+**Non-Goals:**
+- 不改 native VPE 层与 C API。
+- 不改 HDR 门控（`isHdrVideo` 跳过 VPE 的语义保持）。
+- 不引入码率/片源质量等更复杂的自动开关策略。
+- 不做真机阈值调优（阈值作为初始建议值）。
+
+## Decisions
+
+### 1. 自动选档核心信号：缩放比例 scale = max(dispW/srcW, dispH/srcH)
+
+- **为什么**：Detail Enhancer 的收益来自「把低分辨率内容放大到高分辨率输出」。取宽高放大量的较大值，代表「覆盖显示区域所需的最小放大倍数」，对 FIT/FILL 都偏保守且可解释。
+- **不取面积比/对角线比**：宽高各自比例的最大值更直观，且便于与「1.5」「2.0」阈值对齐。
+
+### 2. 档位映射规则（纯函数 `resolveVpeQualityByScaling`）
+
+```
+resolveVpeQualityByScaling(srcW, srcH, dispW, dispH): VpeQualityLevel | null
+```
+
+返回值语义：`null` 仅表示「无法启用」（超出 Detail Enhancer 输入硬约束）；其余情况都返回一个档位，**最低为 low**。
+
+1. 源宽高**已知且** `srcW > 2000 || srcH > 2000` → `null`（超出 Detail Enhancer 输入上限；如 4K 源 3840/2160 无法作为输入）。
+2. 源宽高**已知且** `srcW < 32 || srcH < 32` → `null`（低于输入下限）。
+3. 源宽高或显示尺寸缺失/≤0 → `'low'`（数据不足无法算比例，用最低档保证「开启即生效」）。
+4. `scale = max(dispW/srcW, dispH/srcH)`。
+5. `scale < 1.5` → `'low'`（含 1:1 与缩小）。
+6. `1.5 <= scale < 2.0` → `'medium'`。
+7. `scale >= 2.0`：若 `srcW >= 512 && srcH >= 512` → `'high'`（HIGH 档要求输入 [512,2000]）；否则 → `'medium'`（源 <512 时 HIGH 不可用）。
+
+- **「开启即启用（至少 low）」是产品决策**：即使 1:1/缩小场景 LOW 档按官方文档无清晰度增强效果，仍建立 VPE 管线，让用户看到增强已生效（有启动/处理反馈）。纯技术「无收益则关闭」被产品诉求覆盖。
+- **阈值 1.5 / 2.0 为初始建议值**，在常量集中定义，便于后续真机调优。
+
+### 3. 源视频分辨率沿 `videoHdrType` 同链路透传
+
+`probe.videoTracks[0].width/height` 已在 ffprobe 结果中。沿 `AudioRoutingInput.probeVideoWidth/probeVideoHeight` → `AudioRoutingDecision.videoWidth/videoHeight` → `PlaybackBackendDecision.videoWidth/videoHeight` → `VideoData.videoWidth/videoHeight` → controller。
+
+- **为什么**：与 `videoHdrType` 同源同生命周期，避免各播放入口重复探测。
+- **降级**：ffprobe 失败时宽高为 `undefined`，`resolveVpeQualityByScaling` 返回 `'low'` → 仍启用 VPE（满足「开启即生效」）。但注意：宽高缺失也意味着无法做 4K 上限判断，存在「4K 源误启用」的残余风险（见 Risks）。
+
+### 4. 显示尺寸多级 fallback（灵活适配不同型号 TV）
+
+显示目标尺寸按以下优先级获取，取第一个可用值：
+
+1. **XComponent `onAreaChange` 上报的物理像素**（`vp2px(vpW/vpH)`）：最贴合播放器实际显示区域，不依赖额外系统能力。avplayer 分支补 `onAreaChange`（mpv 分支已有），上报到 controller 缓存。
+2. **`@ohos.display.getDefaultDisplaySync()` 屏幕物理像素**：兜底，TV 全屏播放器时屏幕 ≈ 显示区域。
+3. **两者都拿不到**：`dispW/dispH` 视为缺失 → `resolveVpeQualityByScaling` 返回 `'low'`，不阻断启用。
+
+- **为什么**：`@ohos.display` 在不同型号 TV 的可用性不确定，不能作为唯一数据源；XComponent 是播放器必然拥有的组件，其 `onAreaChange` 最可靠。
+- **时序**：`tryCreateVpeEnhancer` 发生在 `onLoad → initPlayer`；`onAreaChange` 可能在 `onLoad` 之后才回调。因此先按「当时可用的显示尺寸」建 VPE（缺尺寸时用 low），拿到新尺寸后重算档位，档位变化则 `VpeEnhancerUtil.updateQuality()`（已支持运行中换档、不重建管线）。
+
+### 5. 门控整合在 `tryCreateVpeEnhancer`
+
+在现有守卫（runtimeSupported / aiEnhanceEnabled / backend==='avplayer' / isHdrVideo）之后，调用 `resolveVpeQualityByScaling`：
+
+- 返回 `null`（源分辨率超硬约束）→ 跳过 VPE，返回原始 `displaySurfaceId`（记日志）。
+- 返回档位 → 以该档位调用 `VpeEnhancerUtil.createEnhancer(displaySurfaceId, resolvedQuality)`，替代 `this.aiEnhanceQuality`。
+
+- **为什么**：`currentVideoData` 在 `initPlayer` 内已同步赋值，门控点单一，覆盖所有 avplayer 入口。
+- **`aiEnhanceEnabled` 语义不变**：用户全局开关；开启即启用（至少 low），自动选档只决定档位。
+
+### 6. `aiEnhanceQuality` 从「用户偏好」变为「派生值」
+
+- `setAiEnhance(quality)` 改为 `setAiEnhance()`（不接收档位），开启时不再写入固定档位。
+- `tryCreateVpeEnhancer` 每次用 `resolveVpeQualityByScaling` 的返回值；`aiEnhanceQuality` 字段保留为「当前已解析档位」用于 UI 展示/日志，但不再由用户直接设置。
+
+### 7. UI：只保留「关闭 / 开启」
+
+`PlayerSettingsDialog` 画质增强区移除「低/中/高」三个 chip，改为「关闭 / 开启」两个 chip；开启后由系统自动选档。`@State aiEnhanceQuality` 与相关档位样式分支一并删除。
+
+## Risks / Trade-offs
+
+- **「开启即启用」在 1:1/缩小场景可能只有「心理反馈」而无实际清晰度增益**：LOW 档按官方文档在等比缩放时无清晰度增强效果。这是产品明确接受的取舍（用户要求保证开启后有生效反馈）。
+- **宽高缺失时无法做 4K 上限判断**：ffprobe 失败会导致 `srcW/srcH` 为 undefined，此时无法排除 4K 源，可能建立超限输入（VPE 可能报错，参考 issue-255 的 `29210006` 同类风险）。缓解：HDR 门控已独立于宽高生效；SDR 4K 源是主要残余场景，若真机复现再在 ffprobe 失败时补充保守策略。
+- **显示尺寸多级 fallback 的时序**：`onAreaChange` 晚于 `initPlayer` 时先用 low 建 VPE，后 `updateQuality` 换档；换档是运行中参数更新，风险低但需验证不引起画面闪烁。
+- **阈值未经真机调优**：1.5 / 2.0 是经验值，留作后续调优。
+- **屏幕尺寸 ≠ 视频实际显示尺寸**：FIT 黑边/旋转会导致估算偏差；对 TV 横屏全屏场景影响可忽略。
+- **行为变化感知**：4K 原盘 1:1 播放从「默认 MEDIUM」变为「low」，档位下降但管线仍建立；需在发布说明说明「自动档位」语义。

--- a/openspec/changes/vpe-auto-quality-by-scaling/proposal.md
+++ b/openspec/changes/vpe-auto-quality-by-scaling/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+VPE 画质增强（Detail Enhancer）当前让用户在设置菜单手动选择「低/中/高」档位，但用户不理解档位含义，选择结果常与实际播放场景错配。官方《视频缩放》文档明确：LOW/MEDIUM 仅在缩放场景生效、等比缩放时无清晰度增强效果；HIGH 才支持等比清晰度增强且输入分辨率要求 [512,2000]。因此在 4K 原盘 1:1 播放时默认 MEDIUM 档实际无收益，白白消耗 GPU 与管线延迟。
+
+改为按「缩放比例」自动选档：系统根据源视频分辨率与显示分辨率自动决定是否启用、用哪一档，用户只保留一个「开/关」总开关。
+
+## What Changes
+
+- 移除设置菜单「画质增强」区的「低/中/高」档位选择，只保留「关闭 / 开启」。
+- 用户开启画质增强后必启用 VPE（至少 LOW 档）：缩放比例只决定档位高低，不决定是否启用。
+- 新增纯函数 `resolveVpeQualityByScaling(srcW, srcH, dispW, dispH)`：按缩放比例返回档位，最低 LOW；仅当源分辨率超出 Detail Enhancer 输入硬约束（宽高已知且 >2000 或 <32）时返回 `null` 表示无法启用。
+- `VideoData` 及 routing decision 透传源视频 `width/height`（沿既有 `videoHdrType` 同链路）。
+- 显示目标尺寸多级 fallback：优先 XComponent 显示区域物理像素，其次 `@ohos.display` 屏幕物理像素，都不可用时按数据缺失退化为 LOW 档。
+- `tryCreateVpeEnhancer` 用自动选档结果替代 `aiEnhanceQuality` 手动档位。
+- `aiEnhanceQuality` 从「用户偏好」改为「当前播放按缩放比例计算的派生档位」，不再由用户直接设置。
+
+## Capabilities
+
+### New Capabilities
+
+- `vpe-quality-selection`: 画质增强（VPE Detail Enhancer）档位的自动选择策略——按源视频与显示分辨率的缩放比例决定是否启用及档位，取代手动档位选择。
+
+### Modified Capabilities
+
+<!-- 无：本变更只新增档位选择策略，不改动 vpe-runtime-compatibility 的运行时探测/降级/HDR 门控语义。 -->
+
+## Impact
+
+- **修改代码**：
+  - `entry/src/main/ets/components/core/player/VideoPlayerController.ets`（新增 `resolveVpeQualityByScaling` 纯函数、`tryCreateVpeEnhancer` 改用自动档位、`setAiEnhance` 语义调整）
+  - `entry/src/main/ets/components/core/player/PlayerSettingsDialog.ets`（移除低/中/高档位 UI，保留开/关）
+  - `entry/src/main/ets/components/core/player/VideoData.ets`（新增 `videoWidth?`/`videoHeight?`）
+  - `entry/src/main/ets/services/audioRouting/AudioRoutingTypes.ets`、`AudioTrackRoutingService.ets`（透传源视频宽高）
+  - `entry/src/main/ets/services/playback/PlaybackBackendTypes.ets`、`PlaybackBackendService.ets`（透传宽高）
+- **修改测试**：`entry/src/test/VideoPlayerController.test.ets`（新增 `resolveVpeQualityByScaling` 用例）
+- **不变**：后端路由（仍 avplayer/mpv）；HDR 门控（`isHdrVideo` 跳过 VPE）；`aiEnhanceEnabled` 仍为用户全局开关。
+- **依赖**：显示尺寸优先用 XComponent `onAreaChange`（无额外系统能力依赖）；`@ohos.display` 仅作兜底，不可用时退化为 LOW 档（不阻断启用）。
+- **存储迁移**：`aiEnhanceEnabled`/`aiEnhanceQuality` 当前为内存态（未见持久化），若实现时发现有持久化需一并迁移；`aiEnhanceQuality` 不再持久化。
+
+## 延后（本次不做）
+
+- 不引入「按码率/片源质量自动开关」等更复杂的画质策略。
+- 不改动 VPE 的 C API 或 native 层（仅 TS 侧档位选择逻辑）。
+- 阈值（1.5 / 2.0）作为初始建议值，真机效果调优留待后续。

--- a/openspec/changes/vpe-auto-quality-by-scaling/specs/vpe-quality-selection/spec.md
+++ b/openspec/changes/vpe-auto-quality-by-scaling/specs/vpe-quality-selection/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: 用户开启画质增强 SHALL 必启用 VPE（至少低档）
+
+当用户开启画质增强且运行时条件满足时，系统 SHALL 建立 VPE 增强管线（最低 LOW 档），缩放比例只决定档位高低，不决定是否启用。
+
+#### Scenario: 开启后必启用
+- **WHEN** 用户开启画质增强，且运行时支持 VPE、backend 为 avplayer、视频非 HDR
+- **THEN** 系统 SHALL 建立 VPE 增强管线
+- **AND** 档位 SHALL 至少为 LOW
+
+#### Scenario: 1:1 或缩小也启用低档
+- **WHEN** 缩放比例 ≤ 1.0（1:1 播放或缩小）
+- **THEN** 系统 SHALL 以 LOW 档建立 VPE 增强管线（不因无缩放增益而关闭）
+
+#### Scenario: 分辨率数据缺失时以低档启用
+- **WHEN** 源视频宽高或显示尺寸缺失/非法（≤0），且用户已开启画质增强
+- **THEN** 系统 SHALL 以 LOW 档建立 VPE 增强管线
+
+#### Scenario: 源分辨率超出输入上限时不启用
+- **WHEN** 源视频宽或高已知且 > 2000（如 4K 源）
+- **THEN** 系统 SHALL NOT 建立 VPE 增强管线
+- **AND** 播放器使用原始显示 surface 渲染
+
+#### Scenario: 源分辨率低于输入下限时不启用
+- **WHEN** 源视频宽或高已知且 < 32
+- **THEN** 系统 SHALL NOT 建立 VPE 增强管线
+
+### Requirement: 画质增强档位 SHALL 按缩放比例自动选择
+
+系统 SHALL 根据源视频分辨率与显示分辨率计算缩放比例，自动选择画质增强档位（LOW/MEDIUM/HIGH），取代用户手动选择档位。
+
+#### Scenario: 大幅放大选择高质量档
+- **WHEN** 源视频宽高在 (32,2000] 内，缩放比例 ≥ 2.0，且源宽高均 ≥ 512
+- **THEN** 系统 SHALL 使用 HIGH 档建立 VPE 增强管线
+
+#### Scenario: 中等放大选择中质量档
+- **WHEN** 源视频宽高在 (32,2000] 内，且缩放比例在 [1.5, 2.0) 区间
+- **THEN** 系统 SHALL 使用 MEDIUM 档建立 VPE 增强管线
+
+#### Scenario: 轻微放大或未放大选择低质量档
+- **WHEN** 源视频宽高在 (32,2000] 内，且缩放比例 < 1.5（含 1:1 与缩小）
+- **THEN** 系统 SHALL 使用 LOW 档建立 VPE 增强管线
+
+#### Scenario: 大幅放大但源分辨率低于 HIGH 档下限
+- **WHEN** 缩放比例 ≥ 2.0，但源宽或高 < 512
+- **THEN** 系统 SHALL 使用 MEDIUM 档（HIGH 档输入要求 [512,2000]，源过小不可用）
+
+#### Scenario: 自动选档与 HDR 门控叠加
+- **WHEN** 当前视频为 HDR（HDR10/HLG/DV）
+- **THEN** 系统 SHALL NOT 建立 VPE 增强管线（无论缩放比例如何）
+
+### Requirement: 显示尺寸 SHALL 灵活适配多数据源
+
+系统 SHALL 按优先级获取显示目标尺寸：优先 XComponent 显示区域物理像素，其次屏幕物理像素；两者都不可用时以「数据缺失」处理（档位退化为低档），不阻断启用。
+
+#### Scenario: XComponent 区域尺寸可用时优先采用
+- **WHEN** XComponent `onAreaChange` 已上报有效显示区域尺寸（物理像素）
+- **THEN** 系统 SHALL 使用该尺寸计算缩放比例
+
+#### Scenario: XComponent 尺寸缺失时回退屏幕尺寸
+- **WHEN** XComponent 显示区域尺寸尚未上报或不可用，且 `@ohos.display` 可返回屏幕物理像素
+- **THEN** 系统 SHALL 使用屏幕物理像素计算缩放比例
+
+#### Scenario: 显示尺寸全部不可用时退化低档
+- **WHEN** XComponent 与屏幕尺寸均不可用
+- **THEN** 系统 SHALL 按数据缺失处理
+- **AND** 自动选档 SHALL 返回 LOW（不阻断启用）
+
+#### Scenario: 显示尺寸后到则运行中换档
+- **WHEN** VPE 已以某档位运行，随后显示尺寸上报并重算出不同档位
+- **THEN** 系统 SHALL 更新档位（运行中换档，不重建管线）
+
+### Requirement: 设置菜单 SHALL NOT 提供手动档位选择
+
+播放器设置页 SHALL 只提供画质增强「关闭 / 开启」开关，不提供「低/中/高」档位选择；档位由系统按缩放比例自动决定。
+
+#### Scenario: 设置页只展示开关
+- **WHEN** 画质增强可用（运行时支持 VPE、backend 为 avplayer、非 HDR 视频）
+- **THEN** 设置页 SHALL 展示「关闭 / 开启」两个选项
+- **AND** 设置页 SHALL NOT 展示「低 / 中 / 高」档位选项
+
+#### Scenario: 开启后档位自动生效
+- **WHEN** 用户开启画质增强
+- **THEN** 系统 SHALL 按当前视频与显示的缩放比例自动选择档位
+- **AND** 用户无需（也无法）手动指定档位
+
+### Requirement: 源视频分辨率 SHALL 透传到画质增强门控
+
+ffprobe 探测出的源视频宽高 SHALL 沿 routing decision 链路透传到播放器控制器，供自动选档使用。
+
+#### Scenario: 视频流宽高透传
+- **WHEN** ffprobe 探测一个包含视频流的媒体
+- **THEN** 探测结果的视频流 SHALL 携带 `width` / `height`
+- **AND** 播放器控制器 SHALL 可读取到当前视频的源宽高（`videoWidth` / `videoHeight`）
+
+#### Scenario: 探测失败时宽高缺失
+- **WHEN** ffprobe 探测失败或未返回宽高
+- **THEN** 控制器中的源宽高 SHALL 为缺失（undefined）
+- **AND** 自动选档 SHALL 返回 LOW（以低档启用，保证开关生效）

--- a/openspec/changes/vpe-auto-quality-by-scaling/tasks.md
+++ b/openspec/changes/vpe-auto-quality-by-scaling/tasks.md
@@ -1,54 +1,54 @@
 ## 1. TS 类型契约（源视频宽高透传）
 
-- [ ] 1.1 `VideoData` 新增 `videoWidth?: number` / `videoHeight?: number`
-- [ ] 1.2 `AudioRoutingTypes`：`AudioRoutingInput.probeVideoWidth` / `probeVideoHeight`、`AudioRoutingDecision.videoWidth` / `videoHeight`、`DEFAULT_AUDIO_ROUTING_DECISION` 补默认值（`undefined`）
-- [ ] 1.3 `PlaybackBackendTypes`：`PlaybackBackendDecision.videoWidth` / `videoHeight`、`DEFAULT_BACKEND_DECISION` 与 `buildDefaultBackendDecision()` 补默认值
+- [x] 1.1 `VideoData` 新增 `videoWidth?: number` / `videoHeight?: number`
+- [x] 1.2 `AudioRoutingTypes`：`AudioRoutingInput.probeVideoWidth` / `probeVideoHeight`、`AudioRoutingDecision.videoWidth` / `videoHeight`、`DEFAULT_AUDIO_ROUTING_DECISION` 补默认值（`undefined`）
+- [x] 1.3 `PlaybackBackendTypes`：`PlaybackBackendDecision.videoWidth` / `videoHeight`、`DEFAULT_BACKEND_DECISION` 与 `buildDefaultBackendDecision()` 补默认值
 
 ## 2. 路由 service 透传宽高
 
-- [ ] 2.1 `AudioTrackRoutingService.resolveRoutingDecision` 提取 `probe.videoTracks[0].width` / `height`
-- [ ] 2.2 `buildRoutingDecision` 输出 `videoWidth` / `videoHeight`
-- [ ] 2.3 `PlaybackBackendService.chooseBackend` 映射 `videoWidth` / `videoHeight`
-- [ ] 2.4 `VideoPlayerController`（initPlayer 写回 videoData 处）写回 `videoWidth` / `videoHeight` 并在 route-decision 日志带出
+- [x] 2.1 `AudioTrackRoutingService.resolveRoutingDecision` 提取 `probe.videoTracks[0].width` / `height`
+- [x] 2.2 `buildRoutingDecision` 输出 `videoWidth` / `videoHeight`
+- [x] 2.3 `PlaybackBackendService.chooseBackend` 映射 `videoWidth` / `videoHeight`
+- [x] 2.4 `VideoPlayerController`（initPlayer 写回 videoData 处）写回 `videoWidth` / `videoHeight` 并在 route-decision 日志带出
 
 ## 3. 自动选档纯函数
 
-- [ ] 3.1 在 `VideoPlayerController.ets`（或独立 util）新增导出纯函数 `resolveVpeQualityByScaling(srcW, srcH, dispW, dispH): VpeQualityLevel | null`，规则见 design.md「决策 2」
-- [ ] 3.2 阈值常量集中定义（如 `VPE_SCALE_MEDIUM_THRESHOLD = 1.5`、`VPE_SCALE_HIGH_THRESHOLD = 2.0`、输入分辨率上下限 32/2000、HIGH 下限 512）
+- [x] 3.1 在 `VideoPlayerController.ets`（或独立 util）新增导出纯函数 `resolveVpeQualityByScaling(srcW, srcH, dispW, dispH): VpeQualityLevel | null`，规则见 design.md「决策 2」
+- [x] 3.2 阈值常量集中定义（如 `VPE_SCALE_MEDIUM_THRESHOLD = 1.5`、`VPE_SCALE_HIGH_THRESHOLD = 2.0`、输入分辨率上下限 32/2000、HIGH 下限 512）
 
 ## 4. 显示尺寸获取（多级 fallback）
 
-- [ ] 4.1 avplayer 分支 XComponent 补 `onAreaChange`，`vp2px` 转物理像素后缓存到 controller（`displayWidth` / `displayHeight`）；mpv 分支复用同一缓存
-- [ ] 4.2 新增显示尺寸解析工具：优先 XComponent 缓存尺寸，其次 `@ohos.display.getDefaultDisplaySync()` 屏幕物理像素，两者都无则返回 `undefined`
-- [ ] 4.3 显示尺寸后到（`onAreaChange` 晚于 initPlayer）时重算档位，档位变化则 `VpeEnhancerUtil.updateQuality()`（运行中换档，不重建管线）
+- [x] 4.1 avplayer 分支 XComponent 补 `onAreaChange`，`vp2px` 转物理像素后缓存到 controller（`displayWidth` / `displayHeight`）；mpv 分支复用同一缓存
+- [x] 4.2 新增显示尺寸解析工具：优先 XComponent 缓存尺寸，其次 `@ohos.display.getDefaultDisplaySync()` 屏幕物理像素，两者都无则返回 `undefined`
+- [x] 4.3 显示尺寸后到（`onAreaChange` 晚于 initPlayer）时重算档位，档位变化则 `VpeEnhancerUtil.updateQuality()`（运行中换档，不重建管线）
 
 ## 5. Controller 门控整合
 
-- [ ] 5.1 `tryCreateVpeEnhancer` 在 HDR 守卫后调用 `resolveVpeQualityByScaling`；返回 `null`（源分辨率超硬约束）时跳过并记日志，否则以返回档位替代 `this.aiEnhanceQuality` 调用 `VpeEnhancerUtil.createEnhancer`
-- [ ] 5.2 `setAiEnhance` 语义调整：不再接收/存储用户档位（入参删除或忽略），开启即启用（至少 LOW），档位由自动选档决定
-- [ ] 5.3 `aiEnhanceQuality` 改为「当前已解析档位」派生值，不再由用户设置；确认无持久化需迁移（若有则一并迁移）
+- [x] 5.1 `tryCreateVpeEnhancer` 在 HDR 守卫后调用 `resolveVpeQualityByScaling`；返回 `null`（源分辨率超硬约束）时跳过并记日志，否则以返回档位替代 `this.aiEnhanceQuality` 调用 `VpeEnhancerUtil.createEnhancer`
+- [x] 5.2 `setAiEnhance` 语义调整：不再接收/存储用户档位（入参删除或忽略），开启即启用（至少 LOW），档位由自动选档决定
+- [x] 5.3 `aiEnhanceQuality` 改为「当前已解析档位」派生值，不再由用户设置；确认无持久化需迁移（grep 确认无 AppPreferences 持久化）
 
 ## 6. UI 改动
 
-- [ ] 6.1 `PlayerSettingsDialog` 画质增强区移除「低/中/高」三个 chip，保留「关闭 / 开启」两个 chip
-- [ ] 6.2 删除 `@State aiEnhanceQuality` 及档位样式/onClick 分支；开启调用改为不带档位的 `setAiEnhance()`
+- [x] 6.1 `PlayerSettingsDialog` 画质增强区移除「低/中/高」三个 chip，保留「关闭 / 开启」两个 chip
+- [x] 6.2 删除 `@State aiEnhanceQuality` 及档位样式/onClick 分支；开启调用改为不带档位的 `setAiEnhance()`
 
 ## 7. 单元测试
 
-- [ ] 7.1 新增 `resolveVpeQualityByScaling` 用例：大幅放大→high、中等放大→medium、轻微放大/1:1/缩小→low、超上限(>2000)→null、低于下限(<32)→null、源<512 且 scale≥2→medium、数据缺失→low
-- [ ] 7.2 扩展 `tryCreateVpeEnhancer`/门控相关测试（HDR 不建 VPE；开启且非超限必建 VPE）
+- [x] 7.1 新增 `resolveVpeQualityByScaling` 用例：大幅放大→high、中等放大→medium、轻微放大/1:1/缩小→low、超上限(>2000)→null、低于下限(<32)→null、源<512 且 scale≥2→medium、数据缺失→low
+- [x] 7.2 扩展 `tryCreateVpeEnhancer`/门控相关测试（HDR 不建 VPE；开启且非超限必建 VPE）——门控核心下沉到纯函数（`isHdrVideo` + `resolveVpeQualityByScaling`）并补组合用例；`tryCreateVpeEnhancer` 的 native 管线由真机验证覆盖
 
 ## 8. OpenSpec 产物
 
-- [ ] 8.1 `.openspec.yaml` / `proposal.md` / `design.md` / `tasks.md`
-- [ ] 8.2 delta spec `specs/vpe-quality-selection/spec.md`
+- [x] 8.1 `.openspec.yaml` / `proposal.md` / `design.md` / `tasks.md`
+- [x] 8.2 delta spec `specs/vpe-quality-selection/spec.md`
 
 ## 9. 验证
 
-- [ ] 9.1 `openspec validate vpe-auto-quality-by-scaling` 通过
-- [ ] 9.2 `openspec validate --strict vpe-auto-quality-by-scaling` 通过
-- [ ] 9.3 `./hvigorw --mode module -p module=entry@default -p product=default assembleHap` 编译通过
-- [ ] 9.4 `./hvigorw --mode module -p module=entry@default UnitTestBuild --no-daemon` 通过
+- [x] 9.1 `openspec validate vpe-auto-quality-by-scaling` 通过
+- [x] 9.2 `openspec validate --strict vpe-auto-quality-by-scaling` 通过
+- [x] 9.3 `./hvigorw --mode module -p module=entry@default -p product=default assembleHap` 编译通过
+- [x] 9.4 `./hvigorw --mode module -p module=entry@default UnitTestBuild --no-daemon` 通过（测试代码编译通过）
 - [ ] 9.5 真机验证：4K 原盘 1:1 播放以 low 档建 VPE（开启即生效）；1080p 源在 4K 屏放大时按比例选档并日志可见；HDR 源仍跳过 VPE；设置页无档位选项；开启后必见 VPE 管线建立日志
 - [ ] 9.6 真机验证残余风险：ffprobe 失败（源宽高未知）时，SDR 4K 源开启画质增强的行为——确认不会因超限输入导致黑屏/报错；若复现，补「宽高未知时保守不启用」策略（见 design.md Risks）
 

--- a/openspec/changes/vpe-auto-quality-by-scaling/tasks.md
+++ b/openspec/changes/vpe-auto-quality-by-scaling/tasks.md
@@ -1,0 +1,57 @@
+## 1. TS 类型契约（源视频宽高透传）
+
+- [ ] 1.1 `VideoData` 新增 `videoWidth?: number` / `videoHeight?: number`
+- [ ] 1.2 `AudioRoutingTypes`：`AudioRoutingInput.probeVideoWidth` / `probeVideoHeight`、`AudioRoutingDecision.videoWidth` / `videoHeight`、`DEFAULT_AUDIO_ROUTING_DECISION` 补默认值（`undefined`）
+- [ ] 1.3 `PlaybackBackendTypes`：`PlaybackBackendDecision.videoWidth` / `videoHeight`、`DEFAULT_BACKEND_DECISION` 与 `buildDefaultBackendDecision()` 补默认值
+
+## 2. 路由 service 透传宽高
+
+- [ ] 2.1 `AudioTrackRoutingService.resolveRoutingDecision` 提取 `probe.videoTracks[0].width` / `height`
+- [ ] 2.2 `buildRoutingDecision` 输出 `videoWidth` / `videoHeight`
+- [ ] 2.3 `PlaybackBackendService.chooseBackend` 映射 `videoWidth` / `videoHeight`
+- [ ] 2.4 `VideoPlayerController`（initPlayer 写回 videoData 处）写回 `videoWidth` / `videoHeight` 并在 route-decision 日志带出
+
+## 3. 自动选档纯函数
+
+- [ ] 3.1 在 `VideoPlayerController.ets`（或独立 util）新增导出纯函数 `resolveVpeQualityByScaling(srcW, srcH, dispW, dispH): VpeQualityLevel | null`，规则见 design.md「决策 2」
+- [ ] 3.2 阈值常量集中定义（如 `VPE_SCALE_MEDIUM_THRESHOLD = 1.5`、`VPE_SCALE_HIGH_THRESHOLD = 2.0`、输入分辨率上下限 32/2000、HIGH 下限 512）
+
+## 4. 显示尺寸获取（多级 fallback）
+
+- [ ] 4.1 avplayer 分支 XComponent 补 `onAreaChange`，`vp2px` 转物理像素后缓存到 controller（`displayWidth` / `displayHeight`）；mpv 分支复用同一缓存
+- [ ] 4.2 新增显示尺寸解析工具：优先 XComponent 缓存尺寸，其次 `@ohos.display.getDefaultDisplaySync()` 屏幕物理像素，两者都无则返回 `undefined`
+- [ ] 4.3 显示尺寸后到（`onAreaChange` 晚于 initPlayer）时重算档位，档位变化则 `VpeEnhancerUtil.updateQuality()`（运行中换档，不重建管线）
+
+## 5. Controller 门控整合
+
+- [ ] 5.1 `tryCreateVpeEnhancer` 在 HDR 守卫后调用 `resolveVpeQualityByScaling`；返回 `null`（源分辨率超硬约束）时跳过并记日志，否则以返回档位替代 `this.aiEnhanceQuality` 调用 `VpeEnhancerUtil.createEnhancer`
+- [ ] 5.2 `setAiEnhance` 语义调整：不再接收/存储用户档位（入参删除或忽略），开启即启用（至少 LOW），档位由自动选档决定
+- [ ] 5.3 `aiEnhanceQuality` 改为「当前已解析档位」派生值，不再由用户设置；确认无持久化需迁移（若有则一并迁移）
+
+## 6. UI 改动
+
+- [ ] 6.1 `PlayerSettingsDialog` 画质增强区移除「低/中/高」三个 chip，保留「关闭 / 开启」两个 chip
+- [ ] 6.2 删除 `@State aiEnhanceQuality` 及档位样式/onClick 分支；开启调用改为不带档位的 `setAiEnhance()`
+
+## 7. 单元测试
+
+- [ ] 7.1 新增 `resolveVpeQualityByScaling` 用例：大幅放大→high、中等放大→medium、轻微放大/1:1/缩小→low、超上限(>2000)→null、低于下限(<32)→null、源<512 且 scale≥2→medium、数据缺失→low
+- [ ] 7.2 扩展 `tryCreateVpeEnhancer`/门控相关测试（HDR 不建 VPE；开启且非超限必建 VPE）
+
+## 8. OpenSpec 产物
+
+- [ ] 8.1 `.openspec.yaml` / `proposal.md` / `design.md` / `tasks.md`
+- [ ] 8.2 delta spec `specs/vpe-quality-selection/spec.md`
+
+## 9. 验证
+
+- [ ] 9.1 `openspec validate vpe-auto-quality-by-scaling` 通过
+- [ ] 9.2 `openspec validate --strict vpe-auto-quality-by-scaling` 通过
+- [ ] 9.3 `./hvigorw --mode module -p module=entry@default -p product=default assembleHap` 编译通过
+- [ ] 9.4 `./hvigorw --mode module -p module=entry@default UnitTestBuild --no-daemon` 通过
+- [ ] 9.5 真机验证：4K 原盘 1:1 播放以 low 档建 VPE（开启即生效）；1080p 源在 4K 屏放大时按比例选档并日志可见；HDR 源仍跳过 VPE；设置页无档位选项；开启后必见 VPE 管线建立日志
+- [ ] 9.6 真机验证残余风险：ffprobe 失败（源宽高未知）时，SDR 4K 源开启画质增强的行为——确认不会因超限输入导致黑屏/报错；若复现，补「宽高未知时保守不启用」策略（见 design.md Risks）
+
+## 10. 归档（黑屏 issue #255 合并后执行）
+
+- [ ] 10.1 `openspec archive vpe-auto-quality-by-scaling` 并同步 main specs


### PR DESCRIPTION
## 概述

VPE 画质增强（Detail Enhancer）档位从「用户手动选低/中/高」改为「按缩放比例自动选择」，用户只保留「关闭/开启」开关。

## 背景

官方《视频缩放》文档明确 Detail Enhancer 的档位收益与「是否缩放」强相关：LOW/MEDIUM 仅在缩放场景生效、等比缩放时无清晰度增强，HIGH 才支持等比清晰度增强且输入分辨率要求 [512,2000]。手动档位对用户无意义且常与实际播放场景错配。

## 改动

- 移除设置页「低/中/高」手动档位，只保留「关闭/开启」
- 新增纯函数 `resolveVpeQualityByScaling`：`scale = max(显示宽/源宽, 显示高/源高)`
  - `<1.5 → low`、`[1.5,2.0) → medium`、`≥2.0 且源≥512 → high`
  - 仅「源宽高已知且 >2000 或 <32」返回 null（不启用）
  - 数据缺失 → low（开启即生效）
- 源视频宽高沿 routing decision 链路透传（`videoWidth`/`videoHeight`）
- 显示尺寸多级兜底：XComponent `onAreaChange` 物理像素 → `@ohos.display` 屏幕像素 → 缺失退 low
- HDR 门控保持（`isHdrVideo` 跳过 VPE）
- 修复：关闭后重新开启时强制切回自动档位（避免停留在 NONE 透传）

## 验证

- ✅ `openspec validate` 与 `--strict` 通过
- ✅ `assembleHap` 编译通过
- ✅ `UnitTestBuild` 通过（新增 `resolveVpeQualityByScaling` 用例）
- ✅ 真机日志确认：HDR 跳过 VPE、SDR 按缩放选档、切换档位 `ret=0`

## 关联

OpenSpec change: `vpe-auto-quality-by-scaling`
