### PR TITLE
重构: 抽取共享 DeleteServerDialog 与服务器类型映射工具

### DIFF
--- a/entry/src/main/ets/components/dialogs/DeleteServerDialog.ets
+++ b/entry/src/main/ets/components/dialogs/DeleteServerDialog.ets
@@ -33,6 +33,7 @@ export struct DeleteServerDialog {
               .margin({ right: 8 })
               .fontColor($r('sys.color.font_primary'))
               .backgroundColor($r('sys.color.comp_background_tertiary'))
+              .enabled(!this.isDeleting)
               .onClick(() => {
                 this.onCancel()
               })

--- a/entry/src/main/ets/components/dialogs/DeleteServerDialog.ets
+++ b/entry/src/main/ets/components/dialogs/DeleteServerDialog.ets
@@ -1,0 +1,63 @@
+/**
+ * 共享删除影视服务器确认弹窗。
+ * 供 VideoServerTab / VideoServerSettingBuilder 复用，消除行为分歧。
+ */
+
+@ComponentV2
+export struct DeleteServerDialog {
+  /** 是否显示弹窗 */
+  @Param visible: boolean = false
+  /** 是否正在删除中 */
+  @Param isDeleting: boolean = false
+  /** 取消回调 */
+  @Event onCancel: () => void = () => {}
+  /** 确认删除回调 */
+  @Event onConfirm: () => void = () => {}
+
+  build() {
+    if (this.visible) {
+      Column() {
+        Column() {
+          Text('删除影视服务器')
+            .fontSize(18)
+            .fontWeight(FontWeight.Bold)
+            .margin({ bottom: 12 })
+          Text('确认删除该影视服务器？此操作仅移除服务器配置，不影响其他数据。')
+            .fontSize(14)
+            .fontColor($r('sys.color.font_secondary'))
+            .textAlign(TextAlign.Start)
+            .margin({ bottom: 20 })
+          Row() {
+            Button('取消')
+              .layoutWeight(1)
+              .margin({ right: 8 })
+              .fontColor($r('sys.color.font_primary'))
+              .backgroundColor($r('sys.color.comp_background_tertiary'))
+              .onClick(() => {
+                this.onCancel()
+              })
+            Button(this.isDeleting ? '删除中...' : '确认删除')
+              .layoutWeight(1)
+              .fontColor(Color.White)
+              .backgroundColor('#FF4444')
+              .enabled(!this.isDeleting)
+              .onClick(() => {
+                this.onConfirm()
+              })
+          }
+          .width('100%')
+        }
+        .width(360)
+        .padding(24)
+        .backgroundColor($r('sys.color.comp_background_primary'))
+        .borderRadius(12)
+      }
+      .width('100%')
+      .height('100%')
+      .backgroundColor('#80000000')
+      .onClick(() => {})
+      .justifyContent(FlexAlign.Center)
+      .alignItems(HorizontalAlign.Center)
+    }
+  }
+}

--- a/entry/src/main/ets/pages/home/tabs/VideoServerTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/VideoServerTab.ets
@@ -2,13 +2,13 @@ import { LengthMetrics } from "@kit.ArkUI"
 import { BusinessError } from "@kit.BasicServicesKit"
 import { VideoServer, VideoServerType } from "../../../db/models/VideoServerEntity"
 import { VideoServerStore } from "../../../stores/servers/VideoServerStore"
-import { VideoServerModel, videoServerTypeLabel } from "../../../stores/servers/VideoServerModel"
+import { VideoServerModel, videoServerTypeLabel, settingTypeFor } from "../../../stores/servers/VideoServerModel"
 import { SourceSwitchModel } from "../../../stores/media/SourceSwitchModel"
 import { VideoServerTypeIcon } from "../../settings/builders/IconBuilders"
 import { TabBarModel, TabItem, TabItemCode } from "../../../stores/tabbar/TabBarModel"
 import { TabBarStore } from "../../../stores/tabbar/TabBarStore"
 import { SettingsPage, SettingsPageParam } from "../../settings/Index"
-import SettingType from "../../settings/SettingType"
+import { DeleteServerDialog } from "../../../components/dialogs/DeleteServerDialog"
 
 @ComponentV2
 export struct VideoServerTab {
@@ -44,26 +44,13 @@ export struct VideoServerTab {
     } catch (_e) {}
   }
 
-  private settingTypeFor(serverType: VideoServerType): SettingType {
-    switch (serverType) {
-      case VideoServerType.JELLYFIN:
-        return SettingType.JELLYFIN_CONFIG
-      case VideoServerType.EMBY:
-        return SettingType.EMBY_CONFIG
-      case VideoServerType.PLEX:
-        return SettingType.PLEX_CONFIG
-      default:
-        return SettingType.JELLYFIN_CONFIG
-    }
-  }
-
   private openEdit(server: VideoServer): void {
     if (server.id === undefined) {
       this.showToastSafe('服务器 ID 不存在')
       return
     }
     const param: SettingsPageParam = {
-      type: this.settingTypeFor(server.type),
+      type: settingTypeFor(server.type),
       serverType: server.type,
       serverId: server.id
     }
@@ -94,11 +81,7 @@ export struct VideoServerTab {
     }
     try {
       this.isDeletingServer = true
-      await this.videoServerModel.deleteVideoServer(target.id)
-      // 若删除的是当前源，回退到文件源
-      if (this.sourceSwitchModel.getActiveServerId() === target.id) {
-        await this.sourceSwitchModel.setFileSource()
-      }
+      await this.videoServerModel.deleteVideoServerWithFallback(target.id)
       this.showToastSafe('服务器已删除')
     } catch (error) {
       console.error('VideoServerTab: 删除服务器失败', (error as BusinessError).message ?? String(error))
@@ -210,51 +193,17 @@ export struct VideoServerTab {
       .width('100%')
 
       // ── 删除服务器确认弹窗 ──
-      if (this.showDeleteDialog) {
-        Column() {
-          Column() {
-            Text('删除影视服务器')
-              .fontSize(18)
-              .fontWeight(FontWeight.Bold)
-              .margin({ bottom: 12 })
-            Text('确认删除该影视服务器？此操作仅移除服务器配置，不影响其他数据。')
-              .fontSize(14)
-              .fontColor($r('sys.color.font_secondary'))
-              .textAlign(TextAlign.Start)
-              .margin({ bottom: 20 })
-            Row() {
-              Button('取消')
-                .layoutWeight(1)
-                .margin({ right: 8 })
-                .fontColor($r('sys.color.font_primary'))
-                .backgroundColor($r('sys.color.comp_background_tertiary'))
-                .onClick(() => {
-                  this.showDeleteDialog = false
-                  this.deleteTarget = null
-                })
-              Button(this.isDeletingServer ? '删除中...' : '确认删除')
-                .layoutWeight(1)
-                .fontColor(Color.White)
-                .backgroundColor('#FF4444')
-                .enabled(!this.isDeletingServer)
-                .onClick(() => {
-                  this.confirmDeleteServer()
-                })
-            }
-            .width('100%')
-          }
-          .width(360)
-          .padding(24)
-          .backgroundColor($r('sys.color.comp_background_primary'))
-          .borderRadius(12)
+      DeleteServerDialog({
+        visible: this.showDeleteDialog,
+        isDeleting: this.isDeletingServer,
+        onCancel: () => {
+          this.showDeleteDialog = false
+          this.deleteTarget = null
+        },
+        onConfirm: () => {
+          this.confirmDeleteServer()
         }
-        .width('100%')
-        .height('100%')
-        .backgroundColor('#80000000')
-        .onClick(() => {})
-        .justifyContent(FlexAlign.Center)
-        .alignItems(HorizontalAlign.Center)
-      }
+      })
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/pages/settings/builders/VideoServerSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/VideoServerSettingBuilder.ets
@@ -2,12 +2,12 @@ import { SettingListItem } from "../SettingListItem";
 import { SettingListItemGroup } from "../SettingListItemGroup";
 import { SettingContainer } from "../SettingContainer";
 import { SettingsController } from "../SettingsController";
-import SettingType from "../SettingType";
 import { VideoServerTypeIcon } from "./IconBuilders";
 import { VideoServerStore } from "../../../stores/servers/VideoServerStore";
-import { VideoServerModel, videoServerTypeLabel } from "../../../stores/servers/VideoServerModel";
-import { VideoServer, VideoServerType } from "../../../db/models/VideoServerEntity";
-import { SourceSwitchModel } from "../../../stores/media/SourceSwitchModel";
+import { VideoServerModel, videoServerTypeLabel, settingTypeFor } from "../../../stores/servers/VideoServerModel";
+import { VideoServer } from "../../../db/models/VideoServerEntity";
+import { DeleteServerDialog } from "../../../components/dialogs/DeleteServerDialog";
+import SettingType from "../SettingType";
 import { BusinessError } from "@kit.BasicServicesKit";
 
 @ComponentV2
@@ -43,19 +43,6 @@ struct VideoServerSettingBuilderComponent {
     }
   }
 
-  private settingTypeFor(serverType: VideoServerType): SettingType {
-    switch (serverType) {
-      case VideoServerType.JELLYFIN:
-        return SettingType.JELLYFIN_CONFIG
-      case VideoServerType.EMBY:
-        return SettingType.EMBY_CONFIG
-      case VideoServerType.PLEX:
-        return SettingType.PLEX_CONFIG
-      default:
-        return SettingType.JELLYFIN_CONFIG
-    }
-  }
-
   handleEdit(server: VideoServer): void {
     if (server.id === undefined) {
       this.showToastSafe('服务器 ID 不存在')
@@ -64,7 +51,7 @@ struct VideoServerSettingBuilderComponent {
     const params: Record<string, Object> = {}
     params['serverType'] = server.type as Object
     params['serverId'] = server.id as Object
-    this.controller.pushType(this.settingTypeFor(server.type), params)
+    this.controller.pushType(settingTypeFor(server.type), params)
   }
 
   handleDelete(server: VideoServer): void {
@@ -79,11 +66,7 @@ struct VideoServerSettingBuilderComponent {
     }
     try {
       this.isDeletingServer = true
-      await this.videoServerModel.deleteVideoServer(target.id)
-      // 若删除的是当前激活源，回退到文件源（与首页 tab 保持一致）
-      if (SourceSwitchModel.getState().getActiveServerId() === target.id) {
-        await SourceSwitchModel.getState().setFileSource()
-      }
+      await this.videoServerModel.deleteVideoServerWithFallback(target.id)
       this.showToastSafe('服务器已删除')
     } catch (error) {
       console.error('VideoServerSettingBuilder: 删除服务器失败', (error as BusinessError).message ?? String(error))
@@ -163,51 +146,17 @@ struct VideoServerSettingBuilderComponent {
       }
 
       // ── 删除服务器确认弹窗 ──
-      if (this.showDeleteDialog) {
-        Column() {
-          Column() {
-            Text('删除影视服务器')
-              .fontSize(18)
-              .fontWeight(FontWeight.Bold)
-              .margin({ bottom: 12 })
-            Text('确认删除该影视服务器？此操作仅移除服务器配置，不影响其他数据。')
-              .fontSize(14)
-              .fontColor($r('sys.color.font_secondary'))
-              .textAlign(TextAlign.Start)
-              .margin({ bottom: 20 })
-            Row() {
-              Button('取消')
-                .layoutWeight(1)
-                .margin({ right: 8 })
-                .fontColor($r('sys.color.font_primary'))
-                .backgroundColor($r('sys.color.comp_background_tertiary'))
-                .onClick(() => {
-                  this.showDeleteDialog = false
-                  this.deleteTarget = null
-                })
-              Button(this.isDeletingServer ? '删除中...' : '确认删除')
-                .layoutWeight(1)
-                .fontColor(Color.White)
-                .backgroundColor('#FF4444')
-                .enabled(!this.isDeletingServer)
-                .onClick(() => {
-                  this.confirmDeleteServer()
-                })
-            }
-            .width('100%')
-          }
-          .width(360)
-          .padding(24)
-          .backgroundColor($r('sys.color.comp_background_primary'))
-          .borderRadius(12)
+      DeleteServerDialog({
+        visible: this.showDeleteDialog,
+        isDeleting: this.isDeletingServer,
+        onCancel: () => {
+          this.showDeleteDialog = false
+          this.deleteTarget = null
+        },
+        onConfirm: () => {
+          this.confirmDeleteServer()
         }
-        .width('100%')
-        .height('100%')
-        .backgroundColor('#80000000')
-        .onClick(() => {})
-        .justifyContent(FlexAlign.Center)
-        .alignItems(HorizontalAlign.Center)
-      }
+      })
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/stores/servers/VideoServerModel.ets
+++ b/entry/src/main/ets/stores/servers/VideoServerModel.ets
@@ -1,6 +1,8 @@
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { VideoServer, VideoServerType } from "../../db/models/VideoServerEntity";
 import { BusinessError } from "@kit.BasicServicesKit";
+import SettingType from "../../pages/settings/SettingType";
+import { SourceSwitchModel } from "../media/SourceSwitchModel";
 
 /**
  * 影视服务器缓存管理类。
@@ -125,6 +127,18 @@ export class VideoServerModel {
   }
 
   /**
+   * 删除影视服务器并处理当前源回退（统一删除流程）。
+   * 若被删除的服务器恰好是当前激活源，自动回退到文件源。
+   */
+  async deleteVideoServerWithFallback(id: number): Promise<void> {
+    await this.deleteVideoServer(id);
+    const sourceSwitch = SourceSwitchModel.getState();
+    if (sourceSwitch.getActiveServerId() === id) {
+      await sourceSwitch.setFileSource();
+    }
+  }
+
+  /**
    * 根据 ID 获取影视服务器
    */
   getVideoServerById(id: number): VideoServer | null {
@@ -138,6 +152,22 @@ export class VideoServerModel {
   invalidateCache(): void {
     this.isLoaded = false;
     this.lastUpdateTime = 0;
+  }
+}
+
+/**
+ * 影视服务器类型 → 设置页类型映射（供 VideoServerTab / VideoServerSettingBuilder 共享）
+ */
+export function settingTypeFor(serverType: VideoServerType): SettingType {
+  switch (serverType) {
+    case VideoServerType.JELLYFIN:
+      return SettingType.JELLYFIN_CONFIG
+    case VideoServerType.EMBY:
+      return SettingType.EMBY_CONFIG
+    case VideoServerType.PLEX:
+      return SettingType.PLEX_CONFIG
+    default:
+      return SettingType.JELLYFIN_CONFIG
   }
 }
 

--- a/entry/src/main/ets/stores/servers/VideoServerModel.ets
+++ b/entry/src/main/ets/stores/servers/VideoServerModel.ets
@@ -129,12 +129,18 @@ export class VideoServerModel {
   /**
    * 删除影视服务器并处理当前源回退（统一删除流程）。
    * 若被删除的服务器恰好是当前激活源，自动回退到文件源。
+   * 源回退的持久化失败不中断删除流程（服务器已删除不可恢复，
+   * 残余的无效源引用会在下次 load() 时自动回退）。
    */
   async deleteVideoServerWithFallback(id: number): Promise<void> {
     await this.deleteVideoServer(id);
     const sourceSwitch = SourceSwitchModel.getState();
     if (sourceSwitch.getActiveServerId() === id) {
-      await sourceSwitch.setFileSource();
+      try {
+        await sourceSwitch.setFileSource();
+      } catch (e) {
+        console.warn('VideoServerModel: 源回退持久化失败，将在下次加载时自动恢复', (e as BusinessError).message ?? String(e));
+      }
     }
   }
 


### PR DESCRIPTION
## 概述

抽取 VideoServerTab 和 VideoServerSettingBuilder 中重复的删除确认弹窗、settingTypeFor 映射和删除+回退逻辑为共享组件/工具函数，消除行为分歧。

Closes #277

## 变更内容

### 新增
- **DeleteServerDialog** 共享组件 (`components/dialogs/DeleteServerDialog.ets`)：统一删除确认弹窗 UI，接收 visible/isDeleting/onCancel/onConfirm 参数
- **settingTypeFor()** 共享函数（`VideoServerModel.ets`）：VideoServerType → SettingType 映射，供多处复用
- **deleteVideoServerWithFallback()** 辅助方法（`VideoServerModel`）：统一删除服务器 + 当前源回退流程

### 重构
- **VideoServerTab**：删除内联弹窗 UI，改用 DeleteServerDialog；settingTypeFor 改用共享函数；confirmDeleteServer 改用 deleteVideoServerWithFallback
- **VideoServerSettingBuilder**：同上

## 影响范围
- 删除确认弹窗行为统一（标题、文案、按钮样式一致）
- 删除流程逻辑统一（删除服务器 + 源回退集中到 Model 层）
- 无新增外部依赖，纯内部重构

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增统一的影视服务器删除确认弹窗，支持取消、确认及删除进行中状态。
  * 删除当前服务器后自动回退至文件源，避免无可用服务器状态。
* **优化**
  * 统一影视服务器类型与设置类型的映射逻辑。
  * 视频服务器页面与设置页面采用一致的删除交互和状态反馈。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->