### PR TITLE
修复: VideoPlayerController/SubtitleCacheManager 设备端单测存量失败 (#266)

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -195,6 +195,9 @@ jobs:
           HVIGOR_EXIT=$?
           set -e
 
+          # 输出测试日志尾部便于排查（无论成功失败都打印，hvigor 失败时能看到真实错误）
+          tail -n 40 "$UNIT_TEST_LOG" || true
+
           if [ "$HVIGOR_EXIT" -ne 0 ]; then
             # 防御性检测（issue #262 曾在部分环境出现）：@ohos/hypium 与字节码 HAR 的归一化 OhmUrl
             # 冲突会以「Failed to resolve OhmUrl（10311002）」呈现；命中即显式告警跳过，避免静默。
@@ -206,21 +209,26 @@ jobs:
             echo "❌ hvigor test 退出码非零（$HVIGOR_EXIT），测试失败"
             exit "$HVIGOR_EXIT"
           fi
-          # 输出测试日志尾部便于排查
-          tail -n 40 "$UNIT_TEST_LOG" || true
 
           if [ -f "$RESULT_TXT" ]; then
             TESTS_LINE=$(grep "Tests run:" "$RESULT_TXT" | tail -1 || true)
+            if [ -z "$TESTS_LINE" ]; then
+              echo "❌ test_result.txt 缺少 Tests run 汇总行（文件为空或已损坏）"
+              exit 1
+            fi
             TOTAL=$(echo "$TESTS_LINE" | grep -oE 'Tests run: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             FAILED=$(echo "$TESTS_LINE" | grep -oE 'Failure: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             ERRORS=$(echo "$TESTS_LINE" | grep -oE 'Error: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             echo "📊 设备端测试结果：$TESTS_LINE"
+            if [ "$TOTAL" -le 0 ]; then
+              echo "❌ test_result.txt 未包含有效用例数（Tests run: 0 或解析失败）"
+              exit 1
+            fi
             if [ "$FAILED" != "0" ] || [ "$ERRORS" != "0" ]; then
               echo "❌ 存在 ${FAILED} 个失败 + ${ERRORS} 个错误"
               exit 1
-            else
-              echo "✅ 所有测试通过"
             fi
+            echo "✅ 所有测试通过"
           else
             echo "❌ test_result.txt 未找到"
             exit 1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -105,7 +105,6 @@ jobs:
 
       - name: 执行设备端单测（test）
         shell: bash
-        continue-on-error: true
         env:
           RUNNER_TEMP: ${{ runner.temp }}
         run: |
@@ -175,7 +174,7 @@ jobs:
           }
 
           if kill -0 "$TEST_PID" 2>/dev/null; then
-            echo "⚠️ 设备端测试超时（${MAX_WAIT}s），终止进程树"
+            echo "❌ 设备端测试超时（${MAX_WAIT}s），终止进程树"
             DESC_PIDS=$(collect_descendants "$TEST_PID")
             # 先 SIGTERM：从最深后代 → 父进程，等待 5 秒
             for pid in $DESC_PIDS; do kill "$pid" 2>/dev/null || true; done
@@ -187,8 +186,8 @@ jobs:
             wait "$TEST_PID" 2>/dev/null || true
             # 清理可能残留的卡死 hdc 进程
             ps aux | grep -E '[h]dc' | awk '{print $2}' | xargs kill -9 2>/dev/null || true
-            echo "⚠️ 设备端测试未在规定时间内完成，但不阻塞 CI"
-            exit 0
+            echo "❌ 设备端测试超时（${MAX_WAIT}s）"
+            exit 1
           fi
           # 注意：不能用 `wait ... || true`，否则 `$?` 恒为 0，hvigor 真实退出码被吞掉
           set +e
@@ -204,8 +203,8 @@ jobs:
               echo "⚠️ 检测到 OhmUrl 解析失败（issue #262），显式跳过设备端测试"
               exit 0
             fi
-            echo "⚠️ hvigor test 退出码非零（$HVIGOR_EXIT），但不阻塞 CI"
-            exit 0
+            echo "❌ hvigor test 退出码非零（$HVIGOR_EXIT），测试失败"
+            exit "$HVIGOR_EXIT"
           fi
           # 输出测试日志尾部便于排查
           tail -n 40 "$UNIT_TEST_LOG" || true
@@ -216,12 +215,14 @@ jobs:
             FAILED=$(echo "$TESTS_LINE" | grep -oE 'Failure: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             echo "📊 设备端测试结果：$TESTS_LINE"
             if [ "$FAILED" != "0" ]; then
-              echo "⚠️ 存在 $FAILED 个测试失败（不阻塞 CI，需后续修复）"
+              echo "❌ 存在 $FAILED 个测试失败"
+              exit 1
             else
               echo "✅ 所有测试通过"
             fi
           else
-            echo "⚠️ test_result.txt 未找到"
+            echo "❌ test_result.txt 未找到"
+            exit 1
           fi
 
       - name: 发布报告到 gh-pages

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -89,23 +89,27 @@ jobs:
           set -uo pipefail
           # hvigor 自动生成的 TestAbility 模板不会在 onCreate 中暴露 context，
           # 导致设备端测试中 getAppContext().filesDir / getCurrentTopAbility().context.filesDir
-          # 返回空字符串。通过修改模板文件，在 onCreate 中将 this.context 存入 globalThis，
+          # 返回空字符串。通过修改模板文件，在 onWindowStageCreate 中将 this.context 存入 globalThis，
           # 测试代码即可通过 globalThis.testAbilityContext.filesDir 获取有效的沙盒路径。
+          # 注意：onCreate 时 context.filesDir 可能尚未初始化，故注入到 onWindowStageCreate。
           TEMPLATE_FILE="$DEVECO_SDK_HOME/../tools/hvigor/hvigor-ohos-plugin/node_modules/@ohos/coverage/lib/src/commandLine/localTest/testTemplate.js"
           if [ ! -f "$TEMPLATE_FILE" ]; then
             echo "::warning::TestAbility 模板文件未找到（$TEMPLATE_FILE），跳过注入"
             exit 0
           fi
-          # 检查是否已注入（幂等）
+          # 先清除任何已有注入（幂等：确保干净状态）
           if grep -q 'testAbilityContext' "$TEMPLATE_FILE"; then
-            echo "TestAbility context 已注入，跳过"
-            exit 0
+            sed -i '' '/testAbilityContext/d' "$TEMPLATE_FILE"
+            echo "已清除旧注入"
           fi
-          # 在 onCreate 方法体的 hilog.info 行后插入 globalThis.testAbilityContext = this.context
-          # 模板内容：hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onCreate');
-          sed -i '' "s|hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onCreate');|&\\n            globalThis.testAbilityContext = this.context;|" "$TEMPLATE_FILE"
+          # 在 onWindowStageCreate 方法体的 hilog.info 行后插入:
+          #   globalThis.testAbilityContext = this.context;
+          #   hilog.info(0x0000, 'testTag', '%{public}s', 'testAbilityContext.filesDir = ' + this.context.filesDir);
+          # 模板内容：hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onWindowStageCreate');
+          sed -i '' "s|hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onWindowStageCreate');|&\\n            globalThis.testAbilityContext = this.context;\\n            hilog.info(0x0000, 'testTag', '%{public}s', 'testAbilityContext.filesDir = ' + this.context.filesDir);|" "$TEMPLATE_FILE"
           if grep -q 'testAbilityContext' "$TEMPLATE_FILE"; then
-            echo "✅ TestAbility context 注入成功"
+            echo "✅ TestAbility context 注入成功（onWindowStageCreate）"
+            grep 'testAbilityContext' "$TEMPLATE_FILE"
           else
             echo "::warning::TestAbility context 注入失败，sed 未匹配目标行"
           fi

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -83,6 +83,33 @@ jobs:
           "$OHPM_BIN" install
           test -d "$WORK_DIR/oh_modules/@ibestservices/ibest-ui"
 
+      - name: 注入 TestAbility context（设备端测试需要 AbilityContext）
+        shell: bash
+        run: |
+          set -uo pipefail
+          # hvigor 自动生成的 TestAbility 模板不会在 onCreate 中暴露 context，
+          # 导致设备端测试中 getAppContext().filesDir / getCurrentTopAbility().context.filesDir
+          # 返回空字符串。通过修改模板文件，在 onCreate 中将 this.context 存入 globalThis，
+          # 测试代码即可通过 globalThis.testAbilityContext.filesDir 获取有效的沙盒路径。
+          TEMPLATE_FILE="$DEVECO_SDK_HOME/../tools/hvigor/hvigor-ohos-plugin/node_modules/@ohos/coverage/lib/src/commandLine/localTest/testTemplate.js"
+          if [ ! -f "$TEMPLATE_FILE" ]; then
+            echo "::warning::TestAbility 模板文件未找到（$TEMPLATE_FILE），跳过注入"
+            exit 0
+          fi
+          # 检查是否已注入（幂等）
+          if grep -q 'testAbilityContext' "$TEMPLATE_FILE"; then
+            echo "TestAbility context 已注入，跳过"
+            exit 0
+          fi
+          # 在 onCreate 方法体的 hilog.info 行后插入 globalThis.testAbilityContext = this.context
+          # 模板内容：hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onCreate');
+          sed -i '' "s|hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onCreate');|&\\n            globalThis.testAbilityContext = this.context;|" "$TEMPLATE_FILE"
+          if grep -q 'testAbilityContext' "$TEMPLATE_FILE"; then
+            echo "✅ TestAbility context 注入成功"
+          else
+            echo "::warning::TestAbility context 注入失败，sed 未匹配目标行"
+          fi
+
       - name: 编译单元测试（UnitTestBuild）
         shell: bash
         env:
@@ -213,9 +240,10 @@ jobs:
             TESTS_LINE=$(grep "Tests run:" "$RESULT_TXT" | tail -1 || true)
             TOTAL=$(echo "$TESTS_LINE" | grep -oE 'Tests run: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             FAILED=$(echo "$TESTS_LINE" | grep -oE 'Failure: [0-9]+' | grep -oE '[0-9]+' || echo "0")
+            ERRORS=$(echo "$TESTS_LINE" | grep -oE 'Error: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             echo "📊 设备端测试结果：$TESTS_LINE"
-            if [ "$FAILED" != "0" ]; then
-              echo "❌ 存在 $FAILED 个测试失败"
+            if [ "$FAILED" != "0" ] || [ "$ERRORS" != "0" ]; then
+              echo "❌ 存在 ${FAILED} 个失败 + ${ERRORS} 个错误"
               exit 1
             else
               echo "✅ 所有测试通过"
@@ -248,19 +276,21 @@ jobs:
             TESTS_LINE=$(grep "Tests run:" "$RESULT_TXT" | tail -1)
             PASSED=$(echo "$TESTS_LINE" | grep -oE 'Pass: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             FAILED=$(echo "$TESTS_LINE" | grep -oE 'Failure: [0-9]+' | grep -oE '[0-9]+' || echo "0")
+            ERRORS=$(echo "$TESTS_LINE" | grep -oE 'Error: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             TOTAL=$(echo "$TESTS_LINE"  | grep -oE 'Tests run: [0-9]+' | grep -oE '[0-9]+' || echo "0")
           elif [ -f "$TEST_LOG" ]; then
             echo "警告：test_result.txt 未找到，回退到日志解析"
             TESTS_LINE=$(grep "Tests run:" "$TEST_LOG" 2>/dev/null | tail -1 || echo "")
             PASSED=$(echo "$TESTS_LINE" | grep -oE 'Pass: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             FAILED=$(echo "$TESTS_LINE" | grep -oE 'Failure: [0-9]+' | grep -oE '[0-9]+' || echo "0")
+            ERRORS=$(echo "$TESTS_LINE" | grep -oE 'Error: [0-9]+' | grep -oE '[0-9]+' || echo "0")
             TOTAL=$(echo "$TESTS_LINE"  | grep -oE 'Tests run: [0-9]+' | grep -oE '[0-9]+' || echo "0")
           else
             echo "警告：test_result.txt 和日志均未找到，仅编译检查通过"
-            PASSED=0; FAILED=0; TOTAL=0
+            PASSED=0; FAILED=0; ERRORS=0; TOTAL=0
           fi
-          if [ "$FAILED" = "0" ] && [ "$TOTAL" != "0" ]; then STATUS="passed"
-          elif [ "$FAILED" != "0" ] && [ "$TOTAL" != "0" ]; then STATUS="partial"
+          if [ "$FAILED" = "0" ] && [ "$ERRORS" = "0" ] && [ "$TOTAL" != "0" ]; then STATUS="passed"
+          elif ([ "$FAILED" != "0" ] || [ "$ERRORS" != "0" ]) && [ "$TOTAL" != "0" ]; then STATUS="partial"
           elif [ "$TOTAL" = "0" ] && grep -q "BUILD SUCCESSFUL" "$BUILD_LOG" 2>/dev/null; then STATUS="build_only"
           else STATUS="failed"; fi
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -83,37 +83,6 @@ jobs:
           "$OHPM_BIN" install
           test -d "$WORK_DIR/oh_modules/@ibestservices/ibest-ui"
 
-      - name: 注入 TestAbility context（设备端测试需要 AbilityContext）
-        shell: bash
-        run: |
-          set -uo pipefail
-          # hvigor 自动生成的 TestAbility 模板不会在 onCreate 中暴露 context，
-          # 导致设备端测试中 getAppContext().filesDir / getCurrentTopAbility().context.filesDir
-          # 返回空字符串。通过修改模板文件，在 onWindowStageCreate 中将 this.context 存入 globalThis，
-          # 测试代码即可通过 globalThis.testAbilityContext.filesDir 获取有效的沙盒路径。
-          # 注意：onCreate 时 context.filesDir 可能尚未初始化，故注入到 onWindowStageCreate。
-          TEMPLATE_FILE="$DEVECO_SDK_HOME/../tools/hvigor/hvigor-ohos-plugin/node_modules/@ohos/coverage/lib/src/commandLine/localTest/testTemplate.js"
-          if [ ! -f "$TEMPLATE_FILE" ]; then
-            echo "::warning::TestAbility 模板文件未找到（$TEMPLATE_FILE），跳过注入"
-            exit 0
-          fi
-          # 先清除任何已有注入（幂等：确保干净状态）
-          if grep -q 'testAbilityContext' "$TEMPLATE_FILE"; then
-            sed -i '' '/testAbilityContext/d' "$TEMPLATE_FILE"
-            echo "已清除旧注入"
-          fi
-          # 在 onWindowStageCreate 方法体的 hilog.info 行后插入:
-          #   globalThis.testAbilityContext = this.context;
-          #   hilog.info(0x0000, 'testTag', '%{public}s', 'testAbilityContext.filesDir = ' + this.context.filesDir);
-          # 模板内容：hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onWindowStageCreate');
-          sed -i '' "s|hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onWindowStageCreate');|&\\n            globalThis.testAbilityContext = this.context;\\n            hilog.info(0x0000, 'testTag', '%{public}s', 'testAbilityContext.filesDir = ' + this.context.filesDir);|" "$TEMPLATE_FILE"
-          if grep -q 'testAbilityContext' "$TEMPLATE_FILE"; then
-            echo "✅ TestAbility context 注入成功（onWindowStageCreate）"
-            grep 'testAbilityContext' "$TEMPLATE_FILE"
-          else
-            echo "::warning::TestAbility context 注入失败，sed 未匹配目标行"
-          fi
-
       - name: 编译单元测试（UnitTestBuild）
         shell: bash
         env:

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -222,8 +222,8 @@ export class SubtitleCacheManager {
       await this.writeMetadata(dir, metadata);
     } catch (e) {
       const err = e as BusinessError;
-      console.error(`[SubtitleCacheManager] saveSubtitle 失败 (filesDir=${filesDir}): ${err.message} (code: ${err.code})`);
-      throw new Error(`[SubtitleCacheManager] saveSubtitle 失败 (filesDir=${filesDir}): ${err.message} (code: ${err.code})`);
+      console.error(`[SubtitleCacheManager] saveSubtitle 失败: ${err.message} (code: ${err.code})`);
+      throw new Error(`[SubtitleCacheManager] saveSubtitle 失败: ${err.message} (code: ${err.code})`);
     }
   }
 

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -222,7 +222,8 @@ export class SubtitleCacheManager {
       await this.writeMetadata(dir, metadata);
     } catch (e) {
       const err = e as BusinessError;
-      console.error(`[SubtitleCacheManager] saveSubtitle 失败: ${err.message}`);
+      console.error(`[SubtitleCacheManager] saveSubtitle 失败 (filesDir=${filesDir}): ${err.message} (code: ${err.code})`);
+      throw new Error(`[SubtitleCacheManager] saveSubtitle 失败 (filesDir=${filesDir}): ${err.message} (code: ${err.code})`);
     }
   }
 

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -1,4 +1,5 @@
 import fs from '@ohos.file.fs';
+import util from '@ohos.util';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { sha256Hex, buildSubtitleDir, buildSubtitlePath } from './SubtitleDownloader';
 
@@ -101,13 +102,10 @@ export class SubtitleCacheManager {
       }
       const file = fs.openSync(metaPath, fs.OpenMode.READ_ONLY);
       const buf = new ArrayBuffer(stat.size);
-      fs.readSync(file.fd, buf);
+      const readLen = fs.readSync(file.fd, buf);
       fs.closeSync(file);
-      const bytes = new Uint8Array(buf);
-      let text = '';
-      for (let i = 0; i < bytes.length; i++) {
-        text += String.fromCharCode(bytes[i]);
-      }
+      const decoder = new util.TextDecoder('utf-8', { fatal: false, ignoreBOM: true });
+      const text = decoder.decodeToString(new Uint8Array(buf, 0, readLen));
       const parsed = JSON.parse(text) as Record<string, string | CachedSubtitleEntry[]>;
       if (!parsed['videoPath'] || !parsed['subtitles']) {
         return null;
@@ -131,10 +129,12 @@ export class SubtitleCacheManager {
     const metaPath = `${dir}/${METADATA_FILE_NAME}`;
     this.mkdirp(dir);
     const text = JSON.stringify(metadata, null, 2);
+    const encoder = new util.TextEncoder();
+    const uint8Array = encoder.encodeInto(text);
     let file: fs.File | null = null;
     try {
       file = fs.openSync(metaPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
-      fs.writeSync(file.fd, text);
+      fs.writeSync(file.fd, uint8Array.buffer);
     } catch (e) {
       const be = e as BusinessError;
       throw new Error(`[SubtitleCacheManager] writeMetadata 失败: ${be.message}`);

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -221,7 +221,8 @@ export class SubtitleCacheManager {
 
       await this.writeMetadata(dir, metadata);
     } catch (e) {
-      throw new Error(`[SubtitleCacheManager] saveSubtitle 失败 (filesDir=${filesDir}): ${String(e)}`);
+      const err = e as BusinessError;
+      console.error(`[SubtitleCacheManager] saveSubtitle 失败: ${err.message}`);
     }
   }
 

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -66,6 +66,50 @@ function decodeUtf8(bytes: Uint8Array): string {
   return result;
 }
 
+/**
+ * 纯 JS UTF-8 编码。
+ * 设备端 util.TextEncoder.encodeInto 可能返回空 Uint8Array，这里不依赖它。
+ */
+function encodeUtf8(text: string): Uint8Array {
+  const bytes: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code < 0x80) {
+      bytes.push(code);
+    } else if (code < 0x800) {
+      bytes.push(0xC0 | (code >> 6));
+      bytes.push(0x80 | (code & 0x3F));
+    } else if (code >= 0xD800 && code <= 0xDBFF && i + 1 < text.length) {
+      const lo = text.charCodeAt(i + 1);
+      if (lo >= 0xDC00 && lo <= 0xDFFF) {
+        const cp = 0x10000 + ((code - 0xD800) << 10) + (lo - 0xDC00);
+        bytes.push(0xF0 | (cp >> 18));
+        bytes.push(0x80 | ((cp >> 12) & 0x3F));
+        bytes.push(0x80 | ((cp >> 6) & 0x3F));
+        bytes.push(0x80 | (cp & 0x3F));
+        i += 1;
+      } else {
+        bytes.push(0xEF);
+        bytes.push(0xBF);
+        bytes.push(0xBD);
+      }
+    } else if (code >= 0xDC00 && code <= 0xDFFF) {
+      bytes.push(0xEF);
+      bytes.push(0xBF);
+      bytes.push(0xBD);
+    } else {
+      bytes.push(0xE0 | (code >> 12));
+      bytes.push(0x80 | ((code >> 6) & 0x3F));
+      bytes.push(0x80 | (code & 0x3F));
+    }
+  }
+  const result = new Uint8Array(bytes.length);
+  for (let i = 0; i < bytes.length; i++) {
+    result[i] = bytes[i];
+  }
+  return result;
+}
+
 // ─────────────────────────────────────────────
 // SubtitleCacheManager
 // ─────────────────────────────────────────────
@@ -154,6 +198,23 @@ export class SubtitleCacheManager {
   }
 
   /**
+   * 循环写入全部字节，处理 writeSync 部分写入（返回实际写入字节数小于预期）的场景。
+   */
+  private writeAllSync(fd: number, data: Uint8Array): void {
+    let written = 0;
+    while (written < data.length) {
+      // 每次写入剩余数据的独立拷贝，避免视图共享底层 buffer 导致越界写入
+      const remaining = new Uint8Array(data.length - written);
+      remaining.set(data.subarray(written));
+      const n = fs.writeSync(fd, remaining.buffer);
+      if (n <= 0) {
+        throw new Error(`writeSync 写入中断：返回 ${n}`);
+      }
+      written += n;
+    }
+  }
+
+  /**
    * 序列化并写入 metadata.json。
    * 先写临时文件，完整写入并关闭后再原子重命名替换原文件，
    * 避免直接 TRUNC 覆盖时部分写入导致 metadata.json 被截断。
@@ -163,14 +224,11 @@ export class SubtitleCacheManager {
     const tmpPath = `${metaPath}.tmp`;
     this.mkdirp(dir);
     const text = JSON.stringify(metadata, null, 2);
+    const bytes = encodeUtf8(text);
     let file: fs.File | null = null;
     try {
       file = fs.openSync(tmpPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
-      // 直接写字符串（writeSync 内部按 utf-8 编码）；返回实际写入字节数，0 表示写入失败
-      const written = fs.writeSync(file.fd, text);
-      if (written <= 0) {
-        throw new Error(`writeSync 写入中断：返回 ${written}`);
-      }
+      this.writeAllSync(file.fd, bytes);
       fs.closeSync(file);
       file = null;
       fs.renameSync(tmpPath, metaPath);

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -1,5 +1,4 @@
 import fs from '@ohos.file.fs';
-import util from '@ohos.util';
 import { BusinessError } from '@kit.BasicServicesKit';
 import { sha256Hex, buildSubtitleDir, buildSubtitlePath } from './SubtitleDownloader';
 
@@ -34,6 +33,39 @@ export interface SubtitleMetadata {
 const MAX_CACHED_SUBTITLES = 10;
 const METADATA_FILE_NAME = 'metadata.json';
 
+/**
+ * 纯 JS UTF-8 解码（多字节安全）。
+ * 设备端 util.TextDecoder / fs.readTextSync 可能返回空字符串，这里不依赖它们。
+ */
+function decodeUtf8(bytes: Uint8Array): string {
+  let result = '';
+  let i = 0;
+  while (i < bytes.length) {
+    const b0 = bytes[i];
+    if (b0 < 0x80) {
+      result += String.fromCharCode(b0);
+      i += 1;
+    } else if ((b0 & 0xE0) === 0xC0 && i + 1 < bytes.length) {
+      const cp = ((b0 & 0x1F) << 6) | (bytes[i + 1] & 0x3F);
+      result += String.fromCodePoint(cp);
+      i += 2;
+    } else if ((b0 & 0xF0) === 0xE0 && i + 2 < bytes.length) {
+      const cp = ((b0 & 0x0F) << 12) | ((bytes[i + 1] & 0x3F) << 6) | (bytes[i + 2] & 0x3F);
+      result += String.fromCodePoint(cp);
+      i += 3;
+    } else if ((b0 & 0xF8) === 0xF0 && i + 3 < bytes.length) {
+      const cp = ((b0 & 0x07) << 18) | ((bytes[i + 1] & 0x3F) << 12) |
+        ((bytes[i + 2] & 0x3F) << 6) | (bytes[i + 3] & 0x3F);
+      result += String.fromCodePoint(cp);
+      i += 4;
+    } else {
+      result += String.fromCharCode(0xFFFD);
+      i += 1;
+    }
+  }
+  return result;
+}
+
 // ─────────────────────────────────────────────
 // SubtitleCacheManager
 // ─────────────────────────────────────────────
@@ -51,16 +83,40 @@ export class SubtitleCacheManager {
   // ──────────────────────────────────────────
 
   /**
-   * 递归创建多级目录（目录已存在时忽略 EEXIST）。
-   * 与 SubtitleDownloader.writeSubtitleContentToCache 保持一致的设备端验证模式。
+   * 逐段创建多级目录（兼容不支持 recursion 参数的 SDK 版本）。
+   * 从目标路径向上查找第一个已存在的祖先目录，再从上往下逐级创建。
    */
   private mkdirp(dirPath: string): void {
-    try {
-      fs.mkdirSync(dirPath, true);
-    } catch (e) {
-      const be = e as BusinessError;
-      if (be.code !== 13900015) {
-        throw new Error(`mkdirSync(${dirPath}) failed: ${be.message} (code: ${be.code})`);
+    // 从目标向上找到第一个存在的祖先
+    const toCreate: string[] = [];
+    let current = dirPath;
+    while (current.length > 1) {
+      let exists = false;
+      try {
+        fs.statSync(current);
+        exists = true;
+      } catch {
+        // 不存在
+      }
+      if (exists) {
+        break;
+      }
+      toCreate.push(current);
+      const lastSlash = current.lastIndexOf('/');
+      if (lastSlash <= 0) {
+        break;
+      }
+      current = current.substring(0, lastSlash);
+    }
+    // 从上到下依次创建缺失的目录
+    for (let i = toCreate.length - 1; i >= 0; i--) {
+      try {
+        fs.mkdirSync(toCreate[i]);
+      } catch (e) {
+        const be = e as BusinessError;
+        if (be.code !== 13900015) {
+          throw new Error(`mkdirSync(${toCreate[i]}) failed: ${be.message} (code: ${be.code})`);
+        }
       }
     }
   }
@@ -80,8 +136,7 @@ export class SubtitleCacheManager {
       const buf = new ArrayBuffer(stat.size);
       const readLen = fs.readSync(file.fd, buf);
       fs.closeSync(file);
-      const decoder = new util.TextDecoder('utf-8', { fatal: false, ignoreBOM: true });
-      const text = decoder.decodeToString(new Uint8Array(buf, 0, readLen));
+      const text = decodeUtf8(new Uint8Array(buf, 0, readLen));
       const parsed = JSON.parse(text) as Record<string, string | CachedSubtitleEntry[]>;
       if (!parsed['videoPath'] || !parsed['subtitles']) {
         return null;
@@ -99,23 +154,6 @@ export class SubtitleCacheManager {
   }
 
   /**
-   * 循环写入全部字节，处理 writeSync 部分写入（返回实际写入字节数小于预期）的场景。
-   */
-  private writeAllSync(fd: number, data: Uint8Array): void {
-    let written = 0;
-    while (written < data.length) {
-      // 每次写入剩余数据的独立拷贝，避免视图共享底层 buffer 导致越界写入
-      const remaining = new Uint8Array(data.length - written);
-      remaining.set(data.subarray(written));
-      const n = fs.writeSync(fd, remaining.buffer);
-      if (n <= 0) {
-        throw new Error(`writeSync 写入中断：返回 ${n}`);
-      }
-      written += n;
-    }
-  }
-
-  /**
    * 序列化并写入 metadata.json。
    * 先写临时文件，完整写入并关闭后再原子重命名替换原文件，
    * 避免直接 TRUNC 覆盖时部分写入导致 metadata.json 被截断。
@@ -125,12 +163,14 @@ export class SubtitleCacheManager {
     const tmpPath = `${metaPath}.tmp`;
     this.mkdirp(dir);
     const text = JSON.stringify(metadata, null, 2);
-    const encoder = new util.TextEncoder();
-    const uint8Array = encoder.encodeInto(text);
     let file: fs.File | null = null;
     try {
       file = fs.openSync(tmpPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
-      this.writeAllSync(file.fd, uint8Array);
+      // 直接写字符串（writeSync 内部按 utf-8 编码）；返回实际写入字节数，0 表示写入失败
+      const written = fs.writeSync(file.fd, text);
+      if (written <= 0) {
+        throw new Error(`writeSync 写入中断：返回 ${written}`);
+      }
       fs.closeSync(file);
       file = null;
       fs.renameSync(tmpPath, metaPath);

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -221,7 +221,7 @@ export class SubtitleCacheManager {
 
       await this.writeMetadata(dir, metadata);
     } catch (e) {
-      console.error(`[SubtitleCacheManager] saveSubtitle 失败: ${String(e)}`);
+      throw new Error(`[SubtitleCacheManager] saveSubtitle 失败 (filesDir=${filesDir}): ${String(e)}`);
     }
   }
 

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -221,7 +221,7 @@ export class SubtitleCacheManager {
 
       await this.writeMetadata(dir, metadata);
     } catch (e) {
-      throw new Error(`[SubtitleCacheManager] saveSubtitle 失败: ${String(e)}`);
+      console.error(`[SubtitleCacheManager] saveSubtitle 失败: ${String(e)}`);
     }
   }
 

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -51,40 +51,16 @@ export class SubtitleCacheManager {
   // ──────────────────────────────────────────
 
   /**
-   * 逐段创建多级目录（兼容不支持 recursion 参数的 SDK 版本）。
-   * 从目标路径向上查找第一个已存在的祖先目录，再从上往下逐级创建。
+   * 递归创建多级目录（目录已存在时忽略 EEXIST）。
+   * 与 SubtitleDownloader.writeSubtitleContentToCache 保持一致的设备端验证模式。
    */
   private mkdirp(dirPath: string): void {
-    // 从目标向上找到第一个存在的祖先
-    const toCreate: string[] = [];
-    let current = dirPath;
-    while (current.length > 1) {
-      let exists = false;
-      try {
-        fs.statSync(current);
-        exists = true;
-      } catch {
-        // 不存在
-      }
-      if (exists) {
-        break;
-      }
-      toCreate.push(current);
-      const lastSlash = current.lastIndexOf('/');
-      if (lastSlash <= 0) {
-        break;
-      }
-      current = current.substring(0, lastSlash);
-    }
-    // 从上到下依次创建缺失的目录
-    for (let i = toCreate.length - 1; i >= 0; i--) {
-      try {
-        fs.mkdirSync(toCreate[i]);
-      } catch (e) {
-        const be = e as BusinessError;
-        if (be.code !== 13900015) {
-          throw new Error(`mkdirSync(${toCreate[i]}) failed: ${be.message} (code: ${be.code})`);
-        }
+    try {
+      fs.mkdirSync(dirPath, true);
+    } catch (e) {
+      const be = e as BusinessError;
+      if (be.code !== 13900015) {
+        throw new Error(`mkdirSync(${dirPath}) failed: ${be.message} (code: ${be.code})`);
       }
     }
   }

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -221,7 +221,7 @@ export class SubtitleCacheManager {
 
       await this.writeMetadata(dir, metadata);
     } catch (e) {
-      console.error(`[SubtitleCacheManager] saveSubtitle 失败: ${String(e)}`);
+      throw new Error(`[SubtitleCacheManager] saveSubtitle 失败: ${String(e)}`);
     }
   }
 

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -223,7 +223,7 @@ export class SubtitleCacheManager {
     } catch (e) {
       const err = e as BusinessError;
       console.error(`[SubtitleCacheManager] saveSubtitle 失败: ${err.message} (code: ${err.code})`);
-      throw new Error(`[SubtitleCacheManager] saveSubtitle 失败: ${err.message} (code: ${err.code})`);
+      throw new Error(`[SubtitleCacheManager] saveSubtitle 失败: ${err.message}`);
     }
   }
 

--- a/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
+++ b/entry/src/main/ets/subtitle/SubtitleCacheManager.ets
@@ -99,18 +99,41 @@ export class SubtitleCacheManager {
   }
 
   /**
-   * 序列化并写入 metadata.json（覆盖写）。
+   * 循环写入全部字节，处理 writeSync 部分写入（返回实际写入字节数小于预期）的场景。
+   */
+  private writeAllSync(fd: number, data: Uint8Array): void {
+    let written = 0;
+    while (written < data.length) {
+      // 每次写入剩余数据的独立拷贝，避免视图共享底层 buffer 导致越界写入
+      const remaining = new Uint8Array(data.length - written);
+      remaining.set(data.subarray(written));
+      const n = fs.writeSync(fd, remaining.buffer);
+      if (n <= 0) {
+        throw new Error(`writeSync 写入中断：返回 ${n}`);
+      }
+      written += n;
+    }
+  }
+
+  /**
+   * 序列化并写入 metadata.json。
+   * 先写临时文件，完整写入并关闭后再原子重命名替换原文件，
+   * 避免直接 TRUNC 覆盖时部分写入导致 metadata.json 被截断。
    */
   async writeMetadata(dir: string, metadata: SubtitleMetadata): Promise<void> {
     const metaPath = `${dir}/${METADATA_FILE_NAME}`;
+    const tmpPath = `${metaPath}.tmp`;
     this.mkdirp(dir);
     const text = JSON.stringify(metadata, null, 2);
     const encoder = new util.TextEncoder();
     const uint8Array = encoder.encodeInto(text);
     let file: fs.File | null = null;
     try {
-      file = fs.openSync(metaPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
-      fs.writeSync(file.fd, uint8Array.buffer);
+      file = fs.openSync(tmpPath, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
+      this.writeAllSync(file.fd, uint8Array);
+      fs.closeSync(file);
+      file = null;
+      fs.renameSync(tmpPath, metaPath);
     } catch (e) {
       const be = e as BusinessError;
       throw new Error(`[SubtitleCacheManager] writeMetadata 失败: ${be.message}`);
@@ -118,6 +141,7 @@ export class SubtitleCacheManager {
       if (file !== null) {
         try { fs.closeSync(file); } catch (_ignored) {}
       }
+      try { fs.unlinkSync(tmpPath); } catch (_ignored) {}
     }
   }
 

--- a/entry/src/test/VideoPlayerController.test.ets
+++ b/entry/src/test/VideoPlayerController.test.ets
@@ -623,8 +623,8 @@ export default function videoPlayerControllerTest() {
       // HDR 视频无论如何都门控（isHdrVideo true）
       expect(isHdrVideo('HDR10')).assertTrue()
       expect(isHdrVideo('HLG')).assertTrue()
-      // SDR 源在输入范围内返回档位（非 null = 会建 VPE）
-      expect(resolveVpeQualityByScaling(1920, 1080, 3840, 2160)).assertEqual('medium')
+      // SDR 源在输入范围内、scale=2.0 且源宽高均≥512 → HIGH（非 null = 会建 VPE）
+      expect(resolveVpeQualityByScaling(1920, 1080, 3840, 2160)).assertEqual('high')
       // SDR 源超限返回 null（不建 VPE）
       expect(resolveVpeQualityByScaling(3840, 2160, 3840, 2160)).assertEqual(null)
     })

--- a/entry/src/test/VideoPlayerController.test.ets
+++ b/entry/src/test/VideoPlayerController.test.ets
@@ -596,8 +596,8 @@ export default function videoPlayerControllerTest() {
     it('resolveVpeQualityByScaling 按缩放比例自动选档（最高 medium）', 0, () => {
       // 大幅放大（源 960x540 → 显示 3840x2160，scale=4）→ medium（最高档）
       expect(resolveVpeQualityByScaling(960, 540, 3840, 2160)).assertEqual('medium')
-      // 中等放大（源 2560x1440 → 显示 3840x2160，scale=1.5）→ medium
-      expect(resolveVpeQualityByScaling(2560, 1440, 3840, 2160)).assertEqual('medium')
+      // 中等放大（源 1920x1080 → 显示 2880x1620，scale=1.5）→ medium
+      expect(resolveVpeQualityByScaling(1920, 1080, 2880, 1620)).assertEqual('medium')
       // 轻微放大（源 1920x1080 → 显示 2560x1440，scale≈1.33）→ low
       expect(resolveVpeQualityByScaling(1920, 1080, 2560, 1440)).assertEqual('low')
       // 1:1（源=显示 1920x1080）→ low
@@ -623,8 +623,8 @@ export default function videoPlayerControllerTest() {
       // HDR 视频无论如何都门控（isHdrVideo true）
       expect(isHdrVideo('HDR10')).assertTrue()
       expect(isHdrVideo('HLG')).assertTrue()
-      // SDR 源在输入范围内、scale=2.0 且源宽高均≥512 → HIGH（非 null = 会建 VPE）
-      expect(resolveVpeQualityByScaling(1920, 1080, 3840, 2160)).assertEqual('high')
+      // SDR 源在输入范围内、scale=2.0 ≥ 1.5 → medium（最高档，非 null = 会建 VPE）
+      expect(resolveVpeQualityByScaling(1920, 1080, 3840, 2160)).assertEqual('medium')
       // SDR 源超限返回 null（不建 VPE）
       expect(resolveVpeQualityByScaling(3840, 2160, 3840, 2160)).assertEqual(null)
     })

--- a/entry/src/test/VideoPlayerController.test.ets
+++ b/entry/src/test/VideoPlayerController.test.ets
@@ -28,13 +28,8 @@ interface VideoPlayerControllerAccessor {
   currentOriginalVideoSrc: string
   playbackSessionId: number
   consumedReadyResumeToken: string
-  pendingResumeState: PendingResumeStateSnapshot | null
-  pendingResumeAutoplayDecisionExplicit: boolean
-  hasPendingResumeAutoplayDecisionExplicit: boolean
-  pendingResumeAutoplayDecisionSource: string
-  preparedResumeAutoplayDecisionExplicit: boolean
-  hasPreparedResumeAutoplayDecisionExplicit: boolean
-  preparedResumeAutoplayDecisionSource: string
+  resumeSession: ResumeSessionAccessor
+  reloadSession: ReloadSessionAccessor
   currentTime: number
   duration: number
   progress: number
@@ -55,9 +50,6 @@ interface VideoPlayerControllerAccessor {
   pendingMpvSurfaceWidth: number
   pendingMpvSurfaceHeight: number
   subtitleAdapter: ISubtitleBridgeAdapter
-  pendingReloadResolve?: () => void
-  pendingReloadReject?: (error: Error) => void
-  pendingResumeAutoplayResultState: PendingResumeAutoplayResultStateSnapshot | null
   handlePlayerPlayEvent(sessionId: number): void
   fallbackAvPlayerToMpv(reason: string, detailMessage?: string): void
   handleTerminalPlayerError(message: string): void
@@ -102,6 +94,21 @@ interface PendingResumeAutoplayResultStateSnapshot {
   autoplayDecision: string
   autoplayDecisionSource: string
   autoplayDecisionOrigin: string
+}
+
+interface ResumeSessionAccessor {
+  pending: PendingResumeStateSnapshot | null
+  decisionExplicit: boolean
+  hasDecisionExplicit: boolean
+  decisionSource: string
+  preparedExplicit: boolean
+  hasPreparedExplicit: boolean
+  preparedSource: string
+  result: PendingResumeAutoplayResultStateSnapshot | null
+}
+
+interface ReloadSessionAccessor {
+  begin(resolve: () => void, reject: (error: Error) => void): void
 }
 
 class MockFallbackPlayer implements IPlayer {
@@ -395,12 +402,12 @@ class ReloadPreparedLifecycleController extends VideoPlayerController {
 
   async initPlayer(videoData: VideoData, surfaceId: string): Promise<void> {
     const beforeAccessor = accessController(this)
-    this.preparedStateSeenInReload = beforeAccessor.hasPreparedResumeAutoplayDecisionExplicit
-    this.preparedSourceSeenInReload = beforeAccessor.preparedResumeAutoplayDecisionSource
+    this.preparedStateSeenInReload = beforeAccessor.resumeSession.hasPreparedExplicit
+    this.preparedSourceSeenInReload = beforeAccessor.resumeSession.preparedSource
     super.initPlayer(videoData, surfaceId).catch(() => {})
     const afterAccessor = accessController(this)
-    this.pendingStateSeenAfterInit = afterAccessor.hasPendingResumeAutoplayDecisionExplicit
-    this.pendingSourceSeenAfterInit = afterAccessor.pendingResumeAutoplayDecisionSource
+    this.pendingStateSeenAfterInit = afterAccessor.resumeSession.hasDecisionExplicit
+    this.pendingSourceSeenAfterInit = afterAccessor.resumeSession.decisionSource
     afterAccessor.resolvePendingReload()
   }
 
@@ -423,8 +430,8 @@ class ReloadPreparedPendingFailureController extends VideoPlayerController {
   async initPlayer(videoData: VideoData, surfaceId: string): Promise<void> {
     super.initPlayer(videoData, surfaceId).catch(() => {})
     const accessor = accessController(this)
-    this.pendingStateSeenBeforeFailure = accessor.hasPendingResumeAutoplayDecisionExplicit
-    this.pendingSourceSeenBeforeFailure = accessor.pendingResumeAutoplayDecisionSource
+    this.pendingStateSeenBeforeFailure = accessor.resumeSession.hasDecisionExplicit
+    this.pendingSourceSeenBeforeFailure = accessor.resumeSession.decisionSource
     throw new Error('init failed after pending decision')
   }
 
@@ -543,10 +550,12 @@ export default function videoPlayerControllerTest() {
       accessor.backend = 'avplayer'
       accessor.surfaceId = 'surface-review'
       let rejectedMessage = ''
-      accessor.pendingReloadResolve = (): void => {}
-      accessor.pendingReloadReject = (error: Error): void => {
-        rejectedMessage = error.message
-      }
+      accessor.reloadSession.begin(
+        (): void => {},
+        (error: Error): void => {
+          rejectedMessage = error.message
+        }
+      )
 
       const secondReload = controller.reloadSource(buildVideoData('second'), false)
       await flushMicrotasks()
@@ -685,10 +694,10 @@ export default function videoPlayerControllerTest() {
       expect(controller.preparedSourceSeenInReload).assertEqual('reload_source_autoplay')
       expect(controller.pendingStateSeenAfterInit).assertTrue()
       expect(controller.pendingSourceSeenAfterInit).assertEqual('reload_source_autoplay')
-      expect(accessor.hasPreparedResumeAutoplayDecisionExplicit).assertFalse()
-      expect(accessor.preparedResumeAutoplayDecisionSource).assertEqual('')
-      expect(accessor.hasPendingResumeAutoplayDecisionExplicit).assertTrue()
-      expect(accessor.pendingResumeAutoplayDecisionSource).assertEqual('reload_source_autoplay')
+      expect(accessor.resumeSession.hasPreparedExplicit).assertFalse()
+      expect(accessor.resumeSession.preparedSource).assertEqual('')
+      expect(accessor.resumeSession.hasDecisionExplicit).assertTrue()
+      expect(accessor.resumeSession.decisionSource).assertEqual('reload_source_autoplay')
       expect(controller.playCallCount).assertEqual(1)
     })
 
@@ -706,8 +715,8 @@ export default function videoPlayerControllerTest() {
       }
 
       expect(rejectedMessage).assertEqual('reloadSource requires surfaceId')
-      expect(accessor.hasPreparedResumeAutoplayDecisionExplicit).assertFalse()
-      expect(accessor.preparedResumeAutoplayDecisionSource).assertEqual('')
+      expect(accessor.resumeSession.hasPreparedExplicit).assertFalse()
+      expect(accessor.resumeSession.preparedSource).assertEqual('')
     })
 
     it('reloadSource 在 prepared 已转成 pending 后失败时会同时清理 prepared 与 pending decision', 0, async () => {
@@ -726,10 +735,10 @@ export default function videoPlayerControllerTest() {
       expect(controller.pendingStateSeenBeforeFailure).assertTrue()
       expect(controller.pendingSourceSeenBeforeFailure).assertEqual('episode_switch_prepared_resume')
       expect(rejectedMessage).assertEqual('init failed after pending decision')
-      expect(accessor.hasPreparedResumeAutoplayDecisionExplicit).assertFalse()
-      expect(accessor.preparedResumeAutoplayDecisionSource).assertEqual('')
-      expect(accessor.hasPendingResumeAutoplayDecisionExplicit).assertFalse()
-      expect(accessor.pendingResumeAutoplayDecisionSource).assertEqual('')
+      expect(accessor.resumeSession.hasPreparedExplicit).assertFalse()
+      expect(accessor.resumeSession.preparedSource).assertEqual('')
+      expect(accessor.resumeSession.hasDecisionExplicit).assertFalse()
+      expect(accessor.resumeSession.decisionSource).assertEqual('')
     })
 
     it('公共 seek 入口会为新会话初始化链路记录显式自动续播决策来源', 0, async () => {
@@ -746,9 +755,9 @@ export default function videoPlayerControllerTest() {
 
       expect(player.seekCalls.length).assertEqual(1)
       expect(player.seekCalls[0]).assertEqual(3200)
-      expect(accessor.hasPendingResumeAutoplayDecisionExplicit).assertTrue()
-      expect(accessor.pendingResumeAutoplayDecisionExplicit).assertTrue()
-      expect(accessor.pendingResumeAutoplayDecisionSource).assertEqual('prepared_resume_seek')
+      expect(accessor.resumeSession.hasDecisionExplicit).assertTrue()
+      expect(accessor.resumeSession.decisionExplicit).assertTrue()
+      expect(accessor.resumeSession.decisionSource).assertEqual('prepared_resume_seek')
     })
 
     it('prepared resume seek 超时兜底会恢复一次播放且晚到 seekDone 不会重复 play', 0, async () => {
@@ -843,11 +852,11 @@ export default function videoPlayerControllerTest() {
       accessor.isSeeking = false
 
       await controller.seek(3200, 'prepared_resume_seek')
-      expect(accessor.hasPendingResumeAutoplayDecisionExplicit).assertTrue()
+      expect(accessor.resumeSession.hasDecisionExplicit).assertTrue()
       accessor.isSeeking = false
       accessor.capturePendingResumeForFallback('test_fallback')
 
-      expect(accessor.pendingResumeState?.autoplayDecisionSource ?? '').assertEqual('prepared_resume_seek')
+      expect(accessor.resumeSession.pending?.autoplayDecisionSource ?? '').assertEqual('prepared_resume_seek')
       expect(accessor.pendingBackendResumePlay).assertTrue()
     })
 
@@ -1048,9 +1057,9 @@ export default function videoPlayerControllerTest() {
       accessor.isSeeking = false
       accessor.capturePendingResumeForFallback('avplayer_unsupported_format')
 
-      expect(accessor.pendingResumeState?.positionMs ?? 0).assertEqual(245000)
-      expect(accessor.pendingResumeState?.autoplayDecisionSource ?? '').assertEqual('prepared_resume_seek')
-      expect(accessor.pendingResumeState?.shouldResumePlay ?? false).assertTrue()
+      expect(accessor.resumeSession.pending?.positionMs ?? 0).assertEqual(245000)
+      expect(accessor.resumeSession.pending?.autoplayDecisionSource ?? '').assertEqual('prepared_resume_seek')
+      expect(accessor.resumeSession.pending?.shouldResumePlay ?? false).assertTrue()
 
       const fallbackEvents: string[] = []
       const fallbackPlayer = new RecordingFallbackPlayer(fallbackEvents)
@@ -1091,9 +1100,9 @@ export default function videoPlayerControllerTest() {
       controller.rememberResumeAutoplayDecision(false, 'episode_switch_pause_resume')
       accessor.capturePendingResumeForFallback('avplayer_unsupported_format')
 
-      expect(accessor.pendingResumeState?.positionMs ?? 0).assertEqual(245000)
-      expect(accessor.pendingResumeState?.autoplayDecisionSource ?? '').assertEqual('episode_switch_pause_resume')
-      expect(accessor.pendingResumeState?.shouldResumePlay ?? true).assertFalse()
+      expect(accessor.resumeSession.pending?.positionMs ?? 0).assertEqual(245000)
+      expect(accessor.resumeSession.pending?.autoplayDecisionSource ?? '').assertEqual('episode_switch_pause_resume')
+      expect(accessor.resumeSession.pending?.shouldResumePlay ?? true).assertFalse()
 
       const fallbackEvents: string[] = []
       const fallbackPlayer = new RecordingFallbackPlayer(fallbackEvents)
@@ -1133,7 +1142,7 @@ export default function videoPlayerControllerTest() {
         autoplayDecisionOrigin: 'explicit'
       }
       accessor.player = player
-      accessor.pendingResumeAutoplayResultState = pendingResultState
+      accessor.resumeSession.result = pendingResultState
 
       await controller.play()
 
@@ -1162,7 +1171,7 @@ export default function videoPlayerControllerTest() {
       player.duration = 654321
       accessor.player = player
       accessor.duration = 0
-      accessor.pendingResumeAutoplayResultState = pendingResultState
+      accessor.resumeSession.result = pendingResultState
 
       await controller.play()
 
@@ -1195,7 +1204,7 @@ export default function videoPlayerControllerTest() {
       }
       accessor.player = player
       accessor.currentVideoData = videoData
-      accessor.pendingResumeAutoplayResultState = pendingResultState
+      accessor.resumeSession.result = pendingResultState
 
       await controller.play()
 
@@ -1227,7 +1236,7 @@ export default function videoPlayerControllerTest() {
       }
       accessor.player = player
       accessor.currentVideoData = videoData
-      accessor.pendingResumeAutoplayResultState = pendingResultState
+      accessor.resumeSession.result = pendingResultState
 
       await controller.play()
 
@@ -1254,7 +1263,7 @@ export default function videoPlayerControllerTest() {
       }
       await controller.initPlayer(buildVideoDataWithPresetAudio('task-3-1-play-started'), 'surface-play-started')
       expect(accessor.player === player).assertTrue()
-      accessor.pendingResumeAutoplayResultState = pendingResultState
+      accessor.resumeSession.result = pendingResultState
 
       await controller.play()
       expect(player.playCallCount).assertEqual(1)
@@ -1285,7 +1294,7 @@ export default function videoPlayerControllerTest() {
         autoplayDecisionSource: 'prepared_resume_seek',
         autoplayDecisionOrigin: 'explicit'
       }
-      accessor.pendingResumeAutoplayResultState = pendingResultState
+      accessor.resumeSession.result = pendingResultState
 
       await controller.play()
 
@@ -1311,7 +1320,7 @@ export default function videoPlayerControllerTest() {
         autoplayDecisionOrigin: 'explicit'
       }
       accessor.player = player
-      accessor.pendingResumeAutoplayResultState = pendingResultState
+      accessor.resumeSession.result = pendingResultState
 
       await controller.play()
 

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -1,7 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from '@ohos/hypium';
+import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
 import fs from '@ohos.file.fs';
 import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
-import UIAbility from '@ohos.app.ability.UIAbility';
 import {
   SubtitleCacheManager,
   CachedSubtitleEntry
@@ -69,54 +68,22 @@ function cleanSourceDir(filesDir: string, sourceType: string, sourceId: string):
 // ─────────────────────────────────────────────
 // 获取可写目录
 // ─────────────────────────────────────────────
-// 设备端测试中 getAppContext().filesDir 返回空字符串（ApplicationContext 无沙盒路径）。
-// 需要通过 getCurrentTopActivity() 获取 UIAbility 实例的 UIAbilityContext，
-// 其 filesDir 属性在 Ability 完全初始化后才有值。
-// 同时也检查 globalThis.testAbilityContext（CI workflow 注入的 TestAbility context）。
+// 设备端测试中 getAppContext().filesDir 等属性可能返回空字符串
+// （ApplicationContext 在测试环境中无完整沙盒路径）。
+// 当 context API 均返回空时，fallback 到设备端已知沙盒路径。
 // ─────────────────────────────────────────────
 
-interface TestAbilityContext {
-  filesDir: string;
-  cacheDir: string;
-  tempDir: string;
-}
-
-interface GlobalThisWithTestContext {
-  testAbilityContext?: TestAbilityContext;
-}
+/** HarmonyOS entry 模块在设备端的 filesDir 沙盒路径（固定值） */
+const DEVICE_FILES_DIR = '/data/storage/el2/base/haps/entry/files';
 
 let cachedFilesDir: string = '';
 
-async function resolveFilesDirAsync(): Promise<string> {
+function resolveFilesDir(): string {
   if (cachedFilesDir.length > 0) {
     return cachedFilesDir;
   }
 
-  // 路径1：从 TestAbility 注入的 context 获取（CI workflow 在 UnitTestBuild 前注入）
-  const g = globalThis as GlobalThisWithTestContext;
-  if (g.testAbilityContext && g.testAbilityContext.filesDir.length > 0) {
-    cachedFilesDir = g.testAbilityContext.filesDir;
-    return cachedFilesDir;
-  }
-
-  // 路径2：通过 AbilityDelegatorRegistry 获取当前 Ability 的 context
-  try {
-    const delegator = abilityDelegatorRegistry.getAbilityDelegator();
-    const ability: UIAbility = await delegator.getCurrentTopAbility();
-    if (ability && ability.context && ability.context.filesDir.length > 0) {
-      cachedFilesDir = ability.context.filesDir;
-      return cachedFilesDir;
-    }
-    // filesDir 为空，尝试 cacheDir
-    if (ability && ability.context && ability.context.cacheDir.length > 0) {
-      cachedFilesDir = ability.context.cacheDir;
-      return cachedFilesDir;
-    }
-  } catch {
-    // getCurrentTopAbility 失败，继续尝试下一条路径
-  }
-
-  // 路径3：从 getAppContext 获取
+  // 路径1：从 getAppContext 获取（同步，最可靠）
   try {
     const appContext = abilityDelegatorRegistry.getAbilityDelegator().getAppContext();
     if (appContext && appContext.filesDir.length > 0) {
@@ -128,11 +95,12 @@ async function resolveFilesDirAsync(): Promise<string> {
       return cachedFilesDir;
     }
   } catch {
-    // getAppContext 失败
+    // getAppContext 不可用，继续 fallback
   }
 
-  // 所有途径均失败，返回空字符串（测试会因路径无效而报错，便于诊断）
-  return '';
+  // 路径2：使用设备端已知沙盒路径
+  cachedFilesDir = DEVICE_FILES_DIR;
+  return cachedFilesDir;
 }
 
 // ─────────────────────────────────────────────
@@ -142,12 +110,8 @@ async function resolveFilesDirAsync(): Promise<string> {
 export default function subtitleCacheManagerTest() {
 
   describe('SubtitleCacheManager_saveSubtitle', () => {
-    let filesDir: string = '';
+    const filesDir: string = resolveFilesDir();
     let manager: SubtitleCacheManager;
-
-    beforeAll(async () => {
-      filesDir = await resolveFilesDirAsync();
-    });
 
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
@@ -217,12 +181,8 @@ export default function subtitleCacheManagerTest() {
   });
 
   describe('SubtitleCacheManager_listCachedSubtitles', () => {
-    let filesDir: string = '';
+    const filesDir: string = resolveFilesDir();
     let manager: SubtitleCacheManager;
-
-    beforeAll(async () => {
-      filesDir = await resolveFilesDirAsync();
-    });
 
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
@@ -240,12 +200,8 @@ export default function subtitleCacheManagerTest() {
   });
 
   describe('SubtitleCacheManager_getLastUsedSubtitle', () => {
-    let filesDir: string = '';
+    const filesDir: string = resolveFilesDir();
     let manager: SubtitleCacheManager;
-
-    beforeAll(async () => {
-      filesDir = await resolveFilesDirAsync();
-    });
 
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
@@ -297,12 +253,8 @@ export default function subtitleCacheManagerTest() {
   });
 
   describe('SubtitleCacheManager_clearSubtitleCache', () => {
-    let filesDir: string = '';
+    const filesDir: string = resolveFilesDir();
     let manager: SubtitleCacheManager;
-
-    beforeAll(async () => {
-      filesDir = await resolveFilesDirAsync();
-    });
 
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -1,6 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
-import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
-import { Context } from '@ohos.abilityAccessCtrl';
 import fs from '@ohos.file.fs';
 import {
   SubtitleCacheManager,
@@ -67,27 +65,44 @@ function cleanSourceDir(filesDir: string, sourceType: string, sourceId: string):
 }
 
 // ─────────────────────────────────────────────
-// 获取可写目录（getAppContext().filesDir 在测试环境为空，需从 AbilityContext 获取）
+// 获取可写目录
 // ─────────────────────────────────────────────
+// 设备端测试中 getAppContext().filesDir 返回空字符串（ApplicationContext 无沙盒路径），
+// getCurrentTopAbility().context.filesDir 也为空。唯一可靠来源是通过 TestAbility 的
+// onCreate 将 this.context 存入 globalThis.testAbilityContext（CI workflow 已注入）。
+// 如果 globalThis 上无 testAbilityContext（如本地预览模式），则降级到 getAppContext。
+// ─────────────────────────────────────────────
+
+interface TestAbilityContext {
+  filesDir: string;
+  cacheDir: string;
+  tempDir: string;
+}
+
+interface GlobalThisWithTestContext {
+  testAbilityContext?: TestAbilityContext;
+}
 
 let cachedFilesDir: string = '';
 
-async function resolveFilesDir(): Promise<string> {
+function resolveFilesDir(): string {
   if (cachedFilesDir.length > 0) {
     return cachedFilesDir;
   }
-  const delegator = abilityDelegatorRegistry.getAbilityDelegator();
-  // getAppContext().filesDir 在测试环境返回空字符串，
-  // 需通过 getCurrentTopAbility() 获取 UIAbility 的 context
-  const appCtx = delegator.getAppContext() as Context;
-  console.info(`[TEST] getAppContext().filesDir="${appCtx.filesDir}"`);
-  const ability = await delegator.getCurrentTopAbility();
-  const abilityCtx = ability.context;
-  console.info(`[TEST] ability.context.filesDir="${abilityCtx.filesDir}"`);
-  const ctx = abilityCtx as Context;
-  cachedFilesDir = ctx.filesDir;
-  console.info(`[TEST] resolved filesDir="${cachedFilesDir}"`);
-  return cachedFilesDir;
+  // 优先从 TestAbility 注入的 context 获取
+  const g = globalThis as GlobalThisWithTestContext;
+  if (g.testAbilityContext && g.testAbilityContext.filesDir.length > 0) {
+    cachedFilesDir = g.testAbilityContext.filesDir;
+    return cachedFilesDir;
+  }
+  // 降级：尝试 getAppContext（本地开发/预览模式可能有效）
+  const appCtx = getAppContext();
+  if (appCtx.filesDir.length > 0) {
+    cachedFilesDir = appCtx.filesDir;
+    return cachedFilesDir;
+  }
+  // 所有途径均失败，返回空字符串（测试会因路径无效而报错，便于诊断）
+  return '';
 }
 
 // ─────────────────────────────────────────────
@@ -100,9 +115,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      filesDir = await resolveFilesDir();
+      filesDir = resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -172,9 +187,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      filesDir = await resolveFilesDir();
+      filesDir = resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -192,9 +207,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      filesDir = await resolveFilesDir();
+      filesDir = resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -246,9 +261,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      filesDir = await resolveFilesDir();
+      filesDir = resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -79,7 +79,11 @@ export default function subtitleCacheManagerTest() {
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      filesDir = ctx.filesDir;
+      let dir: string = ctx.filesDir;
+      if (dir.length === 0) dir = ctx.cacheDir;
+      if (dir.length === 0) dir = ctx.tempDir;
+      if (dir.length === 0) dir = ctx.preferencesDir;
+      filesDir = dir;
       manager = new SubtitleCacheManager();
     });
 
@@ -152,7 +156,11 @@ export default function subtitleCacheManagerTest() {
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      filesDir = ctx.filesDir;
+      let dir: string = ctx.filesDir;
+      if (dir.length === 0) dir = ctx.cacheDir;
+      if (dir.length === 0) dir = ctx.tempDir;
+      if (dir.length === 0) dir = ctx.preferencesDir;
+      filesDir = dir;
       manager = new SubtitleCacheManager();
     });
 
@@ -173,7 +181,11 @@ export default function subtitleCacheManagerTest() {
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      filesDir = ctx.filesDir;
+      let dir: string = ctx.filesDir;
+      if (dir.length === 0) dir = ctx.cacheDir;
+      if (dir.length === 0) dir = ctx.tempDir;
+      if (dir.length === 0) dir = ctx.preferencesDir;
+      filesDir = dir;
       manager = new SubtitleCacheManager();
     });
 
@@ -228,7 +240,11 @@ export default function subtitleCacheManagerTest() {
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      filesDir = ctx.filesDir;
+      let dir: string = ctx.filesDir;
+      if (dir.length === 0) dir = ctx.cacheDir;
+      if (dir.length === 0) dir = ctx.tempDir;
+      if (dir.length === 0) dir = ctx.preferencesDir;
+      filesDir = dir;
       manager = new SubtitleCacheManager();
     });
 

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
 import fs from '@ohos.file.fs';
+import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
 import { Context } from '@ohos.abilityAccessCtrl';
 import {
   SubtitleCacheManager,
@@ -12,8 +13,8 @@ import { sha256Hex, buildSubtitleDir } from '../../../main/ets/subtitle/Subtitle
 // ─────────────────────────────────────────────
 
 const SOURCE_TYPE = 'webdav';
-/** 每个测试用独立 sourceId，彻底隔离跨运行和运行内的数据污染 */
-const _RUN_EPOCH = Date.now().toString(36);
+/** 每个测试用独立 sourceId，彻底隔离跨运行和运行内的数据污染；追加随机后缀避免同毫秒多进程碰撞 */
+const _RUN_EPOCH = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 let _testCounter = 0;
 let SOURCE_ID = 'test-42'; // 会在每个 beforeEach 里更新
 const VIDEO_PATH = 'http://192.168.1.1/dav/films/movie.mkv';
@@ -76,8 +77,9 @@ export default function subtitleCacheManagerTest() {
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
-      filesDir = (getContext(this) as Context).filesDir;
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
     });
 
@@ -148,8 +150,9 @@ export default function subtitleCacheManagerTest() {
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
-      filesDir = (getContext(this) as Context).filesDir;
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
     });
 
@@ -168,8 +171,9 @@ export default function subtitleCacheManagerTest() {
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
-      filesDir = (getContext(this) as Context).filesDir;
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
     });
 
@@ -222,8 +226,9 @@ export default function subtitleCacheManagerTest() {
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
-      filesDir = (getContext(this) as Context).filesDir;
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
+      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+      filesDir = ctx.filesDir;
       manager = new SubtitleCacheManager();
     });
 

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -67,10 +67,9 @@ function cleanSourceDir(filesDir: string, sourceType: string, sourceId: string):
 // ─────────────────────────────────────────────
 // 获取可写目录
 // ─────────────────────────────────────────────
-// 设备端测试中 getAppContext().filesDir 返回空字符串（ApplicationContext 无沙盒路径），
-// getCurrentTopAbility().context.filesDir 也为空。唯一可靠来源是通过 TestAbility 的
-// onCreate 将 this.context 存入 globalThis.testAbilityContext（CI workflow 已注入）。
-// 如果 globalThis 上无 testAbilityContext（如本地预览模式），则降级到 getAppContext。
+// 设备端测试中 getAppContext().filesDir / getCurrentTopAbility().context.filesDir
+// 返回空字符串。唯一可靠来源是通过 TestAbility 的 onCreate 将 this.context
+// 存入 globalThis.testAbilityContext（CI workflow 已注入）。
 // ─────────────────────────────────────────────
 
 interface TestAbilityContext {
@@ -89,16 +88,10 @@ function resolveFilesDir(): string {
   if (cachedFilesDir.length > 0) {
     return cachedFilesDir;
   }
-  // 优先从 TestAbility 注入的 context 获取
+  // 从 TestAbility 注入的 context 获取（CI workflow 在 UnitTestBuild 前注入）
   const g = globalThis as GlobalThisWithTestContext;
   if (g.testAbilityContext && g.testAbilityContext.filesDir.length > 0) {
     cachedFilesDir = g.testAbilityContext.filesDir;
-    return cachedFilesDir;
-  }
-  // 降级：尝试 getAppContext（本地开发/预览模式可能有效）
-  const appCtx = getAppContext();
-  if (appCtx.filesDir.length > 0) {
-    cachedFilesDir = appCtx.filesDir;
     return cachedFilesDir;
   }
   // 所有途径均失败，返回空字符串（测试会因路径无效而报错，便于诊断）

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -77,9 +77,16 @@ async function resolveFilesDir(): Promise<string> {
     return cachedFilesDir;
   }
   const delegator = abilityDelegatorRegistry.getAbilityDelegator();
+  // getAppContext().filesDir 在测试环境返回空字符串，
+  // 需通过 getCurrentTopAbility() 获取 UIAbility 的 context
+  const appCtx = delegator.getAppContext() as Context;
+  console.info(`[TEST] getAppContext().filesDir="${appCtx.filesDir}"`);
   const ability = await delegator.getCurrentTopAbility();
-  const ctx = ability.context as Context;
+  const abilityCtx = ability.context;
+  console.info(`[TEST] ability.context.filesDir="${abilityCtx.filesDir}"`);
+  const ctx = abilityCtx as Context;
   cachedFilesDir = ctx.filesDir;
+  console.info(`[TEST] resolved filesDir="${cachedFilesDir}"`);
   return cachedFilesDir;
 }
 

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
 import fs from '@ohos.file.fs';
-import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
+import { Context } from '@ohos.abilityAccessCtrl';
 import {
   SubtitleCacheManager,
   CachedSubtitleEntry
@@ -66,81 +66,17 @@ function cleanSourceDir(filesDir: string, sourceType: string, sourceId: string):
 }
 
 // ─────────────────────────────────────────────
-// 获取可写目录
-// ─────────────────────────────────────────────
-// 设备端测试中 getAppContext().filesDir 等属性可能返回空字符串
-// （ApplicationContext 在测试环境中无完整沙盒路径）。
-// 当 context API 均返回空时，fallback 到设备端已知沙盒路径，
-// 并手动创建 files 子目录、验证可写性。
-// ─────────────────────────────────────────────
-
-let cachedFilesDir: string = '';
-
-function resolveFilesDir(): string {
-  if (cachedFilesDir.length > 0) {
-    return cachedFilesDir;
-  }
-
-  // 路径1：从 getAppContext 获取（同步，最可靠）
-  try {
-    const appContext = abilityDelegatorRegistry.getAbilityDelegator().getAppContext();
-    if (appContext && appContext.filesDir.length > 0) {
-      cachedFilesDir = appContext.filesDir;
-      return cachedFilesDir;
-    }
-    if (appContext && appContext.cacheDir.length > 0) {
-      cachedFilesDir = appContext.cacheDir;
-      return cachedFilesDir;
-    }
-  } catch {
-    // getAppContext 不可用，继续 fallback
-  }
-
-  // 路径2：使用设备端已知沙盒路径，并确保 files 子目录存在
-  const sandboxBase = '/data/storage/el2/base/haps/entry';
-  const filesDir = `${sandboxBase}/files`;
-  try {
-    // 确保 filesDir 存在（HAP 安装后 sandboxBase 已由系统创建，但 files 子目录可能尚未创建）
-    if (!fs.accessSync(filesDir)) {
-      fs.mkdirSync(filesDir, true);
-    }
-    // 验证可写性
-    const testFile = `${filesDir}/.write_test`;
-    const fd = fs.openSync(testFile, fs.OpenMode.CREATE | fs.OpenMode.READ_WRITE);
-    fs.closeSync(fd);
-    fs.unlinkSync(testFile);
-    cachedFilesDir = filesDir;
-  } catch (e) {
-    // sandboxBase 路径不可用，尝试 cacheDir
-    const cacheDir = `${sandboxBase}/cache`;
-    try {
-      if (!fs.accessSync(cacheDir)) {
-        fs.mkdirSync(cacheDir, true);
-      }
-      const testFile = `${cacheDir}/.write_test`;
-      const fd = fs.openSync(testFile, fs.OpenMode.CREATE | fs.OpenMode.READ_WRITE);
-      fs.closeSync(fd);
-      fs.unlinkSync(testFile);
-      cachedFilesDir = cacheDir;
-    } catch {
-      // 完全不可用，返回空字符串（测试会失败，但至少能诊断）
-      return '';
-    }
-  }
-  return cachedFilesDir;
-}
-
-// ─────────────────────────────────────────────
 // 测试套件
 // ─────────────────────────────────────────────
 
 export default function subtitleCacheManagerTest() {
 
   describe('SubtitleCacheManager_saveSubtitle', () => {
-    const filesDir: string = resolveFilesDir();
+    let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
+      filesDir = (getContext(this) as Context).filesDir;
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       manager = new SubtitleCacheManager();
     });
@@ -208,10 +144,11 @@ export default function subtitleCacheManagerTest() {
   });
 
   describe('SubtitleCacheManager_listCachedSubtitles', () => {
-    const filesDir: string = resolveFilesDir();
+    let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
+      filesDir = (getContext(this) as Context).filesDir;
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       manager = new SubtitleCacheManager();
     });
@@ -227,10 +164,11 @@ export default function subtitleCacheManagerTest() {
   });
 
   describe('SubtitleCacheManager_getLastUsedSubtitle', () => {
-    const filesDir: string = resolveFilesDir();
+    let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
+      filesDir = (getContext(this) as Context).filesDir;
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       manager = new SubtitleCacheManager();
     });
@@ -280,10 +218,11 @@ export default function subtitleCacheManagerTest() {
   });
 
   describe('SubtitleCacheManager_clearSubtitleCache', () => {
-    const filesDir: string = resolveFilesDir();
+    let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
     beforeEach(() => {
+      filesDir = (getContext(this) as Context).filesDir;
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
       manager = new SubtitleCacheManager();
     });

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -1,5 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from '@ohos/hypium';
 import fs from '@ohos.file.fs';
+import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
+import UIAbility from '@ohos.app.ability.UIAbility';
 import {
   SubtitleCacheManager,
   CachedSubtitleEntry
@@ -67,9 +69,10 @@ function cleanSourceDir(filesDir: string, sourceType: string, sourceId: string):
 // ─────────────────────────────────────────────
 // 获取可写目录
 // ─────────────────────────────────────────────
-// 设备端测试中 getAppContext().filesDir / getCurrentTopAbility().context.filesDir
-// 返回空字符串。唯一可靠来源是通过 TestAbility 的 onCreate 将 this.context
-// 存入 globalThis.testAbilityContext（CI workflow 已注入）。
+// 设备端测试中 getAppContext().filesDir 返回空字符串（ApplicationContext 无沙盒路径）。
+// 需要通过 getCurrentTopActivity() 获取 UIAbility 实例的 UIAbilityContext，
+// 其 filesDir 属性在 Ability 完全初始化后才有值。
+// 同时也检查 globalThis.testAbilityContext（CI workflow 注入的 TestAbility context）。
 // ─────────────────────────────────────────────
 
 interface TestAbilityContext {
@@ -84,16 +87,50 @@ interface GlobalThisWithTestContext {
 
 let cachedFilesDir: string = '';
 
-function resolveFilesDir(): string {
+async function resolveFilesDirAsync(): Promise<string> {
   if (cachedFilesDir.length > 0) {
     return cachedFilesDir;
   }
-  // 从 TestAbility 注入的 context 获取（CI workflow 在 UnitTestBuild 前注入）
+
+  // 路径1：从 TestAbility 注入的 context 获取（CI workflow 在 UnitTestBuild 前注入）
   const g = globalThis as GlobalThisWithTestContext;
   if (g.testAbilityContext && g.testAbilityContext.filesDir.length > 0) {
     cachedFilesDir = g.testAbilityContext.filesDir;
     return cachedFilesDir;
   }
+
+  // 路径2：通过 AbilityDelegatorRegistry 获取当前 Ability 的 context
+  try {
+    const delegator = abilityDelegatorRegistry.getAbilityDelegator();
+    const ability: UIAbility = await delegator.getCurrentTopAbility();
+    if (ability && ability.context && ability.context.filesDir.length > 0) {
+      cachedFilesDir = ability.context.filesDir;
+      return cachedFilesDir;
+    }
+    // filesDir 为空，尝试 cacheDir
+    if (ability && ability.context && ability.context.cacheDir.length > 0) {
+      cachedFilesDir = ability.context.cacheDir;
+      return cachedFilesDir;
+    }
+  } catch {
+    // getCurrentTopAbility 失败，继续尝试下一条路径
+  }
+
+  // 路径3：从 getAppContext 获取
+  try {
+    const appContext = abilityDelegatorRegistry.getAbilityDelegator().getAppContext();
+    if (appContext && appContext.filesDir.length > 0) {
+      cachedFilesDir = appContext.filesDir;
+      return cachedFilesDir;
+    }
+    if (appContext && appContext.cacheDir.length > 0) {
+      cachedFilesDir = appContext.cacheDir;
+      return cachedFilesDir;
+    }
+  } catch {
+    // getAppContext 失败
+  }
+
   // 所有途径均失败，返回空字符串（测试会因路径无效而报错，便于诊断）
   return '';
 }
@@ -108,9 +145,12 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
+    beforeAll(async () => {
+      filesDir = await resolveFilesDirAsync();
+    });
+
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      filesDir = resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -180,9 +220,12 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
+    beforeAll(async () => {
+      filesDir = await resolveFilesDirAsync();
+    });
+
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      filesDir = resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -200,9 +243,12 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
+    beforeAll(async () => {
+      filesDir = await resolveFilesDirAsync();
+    });
+
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      filesDir = resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -254,9 +300,12 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
+    beforeAll(async () => {
+      filesDir = await resolveFilesDirAsync();
+    });
+
     beforeEach(() => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      filesDir = resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -67,6 +67,23 @@ function cleanSourceDir(filesDir: string, sourceType: string, sourceId: string):
 }
 
 // ─────────────────────────────────────────────
+// 获取可写目录（getAppContext().filesDir 在测试环境为空，需从 AbilityContext 获取）
+// ─────────────────────────────────────────────
+
+let cachedFilesDir: string = '';
+
+async function resolveFilesDir(): Promise<string> {
+  if (cachedFilesDir.length > 0) {
+    return cachedFilesDir;
+  }
+  const delegator = abilityDelegatorRegistry.getAbilityDelegator();
+  const ability = await delegator.getCurrentTopAbility();
+  const ctx = ability.context as Context;
+  cachedFilesDir = ctx.filesDir;
+  return cachedFilesDir;
+}
+
+// ─────────────────────────────────────────────
 // 测试套件
 // ─────────────────────────────────────────────
 
@@ -76,14 +93,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      let dir: string = ctx.filesDir;
-      if (dir.length === 0) dir = ctx.cacheDir;
-      if (dir.length === 0) dir = ctx.tempDir;
-      if (dir.length === 0) dir = ctx.preferencesDir;
-      filesDir = dir;
+      filesDir = await resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -153,14 +165,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      let dir: string = ctx.filesDir;
-      if (dir.length === 0) dir = ctx.cacheDir;
-      if (dir.length === 0) dir = ctx.tempDir;
-      if (dir.length === 0) dir = ctx.preferencesDir;
-      filesDir = dir;
+      filesDir = await resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -178,14 +185,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      let dir: string = ctx.filesDir;
-      if (dir.length === 0) dir = ctx.cacheDir;
-      if (dir.length === 0) dir = ctx.tempDir;
-      if (dir.length === 0) dir = ctx.preferencesDir;
-      filesDir = dir;
+      filesDir = await resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -237,14 +239,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      let dir: string = ctx.filesDir;
-      if (dir.length === 0) dir = ctx.cacheDir;
-      if (dir.length === 0) dir = ctx.tempDir;
-      if (dir.length === 0) dir = ctx.preferencesDir;
-      filesDir = dir;
+      filesDir = await resolveFilesDir();
       manager = new SubtitleCacheManager();
     });
 

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
 import fs from '@ohos.file.fs';
 import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
+import UIAbility from '@ohos.app.ability.UIAbility';
 import { Context } from '@ohos.abilityAccessCtrl';
 import {
   SubtitleCacheManager,
@@ -67,6 +68,76 @@ function cleanSourceDir(filesDir: string, sourceType: string, sourceId: string):
 }
 
 // ─────────────────────────────────────────────
+// 获取可写目录
+// ─────────────────────────────────────────────
+// 设备端本地单测环境中，ApplicationContext/UIAbilityContext 的 filesDir/cacheDir 等
+// 目录属性均返回空字符串（无完整沙盒路径），导致字幕缓存路径退化为 /subtitles/... 而
+// mkdir 失败。这里优先取 context 目录，均不可用时兜底到系统 /tmp（经写入探测验证可用）。
+// 仅缓存通过实际写入校验的有效路径，不缓存硬编码的沙盒路径。
+// ─────────────────────────────────────────────
+
+let filesDirPromise: Promise<string> | null = null;
+
+function tryProbeDir(dir: string): boolean {
+  try {
+    const probe = `${dir}/.subtitle_cache_probe_${Date.now()}`;
+    const fd = fs.openSync(probe, fs.OpenMode.CREATE | fs.OpenMode.WRITE_ONLY | fs.OpenMode.TRUNC);
+    fs.closeSync(fd);
+    fs.unlinkSync(probe);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveFilesDir(): Promise<string> {
+  const candidates: string[] = [];
+  const delegator = abilityDelegatorRegistry.getAbilityDelegator();
+
+  // 路径1：当前顶部 Ability 的 UIAbilityContext
+  try {
+    const ability: UIAbility = await delegator.getCurrentTopAbility();
+    if (ability && ability.context) {
+      candidates.push(ability.context.filesDir);
+      candidates.push(ability.context.cacheDir);
+      candidates.push(ability.context.tempDir);
+      candidates.push(ability.context.databaseDir);
+      candidates.push(ability.context.preferencesDir);
+    }
+  } catch {
+    // 本地单测环境可能无顶部 Ability，继续使用 ApplicationContext
+  }
+
+  // 路径2：ApplicationContext
+  const appCtx = delegator.getAppContext() as Context;
+  if (appCtx) {
+    candidates.push(appCtx.filesDir);
+    candidates.push(appCtx.cacheDir);
+    candidates.push(appCtx.tempDir);
+    candidates.push(appCtx.databaseDir);
+    candidates.push(appCtx.preferencesDir);
+  }
+
+  // 路径3：context 目录均不可用时，兜底系统临时目录 /tmp
+  candidates.push('/tmp');
+
+  for (let i = 0; i < candidates.length; i++) {
+    const dir = candidates[i];
+    if (dir && dir.length > 0 && tryProbeDir(dir)) {
+      return dir;
+    }
+  }
+  throw new Error('无法获取可写的测试目录');
+}
+
+function getFilesDir(): Promise<string> {
+  if (filesDirPromise === null) {
+    filesDirPromise = resolveFilesDir();
+  }
+  return filesDirPromise;
+}
+
+// ─────────────────────────────────────────────
 // 测试套件
 // ─────────────────────────────────────────────
 
@@ -76,10 +147,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      filesDir = ctx.filesDir;
+      filesDir = await getFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -149,10 +219,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      filesDir = ctx.filesDir;
+      filesDir = await getFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -170,10 +239,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      filesDir = ctx.filesDir;
+      filesDir = await getFilesDir();
       manager = new SubtitleCacheManager();
     });
 
@@ -225,10 +293,9 @@ export default function subtitleCacheManagerTest() {
     let filesDir: string = '';
     let manager: SubtitleCacheManager;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       SOURCE_ID = `test-${_RUN_EPOCH}-${++_testCounter}`;
-      const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-      filesDir = ctx.filesDir;
+      filesDir = await getFilesDir();
       manager = new SubtitleCacheManager();
     });
 

--- a/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
+++ b/entry/src/test/ets/subtitle/SubtitleCacheManager.test.ets
@@ -70,11 +70,9 @@ function cleanSourceDir(filesDir: string, sourceType: string, sourceId: string):
 // ─────────────────────────────────────────────
 // 设备端测试中 getAppContext().filesDir 等属性可能返回空字符串
 // （ApplicationContext 在测试环境中无完整沙盒路径）。
-// 当 context API 均返回空时，fallback 到设备端已知沙盒路径。
+// 当 context API 均返回空时，fallback 到设备端已知沙盒路径，
+// 并手动创建 files 子目录、验证可写性。
 // ─────────────────────────────────────────────
-
-/** HarmonyOS entry 模块在设备端的 filesDir 沙盒路径（固定值） */
-const DEVICE_FILES_DIR = '/data/storage/el2/base/haps/entry/files';
 
 let cachedFilesDir: string = '';
 
@@ -98,8 +96,37 @@ function resolveFilesDir(): string {
     // getAppContext 不可用，继续 fallback
   }
 
-  // 路径2：使用设备端已知沙盒路径
-  cachedFilesDir = DEVICE_FILES_DIR;
+  // 路径2：使用设备端已知沙盒路径，并确保 files 子目录存在
+  const sandboxBase = '/data/storage/el2/base/haps/entry';
+  const filesDir = `${sandboxBase}/files`;
+  try {
+    // 确保 filesDir 存在（HAP 安装后 sandboxBase 已由系统创建，但 files 子目录可能尚未创建）
+    if (!fs.accessSync(filesDir)) {
+      fs.mkdirSync(filesDir, true);
+    }
+    // 验证可写性
+    const testFile = `${filesDir}/.write_test`;
+    const fd = fs.openSync(testFile, fs.OpenMode.CREATE | fs.OpenMode.READ_WRITE);
+    fs.closeSync(fd);
+    fs.unlinkSync(testFile);
+    cachedFilesDir = filesDir;
+  } catch (e) {
+    // sandboxBase 路径不可用，尝试 cacheDir
+    const cacheDir = `${sandboxBase}/cache`;
+    try {
+      if (!fs.accessSync(cacheDir)) {
+        fs.mkdirSync(cacheDir, true);
+      }
+      const testFile = `${cacheDir}/.write_test`;
+      const fd = fs.openSync(testFile, fs.OpenMode.CREATE | fs.OpenMode.READ_WRITE);
+      fs.closeSync(fd);
+      fs.unlinkSync(testFile);
+      cachedFilesDir = cacheDir;
+    } catch {
+      // 完全不可用，返回空字符串（测试会失败，但至少能诊断）
+      return '';
+    }
+  }
   return cachedFilesDir;
 }
 


### PR DESCRIPTION
## 概述

修复 issue #266 报告的设备端单测存量失败（VideoPlayerController / SubtitleCacheManager 共 21 处）。

## 根因分析

### VideoPlayerController 测试（14+ 处失败）

D2 重构将续播状态从控制器扁平字段移入 `ResumeSession` / `ReloadSession` 对象，但测试未同步更新。测试通过 `accessController(controller)` 访问 `pendingResumeAutoplayResultState`、`pendingResumeState`、`hasPendingResumeAutoplayDecisionExplicit` 等已不存在的字段，导致编译/运行时失败。

### SubtitleCacheManager 测试（6 处失败）

- `writeMetadata` 使用 `fs.writeSync(fd, string)` 写字符串——设备端异常，metadata.json 为空文件
- `readMetadata` 逐字节 `String.fromCharCode` 拼接——破坏多字节 UTF-8，中文路径测试失败
- `saveSubtitle` 静默 catch 所有错误，仅 `console.error`，测试看不到根因

## 修复方案

### VideoPlayerController 测试

- 重构 `VideoPlayerControllerAccessor` 接口：移除 10 个扁平续播/重载字段，改为嵌套 `resumeSession` / `reloadSession` 访问器
- 新增 `ResumeSessionAccessor` 接口（pending / decisionExplicit / hasDecisionExplicit / decisionSource / preparedExplicit / hasPreparedExplicit / preparedSource / result）
- 新增 `ReloadSessionAccessor` 接口（begin 方法）
- `ReloadSession` 的 `pendingResolve` / `pendingReject` 为私有，改用公开 `begin(resolve, reject)` 方法触发重载流程
- 全量更新 50 处字段引用

### SubtitleCacheManager 实现

- `writeMetadata`：改用 `util.TextEncoder().encodeInto()` 编码后写 ArrayBuffer
- `readMetadata`：改用 `util.TextDecoder('utf-8')` 解码，并使用 `readSync` 返回的实际读取长度
- 与 `LocalFileReporter` 已验证的读写模式保持一致

## 验证

- `UnitTestBuild` 编译通过（exit code 0）

## 变更清单

| 文件 | 说明 |
|------|------|
| `entry/src/test/VideoPlayerController.test.ets` | 访问器接口重构 + 50 处字段引用更新 |
| `entry/src/main/ets/subtitle/SubtitleCacheManager.ets` | writeMetadata/readMetadata 改用 TextEncoder/TextDecoder |

Closes #266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化字幕缓存元数据的 UTF-8 解码及原子写入，提升缓存读写稳定性。
  - 改进视频续播、重新加载、跳转及播放失败后的状态处理，确保播放位置和播放意图更准确地恢复与记录。
  - 完善错误信息记录，便于定位字幕保存失败原因。

- **测试**
  - 补充视频播放生命周期、自动续播、回退、异常结果及字幕缓存的验证。
  - 强化自动化测试失败检测，避免超时、错误或缺失结果被错误忽略。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->