### PR TITLE
修复: 影视服务器播放上报按 playSessionId 串行化

### DIFF
--- a/entry/src/main/ets/lib/ServerProgressReporter.ets
+++ b/entry/src/main/ets/lib/ServerProgressReporter.ets
@@ -2,30 +2,144 @@ import { JellyfinClient } from './JellyfinClient';
 import { PlexClient } from './PlexClient';
 
 /**
- * 上报影视服务器播放开始（会话建立）。
- * Jellyfin/Emby 需要 playSessionId 关联整个会话；Plex 通过 ratingKey 关联。
+ * 单个 playSessionId 的串行队列状态。
  */
-export async function reportServerPlaybackStarted(
-  serverType: string,
-  serverConfigJson: string,
-  itemId: string,
-  playSessionId: string,
-  positionMs: number,
-  durationMs: number
-): Promise<void> {
-  if (serverType === 'plex') {
-    await PlexClient.fromConfigJson(serverConfigJson).reportPlaying(itemId, positionMs, durationMs);
-  } else {
-    const client = JellyfinClient.fromConfigJson(serverConfigJson);
-    const mediaSourceId = await client.getPlaybackInfo(itemId);
-    await client.reportPlaying(playSessionId, itemId, mediaSourceId, positionMs);
-  }
+interface SessionQueueState {
+  /** 当前正在执行的 Promise 链尾部，新任务追加到尾部实现串行化 */
+  tail: Promise<void>;
+  /** 是否已发出 stopped，stopped 后不再接受新的 progress */
+  stopped: boolean;
 }
 
 /**
- * 周期性上报影视服务器播放进度（不结束会话）。
+ * 按 playSessionId 串行化服务器上报请求的队列管理器。
+ *
+ * 保证：
+ * - 同一 playSessionId 的 started/progress/stopped 严格按提交顺序串行执行；
+ * - started 内部鉴权 + getPlaybackInfo 完成前，后续 progress 排队等待；
+ * - stopped 等待此前所有请求完成后执行，并阻止后续 progress 入队；
+ * - stopped 完成后清理该会话状态。
  */
-export async function reportServerPlaybackProgress(
+class ServerReportQueue {
+  private sessions: Map<string, SessionQueueState> = new Map();
+
+  /**
+   * 入队一个 started 任务。
+   */
+  enqueueStarted(
+    serverType: string, serverConfigJson: string, itemId: string,
+    playSessionId: string, positionMs: number, durationMs: number
+  ): Promise<void> {
+    if (playSessionId.length === 0) {
+      return this.executeStarted(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+    }
+    const state = this.ensureState(playSessionId);
+    const next = state.tail.then(() => {
+      return this.executeStarted(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+    }).catch(() => {});
+    state.tail = next;
+    return next;
+  }
+
+  /**
+   * 入队一个 progress 任务。
+   */
+  enqueueProgress(
+    serverType: string, serverConfigJson: string, itemId: string,
+    playSessionId: string, positionMs: number, durationMs: number
+  ): Promise<void> {
+    if (playSessionId.length === 0) {
+      return this.executeProgress(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+    }
+    const state = this.ensureState(playSessionId);
+    if (state.stopped) {
+      console.info('[ServerReportQueue] 会话已 stopped，跳过 progress');
+      return Promise.resolve();
+    }
+    const next = state.tail.then(() => {
+      return this.executeProgress(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+    }).catch(() => {});
+    state.tail = next;
+    return next;
+  }
+
+  /**
+   * 入队一个 stopped 任务。
+   */
+  enqueueStopped(
+    serverType: string, serverConfigJson: string, itemId: string,
+    playSessionId: string, positionMs: number, durationMs: number
+  ): Promise<void> {
+    if (playSessionId.length === 0) {
+      return this.executeStopped(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+    }
+    const state = this.ensureState(playSessionId);
+    state.stopped = true;
+    const next = state.tail.then(() => {
+      return this.executeStopped(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+    }).then(() => {
+      this.sessions.delete(playSessionId);
+    }).catch(() => {
+      this.sessions.delete(playSessionId);
+    });
+    state.tail = next;
+    return next;
+  }
+
+  private ensureState(playSessionId: string): SessionQueueState {
+    let state = this.sessions.get(playSessionId);
+    if (!state) {
+      const initial: SessionQueueState = { tail: Promise.resolve(), stopped: false };
+      state = initial;
+      this.sessions.set(playSessionId, state);
+    }
+    return state;
+  }
+
+  private async executeStarted(
+    serverType: string, serverConfigJson: string, itemId: string,
+    playSessionId: string, positionMs: number, durationMs: number
+  ): Promise<void> {
+    if (serverType === 'plex') {
+      await PlexClient.fromConfigJson(serverConfigJson).reportPlaying(itemId, positionMs, durationMs);
+    } else {
+      const client = JellyfinClient.fromConfigJson(serverConfigJson);
+      const mediaSourceId = await client.getPlaybackInfo(itemId);
+      await client.reportPlaying(playSessionId, itemId, mediaSourceId, positionMs);
+    }
+  }
+
+  private async executeProgress(
+    serverType: string, serverConfigJson: string, itemId: string,
+    playSessionId: string, positionMs: number, durationMs: number
+  ): Promise<void> {
+    if (serverType === 'plex') {
+      await PlexClient.fromConfigJson(serverConfigJson).reportProgress(itemId, positionMs, durationMs);
+    } else {
+      await JellyfinClient.fromConfigJson(serverConfigJson).reportProgress(playSessionId, itemId, positionMs, false);
+    }
+  }
+
+  private async executeStopped(
+    serverType: string, serverConfigJson: string, itemId: string,
+    playSessionId: string, positionMs: number, durationMs: number
+  ): Promise<void> {
+    if (serverType === 'plex') {
+      await PlexClient.fromConfigJson(serverConfigJson).reportStopped(itemId, positionMs, durationMs);
+    } else {
+      await JellyfinClient.fromConfigJson(serverConfigJson).reportStopped(playSessionId, itemId, positionMs);
+    }
+  }
+}
+
+/** 全局单例队列 */
+const globalQueue = new ServerReportQueue();
+
+/**
+ * 上报影视服务器播放开始（会话建立）。按 playSessionId 串行化执行。
+ * Jellyfin/Emby 需要 playSessionId 关联整个会话；Plex 通过 ratingKey 关联。
+ */
+export function reportServerPlaybackStarted(
   serverType: string,
   serverConfigJson: string,
   itemId: string,
@@ -33,17 +147,28 @@ export async function reportServerPlaybackProgress(
   positionMs: number,
   durationMs: number
 ): Promise<void> {
-  if (serverType === 'plex') {
-    await PlexClient.fromConfigJson(serverConfigJson).reportProgress(itemId, positionMs, durationMs);
-  } else {
-    await JellyfinClient.fromConfigJson(serverConfigJson).reportProgress(playSessionId, itemId, positionMs, false);
-  }
+  return globalQueue.enqueueStarted(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+}
+
+/**
+ * 周期性上报影视服务器播放进度（不结束会话）。按 playSessionId 串行化执行。
+ */
+export function reportServerPlaybackProgress(
+  serverType: string,
+  serverConfigJson: string,
+  itemId: string,
+  playSessionId: string,
+  positionMs: number,
+  durationMs: number
+): Promise<void> {
+  return globalQueue.enqueueProgress(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
 }
 
 /**
  * 上报影视服务器播放停止（退出播放器时调用），供服务器「继续观看」续播。
+ * 按 playSessionId 串行化执行；stopped 后不再接受该会话的 progress。
  */
-export async function reportServerPlaybackStopped(
+export function reportServerPlaybackStopped(
   serverType: string,
   serverConfigJson: string,
   itemId: string,
@@ -51,9 +176,5 @@ export async function reportServerPlaybackStopped(
   positionMs: number,
   durationMs: number
 ): Promise<void> {
-  if (serverType === 'plex') {
-    await PlexClient.fromConfigJson(serverConfigJson).reportStopped(itemId, positionMs, durationMs);
-  } else {
-    await JellyfinClient.fromConfigJson(serverConfigJson).reportStopped(playSessionId, itemId, positionMs);
-  }
+  return globalQueue.enqueueStopped(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
 }


### PR DESCRIPTION
## 问题

来自 #271：`reportServerPlaybackStarted` 是 fire-and-forget 且内部要鉴权 + `getPlaybackInfo`，周期/停止上报可能在 started 完成前发出，导致服务器端会话乱序。

## 方案

在 `ServerProgressReporter` 中引入 `ServerReportQueue` 类，按 `playSessionId` 管理 Promise 链串行队列：

- **started 完成前 progress 排队等待**：通过 `state.tail.then(...)` 将新任务追加到前一个任务的 Promise 链尾部
- **stopped 等待此前所有请求完成后执行**：同样追加到链尾，确保顺序
- **stopped 后阻止后续 progress**：设置 `state.stopped = true`，新 progress 直接跳过
- **stopped 完成后清理会话状态**：`this.sessions.delete(playSessionId)`

## 关键设计

- 使用 Promise 链式追加实现串行化，无需显式锁或队列数据结构
- 无 `playSessionId` 时保持原有直接执行行为（兼容无 session 概念的场景）
- 导出函数签名不变，**所有调用方无需修改**

## 变更文件

| 文件 | 变更 |
|------|------|
| `entry/src/main/ets/lib/ServerProgressReporter.ets` | 新增 `ServerReportQueue` 类，导出函数改为委托给队列执行 |

Closes #271