### PR TITLE
修复: loadServerHome 增加请求序号守卫，防止快速切换服务器竞态

### DIFF
--- a/entry/src/main/ets/lib/JellyfinClient.ets
+++ b/entry/src/main/ets/lib/JellyfinClient.ets
@@ -129,6 +129,12 @@ export interface VideoServerHome {
   latest: VideoServerLatestSection[];
 }
 
+/** fetchServerHome 返回的聚合结果，供调用方在序号守卫后统一写入 */
+export interface ServerHomeResult {
+  libraries: VideoServerLibrary[];
+  home: VideoServerHome;
+}
+
 /**
  * Jellyfin / Emby 客户端配置（运行时解析，凭据已解密）
  */

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -36,7 +36,8 @@ import {
   VideoServerLibrary,
   VideoServerHome,
   VideoServerMediaItem,
-  VideoServerLatestSection
+  VideoServerLatestSection,
+  ServerHomeResult
 } from "../../../lib/JellyfinClient"
 import { PlexClient } from "../../../lib/PlexClient"
 import { reportServerPlaybackStarted } from "../../../lib/ServerProgressReporter"
@@ -661,6 +662,8 @@ export struct MediaLibraryTab {
   @Local serverHome: VideoServerHome = { continueWatching: [], nextUp: [], latest: [] }
   @Local serverLoading: boolean = false
   @Local serverError: string = ''
+  // 请求序号守卫：快速切换服务器时丢弃过期响应
+  private _serverHomeSeq: number = 0
 
   aboutToAppear(): void {
     FileSourceDatabase.onReady(() => {
@@ -742,11 +745,14 @@ export struct MediaLibraryTab {
       this.serverHome = { continueWatching: [], nextUp: [], latest: [] }
       return
     }
+    // 递增序号，后续 async 断点后检查是否仍为最新
+    const seq = ++this._serverHomeSeq
     this.serverLoading = true
     this.serverError = ''
     try {
       // 强制重载：避免首帧凭据解密竞态导致拿到旧/密文配置
       await this.videoServerModel.loadVideoServers(true)
+      if (this._serverHomeSeq !== seq) return // 已被更新的请求取代
       let server: VideoServer | null = this.videoServerModel.getVideoServerById(serverId)
       if (!server) {
         this.serverError = '服务器不存在'
@@ -755,11 +761,15 @@ export struct MediaLibraryTab {
         return
       }
       try {
-        await this.fetchServerHome(server)
+        const result = await this.fetchServerHome(server)
+        if (this._serverHomeSeq !== seq) return
+        this.serverLibraries = result.libraries
+        this.serverHome = result.home
       } catch (e) {
         console.warn('[MediaLibraryTab] 首次加载服务器失败，重试一次', (e as Error).message)
         // 鉴权失败可能是凭据解密竞态，强制重读后再试一次
         await this.videoServerModel.loadVideoServers(true)
+        if (this._serverHomeSeq !== seq) return
         server = this.videoServerModel.getVideoServerById(serverId)
         if (!server) {
           this.serverError = '服务器不存在'
@@ -767,26 +777,37 @@ export struct MediaLibraryTab {
           this.serverHome = { continueWatching: [], nextUp: [], latest: [] }
           return
         }
-        await this.fetchServerHome(server)
+        const result = await this.fetchServerHome(server)
+        if (this._serverHomeSeq !== seq) return
+        this.serverLibraries = result.libraries
+        this.serverHome = result.home
       }
     } catch (e2) {
+      if (this._serverHomeSeq !== seq) return
       this.serverLibraries = []
       this.serverHome = { continueWatching: [], nextUp: [], latest: [] }
       this.serverError = (e2 as Error).message ?? '无法连接服务器'
     } finally {
-      this.serverLoading = false
+      // 仅当序号仍为最新时才置 loading=false，避免后续请求被误关
+      if (this._serverHomeSeq === seq) {
+        this.serverLoading = false
+      }
     }
   }
 
-  private async fetchServerHome(server: VideoServer): Promise<void> {
+  private async fetchServerHome(server: VideoServer): Promise<ServerHomeResult> {
     if (server.type === VideoServerType.PLEX) {
       const client = PlexClient.fromConfigJson(server.configJson)
-      this.serverLibraries = await client.getLibraries()
-      this.serverHome = await client.getHome()
+      const libraries: VideoServerLibrary[] = await client.getLibraries()
+      const home: VideoServerHome = await client.getHome()
+      const result: ServerHomeResult = { libraries, home }
+      return result
     } else {
       const client = JellyfinClient.fromConfigJson(server.configJson)
-      this.serverLibraries = await client.getLibraries()
-      this.serverHome = await client.getHome()
+      const libraries: VideoServerLibrary[] = await client.getLibraries()
+      const home: VideoServerHome = await client.getHome()
+      const result: ServerHomeResult = { libraries, home }
+      return result
     }
   }
 
@@ -798,20 +819,22 @@ export struct MediaLibraryTab {
     if (serverId === undefined) {
       return
     }
-    try {
-      await this.videoServerModel.loadVideoServers(true)
-      const server: VideoServer | null = this.videoServerModel.getVideoServerById(serverId)
-      if (!server) {
-        return
-      }
-      if (server.type === VideoServerType.PLEX) {
-        this.serverHome = await PlexClient.fromConfigJson(server.configJson).getHome()
-      } else {
-        this.serverHome = await JellyfinClient.fromConfigJson(server.configJson).getHome()
-      }
-    } catch (e) {
-      console.warn('[MediaLibraryTab] 刷新服务器继续观看失败', (e as Error).message)
-    }
+   const seq = ++this._serverHomeSeq
+   try {
+     await this.videoServerModel.loadVideoServers(true)
+     if (this._serverHomeSeq !== seq) return
+     const server: VideoServer | null = this.videoServerModel.getVideoServerById(serverId)
+     if (!server) {
+       return
+     }
+     const result = await this.fetchServerHome(server)
+     if (this._serverHomeSeq !== seq) return
+     this.serverLibraries = result.libraries
+     this.serverHome = result.home
+   } catch (e) {
+     if (this._serverHomeSeq !== seq) return
+     console.warn('[MediaLibraryTab] 刷新服务器继续观看失败', (e as Error).message)
+   }
   }
 
   /**

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -766,7 +766,8 @@ export struct MediaLibraryTab {
         this.serverLibraries = result.libraries
         this.serverHome = result.home
       } catch (e) {
-        console.warn('[MediaLibraryTab] 首次加载服务器失败，重试一次', (e as Error).message)
+        const error = e as BusinessError
+        console.warn('[MediaLibraryTab] 首次加载服务器失败，重试一次', error.message)
         // 鉴权失败可能是凭据解密竞态，强制重读后再试一次
         await this.videoServerModel.loadVideoServers(true)
         if (this._serverHomeSeq !== seq) return
@@ -784,9 +785,10 @@ export struct MediaLibraryTab {
       }
     } catch (e2) {
       if (this._serverHomeSeq !== seq) return
+      const error = e2 as BusinessError
       this.serverLibraries = []
       this.serverHome = { continueWatching: [], nextUp: [], latest: [] }
-      this.serverError = (e2 as Error).message ?? '无法连接服务器'
+      this.serverError = error.message ?? '无法连接服务器'
     } finally {
       // 仅当序号仍为最新时才置 loading=false，避免后续请求被误关
       if (this._serverHomeSeq === seq) {
@@ -833,7 +835,8 @@ export struct MediaLibraryTab {
      this.serverHome = result.home
    } catch (e) {
      if (this._serverHomeSeq !== seq) return
-     console.warn('[MediaLibraryTab] 刷新服务器继续观看失败', (e as Error).message)
+     const error = e as BusinessError
+     console.warn('[MediaLibraryTab] 刷新服务器继续观看失败', error.message)
    }
   }
 


### PR DESCRIPTION
- 新增 _serverHomeSeq 单调递增序号字段
- fetchServerHome 重构为纯函数返回 ServerHomeResult
- loadServerHome 每个 async 断点后检查序号，过期响应丢弃
- refreshServerHomeSilently 同样加入序号守卫
- finally 仅在序号最新时置 serverLoading=false

Closes #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 统一处理服务器首页内容与媒体库列表，提升首页数据加载的一致性。
  - 切换不同服务器或数据源时，仅展示最新请求返回的内容，避免旧数据覆盖当前页面。
  - 优化首页加载失败后的重试流程。
  - 静默刷新“继续观看”内容时，数据更新更加稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->