### PR TITLE
优化: getHome 最近添加改为 Promise.all 并发请求

### DIFF
--- a/entry/src/main/ets/lib/JellyfinClient.ets
+++ b/entry/src/main/ets/lib/JellyfinClient.ets
@@ -1,4 +1,5 @@
 import { JsonHttpClient } from './JsonHttpClient';
+import { BusinessError } from '@kit.BasicServicesKit';
 
 /**
  * 顶层媒体库 / 视图描述（供媒体库切换后展示）
@@ -519,7 +520,7 @@ export class JellyfinClient {
         }
       }
     } catch (e) {
-      console.warn(`[JellyfinClient] 媒体库 ${libraryName} 最近添加获取失败`, (e as Error).message);
+      console.warn(`[JellyfinClient] 媒体库 ${libraryName} 最近添加获取失败`, (e as BusinessError).message);
     }
     return null;
   }

--- a/entry/src/main/ets/lib/JellyfinClient.ets
+++ b/entry/src/main/ets/lib/JellyfinClient.ets
@@ -482,28 +482,46 @@ export class JellyfinClient {
       console.warn('[JellyfinClient] 接下来获取失败', (e as Error).message);
     }
 
-    // 最近添加（按媒体库）
-    const latest: VideoServerLatestSection[] = [];
+    // 最近添加（按媒体库，并发请求）
     const libraries = await this.getLibraries();
-    for (const lib of libraries) {
-      try {
-        const latestResp = await JsonHttpClient.get(
-          `${baseUrl}/Users/${userId}/Items/Latest?Limit=16&Fields=PrimaryImageAspectRatio%2CPath` +
-            `&ImageTypeLimit=1&EnableImageTypes=Primary%2CBackdrop%2CThumb&ParentId=${encodeURIComponent(lib.id)}`,
-          headers
-        );
-        if (latestResp.statusCode >= 200 && latestResp.statusCode < 300) {
-          const items = this.parseItems(latestResp.body);
-          if (items.length > 0) {
-            latest.push({ libraryName: lib.name, items });
-          }
-        }
-      } catch (e) {
-        console.warn(`[JellyfinClient] 媒体库 ${lib.name} 最近添加获取失败`, (e as Error).message);
+    const latestTasks: Promise<VideoServerLatestSection | null>[] = libraries.map((lib: VideoServerLibrary) =>
+      this.fetchLatestForLibrary(baseUrl, userId, headers, lib.id, lib.name)
+    );
+    const latestResults = await Promise.all(latestTasks);
+    const latest: VideoServerLatestSection[] = [];
+    for (const result of latestResults) {
+      if (result !== null) {
+        latest.push(result);
       }
     }
 
     return { continueWatching, nextUp, latest };
+  }
+
+  /**
+   * 获取单个媒体库的「最近添加」数据（供 Promise.all 并发调用）。
+   */
+  private async fetchLatestForLibrary(
+    baseUrl: string, userId: string, headers: Record<string, string>,
+    libraryId: string, libraryName: string
+  ): Promise<VideoServerLatestSection | null> {
+    try {
+      const latestResp = await JsonHttpClient.get(
+        `${baseUrl}/Users/${userId}/Items/Latest?Limit=16&Fields=PrimaryImageAspectRatio%2CPath` +
+          `&ImageTypeLimit=1&EnableImageTypes=Primary%2CBackdrop%2CThumb&ParentId=${encodeURIComponent(libraryId)}`,
+        headers
+      );
+      if (latestResp.statusCode >= 200 && latestResp.statusCode < 300) {
+        const items = this.parseItems(latestResp.body);
+        if (items.length > 0) {
+          const section: VideoServerLatestSection = { libraryName, items };
+          return section;
+        }
+      }
+    } catch (e) {
+      console.warn(`[JellyfinClient] 媒体库 ${libraryName} 最近添加获取失败`, (e as Error).message);
+    }
+    return null;
   }
 
   /**

--- a/entry/src/main/ets/lib/PlexClient.ets
+++ b/entry/src/main/ets/lib/PlexClient.ets
@@ -293,7 +293,7 @@ export class PlexClient {
         }
       }
     } catch (e) {
-      console.warn(`[PlexClient] 媒体库 ${libraryName} 最近添加获取失败`, (e as Error).message);
+      console.warn(`[PlexClient] 媒体库 ${libraryName} 最近添加获取失败`, (e as BusinessError).message);
     }
     return null;
   }

--- a/entry/src/main/ets/lib/PlexClient.ets
+++ b/entry/src/main/ets/lib/PlexClient.ets
@@ -257,27 +257,45 @@ export class PlexClient {
       console.warn('[PlexClient] onDeck 获取失败', (e as Error).message);
     }
 
-    // 最近添加（按媒体库）
-    const latest: VideoServerLatestSection[] = [];
+    // 最近添加（按媒体库，并发请求）
     const libraries = await this.getLibraries();
-    for (const lib of libraries) {
-      try {
-        const resp = await JsonHttpClient.get(
-          `${baseUrl}/library/sections/${encodeURIComponent(lib.id)}/recentlyAdded`,
-          headers
-        );
-        if (resp.statusCode >= 200 && resp.statusCode < 300) {
-          const items = this.parseMetadata(resp.body);
-          if (items.length > 0) {
-            latest.push({ libraryName: lib.name, items });
-          }
-        }
-      } catch (e) {
-        console.warn(`[PlexClient] 媒体库 ${lib.name} 最近添加获取失败`, (e as Error).message);
+    const latestTasks: Promise<VideoServerLatestSection | null>[] = libraries.map((lib: VideoServerLibrary) =>
+      this.fetchLatestForLibrary(baseUrl, headers, lib.id, lib.name)
+    );
+    const latestResults = await Promise.all(latestTasks);
+    const latest: VideoServerLatestSection[] = [];
+    for (const result of latestResults) {
+      if (result !== null) {
+        latest.push(result);
       }
     }
 
     return { continueWatching, nextUp: [], latest };
+  }
+
+  /**
+   * 获取单个媒体库的「最近添加」数据（供 Promise.all 并发调用）。
+   */
+  private async fetchLatestForLibrary(
+    baseUrl: string, headers: Record<string, string>,
+    libraryId: string, libraryName: string
+  ): Promise<VideoServerLatestSection | null> {
+    try {
+      const resp = await JsonHttpClient.get(
+        `${baseUrl}/library/sections/${encodeURIComponent(libraryId)}/recentlyAdded`,
+        headers
+      );
+      if (resp.statusCode >= 200 && resp.statusCode < 300) {
+        const items = this.parseMetadata(resp.body);
+        if (items.length > 0) {
+          const section: VideoServerLatestSection = { libraryName, items };
+          return section;
+        }
+      }
+    } catch (e) {
+      console.warn(`[PlexClient] 媒体库 ${libraryName} 最近添加获取失败`, (e as Error).message);
+    }
+    return null;
   }
 
   private parseMetadata(body: string): VideoServerMediaItem[] {


### PR DESCRIPTION
## 概述

将 `JellyfinClient.getHome()` 和 `PlexClient.getHome()` 中「最近添加」的串行请求改为 `Promise.all` 并发，显著缩短首页首屏加载耗时。

## 改动内容

### JellyfinClient.ets
- `getHome()` 最近添加循环从 `for...of await` 改为 `libraries.map() + Promise.all` 并发
- 提取 `fetchLatestForLibrary()` 私有方法，保持各库独立 `try/catch` 错误隔离
- 返回结果按 `libraries` 顺序一致，空结果（`null`）过滤后剔除
- `VideoServerLatestSection` 类型变量显式声明，符合 ArkTS `arkts-no-untyped-obj-literals` 规范

### PlexClient.ets
- 同上改动逻辑，提取 `fetchLatestForLibrary()` 私有方法

## 行为一致性

| 行为 | 改前 | 改后 |
|------|------|------|
| 各库独立错误隔离 | ✅ try/catch 逐库 | ✅ fetchLatestForLibrary 内 try/catch |
| 结果顺序 | 按 libraries 顺序 | 按 libraries 顺序（Promise.all 保序） |
| 空库跳过 | ✅ items.length === 0 不 push | ✅ 返回 null 后过滤 |
| 首屏耗时 | N 个媒体库延迟之和 | 最慢单个媒体库延迟 |

Closes #270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化首页最近添加内容的加载方式，多个媒体库现在可并行请求，缩短整体加载等待时间。
  * 单个媒体库请求失败时不会影响其他媒体库内容的展示。
  * 改进空结果处理，避免生成无内容的分区。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->