### PR TITLE
修复: 中文季号后缀目录名识别与季号提取

### DIFF
--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -295,6 +295,17 @@ export class FileSourceDatabase {
     await this.scrapeInfoDao.clearScrapeInfoForVideo(videoId);
   }
 
+  async clearScrapeInfoByTvSeriesId(tvSeriesId: number): Promise<void> {
+    await this.scrapeInfoDao.clearScrapeInfoByTvSeriesId(tvSeriesId);
+  }
+
+  /** 删除指定电视剧的所有数据（刮削信息、进度、历史记录），用于重新刮削 */
+  async deleteSeriesAllData(tvSeriesId: number, seriesProviderId: string): Promise<void> {
+    await this.scrapeInfoDao.clearScrapeInfoByTvSeriesId(tvSeriesId);
+    await this.playProgressDao.clearPlayProgressBySeries(seriesProviderId);
+    await this.playProgressDao.clearAllMediaProgressBySeries(seriesProviderId);
+  }
+
   // ─────────────────────────────────────────────
   // play_progress / media_progress
   // ─────────────────────────────────────────────

--- a/entry/src/main/ets/db/files/ScrapeInfoDao.ets
+++ b/entry/src/main/ets/db/files/ScrapeInfoDao.ets
@@ -142,6 +142,22 @@ export class ScrapeInfoDao {
     }
   }
 
