### PR TITLE
修复: 移除导航参数中的已解密服务器配置（安全）

### DIFF
--- a/entry/src/main/ets/lib/ServerProgressReporter.ets
+++ b/entry/src/main/ets/lib/ServerProgressReporter.ets
@@ -1,5 +1,6 @@
 import { JellyfinClient } from './JellyfinClient';
 import { PlexClient } from './PlexClient';
+import { FileSourceDatabase } from '../db/files/FileSourceDatabase';
 
 /**
  * 单个 playSessionId 的串行队列状态。
@@ -19,23 +20,38 @@ interface SessionQueueState {
  * - started 内部鉴权 + getPlaybackInfo 完成前，后续 progress 排队等待；
  * - stopped 等待此前所有请求完成后执行，并阻止后续 progress 入队；
  * - stopped 完成后清理该会话状态。
+ *
+ * 所有方法接收 serverId，内部按需从数据库读取配置，避免凭据长期驻留调用方。
  */
 class ServerReportQueue {
   private sessions: Map<string, SessionQueueState> = new Map();
 
   /**
+   * 按 serverId 从数据库读取 configJson；读不到返回空字符串。
+   */
+  private async readConfigJson(serverId: number): Promise<string> {
+    try {
+      const server = await FileSourceDatabase.getInstance().getVideoServerById(serverId);
+      return server?.configJson ?? '';
+    } catch (e) {
+      console.warn('[ServerReportQueue] 读取服务器配置失败, serverId=' + serverId, (e as Error).message ?? String(e));
+      return '';
+    }
+  }
+
+  /**
    * 入队一个 started 任务。
    */
   enqueueStarted(
-    serverType: string, serverConfigJson: string, itemId: string,
+    serverType: string, serverId: number, itemId: string,
     playSessionId: string, positionMs: number, durationMs: number
   ): Promise<void> {
     if (playSessionId.length === 0) {
-      return this.executeStarted(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+      return this.executeStarted(serverType, serverId, itemId, playSessionId, positionMs, durationMs);
     }
     const state = this.ensureState(playSessionId);
     const next = state.tail.then(() => {
-      return this.executeStarted(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+      return this.executeStarted(serverType, serverId, itemId, playSessionId, positionMs, durationMs);
     }).catch(() => {});
     state.tail = next;
     return next;
@@ -45,11 +61,11 @@ class ServerReportQueue {
    * 入队一个 progress 任务。
    */
   enqueueProgress(
-    serverType: string, serverConfigJson: string, itemId: string,
+    serverType: string, serverId: number, itemId: string,
     playSessionId: string, positionMs: number, durationMs: number
   ): Promise<void> {
     if (playSessionId.length === 0) {
-      return this.executeProgress(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+      return this.executeProgress(serverType, serverId, itemId, playSessionId, positionMs, durationMs);
     }
     const state = this.ensureState(playSessionId);
     if (state.stopped) {
@@ -57,7 +73,7 @@ class ServerReportQueue {
       return Promise.resolve();
     }
     const next = state.tail.then(() => {
-      return this.executeProgress(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+      return this.executeProgress(serverType, serverId, itemId, playSessionId, positionMs, durationMs);
     }).catch(() => {});
     state.tail = next;
     return next;
@@ -67,16 +83,16 @@ class ServerReportQueue {
    * 入队一个 stopped 任务。
    */
   enqueueStopped(
-    serverType: string, serverConfigJson: string, itemId: string,
+    serverType: string, serverId: number, itemId: string,
     playSessionId: string, positionMs: number, durationMs: number
   ): Promise<void> {
     if (playSessionId.length === 0) {
-      return this.executeStopped(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+      return this.executeStopped(serverType, serverId, itemId, playSessionId, positionMs, durationMs);
     }
     const state = this.ensureState(playSessionId);
     state.stopped = true;
     const next = state.tail.then(() => {
-      return this.executeStopped(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+      return this.executeStopped(serverType, serverId, itemId, playSessionId, positionMs, durationMs);
     }).then(() => {
       this.sessions.delete(playSessionId);
     }).catch(() => {
@@ -97,37 +113,51 @@ class ServerReportQueue {
   }
 
   private async executeStarted(
-    serverType: string, serverConfigJson: string, itemId: string,
+    serverType: string, serverId: number, itemId: string,
     playSessionId: string, positionMs: number, durationMs: number
   ): Promise<void> {
+    const configJson = await this.readConfigJson(serverId);
+    if (configJson.length === 0) {
+      console.warn('[ServerReportQueue] started 跳过：读取服务器配置为空, serverId=' + serverId);
+      return;
+    }
     if (serverType === 'plex') {
-      await PlexClient.fromConfigJson(serverConfigJson).reportPlaying(itemId, positionMs, durationMs);
+      await PlexClient.fromConfigJson(configJson).reportPlaying(itemId, positionMs, durationMs);
     } else {
-      const client = JellyfinClient.fromConfigJson(serverConfigJson);
+      const client = JellyfinClient.fromConfigJson(configJson);
       const mediaSourceId = await client.getPlaybackInfo(itemId);
       await client.reportPlaying(playSessionId, itemId, mediaSourceId, positionMs);
     }
   }
 
   private async executeProgress(
-    serverType: string, serverConfigJson: string, itemId: string,
+    serverType: string, serverId: number, itemId: string,
     playSessionId: string, positionMs: number, durationMs: number
   ): Promise<void> {
+    const configJson = await this.readConfigJson(serverId);
+    if (configJson.length === 0) {
+      return;
+    }
     if (serverType === 'plex') {
-      await PlexClient.fromConfigJson(serverConfigJson).reportProgress(itemId, positionMs, durationMs);
+      await PlexClient.fromConfigJson(configJson).reportProgress(itemId, positionMs, durationMs);
     } else {
-      await JellyfinClient.fromConfigJson(serverConfigJson).reportProgress(playSessionId, itemId, positionMs, false);
+      await JellyfinClient.fromConfigJson(configJson).reportProgress(playSessionId, itemId, positionMs, false);
     }
   }
 
   private async executeStopped(
-    serverType: string, serverConfigJson: string, itemId: string,
+    serverType: string, serverId: number, itemId: string,
     playSessionId: string, positionMs: number, durationMs: number
   ): Promise<void> {
+    const configJson = await this.readConfigJson(serverId);
+    if (configJson.length === 0) {
+      console.warn('[ServerReportQueue] stopped 跳过：读取服务器配置为空, serverId=' + serverId);
+      return;
+    }
     if (serverType === 'plex') {
-      await PlexClient.fromConfigJson(serverConfigJson).reportStopped(itemId, positionMs, durationMs);
+      await PlexClient.fromConfigJson(configJson).reportStopped(itemId, positionMs, durationMs);
     } else {
-      await JellyfinClient.fromConfigJson(serverConfigJson).reportStopped(playSessionId, itemId, positionMs);
+      await JellyfinClient.fromConfigJson(configJson).reportStopped(playSessionId, itemId, positionMs);
     }
   }
 }
@@ -138,43 +168,46 @@ const globalQueue = new ServerReportQueue();
 /**
  * 上报影视服务器播放开始（会话建立）。按 playSessionId 串行化执行。
  * Jellyfin/Emby 需要 playSessionId 关联整个会话；Plex 通过 ratingKey 关联。
+ * 内部按 serverId 从数据库按需读取配置，避免凭据长期驻留调用方。
  */
 export function reportServerPlaybackStarted(
   serverType: string,
-  serverConfigJson: string,
+  serverId: number,
   itemId: string,
   playSessionId: string,
   positionMs: number,
   durationMs: number
 ): Promise<void> {
-  return globalQueue.enqueueStarted(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+  return globalQueue.enqueueStarted(serverType, serverId, itemId, playSessionId, positionMs, durationMs);
 }
 
 /**
  * 周期性上报影视服务器播放进度（不结束会话）。按 playSessionId 串行化执行。
+ * 内部按 serverId 从数据库按需读取配置，避免凭据长期驻留调用方。
  */
 export function reportServerPlaybackProgress(
   serverType: string,
-  serverConfigJson: string,
+  serverId: number,
   itemId: string,
   playSessionId: string,
   positionMs: number,
   durationMs: number
 ): Promise<void> {
-  return globalQueue.enqueueProgress(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+  return globalQueue.enqueueProgress(serverType, serverId, itemId, playSessionId, positionMs, durationMs);
 }
 
 /**
  * 上报影视服务器播放停止（退出播放器时调用），供服务器「继续观看」续播。
  * 按 playSessionId 串行化执行；stopped 后不再接受该会话的 progress。
+ * 内部按 serverId 从数据库按需读取配置，避免凭据长期驻留调用方。
  */
 export function reportServerPlaybackStopped(
   serverType: string,
-  serverConfigJson: string,
+  serverId: number,
   itemId: string,
   playSessionId: string,
   positionMs: number,
   durationMs: number
 ): Promise<void> {
-  return globalQueue.enqueueStopped(serverType, serverConfigJson, itemId, playSessionId, positionMs, durationMs);
+  return globalQueue.enqueueStopped(serverType, serverId, itemId, playSessionId, positionMs, durationMs);
 }

--- a/entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets
@@ -161,10 +161,10 @@ export struct ServerMediaDetailPage {
         durationHintMs: target.durationMs > 0 ? target.durationMs : undefined,
         serverType: server.type,
         serverItemId: target.id,
-        serverConfigJson: server.configJson,
+        serverId: server.id,
         serverPlaySessionId: playSessionId
       }
-      reportServerPlaybackStarted(server.type, server.configJson, target.id, playSessionId, target.positionMs, target.durationMs)
+      reportServerPlaybackStarted(server.type, server.id ?? 0, target.id, playSessionId, target.positionMs, target.durationMs)
         .catch(() => {})
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param)
     } catch (e) {

--- a/entry/src/main/ets/pages/detail/ServerSeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/ServerSeasonDetailPage.ets
@@ -212,10 +212,10 @@ export struct ServerSeasonDetailPage {
         durationHintMs: ep.durationMs > 0 ? ep.durationMs : undefined,
         serverType: server.type,
         serverItemId: ep.id,
-        serverConfigJson: server.configJson,
+        serverId: server.id,
         serverPlaySessionId: playSessionId
       }
-      reportServerPlaybackStarted(server.type, server.configJson, ep.id, playSessionId, ep.positionMs, ep.durationMs)
+      reportServerPlaybackStarted(server.type, server.id ?? 0, ep.id, playSessionId, ep.positionMs, ep.durationMs)
         .catch(() => {})
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param)
     } catch (e) {
@@ -342,10 +342,10 @@ export struct ServerSeasonDetailPage {
         durationHintMs: item.durationMs > 0 ? item.durationMs : undefined,
         serverType: server.type,
         serverItemId: item.id,
-        serverConfigJson: server.configJson,
+        serverId: server.id,
         serverPlaySessionId: playSessionId
       }
-      reportServerPlaybackStarted(server.type, server.configJson, item.id, playSessionId, item.positionMs, item.durationMs)
+      reportServerPlaybackStarted(server.type, server.id ?? 0, item.id, playSessionId, item.positionMs, item.durationMs)
         .catch(() => {})
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param)
     } catch (e) {

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -879,11 +879,11 @@ export struct MediaLibraryTab {
         durationHintMs: item.durationMs > 0 ? item.durationMs : undefined,
         serverType: server.type,
         serverItemId: item.id,
-        serverConfigJson: server.configJson,
+        serverId: server.id,
         serverPlaySessionId: playSessionId
       }
       // 上报播放开始（会话建立），与退出时的 stopped 共用同一 playSessionId
-      reportServerPlaybackStarted(server.type, server.configJson, item.id, playSessionId, item.positionMs, item.durationMs)
+      reportServerPlaybackStarted(server.type, server.id ?? 0, item.id, playSessionId, item.positionMs, item.durationMs)
         .catch((e: Error) => {
           console.warn('[MediaLibraryTab] 上报播放开始失败', e.message)
         })

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -102,9 +102,9 @@ export interface PlayerPageParam {
    */
   serverItemId?: string;
   /**
-   * 影视服务器配置 JSON（可选，凭据已解密）。用于上报进度时重建客户端。
+   * 影视服务器 ID（可选，对应 VideoServer.id）。用于按需从数据库读取配置，避免凭据长期驻留导航参数。
    */
-  serverConfigJson?: string;
+  serverId?: number;
   /**
    * 影视服务器播放会话 ID（可选）。Jellyfin/Emby 上报进度时关联同一会话。
    */
@@ -229,7 +229,11 @@ export function buildMediaLibraryEpisodeSwitchParam(
     fileSourceId: resolvedSource.sourceIdentity.sourceId,
     mediaKey,
     startPositionMs: resolvedSource.startPositionMs,
-    playbackContext: mediaLibraryContext
+    playbackContext: mediaLibraryContext,
+    serverType: currentParam.serverType,
+    serverItemId: currentParam.serverItemId,
+    serverId: currentParam.serverId,
+    serverPlaySessionId: currentParam.serverPlaySessionId
   };
   return nextParam;
 }
@@ -1114,24 +1118,22 @@ export struct PlayerPage {
 
   /**
    * 周期性把影视服务器播放进度上报回服务器（不结束会话）。
-   * 仅在服务器媒体（serverItemId/serverType 存在）时生效。
+   * 仅在服务器媒体（serverItemId/serverType/serverId 存在）时生效。
+   * 按 serverId 从数据库按需读取配置，避免凭据长期驻留导航参数。
    */
   private reportServerPeriodicProgress(): void {
     const param = this.currentPageParam
-    if (!param || !param.serverItemId || !param.serverType) {
+    if (!param || !param.serverItemId || !param.serverType || param.serverId === undefined) {
       return
     }
-    const configJson = param.serverConfigJson ?? ''
-    if (configJson.length === 0) {
-      return
-    }
+    const serverId = param.serverId
     const posMs = this.videoPlayerController.currentTime
     const durMs = this.videoPlayerController.duration
     if (!this.videoPlayerController.isPlaying || posMs <= 0) {
       return
     }
     const playSessionId = param.serverPlaySessionId ?? ''
-    reportServerPlaybackProgress(param.serverType, configJson, param.serverItemId, playSessionId, posMs, durMs)
+    reportServerPlaybackProgress(param.serverType, serverId, param.serverItemId, playSessionId, posMs, durMs)
       .catch((e: BusinessError) => {
         console.warn('[PlayerPage] 周期性上报服务器进度失败', e.message ?? String(e))
       })
@@ -1140,19 +1142,17 @@ export struct PlayerPage {
   /**
    * 退出播放器时，把影视服务器的播放进度上报回服务器。
    * 返回是否已上报（用于决定是否 emit 刷新事件）。
+   * 按 serverId 从数据库按需读取配置，避免凭据长期驻留导航参数。
    */
   private reportServerProgress(posMs: number, durMs: number): Promise<boolean> {
     const param = this.currentPageParam
-    if (!param || !param.serverItemId || !param.serverType) {
+    if (!param || !param.serverItemId || !param.serverType || param.serverId === undefined) {
       return Promise.resolve(false)
     }
-    const configJson = param.serverConfigJson ?? ''
-    if (configJson.length === 0) {
-      return Promise.resolve(false)
-    }
+    const serverId = param.serverId
     const playSessionId = param.serverPlaySessionId ?? ''
     try {
-      return reportServerPlaybackStopped(param.serverType, configJson, param.serverItemId, playSessionId, posMs, durMs)
+      return reportServerPlaybackStopped(param.serverType, serverId, param.serverItemId, playSessionId, posMs, durMs)
         .then(() => true)
         .catch((e: BusinessError) => {
           console.warn('[PlayerPage] 上报服务器进度失败', e.message ?? String(e))


### PR DESCRIPTION
## 问题

来自 PR #269 CodeRabbit 评论。`PlayerPageParam` 中 `serverConfigJson` 字段携带已解密的服务器凭据（含明文 token/apiKey/password），通过导航参数传递并被 `currentPageParam` 长期保存，存在凭据泄露风险。

## 修改方案

将导航参数中的 `serverConfigJson` 替换为 `serverId`，PlayerPage 和 ServerProgressReporter 按需从数据库读取配置，延迟到实际请求前才生成客户端，避免凭据长期驻留。

## 变更清单

| 文件 | 变更说明 |
|------|----------|
| `PlayerPageParam` (player/index.ets) | `serverConfigJson?: string` → `serverId?: number` |
| `ServerProgressReporter` | API 签名 `serverConfigJson` → `serverId`，内部按需读 DB |
| `PlayerPage` | `reportServerPeriodicProgress` / `reportServerProgress` 改用 `serverId` |
| `MediaLibraryTab` | 传 `serverId` 替代 `server.configJson` |
| `ServerSeasonDetailPage` | 传 `serverId` 替代 `server.configJson`（2处） |
| `ServerMediaDetailPage` | 传 `serverId` 替代 `server.configJson` |
| `buildMediaLibraryEpisodeSwitchParam` | 透传 `serverType/serverItemId/serverId/serverPlaySessionId`（修复连播切集时服务器上报丢失的已有问题） |

## 验证建议

- 播放 Jellyfin/Emby/Plex 服务器媒体，确认进度上报正常（started / progress / stopped）
- 连播切集场景确认服务器上报正常
- 退出播放器后确认 stopped 上报正常

Closes #273
