### PR TITLE
文档: 拆分 Plex 与 Jellyfin/Emby 最近添加接口场景

### DIFF
--- a/openspec/specs/video-server-detail-pages/spec.md
+++ b/openspec/specs/video-server-detail-pages/spec.md
@@ -78,19 +78,19 @@
 - **THEN** 缩略图使用该剧集的 Thumb 横版图（16:9），而非集截图
 
 ### Requirement: 最近添加接口（Jellyfin / Emby）
-系统 SHALL 对 Jellyfin / Emby 服务器首页的「最近添加」分区通过 /Users/{userId}/Items/Latest 接口拉取，按媒体库拆分展示。
+系统 SHALL 对 Jellyfin / Emby 服务器首页的「最近添加」分区通过 /Users/{userId}/Items/Latest 接口拉取，请求头携带 X-Emby-Token 认证，按媒体库拆分展示。
 
 #### Scenario: Jellyfin / Emby 最近添加
 - **WHEN** Jellyfin / Emby 服务器首页展示「最近添加的 X」分区
-- **THEN** 通过 GET /Users/{userId}/Items/Latest?ParentId={libraryId}&Limit=16&Fields=PrimaryImageAspectRatio,Overview 接口拉取，请求头携带 X-Emby-Authorization（含 API Key 或用户名密码），按 ParentId 对应的媒体库拆分展示
+- **THEN** 通过 GET /Users/{userId}/Items/Latest?ParentId={libraryId}&Limit=16&Fields=PrimaryImageAspectRatio,Overview&EnableImages=true&EnableImageTypes=Primary 接口拉取，请求头携带 X-Emby-Token（用户名密码认证通过 POST /Users/AuthenticateByName 获取 AccessToken，API Key 认证直接使用 API Key），按 ParentId 对应的媒体库拆分展示
 
 ### Requirement: 最近添加接口（Plex）
-系统 SHALL 对 Plex 服务器首页的「最近添加」分区通过 /library/sections/{id}/recentlyAdded 接口拉取，请求携带 X-Plex-Token 认证，并将 MediaContainer.Metadata 映射为统一的媒体条目模型。
+系统 SHALL 对 Plex 服务器首页的「最近添加」分区通过 /library/sections/{id}/recentlyAdded 接口拉取，请求头携带 X-Plex-Token 认证，并将 MediaContainer.Metadata 映射为统一的媒体条目模型。
 
 #### Scenario: Plex 最近添加
 - **WHEN** Plex 服务器首页展示「最近添加的 X」分区
-- **THEN** 通过 GET /library/sections/{sectionKey}/recentlyAdded?X-Plex-Token={token}&X-Plex-Container-Start=0&X-Plex-Container-Size=16 接口拉取，响应中的 MediaContainer.Metadata 数组映射为统一条目模型（title→标题、year→年份、thumb→缩略图、ratingKey→条目 ID、type→类型 movie/season/show），按 sectionKey 对应的媒体库拆分展示
+- **THEN** 通过 GET /library/sections/{sectionKey}/recentlyAdded?X-Plex-Container-Start=0&X-Plex-Container-Size=16 接口拉取，请求头携带 X-Plex-Token（非查询参数），响应中的 MediaContainer.Metadata 数组映射为统一条目模型（title→标题、year→年份、thumb→缩略图、ratingKey→条目 ID、type→类型 movie/season/show/episode），按 sectionKey 对应的媒体库拆分展示
 
 #### Scenario: Plex 分页加载
 - **WHEN** 用户滚动到 Plex「最近添加」分区底部
-- **THEN** 递增 X-Plex-Container-Start 并保持 X-Plex-Container-Size=16 请求下一页
+- **THEN** 下一页请求的 X-Plex-Container-Start 取上一页响应的 offset + size，保持 X-Plex-Container-Size=16；当 offset + size >= totalSize 时停止加载，若响应缺少 totalSize 则在 Metadata 数量少于 16 时停止加载