+  /** 删除指定 tv_series_id 下所有 scrape_info，再级联清理孤立媒体数据 */
+  async clearScrapeInfoByTvSeriesId(tvSeriesId: number): Promise<void> {
+    if (!this.core.isReady()) { return; }
+    const store = this.core.getStore();
+    try {
+      const pred = new relationalStore.RdbPredicates(TABLE_SCRAPE_INFO);
+      pred.equalTo('tv_series_id', tvSeriesId);
+      await store.delete(pred);
+      await this.cleanupOrphanScrapeMedia();
+      console.info(`[DB][clearScrapeInfoByTvSeriesId] tvSeriesId=${tvSeriesId} 已清理`);
+    } catch (e) {
+      const err = e as BusinessError;
+      hilog.error(0x0000, 'FileSourceDatabase', `clearScrapeInfoByTvSeriesId 失败: ${err.message}`);
+    }
+  }
+
   async clearScrapeInfoForVideo(videoId: number): Promise<void> {
     const store = this.core.getStore();
     try {

--- a/entry/src/main/ets/lib/MediaTypeClassifier.ets
+++ b/entry/src/main/ets/lib/MediaTypeClassifier.ets
@@ -126,14 +126,50 @@ const SEASON_DIRECTORY_PATTERNS: RegExp[] = [
  */
 const CHINESE_SEASON_SUFFIX_PATTERN = /第\s*([\d一二三四五六七八九十百]+)\s*[季部]$/;
 
-/** 中文数字到阿拉伯数字的映射 */
-const CHINESE_DIGIT_MAP: Record<string, number> = {
+/** 中文个位数字到阿拉伯数字的映射 */
+const CHINESE_UNIT_MAP: Record<string, number> = {
   '一': 1, '二': 2, '三': 3, '四': 4, '五': 5,
-  '六': 6, '七': 7, '八': 8, '九': 9, '十': 10,
-  '十一': 11, '十二': 12, '十三': 13, '十四': 14, '十五': 15,
-  '十六': 16, '十七': 17, '十八': 18, '十九': 19, '二十': 20
+  '六': 6, '七': 7, '八': 8, '九': 9
 };
 
+/**
+ * 解析百级中文数字的剩余部分（"百"之后的内容）
+ *
+ * - "" → 0
+ * - "零三" → 3
+ * - "十" → 10
+ * - "二十" → 20
+ * - "二十三" → 23
+ */
+function parseHundredRemainder(rest: string): number | undefined {
+  // 零Y → Y
+  const zeroMatch = rest.match(/^零([一二三四五六七八九])$/);
+  if (zeroMatch) {
+    return CHINESE_UNIT_MAP[zeroMatch[1]] ?? 0;
+  }
+  // [Y]十[Z] → Y*10 + Z
+  const tenMatch = rest.match(/^([一二三四五六七八九])?十([一二三四五六七八九])?$/);
+  if (tenMatch) {
+    const tens = tenMatch[1] ? (CHINESE_UNIT_MAP[tenMatch[1]] ?? 0) * 10 : 10;
+    const ones = tenMatch[2] ? (CHINESE_UNIT_MAP[tenMatch[2]] ?? 0) : 0;
+    return tens + ones;
+  }
+  // 空 → 纯百
+  if (rest.length === 0) {
+    return 0;
+  }
+  return undefined;
+}
+
+/**
+ * 解析中文数字为阿拉伯数字
+ *
+ * 支持范围：
+ * - 阿拉伯数字：如 "3" → 3
+ * - 个位中文：如 "三" → 3
+ * - "十"级别：如 "十" → 10, "十三" → 13, "二十一" → 21, "三十" → 30, "九十九" → 99
+ * - "百"级别：如 "一百" → 100, "一百零三" → 103, "一百二十" → 120
+ */
 function parseChineseSeasonNumber(text: string): number | undefined {
   const trimmed = text.trim();
   // 阿拉伯数字
@@ -141,17 +177,27 @@ function parseChineseSeasonNumber(text: string): number | undefined {
   if (arabicMatch) {
     return parseInt(arabicMatch[0]);
   }
-  // 中文数字
-  const mapped = CHINESE_DIGIT_MAP[trimmed];
-  if (mapped !== undefined) {
-    return mapped;
+  // 百级：[X]百[余]
+  const hundredMatch = trimmed.match(/^([一二三四五六七八九])?百(.*)$/);
+  if (hundredMatch) {
+    const hundreds = hundredMatch[1] ? (CHINESE_UNIT_MAP[hundredMatch[1]] ?? 1) : 1;
+    const remainder = parseHundredRemainder(hundredMatch[2]);
+    if (remainder !== undefined) {
+      return hundreds * 100 + remainder;
+    }
+    return undefined;
   }
-  // 复合中文数字如 "二十一" 等（10-99 范围）
-  const tenMatch = trimmed.match(/^(二)?十([一二三四五六七八九])?$/);
+  // 十级：[X]十[Y]（X=1-9, Y=0-9）
+  const tenMatch = trimmed.match(/^([一二三四五六七八九])?十([一二三四五六七八九])?$/);
   if (tenMatch) {
-    const tens = tenMatch[1] ? 20 : 10;
-    const ones = tenMatch[2] ? (CHINESE_DIGIT_MAP[tenMatch[2]] ?? 0) : 0;
+    const tens = tenMatch[1] ? (CHINESE_UNIT_MAP[tenMatch[1]] ?? 0) * 10 : 10;
+    const ones = tenMatch[2] ? (CHINESE_UNIT_MAP[tenMatch[2]] ?? 0) : 0;
     return tens + ones;
+  }
+  // 个位中文数字
+  const unitVal = CHINESE_UNIT_MAP[trimmed];
+  if (unitVal !== undefined) {
+    return unitVal;
   }
   return undefined;
 }

--- a/entry/src/main/ets/lib/MediaTypeClassifier.ets
+++ b/entry/src/main/ets/lib/MediaTypeClassifier.ets
@@ -119,6 +119,43 @@ const SEASON_DIRECTORY_PATTERNS: RegExp[] = [
   /^season\s+\d+/i
 ];
 
+/**
+ * 中文季号后缀模式：匹配目录名末尾的"第X季"/"第X部"等
+ * 支持：第二季、第二部、第2季、第2部
+ * 不匹配纯数字季号（如 "2"），仅匹配中文"第...季/部"格式
+ */
+const CHINESE_SEASON_SUFFIX_PATTERN = /第\s*([\d一二三四五六七八九十百]+)\s*[季部]$/;
+
+/** 中文数字到阿拉伯数字的映射 */
+const CHINESE_DIGIT_MAP: Record<string, number> = {
+  '一': 1, '二': 2, '三': 3, '四': 4, '五': 5,
+  '六': 6, '七': 7, '八': 8, '九': 9, '十': 10,
+  '十一': 11, '十二': 12, '十三': 13, '十四': 14, '十五': 15,
+  '十六': 16, '十七': 17, '十八': 18, '十九': 19, '二十': 20
+};
+
+function parseChineseSeasonNumber(text: string): number | undefined {
+  const trimmed = text.trim();
+  // 阿拉伯数字
+  const arabicMatch = trimmed.match(/^\d+$/);
+  if (arabicMatch) {
+    return parseInt(arabicMatch[0]);
+  }
+  // 中文数字
+  const mapped = CHINESE_DIGIT_MAP[trimmed];
+  if (mapped !== undefined) {
+    return mapped;
+  }
+  // 复合中文数字如 "二十一" 等（10-99 范围）
+  const tenMatch = trimmed.match(/^(二)?十([一二三四五六七八九])?$/);
+  if (tenMatch) {
+    const tens = tenMatch[1] ? 20 : 10;
+    const ones = tenMatch[2] ? (CHINESE_DIGIT_MAP[tenMatch[2]] ?? 0) : 0;
+    return tens + ones;
+  }
+  return undefined;
+}
+
 function normalizePathSegments(filePath: string): string[] {
   const normalizedPath = filePath.replace(/\\/g, '/');
   return normalizedPath.split('/').filter((segment: string) => segment.length > 0);
@@ -220,7 +257,74 @@ function hasStrongMovieSignal(fileNameInfo?: FileNameSemanticInfo): boolean {
 export function isSeasonDirectorySegment(segment: string): boolean {
   const normalizedSegment = normalizeSemanticToken(segment);
   return SEASON_DIRECTORY_PATTERNS.some((pattern: RegExp) => pattern.test(normalizedSegment)) ||
-    /^第\s*[\d一二三四五六七八九十百]+\s*季/.test(segment);
+    /^第\s*[\d一二三四五六七八九十百]+\s*季/.test(segment) ||
+    CHINESE_SEASON_SUFFIX_PATTERN.test(segment);
+}
+
+/**
+ * 从目录名中提取季号
+ *
+ * 支持格式：
+ * - "御赐小仵作第二季" → 2
+ * - "庆余年第二部" → 2
+ * - "Season 2" → 2
+ * - "第二季" → 2
+ * - "S02" → 2
+ * - "御赐小仵作" → undefined（无季号信息）
+ *
+ * @param directoryName 目录名
+ * @returns 季号，无法提取时返回 undefined
+ */
+export function extractSeasonNumberFromDirectoryName(directoryName: string): number | undefined {
+  // 1. 中文季号后缀（如"御赐小仵作第二季"）
+  const chineseMatch = directoryName.match(CHINESE_SEASON_SUFFIX_PATTERN);
+  if (chineseMatch) {
+    return parseChineseSeasonNumber(chineseMatch[1]);
+  }
+
+  // 2. 纯中文季号前缀（如"第二季"）
+  const pureChineseMatch = directoryName.match(/^第\s*([\d一二三四五六七八九十百]+)\s*季/);
+  if (pureChineseMatch) {
+    return parseChineseSeasonNumber(pureChineseMatch[1]);
+  }
+
+  // 3. Season N 格式
+  const seasonNorm = normalizeSemanticToken(directoryName);
+  const seasonMatch = seasonNorm.match(/season\s+(\d+)/i);
+  if (seasonMatch) {
+    return parseInt(seasonMatch[1]);
+  }
+
+  // 4. Sxx 格式（目录名整体匹配）
+  const sMatch = seasonNorm.match(/^s(\d{1,2})$/i);
+  if (sMatch) {
+    return parseInt(sMatch[1]);
+  }
+
+  return undefined;
+}
+
+/**
+ * 从"剧名+季号后缀"的目录名中去除季号后缀，提取纯剧名
+ *
+ * 支持：
+ * - "御赐小仵作第二季" → "御赐小仵作"
+ * - "庆余年第二部" → "庆余年"
+ * - "我的剧第3季" → "我的剧"
+ * - "Season 2" → undefined（纯季目录，无剧名部分）
+ * - "御赐小仵作" → undefined（无季号后缀）
+ *
+ * @param directoryName 目录名
+ * @returns 纯剧名，如果无法提取则返回 undefined
+ */
+export function stripSeasonSuffixFromDirectoryName(directoryName: string): string | undefined {
+  const match = directoryName.match(CHINESE_SEASON_SUFFIX_PATTERN);
+  if (!match) {
+    return undefined;
+  }
+  const suffixStart = match.index ?? 0;
+  const stripped = directoryName.substring(0, suffixStart).trim();
+  return stripped.length > 0 ? stripped : undefined;
 }
 
 function isGenericTvSemanticSegment(segment: string): boolean {
@@ -302,6 +406,12 @@ export function extractSeriesHintFromFilePath(filePath: string): string | undefi
       continue;
     }
     if (isSeasonDirectorySegment(segment)) {
+      // 纯季目录（如"Season 2"、"第二季"），跳过
+      // 但如果是"剧名+季号后缀"（如"御赐小仵作第二季"），提取剧名部分
+      const stripped = stripSeasonSuffixFromDirectoryName(segment);
+      if (stripped !== undefined) {
+        return stripped;
+      }
       continue;
     }
     if (isGenericTvSemanticSegment(segment)) {

--- a/entry/src/main/ets/lib/MediaTypeClassifier.ets
+++ b/entry/src/main/ets/lib/MediaTypeClassifier.ets
@@ -124,7 +124,7 @@ const SEASON_DIRECTORY_PATTERNS: RegExp[] = [
  * 支持：第二季、第二部、第2季、第2部
  * 不匹配纯数字季号（如 "2"），仅匹配中文"第...季/部"格式
  */
-const CHINESE_SEASON_SUFFIX_PATTERN = /第\s*([\d一二三四五六七八九十百]+)\s*[季部]$/;
+const CHINESE_SEASON_SUFFIX_PATTERN = /第\s*([\d一二三四五六七八九十百零〇]+)\s*[季部]$/;
 
 /** 中文个位数字到阿拉伯数字的映射 */
 const CHINESE_UNIT_MAP: Record<string, number> = {
@@ -303,7 +303,7 @@ function hasStrongMovieSignal(fileNameInfo?: FileNameSemanticInfo): boolean {
 export function isSeasonDirectorySegment(segment: string): boolean {
   const normalizedSegment = normalizeSemanticToken(segment);
   return SEASON_DIRECTORY_PATTERNS.some((pattern: RegExp) => pattern.test(normalizedSegment)) ||
-    /^第\s*[\d一二三四五六七八九十百]+\s*季/.test(segment) ||
+    /^第\s*[\d一二三四五六七八九十百零〇]+\s*季/.test(segment) ||
     CHINESE_SEASON_SUFFIX_PATTERN.test(segment);
 }
 
@@ -329,7 +329,7 @@ export function extractSeasonNumberFromDirectoryName(directoryName: string): num
   }
 
   // 2. 纯中文季号前缀（如"第二季"）
-  const pureChineseMatch = directoryName.match(/^第\s*([\d一二三四五六七八九十百]+)\s*季/);
+  const pureChineseMatch = directoryName.match(/^第\s*([\d一二三四五六七八九十百零〇]+)\s*季/);
   if (pureChineseMatch) {
     return parseChineseSeasonNumber(pureChineseMatch[1]);
   }

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -119,6 +119,8 @@ export struct SeriesDetailPage {
   /** ContinueWatchingCard 主按钮交互状态 */
   @Local focusedContinueActionKey: string = ''
   @Local hoveredContinueActionKey: string = ''
+  /** 删除系列确认弹窗 */
+  @Local showDeleteDialog: boolean = false
 
   private progressRefreshCallback: () => void = () => {};
 
@@ -768,6 +770,33 @@ export struct SeriesDetailPage {
     });
   }
 
+  /** 弹窗确认删除整个系列的所有数据（刮削信息、播放进度、历史记录） */
+  private confirmDeleteSeries(): void {
+    const tvSeriesId = this.seriesEntity?.id;
+    const providerId = this.seriesEntity?.providerId;
+    if (tvSeriesId === undefined || providerId === undefined) { return; }
+    this.getUIContext().showAlertDialog({
+      title: '删除系列数据',
+      message: `将删除「${this.getTitle()}」的所有刮削信息、播放进度和历史记录，删除后可重新刮削。此操作不可撤销。`,
+      autoCancel: true,
+      primaryButton: {
+        value: '删除',
+        fontColor: '#FF5252',
+        action: () => {
+          FileSourceDatabase.getInstance().deleteSeriesAllData(tvSeriesId, providerId)
+            .then(() => {
+              this.pageStack.pop();
+            })
+            .catch(() => {});
+        }
+      },
+      secondaryButton: {
+        value: '取消',
+        action: () => {}
+      }
+    });
+  }
+
   /** 删除后重新从 DB 加载集列表（不重新刮削，仅刷新本地数据） */
   private reloadEpisodes(): void {
     const seriesId = this.seriesEntity?.id;
@@ -1246,6 +1275,19 @@ export struct SeriesDetailPage {
               }
             })
             this.SimilarSection()
+            // 删除系列按钮（临时，用于测试重新刮削）
+            Row() {
+              Button('删除系列数据')
+                .fontSize(14)
+                .fontColor('#FF5252')
+                .backgroundColor(Color.Transparent)
+                .border({ width: 1, color: '#FF5252', radius: 8 })
+                .padding({ left: 16, right: 16, top: 8, bottom: 8 })
+                .onClick(() => { this.confirmDeleteSeries(); })
+            }
+            .width('100%')
+            .justifyContent(FlexAlign.Center)
+            .margin({ top: 24, bottom: 16 })
             Column().height(80)
           }
           .width('100%')

--- a/entry/src/main/ets/utils/VideoScrapeProcessor.ets
+++ b/entry/src/main/ets/utils/VideoScrapeProcessor.ets
@@ -1,9 +1,19 @@
 import { FileSourceDatabase } from '../db/files/FileSourceDatabase';
 import { ScrapeClient, parseFileName, TvSeriesScrapeResult } from '../lib/ScrapeClient';
 import { ScrapeInfoEntity, MovieEntity, TvSeriesEntity, TvSeasonEntity, TvEpisodeEntity } from '../db/models/MediaEntity';
-import { extractSeriesHintFromFilePath, formatMediaTypeClassificationSignals } from '../lib/MediaTypeClassifier';
+import { extractSeriesHintFromFilePath, formatMediaTypeClassificationSignals, extractSeasonNumberFromDirectoryName } from '../lib/MediaTypeClassifier';
 import { VideoFileInfo, VideoScrapeContext, ScanMode } from './VideoScannerTypes';
 import { classifyVideoScrapeTarget, hasCompleteScrapeAssociation, extractEpisodeNumberFromWeakSemanticFileName, clearStaleScrapeAssociationsForOverwrite } from './VideoScannerHelpers';
+
+function extractParentDirectoryName(filePath: string): string | undefined {
+  const normalizedPath = filePath.replace(/\\/g, '/').replace(/\/+$/g, '');
+  const segments = normalizedPath.split('/').filter((segment: string) => segment.length > 0);
+  // segments[last] = 文件名, segments[last-1] = 父目录名
+  if (segments.length < 2) {
+    return undefined;
+  }
+  return segments[segments.length - 2];
+}
 
 /**
  * 对单个视频执行「分类 → 刮削 → 入库 → 写 scrape_info」。
@@ -176,12 +186,19 @@ export async function processVideoScrape(
     }
   } else {
     try {
-      // 只有无法解析标准季集标记时，才将弱语义集数按第一季兜底。
+      // 只有无法解析标准季集标记时，才将弱语义集数按季号兜底。
       const parsedFileName = parseFileName(fileName);
       const explicitEpisodeNum = parsedFileName.episodeNumber === undefined
         ? extractEpisodeNumberFromWeakSemanticFileName(fileName)
         : undefined;
-      const explicitSeasonNum = explicitEpisodeNum !== undefined ? 1 : undefined;
+      // 从文件路径的父目录名提取季号（如"御赐小仵作第二季"→2），无目录季号时回退到1
+      const parentDirName = extractParentDirectoryName(info.filePath);
+      const directorySeasonNum = parentDirName !== undefined
+        ? extractSeasonNumberFromDirectoryName(parentDirName)
+        : undefined;
+      const explicitSeasonNum = explicitEpisodeNum !== undefined
+        ? (directorySeasonNum ?? 1)
+        : undefined;
       const result = await scrapeClient.autoScrapeTvEpisode(fileName, seriesHint, classification.mediaType, explicitEpisodeNum, explicitSeasonNum);
       if (!result.series) {
         await clearStaleScrapeAssociationsForOverwrite(

--- a/entry/src/test/MediaTypeClassifierContract.test.ets
+++ b/entry/src/test/MediaTypeClassifierContract.test.ets
@@ -216,5 +216,25 @@ export default function mediaTypeClassifierContractTest() {
       const hint = extractSeriesHintFromFilePath('/电视剧/狂飙/Season 1/19 4K.mp4');
       expect(hint).assertEqual('狂飙');
     });
+
+    // ─── #254 中文大季号回归（CodeRabbit 评审） ───
+
+    it('should parse Chinese season numbers beyond 29', 0, () => {
+      expect(extractSeasonNumberFromDirectoryName('长剧第三十季')).assertEqual(30);
+      expect(extractSeasonNumberFromDirectoryName('长剧第三十一季')).assertEqual(31);
+      expect(extractSeasonNumberFromDirectoryName('长剧第五十季')).assertEqual(50);
+      expect(extractSeasonNumberFromDirectoryName('长剧第九十九季')).assertEqual(99);
+    });
+
+    it('should parse Chinese season numbers at hundred level', 0, () => {
+      expect(extractSeasonNumberFromDirectoryName('超级剧第一百季')).assertEqual(100);
+      expect(extractSeasonNumberFromDirectoryName('超级剧第一百零三季')).assertEqual(103);
+      expect(extractSeasonNumberFromDirectoryName('超级剧第一百二十季')).assertEqual(120);
+    });
+
+    it('should strip season suffix for large Chinese season numbers', 0, () => {
+      expect(stripSeasonSuffixFromDirectoryName('长剧第三十季')).assertEqual('长剧');
+      expect(stripSeasonSuffixFromDirectoryName('超级剧第一百季')).assertEqual('超级剧');
+    });
   });
 }

--- a/entry/src/test/MediaTypeClassifierContract.test.ets
+++ b/entry/src/test/MediaTypeClassifierContract.test.ets
@@ -7,7 +7,10 @@ import {
   classifyMediaType,
   createFileNameSemanticInfo,
   createMediaTypeClassificationResult,
-  extractSeriesHintFromFilePath
+  extractSeriesHintFromFilePath,
+  extractSeasonNumberFromDirectoryName,
+  stripSeasonSuffixFromDirectoryName,
+  isSeasonDirectorySegment
 } from '../main/ets/lib/MediaTypeClassifier';
 import { parseFileName } from '../main/ets/lib/ScrapeClient';
 import { classifyVideoScrapeTarget } from '../main/ets/utils/VideoScannerHelpers';
@@ -173,6 +176,45 @@ export default function mediaTypeClassifierContractTest() {
       expect(explicitFalseClassification.reason).assertEqual('insufficient-evidence');
       expect(omittedClassification.mediaType).assertEqual('unknown');
       expect(omittedClassification.reason).assertEqual('insufficient-evidence');
+    });
+
+    // ─── #254 中文季号后缀目录名 ───
+
+    it('should recognize Chinese season suffix directory as season directory', 0, () => {
+      expect(isSeasonDirectorySegment('御赐小仵作第二季')).assertTrue();
+      expect(isSeasonDirectorySegment('庆余年第二部')).assertTrue();
+      expect(isSeasonDirectorySegment('我的剧第3季')).assertTrue();
+      expect(isSeasonDirectorySegment('御赐小仵作')).assertFalse();
+    });
+
+    it('should extract season number from Chinese season suffix directory names', 0, () => {
+      expect(extractSeasonNumberFromDirectoryName('御赐小仵作第二季')).assertEqual(2);
+      expect(extractSeasonNumberFromDirectoryName('庆余年第二部')).assertEqual(2);
+      expect(extractSeasonNumberFromDirectoryName('我的剧第3季')).assertEqual(3);
+      expect(extractSeasonNumberFromDirectoryName('我的剧第三季')).assertEqual(3);
+      expect(extractSeasonNumberFromDirectoryName('第二季')).assertEqual(2);
+      expect(extractSeasonNumberFromDirectoryName('Season 2')).assertEqual(2);
+      expect(extractSeasonNumberFromDirectoryName('S02')).assertEqual(2);
+      expect(extractSeasonNumberFromDirectoryName('御赐小仵作')).assertEqual(undefined);
+    });
+
+    it('should strip Chinese season suffix to extract series title from directory name', 0, () => {
+      expect(stripSeasonSuffixFromDirectoryName('御赐小仵作第二季')).assertEqual('御赐小仵作');
+      expect(stripSeasonSuffixFromDirectoryName('庆余年第二部')).assertEqual('庆余年');
+      expect(stripSeasonSuffixFromDirectoryName('我的剧第3季')).assertEqual('我的剧');
+      expect(stripSeasonSuffixFromDirectoryName('第二季')).assertEqual(undefined);
+      expect(stripSeasonSuffixFromDirectoryName('御赐小仵作')).assertEqual(undefined);
+    });
+
+    it('should extract correct series hint from Chinese season suffix directory path', 0, () => {
+      // #254: "御赐小仵作第二季" 应提取出 "御赐小仵作" 而非整个目录名
+      const hint = extractSeriesHintFromFilePath('/Videos/TV Series/御赐小仵作第二季/01.mp4');
+      expect(hint).assertEqual('御赐小仵作');
+    });
+
+    it('should still extract series hint correctly for standard Season N directories', 0, () => {
+      const hint = extractSeriesHintFromFilePath('/电视剧/狂飙/Season 1/19 4K.mp4');
+      expect(hint).assertEqual('狂飙');
     });
   });
 }


### PR DESCRIPTION
## 问题

目录名 `御赐小仵作第二季` 包含中文季号后缀"第二季"，但刮削系统未能识别：

1. **`extractSeriesHintFromFilePath`** 将整个 `御赐小仵作第二季` 当作剧名搜索提示 → TMDB 搜不到
2. **`isSeasonDirectorySegment`** 不识别"剧名+中文季号后缀"格式 → 季号信息丢失
3. **`VideoScrapeProcessor`** 在弱语义文件名时将 `explicitSeasonNum` 硬编码为 `1` → 第二季文件被归到第一季

## 修复

### MediaTypeClassifier.ets
- 新增 `CHINESE_SEASON_SUFFIX_PATTERN`：匹配目录名末尾的"第X季/部"格式
- 新增 `extractSeasonNumberFromDirectoryName()`：从目录名提取季号（支持中文数字、阿拉伯数字、Season N、Sxx）
- 新增 `stripSeasonSuffixFromDirectoryName()`：从"剧名+季号后缀"提取纯剧名
- 更新 `isSeasonDirectorySegment()`：支持中文季号后缀目录名
- 更新 `extractSeriesHintFromFilePath()`：对"剧名+季号"目录提取纯剧名（如 `御赐小仵作第二季` → `御赐小仵作`）

### VideoScrapeProcessor.ets
- `explicitSeasonNum` 改为从父目录名提取季号，无目录季号时才回退到 1

## 测试

新增 `MediaTypeClassifierContract` 测试用例：
- 中文季号后缀目录识别
- `extractSeasonNumberFromDirectoryName` 多格式验证
- `stripSeasonSuffixFromDirectoryName` 边界场景
- `extractSeriesHintFromFilePath` 中文季号路径提取
- 回归验证标准 Season N 路径

Closes #254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持识别“第X季”“第X部”等中文季号后缀，兼容中文数字和阿拉伯数字。
  * 可从目录名称中提取季号，并在剧名中移除季号后缀。
  * 视频文件将优先根据所在目录识别季号，无法识别时仍默认归入第一季。
* **问题修复**
  * 改进中文季目录下的剧名和季号识别，避免剧名包含多余季号信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->