--- a/openspec/specs/video-server-detail-pages/spec.md
+++ b/openspec/specs/video-server-detail-pages/spec.md
@@ -70,13 +70,27 @@
 - **WHEN** 用户点击视频列表页中的某一条目
 - **THEN** 进入该条目的详情页
 
-### Requirement: 服务器缩略图与最近添加接口
-系统 SHALL 对服务器首页「继续观看/接下来」的剧集缩略图使用剧集 Thumb（16:9 横版），「最近添加」使用 /Items/Latest 接口。
+### Requirement: 服务器缩略图
+系统 SHALL 对服务器首页「继续观看/接下来」的剧集缩略图使用剧集 Thumb（16:9 横版）。
 
 #### Scenario: 继续观看/接下来缩略图
 - **WHEN** 服务器首页展示「继续观看」或「接下来」分区的剧集条目
 - **THEN** 缩略图使用该剧集的 Thumb 横版图（16:9），而非集截图
 
-#### Scenario: 最近添加接口
-- **WHEN** 服务器首页展示「最近添加的 X」分区
-- **THEN** 通过 /Users/{userId}/Items/Latest 接口拉取，并按媒体库拆分展示
+### Requirement: 最近添加接口（Jellyfin / Emby）
+系统 SHALL 对 Jellyfin / Emby 服务器首页的「最近添加」分区通过 /Users/{userId}/Items/Latest 接口拉取，按媒体库拆分展示。
+
+#### Scenario: Jellyfin / Emby 最近添加
+- **WHEN** Jellyfin / Emby 服务器首页展示「最近添加的 X」分区
+- **THEN** 通过 GET /Users/{userId}/Items/Latest?ParentId={libraryId}&Limit=16&Fields=PrimaryImageAspectRatio,Overview 接口拉取，请求头携带 X-Emby-Authorization（含 API Key 或用户名密码），按 ParentId 对应的媒体库拆分展示
+
+### Requirement: 最近添加接口（Plex）
+系统 SHALL 对 Plex 服务器首页的「最近添加」分区通过 /library/sections/{id}/recentlyAdded 接口拉取，请求携带 X-Plex-Token 认证，并将 MediaContainer.Metadata 映射为统一的媒体条目模型。
+
+#### Scenario: Plex 最近添加
+- **WHEN** Plex 服务器首页展示「最近添加的 X」分区
+- **THEN** 通过 GET /library/sections/{sectionKey}/recentlyAdded?X-Plex-Token={token}&X-Plex-Container-Start=0&X-Plex-Container-Size=16 接口拉取，响应中的 MediaContainer.Metadata 数组映射为统一条目模型（title→标题、year→年份、thumb→缩略图、ratingKey→条目 ID、type→类型 movie/season/show），按 sectionKey 对应的媒体库拆分展示
+
+#### Scenario: Plex 分页加载
+- **WHEN** 用户滚动到 Plex「最近添加」分区底部
+- **THEN** 递增 X-Plex-Container-Start 并保持 X-Plex-Container-Size=16 请求下一页


### PR DESCRIPTION
## 概述

来自 PR #269 CodeRabbit 评论，Issue #276。

## 问题

 规范中「最近添加接口」只有一个通用场景，将所有服务器约束为 ，未体现 Plex 的差异路径和认证方式。

## 修改内容

将通用场景拆分为三个独立 Requirement：

1. **服务器缩略图**（原场景保留，仅缩略图相关）
2. **最近添加接口（Jellyfin / Emby）**：明确使用  +  认证
3. **最近添加接口（Plex）**：
   - 请求路径：
   - 认证方式： 查询参数
   - 响应映射： → 统一条目模型（title/year/thumb/ratingKey/type）
   - 分页： + 

## 关联

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 将“最近添加”内容按 Jellyfin/Emby 与 Plex 分开处理。
  - 明确不同媒体服务器的接口请求与认证方式。
  - 支持按媒体库拆分展示最近添加内容。
  - 补充 Plex 条目字段映射，并支持滚动分页加载。
- **保持不变**
  - 服务器缩略图相关要求维持现有行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->