### PR TITLE
新增: 接入 AVSession 播控服务，支持小艺语音/遥控器控制与系统媒体中心封面展示

### DIFF
--- a/entry/src/main/ets/components/media/ContinueWatchCard.ets
+++ b/entry/src/main/ets/components/media/ContinueWatchCard.ets
@@ -60,6 +60,20 @@ export function buildContinueWatchPlayerParam(input: ContinueWatchPlayerParamInp
   if (input.fileSourceId !== undefined) {
     param.fileSourceId = input.fileSourceId;
   }
+  // 透传封面字段，供系统媒体中心（AVSession）展示海报
+  const item = input.item;
+  if (item.backdropLocalPath !== undefined && item.backdropLocalPath.length > 0) {
+    param.backdropLocalPath = item.backdropLocalPath;
+  }
+  if (item.posterLocalPath !== undefined && item.posterLocalPath.length > 0) {
+    param.posterLocalPath = item.posterLocalPath;
+  }
+  if (item.backdropUrl !== undefined && item.backdropUrl.length > 0) {
+    param.backdropUrl = item.backdropUrl;
+  }
+  if (item.posterUrl !== undefined && item.posterUrl.length > 0) {
+    param.posterUrl = item.posterUrl;
+  }
   return param;
 }
 

--- a/entry/src/main/ets/pages/detail/MovieDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/MovieDetailPage.ets
@@ -391,7 +391,12 @@ export struct MovieDetailPage {
         tmdbId: this.movieEntity?.providerId ?? item.providerId,
         imdbId: extractImdbIdFromRawJson(this.movieEntity?.rawJson),
         fileSourceType,
-        fileSourceId
+        fileSourceId,
+        // 透传封面字段，供系统媒体中心（AVSession）展示海报
+        posterLocalPath: this.item?.posterLocalPath ?? undefined,
+        posterUrl: this.movieEntity?.posterUrl ?? this.item?.posterUrl ?? undefined,
+        backdropLocalPath: this.movieEntity?.backdropLocalPath ?? this.item?.backdropLocalPath ?? undefined,
+        backdropUrl: this.movieEntity?.backdropUrl ?? this.item?.backdropUrl ?? undefined
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
     } catch (e) {

--- a/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeasonDetailPage.ets
@@ -744,7 +744,12 @@ export struct SeasonDetailPage {
         tmdbId: this.seriesEntity?.providerId,
         imdbId: extractImdbIdFromRawJson(this.seriesEntity?.rawJson),
         fileSourceType,
-        fileSourceId
+        fileSourceId,
+        // 透传封面字段，供系统媒体中心（AVSession）展示海报
+        posterLocalPath: this.seriesEntity?.posterLocalPath ?? undefined,
+        posterUrl: this.seriesEntity?.posterUrl ?? undefined,
+        backdropLocalPath: this.seriesEntity?.backdropLocalPath ?? undefined,
+        backdropUrl: this.seriesEntity?.backdropUrl ?? undefined
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param, (popInfo: PopInfo) => {
         if (popInfo.result !== null && popInfo.result !== undefined) {

--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -732,7 +732,12 @@ export struct SeriesDetailPage {
         tmdbId: this.seriesEntity?.providerId,
         imdbId: extractImdbIdFromRawJson(this.seriesEntity?.rawJson),
         fileSourceType,
-        fileSourceId
+        fileSourceId,
+        // 透传封面字段，供系统媒体中心（AVSession）展示海报
+        posterLocalPath: this.seriesEntity?.posterLocalPath ?? undefined,
+        posterUrl: this.seriesEntity?.posterUrl ?? undefined,
+        backdropLocalPath: this.seriesEntity?.backdropLocalPath ?? undefined,
+        backdropUrl: this.seriesEntity?.backdropUrl ?? undefined
       };
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param, (popInfo: PopInfo) => {
         if (popInfo.result !== null && popInfo.result !== undefined) {

--- a/entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets
@@ -162,7 +162,10 @@ export struct ServerMediaDetailPage {
         serverType: server.type,
         serverItemId: target.id,
         serverId: server.id,
-        serverPlaySessionId: playSessionId
+        serverPlaySessionId: playSessionId,
+        // 透传封面字段，供系统媒体中心（AVSession）展示海报
+        posterUrl: target.posterUrl.length > 0 ? target.posterUrl : undefined,
+        backdropUrl: target.backdropUrl.length > 0 ? target.backdropUrl : undefined
       }
       reportServerPlaybackStarted(server.type, server.id ?? 0, target.id, playSessionId, target.positionMs, target.durationMs)
         .catch(() => {})

--- a/entry/src/main/ets/pages/detail/ServerSeasonDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/ServerSeasonDetailPage.ets
@@ -213,7 +213,10 @@ export struct ServerSeasonDetailPage {
         serverType: server.type,
         serverItemId: ep.id,
         serverId: server.id,
-        serverPlaySessionId: playSessionId
+        serverPlaySessionId: playSessionId,
+        // 透传封面字段，供系统媒体中心（AVSession）展示海报
+        posterUrl: this.seasonPosterUrl.length > 0 ? this.seasonPosterUrl : undefined,
+        backdropUrl: this.seriesBackdropUrl.length > 0 ? this.seriesBackdropUrl : undefined
       }
       reportServerPlaybackStarted(server.type, server.id ?? 0, ep.id, playSessionId, ep.positionMs, ep.durationMs)
         .catch(() => {})
@@ -343,7 +346,10 @@ export struct ServerSeasonDetailPage {
         serverType: server.type,
         serverItemId: item.id,
         serverId: server.id,
-        serverPlaySessionId: playSessionId
+        serverPlaySessionId: playSessionId,
+        // 透传封面字段，供系统媒体中心（AVSession）展示海报
+        posterUrl: this.seasonPosterUrl.length > 0 ? this.seasonPosterUrl : undefined,
+        backdropUrl: this.seriesBackdropUrl.length > 0 ? this.seriesBackdropUrl : undefined
       }
       reportServerPlaybackStarted(server.type, server.id ?? 0, item.id, playSessionId, item.positionMs, item.durationMs)
         .catch(() => {})

--- a/entry/src/main/ets/pages/history/PlayHistoryPage.ets
+++ b/entry/src/main/ets/pages/history/PlayHistoryPage.ets
@@ -347,6 +347,9 @@ export struct PlayHistoryPage {
       presetSubtitleTracks: presetResult.presetSubtitleTracks,
       mediaKey: fromStart ? undefined : item.mediaKey,
       startPositionMs: fromStart ? 0 : (item.positionMs > 0 ? item.positionMs : undefined),
+      // 透传封面字段，供系统媒体中心（AVSession）展示海报
+      posterLocalPath: item.posterLocalPath.length > 0 ? item.posterLocalPath : undefined,
+      posterUrl: item.posterUrl.length > 0 ? item.posterUrl : undefined,
     };
     this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param);
   }

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -880,7 +880,10 @@ export struct MediaLibraryTab {
         serverType: server.type,
         serverItemId: item.id,
         serverId: server.id,
-        serverPlaySessionId: playSessionId
+        serverPlaySessionId: playSessionId,
+        // 透传封面字段，供系统媒体中心（AVSession）展示海报
+        posterUrl: item.posterUrl.length > 0 ? item.posterUrl : undefined,
+        backdropUrl: item.backdropUrl.length > 0 ? item.backdropUrl : undefined
       }
       // 上报播放开始（会话建立），与退出时的 stopped 共用同一 playSessionId
       reportServerPlaybackStarted(server.type, server.id ?? 0, item.id, playSessionId, item.positionMs, item.durationMs)

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -28,6 +28,7 @@ import {
 } from "../../services/playbackProgress/PlaybackProgressService";
 import { PlaybackResumeDecision } from "../../services/playbackProgress/PlaybackResumeDecision";
 import { reportServerPlaybackStopped, reportServerPlaybackProgress } from "../../lib/ServerProgressReporter";
+import { AvSessionService, AvSessionCommand, AvSessionSyncState } from "../../services/avSession/AvSessionService";
 
 export interface PlayerPageParam {
   fileUrl?: string;
@@ -281,6 +282,8 @@ export struct PlayerPage {
   private currentPageParam?: PlayerPageParam
   private pageParamToken: number = 0
   private episodeSwitching: boolean = false
+  /** 小艺语音 / 智慧屏遥控器 / 系统媒体中心播控会话（生命周期跟随本页） */
+  private avSessionService?: AvSessionService
   private readonly episodePlaybackManager = new EpisodePlaybackManager()
   @Local isBackPressedOnce: boolean = false
   /** 续播提示弹窗 */
@@ -353,6 +356,71 @@ export struct PlayerPage {
       }
     } catch {
       // 获取 context 失败时，步骤 4 缓存查询将跳过
+    }
+    this.initAvSession();
+  }
+
+  /**
+   * 接入 AVSession（系统播控服务），让小艺语音、智慧屏遥控器播放/暂停键、
+   * 系统媒体中心能够控制本播放器：
+   * 小艺识别「播放/暂停/停止/快进/倍速」→ 系统媒体播控向本会话下发命令 →
+   * onCommand 桥接到 VideoPlayerController.play()/pause()/seek()/setPlaybackSpeed()。
+   */
+  private initAvSession(): void {
+    try {
+      const hostCtx = this.getUIContext().getHostContext()
+      if (!hostCtx) {
+        return
+      }
+      const service = new AvSessionService({
+        context: hostCtx as common.Context,
+        tag: 'VidAll TV',
+        onCommand: (cmd: AvSessionCommand, args?: number) => this.handleAvSessionCommand(cmd, args),
+        getState: (): AvSessionSyncState => {
+          const name = this.videoPlayerController.name
+          return {
+            title: typeof name === 'string' ? name : '',
+            playing: this.videoPlayerController.isPlaying,
+            buffering: this.videoPlayerController.isLoading,
+            positionMs: this.videoPlayerController.currentTime,
+            durationMs: this.videoPlayerController.duration,
+            speed: this.videoPlayerController.playbackSpeed
+          };
+        },
+        syncIntervalMs: 1000
+      });
+      service.init().then((ok: boolean) => {
+        if (ok) {
+          this.avSessionService = service;
+        }
+      });
+    } catch (err) {
+      console.warn(`[PlayerPage] AVSession 初始化失败: ${JSON.stringify(err)}`);
+    }
+  }
+
+  /** 处理系统播控（小艺语音/遥控器/媒体中心）下发的控制命令 */
+  private handleAvSessionCommand(cmd: AvSessionCommand, args?: number): void {
+    switch (cmd) {
+      case 'play':
+        this.videoPlayerController.play().catch(() => {});
+        break;
+      case 'pause':
+      case 'stop':
+        this.videoPlayerController.pause().catch(() => {});
+        break;
+      case 'seek':
+        if (args !== undefined && args >= 0) {
+          this.videoPlayerController.seek(args, 'avsession_seek').catch(() => {});
+        }
+        break;
+      case 'setSpeed':
+        if (args !== undefined && args > 0) {
+          this.videoPlayerController.setPlaybackSpeed(args);
+        }
+        break;
+      default:
+        break;
     }
   }
 
@@ -669,6 +737,8 @@ export struct PlayerPage {
       this.registerPreparedResume(pageParam, token);
     }
     this.videoPlayerController.playbackContext = pageParam.playbackContext;
+    // 新媒体的标题/时长变化后立即刷新系统播控元数据（定时器也会兜底检测）
+    this.avSessionService?.refreshMetadata();
   }
 
   private persistCurrentPlaybackState(): void {
@@ -1204,5 +1274,10 @@ export struct PlayerPage {
     });
     this.videoPlayerController.saveProgressNow()
     this.videoPlayerController.release()
+    // 销毁 AVSession：取消命令监听并释放系统播控会话
+    if (this.avSessionService) {
+      this.avSessionService.destroy();
+      this.avSessionService = undefined;
+    }
   }
 }

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -7,6 +7,8 @@ import {
 } from "../../components/core/player/VideoPlayerController";
 import { SubtitleCacheContext } from "../../subtitle/SubtitleDispatcher";
 import { common } from "@kit.AbilityKit";
+import { image } from '@kit.ImageKit';
+import { http } from '@kit.NetworkKit';
 import { PlaybackContext, PlaybackContextItem, MediaLibraryContext, FileExplorerContext } from "../../components/core/player/PlaybackContext";
 import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { PlayProgressEntity } from "../../db/models/MediaEntity";
@@ -110,6 +112,17 @@ export interface PlayerPageParam {
    * 影视服务器播放会话 ID（可选）。Jellyfin/Emby 上报进度时关联同一会话。
    */
   serverPlaySessionId?: string;
+  /**
+   * 海报本地路径（可选，如沙箱文件路径）。用于系统媒体中心封面展示，
+   * 播放页会以 file:// URI 形式同步到 AVSession。
+   */
+  posterLocalPath?: string;
+  /** 海报网络 URL（可选，TMDB/影视服务器）。用于系统媒体中心封面展示。 */
+  posterUrl?: string;
+  /** 横版背景图本地路径（可选）。封面优先 backdrop 再降级 poster。 */
+  backdropLocalPath?: string;
+  /** 横版背景图网络 URL（可选）。封面优先 backdrop 再降级 poster。 */
+  backdropUrl?: string;
 }
 
 export interface ResolvedEpisodePlaybackSource {
@@ -234,7 +247,12 @@ export function buildMediaLibraryEpisodeSwitchParam(
     serverType: currentParam.serverType,
     serverItemId: currentParam.serverItemId,
     serverId: currentParam.serverId,
-    serverPlaySessionId: currentParam.serverPlaySessionId
+    serverPlaySessionId: currentParam.serverPlaySessionId,
+    // 透传封面字段，切集后系统媒体中心仍显示海报
+    posterLocalPath: currentParam.posterLocalPath,
+    posterUrl: currentParam.posterUrl,
+    backdropLocalPath: currentParam.backdropLocalPath,
+    backdropUrl: currentParam.backdropUrl
   };
   return nextParam;
 }
@@ -269,7 +287,12 @@ export function buildFileExplorerEpisodeSwitchParam(
     preferredBackend: currentParam.preferredBackend,
     fileSourceType: currentParam.fileSourceType,
     fileSourceId: currentParam.fileSourceId,
-    playbackContext: context
+    playbackContext: context,
+    // 透传封面字段（文件源通常无刮削海报，保持与来源一致）
+    posterLocalPath: currentParam.posterLocalPath,
+    posterUrl: currentParam.posterUrl,
+    backdropLocalPath: currentParam.backdropLocalPath,
+    backdropUrl: currentParam.backdropUrl
   };
   return nextParam;
 }
@@ -284,6 +307,11 @@ export struct PlayerPage {
   private episodeSwitching: boolean = false
   /** 小艺语音 / 智慧屏遥控器 / 系统媒体中心播控会话（生命周期跟随本页） */
   private avSessionService?: AvSessionService
+  /**
+   * 同步到系统媒体中心的封面（PixelMap 或 file:// URI）。
+   * 由当前播放参数解析：本地路径优先，网络 URL 异步下载解码为 PixelMap。
+   */
+  private avMediaImage: image.PixelMap | string | undefined = undefined
   private readonly episodePlaybackManager = new EpisodePlaybackManager()
   @Local isBackPressedOnce: boolean = false
   /** 续播提示弹窗 */
@@ -384,7 +412,8 @@ export struct PlayerPage {
             buffering: this.videoPlayerController.isLoading,
             positionMs: this.videoPlayerController.currentTime,
             durationMs: this.videoPlayerController.duration,
-            speed: this.videoPlayerController.playbackSpeed
+            speed: this.videoPlayerController.playbackSpeed,
+            mediaImage: this.avMediaImage
           };
         },
         syncIntervalMs: 1000
@@ -739,6 +768,74 @@ export struct PlayerPage {
     this.videoPlayerController.playbackContext = pageParam.playbackContext;
     // 新媒体的标题/时长变化后立即刷新系统播控元数据（定时器也会兜底检测）
     this.avSessionService?.refreshMetadata();
+    // 解析新媒体封面（本地 URI / 网络 PixelMap），完成后同步到系统媒体中心
+    this.loadMediaImageForAvSession(pageParam);
+  }
+
+  /**
+   * 解析当前媒体的封面并同步到 AVSession（系统媒体中心展示）。
+   * 优先级：backdrop 本地 → poster 本地 → backdrop 网络 → poster 网络。
+   * 本地路径直接以 file:// URI 上传；网络 URL 异步下载解码为 PixelMap 后再上传。
+   */
+  private loadMediaImageForAvSession(pageParam: PlayerPageParam): void {
+    const local = pageParam.backdropLocalPath ?? pageParam.posterLocalPath ?? '';
+    if (local.length > 0) {
+      const uri = local.startsWith('file://') ? local : 'file://' + local;
+      if (this.avMediaImage !== uri) {
+        this.avMediaImage = uri;
+        this.avSessionService?.refreshMetadata();
+      }
+      return;
+    }
+    const url = pageParam.backdropUrl ?? pageParam.posterUrl ?? '';
+    if (url.length === 0) {
+      if (this.avMediaImage !== undefined) {
+        this.avMediaImage = undefined;
+        this.avSessionService?.refreshMetadata();
+      }
+      return;
+    }
+    // 网络封面：异步下载解码，成功后刷新；失败保持无封面（优雅降级）
+    this.downloadPosterToPixelMap(url).then((pm: image.PixelMap | undefined) => {
+      if (pm !== undefined) {
+        this.avMediaImage = pm;
+        this.avSessionService?.refreshMetadata();
+      }
+    }).catch(() => {});
+  }
+
+  /** 网络图片下载并解码为小尺寸 PixelMap（供系统媒体中心展示） */
+  private async downloadPosterToPixelMap(url: string): Promise<image.PixelMap | undefined> {
+    let req: http.HttpRequest | undefined = undefined;
+    try {
+      req = http.createHttp();
+      const resp = await req.request(url, {
+        method: http.RequestMethod.GET,
+        expectDataType: http.HttpDataType.ARRAY_BUFFER,
+        connectTimeout: 8000,
+        readTimeout: 8000
+      });
+      if (resp.responseCode !== 200) {
+        return undefined;
+      }
+      const buf = resp.result as ArrayBuffer;
+      if (buf === undefined || buf.byteLength === 0) {
+        return undefined;
+      }
+      const imgSrc = image.createImageSource(buf);
+      const pm = await imgSrc.createPixelMap({
+        desiredSize: { width: 480, height: 270 },
+        desiredPixelFormat: image.PixelMapFormat.RGBA_8888
+      });
+      imgSrc.release();
+      return pm;
+    } catch (e) {
+      return undefined;
+    } finally {
+      if (req !== undefined) {
+        req.destroy();
+      }
+    }
   }
 
   private persistCurrentPlaybackState(): void {

--- a/entry/src/main/ets/services/avSession/AvSessionService.ets
+++ b/entry/src/main/ets/services/avSession/AvSessionService.ets
@@ -1,6 +1,7 @@
 import { avSession as AVSessionManager } from '@kit.AVSessionKit';
 import { wantAgent, common } from '@kit.AbilityKit';
 import { BusinessError } from '@kit.BasicServicesKit';
+import { image } from '@kit.ImageKit';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 
 const TAG = '[AvSessionService]';
@@ -22,6 +23,8 @@ export interface AvSessionSyncState {
   positionMs: number;
   durationMs: number;
   speed: number;
+  /** 媒体封面：PixelMap 或本地图片 URI（file://），用于系统媒体中心展示 */
+  mediaImage?: image.PixelMap | string;
 }
 
 export interface AvSessionServiceOptions {
@@ -220,15 +223,30 @@ export class AvSessionService {
     }
   }
 
-  /** 标题/时长变化时才写元数据（setAVMetadata 属于 IPC，需去重） */
+  /** 标题/时长/封面变化时才写元数据（setAVMetadata 属于 IPC，需去重） */
   private syncMetadataIfChanged(force: boolean): void {
     const s = this.options.getState();
-    const key = `${s.title}|${Math.round(s.durationMs)}`;
+    const key = `${s.title}|${Math.round(s.durationMs)}|${this.mediaImageKey(s.mediaImage)}`;
     if (!force && key === this.lastMetadataKey) {
       return;
     }
     this.lastMetadataKey = key;
     this.syncMetadataNow(s);
+  }
+
+  /**
+   * mediaImage 的去重标识：
+   * - string（本地 URI）：直接用字符串
+   * - PixelMap：无法字符串化，用固定标记；宿主在替换封面后调用 refreshMetadata() 强制刷新
+   */
+  private mediaImageKey(mediaImage: image.PixelMap | string | undefined): string {
+    if (mediaImage === undefined) {
+      return '';
+    }
+    if (typeof mediaImage === 'string') {
+      return mediaImage;
+    }
+    return 'pixelmap';
   }
 
   private syncMetadataNow(s: AvSessionSyncState): void {
@@ -241,6 +259,9 @@ export class AvSessionService {
       title: s.title.length > 0 ? s.title : this.options.tag,
       duration: Math.max(0, Math.round(s.durationMs))
     };
+    if (s.mediaImage !== undefined) {
+      metadata.mediaImage = s.mediaImage;
+    }
     session.setAVMetadata(metadata).catch((err: BusinessError) => {
       hilog.warn(DOMAIN, TAG, 'setAVMetadata failed: %{public}s', err.message ?? String(err));
     });

--- a/entry/src/main/ets/services/avSession/AvSessionService.ets
+++ b/entry/src/main/ets/services/avSession/AvSessionService.ets
@@ -1,0 +1,281 @@
+import { avSession as AVSessionManager } from '@kit.AVSessionKit';
+import { wantAgent, common } from '@kit.AbilityKit';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+
+const TAG = '[AvSessionService]';
+const DOMAIN = 0x0000;
+
+/**
+ * 小艺语音 / 智慧屏遥控器 / 系统媒体中心可下发的媒体控制命令。
+ * 小艺说「播放」「暂停」「继续播放」「停止播放」「快进到 xx」等，
+ * 系统会转成以下命令下发到当前激活的 AVSession。
+ */
+export type AvSessionCommand = 'play' | 'pause' | 'stop' | 'seek' | 'setSpeed';
+
+/** AVSession 状态快照，由宿主页面从 VideoPlayerController 实时读取 */
+export interface AvSessionSyncState {
+  /** 当前媒体标题（用于系统播控卡片展示） */
+  title: string;
+  playing: boolean;
+  buffering: boolean;
+  positionMs: number;
+  durationMs: number;
+  speed: number;
+}
+
+export interface AvSessionServiceOptions {
+  /** 用于创建 AVSession 的上下文（UIAbilityContext / common.Context） */
+  context: common.Context;
+  /** 会话标签，展示在系统播控中的应用名 */
+  tag: string;
+  /** 命令回调：cmd + 可选参数（seek 为毫秒、setSpeed 为倍速） */
+  onCommand: (cmd: AvSessionCommand, args?: number) => void;
+  /** 实时读取播放器状态快照（宿主页面从 controller 读取） */
+  getState: () => AvSessionSyncState;
+  /** 播放状态同步周期（ms），默认 1000 */
+  syncIntervalMs?: number;
+}
+
+/**
+ * AVSession Provider 封装：
+ * 1. 创建并激活 AVSession（应用作为媒体会话提供方）；
+ * 2. 注册 play/pause/stop/seek/setSpeed 命令监听 —— 小艺语音、遥控器、
+ *    系统媒体中心下发的控制命令都通过这里到达应用；
+ * 3. 周期性把标题、时长、播放状态/进度同步到系统，供播控卡片展示。
+ *
+ * 一个 UIAbility 只能创建一个 AVSession，且会话需在播放期间保持存活，
+ * 因此本服务生命周期跟随 PlayerPage（aboutToAppear 创建 / aboutToDisappear 销毁）。
+ */
+export class AvSessionService {
+  private session: AVSessionManager.AVSession | undefined;
+  private readonly options: AvSessionServiceOptions;
+  private syncTimer: number | undefined;
+  private lastStateKey: string = '';
+  private lastMetadataKey: string = '';
+  private destroyed: boolean = false;
+
+  constructor(options: AvSessionServiceOptions) {
+    this.options = options;
+  }
+
+  /** 创建并激活 AVSession，注册命令监听。返回是否成功。 */
+  async init(): Promise<boolean> {
+    if (this.session) {
+      return true;
+    }
+    try {
+      const type: AVSessionManager.AVSessionType = 'video';
+      const session = await AVSessionManager.createAVSession(this.options.context, this.options.tag, type);
+      this.session = session;
+      await session.activate();
+      this.registerCommandListeners();
+      this.setLaunchAbility();
+      // 首次立即同步，避免播控中心等待一个周期
+      this.syncMetadataIfChanged(true);
+      this.syncPlaybackState(true);
+      this.startSyncTimer();
+      hilog.info(DOMAIN, TAG, 'AVSession created & activated: %{public}s', session.sessionId);
+      return true;
+    } catch (err) {
+      const e = err as BusinessError;
+      hilog.error(DOMAIN, TAG, 'createAVSession failed: code=%{public}s msg=%{public}s',
+        String(e.code), e.message ?? String(e));
+      this.session = undefined;
+      return false;
+    }
+  }
+
+  /**
+   * 销毁会话（页面退出时调用）。
+   * 取消命令监听并销毁会话；静默失败，不抛异常。
+   */
+  async destroy(): Promise<void> {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.stopSyncTimer();
+    const session = this.session;
+    this.session = undefined;
+    if (!session) {
+      return;
+    }
+    try {
+      session.off('play');
+      session.off('pause');
+      session.off('stop');
+      session.off('seek');
+      session.off('setSpeed');
+      await session.destroy();
+      hilog.info(DOMAIN, TAG, 'AVSession destroyed');
+    } catch (err) {
+      const e = err as BusinessError;
+      hilog.warn(DOMAIN, TAG, 'destroy AVSession failed: %{public}s', e.message ?? String(e));
+    }
+  }
+
+  /** 立即刷新元数据（标题/时长变化时由宿主调用，如切换剧集后） */
+  refreshMetadata(): void {
+    this.syncMetadataIfChanged(true);
+  }
+
+  /** 立即刷新播放状态（播放/暂停事件时由宿主调用） */
+  refreshPlaybackState(): void {
+    this.syncPlaybackState(true);
+  }
+
+  // ─── 命令监听 ──────────────────────────────────────────────
+
+  /**
+   * 注册固定播放控制命令监听。
+   * 注册后命令会出现在系统播控 getValidCommands() 中，
+   * 小艺语音「播放/暂停/停止」「进度跳转」「倍速」等即可命中。
+   */
+  private registerCommandListeners(): void {
+    const session = this.session;
+    if (!session) {
+      return;
+    }
+    try {
+      session.on('play', () => {
+        hilog.info(DOMAIN, TAG, 'AVSession command: play');
+        this.options.onCommand('play');
+      });
+      session.on('pause', () => {
+        hilog.info(DOMAIN, TAG, 'AVSession command: pause');
+        this.options.onCommand('pause');
+      });
+      session.on('stop', () => {
+        hilog.info(DOMAIN, TAG, 'AVSession command: stop');
+        this.options.onCommand('stop');
+      });
+      session.on('seek', (time: number) => {
+        hilog.info(DOMAIN, TAG, 'AVSession command: seek %{public}dms', time);
+        this.options.onCommand('seek', time);
+      });
+      session.on('setSpeed', (speed: number) => {
+        hilog.info(DOMAIN, TAG, 'AVSession command: setSpeed %{public}f', speed);
+        this.options.onCommand('setSpeed', speed);
+      });
+    } catch (err) {
+      const e = err as BusinessError;
+      hilog.warn(DOMAIN, TAG, 'registerCommandListeners failed: %{public}s', e.message ?? String(e));
+    }
+  }
+
+  /**
+   * 设置点击系统播控卡片时的拉起目标（应用主页）。
+   * 失败不阻塞会话创建，仅记录日志。
+   */
+  private setLaunchAbility(): void {
+    const session = this.session;
+    if (!session) {
+      return;
+    }
+    try {
+      const bundleName = this.options.context.applicationInfo.name;
+      const wantAgentInfo: wantAgent.WantAgentInfo = {
+        wants: [
+          {
+            bundleName: bundleName,
+            abilityName: 'EntryAbility'
+          }
+        ],
+        operationType: wantAgent.OperationType.START_ABILITIES,
+        requestCode: 0,
+        wantAgentFlags: [wantAgent.WantAgentFlags.UPDATE_PRESENT_FLAG]
+      };
+      wantAgent.getWantAgent(wantAgentInfo).then((agent) => {
+        session.setLaunchAbility(agent).catch((err: BusinessError) => {
+          hilog.warn(DOMAIN, TAG, 'setLaunchAbility failed: %{public}s', err.message ?? String(err));
+        });
+      }).catch((err: BusinessError) => {
+        hilog.warn(DOMAIN, TAG, 'getWantAgent failed: %{public}s', err.message ?? String(err));
+      });
+    } catch (err) {
+      const e = err as BusinessError;
+      hilog.warn(DOMAIN, TAG, 'setLaunchAbility exception: %{public}s', e.message ?? String(e));
+    }
+  }
+
+  // ─── 状态同步 ──────────────────────────────────────────────
+
+  private startSyncTimer(): void {
+    this.stopSyncTimer();
+    const interval = this.options.syncIntervalMs ?? 1000;
+    this.syncTimer = setInterval(() => {
+      if (this.destroyed || !this.session) {
+        return;
+      }
+      this.syncMetadataIfChanged(false);
+      this.syncPlaybackState(false);
+    }, interval);
+  }
+
+  private stopSyncTimer(): void {
+    if (this.syncTimer !== undefined) {
+      clearInterval(this.syncTimer);
+      this.syncTimer = undefined;
+    }
+  }
+
+  /** 标题/时长变化时才写元数据（setAVMetadata 属于 IPC，需去重） */
+  private syncMetadataIfChanged(force: boolean): void {
+    const s = this.options.getState();
+    const key = `${s.title}|${Math.round(s.durationMs)}`;
+    if (!force && key === this.lastMetadataKey) {
+      return;
+    }
+    this.lastMetadataKey = key;
+    this.syncMetadataNow(s);
+  }
+
+  private syncMetadataNow(s: AvSessionSyncState): void {
+    const session = this.session;
+    if (!session) {
+      return;
+    }
+    const metadata: AVSessionManager.AVMetadata = {
+      assetId: 'vidall-current',
+      title: s.title.length > 0 ? s.title : this.options.tag,
+      duration: Math.max(0, Math.round(s.durationMs))
+    };
+    session.setAVMetadata(metadata).catch((err: BusinessError) => {
+      hilog.warn(DOMAIN, TAG, 'setAVMetadata failed: %{public}s', err.message ?? String(err));
+    });
+  }
+
+  /** 播放状态/进度变化时才写（position 单位 ms） */
+  private syncPlaybackState(force: boolean): void {
+    const session = this.session;
+    if (!session) {
+      return;
+    }
+    const s = this.options.getState();
+    let state: AVSessionManager.PlaybackState;
+    if (s.playing) {
+      state = s.buffering
+        ? AVSessionManager.PlaybackState.PLAYBACK_STATE_BUFFERING
+        : AVSessionManager.PlaybackState.PLAYBACK_STATE_PLAY;
+    } else {
+      state = AVSessionManager.PlaybackState.PLAYBACK_STATE_PAUSE;
+    }
+    const key = `${state}|${Math.round(s.positionMs)}|${s.speed}`;
+    if (!force && key === this.lastStateKey) {
+      return;
+    }
+    this.lastStateKey = key;
+    const playbackState: AVSessionManager.AVPlaybackState = {
+      state: state,
+      position: {
+        elapsedTime: Math.max(0, Math.round(s.positionMs)),
+        updateTime: Date.now()
+      },
+      speed: s.speed > 0 ? s.speed : 1.0
+    };
+    session.setAVPlaybackState(playbackState).catch((err: BusinessError) => {
+      hilog.warn(DOMAIN, TAG, 'setAVPlaybackState failed: %{public}s', err.message ?? String(err));
+    });
+  }
+}

--- a/openspec/changes/2026-08-21-avsession-voice-control/.openspec.yaml
+++ b/openspec/changes/2026-08-21-avsession-voice-control/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/2026-08-21-avsession-voice-control/design.md
+++ b/openspec/changes/2026-08-21-avsession-voice-control/design.md
@@ -1,0 +1,64 @@
+## Context
+
+- 应用为 HarmonyOS TV 视频播放器（`deviceTypes: ["tv"]`），targetSdkVersion 22 / compatibleSdkVersion 19，完全支持 AVSession Kit（API 10+）。
+- 播放内核统一由 `VideoPlayerController` 暴露 `play()/pause()/seek()/setPlaybackSpeed()` 等接口，不依赖具体 backend（AVPlayer/MPV）。
+- 播放器页面 `PlayerPage`（`pages/player/index.ets`）持有唯一 `VideoPlayerController` 实例，生命周期明确（`aboutToAppear`/`aboutToDisappear`），是接入系统播控的天然宿主。
+- 华为智慧屏小艺语音的「播放/暂停」等媒体控制指令，经系统媒体播控中心向当前激活的 AVSession 下发固定控制命令（`play`/`pause`/`stop`/`seek`/`setSpeed`），遥控器媒体键与手机媒体中心走同一通道。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 让小艺语音、智慧屏遥控器播放键、系统媒体中心能够控制播放器的播放/暂停/进度/倍速
+- 将当前媒体标题、时长、播放状态与进度同步到系统播控侧展示
+- 播放器页面退出时干净释放会话，不残留系统级状态
+- 接入失败不阻塞播放（优雅降级）
+
+**Non-Goals:**
+- 不接入小艺技能开放平台（Skills）实现「播放《XXX》第3集」类自定义语义指令（属于独立路线，后续可扩展）
+- 不实现 `playNext`/`playPrevious` 命令控制切集（依赖播放列表上下文，复杂度高，暂不注册）
+- 不处理 HarmonyOS 手机端的投播（AVCastPicker）
+- 不改动 `VideoPlayerController` 内部播放逻辑与后端路由
+
+## Decisions
+
+### 1. 独立服务类 `AvSessionService` 封装 AVSession，回调注入解耦
+
+新建 `services/avSession/AvSessionService.ets`，通过构造函数注入 `context`、`onCommand` 回调与 `getState` 快照读取器，**不直接 import `VideoPlayerController`**，避免服务层与播放器控制器产生循环依赖，同时便于单元测试。
+
+- 命令回调：`onCommand(cmd, args?)`，由宿主页面映射到 controller 方法
+- 状态快照：`getState(): AvSessionSyncState`（标题/播放中/缓冲/进度/时长/倍速），由宿主页面从 controller 实时读取
+
+### 2. 会话类型与命令集
+
+- `createAVSession(context, 'VidAll TV', 'video')` + `activate()`
+- 注册固定命令：`play`、`pause`、`stop`、`seek`、`setSpeed`。只注册支持的命令，保证 `getValidCommands()` 反映真实能力
+- `stop` 在应用侧映射为 `pause()`（保持播放会话，不退出播放页）
+
+### 3. 状态同步策略：1s 定时器 + 去重
+
+- 会话激活后启动 1s 定时器，周期性调用 `setAVPlaybackState`（播放/暂停/缓冲 + `PlaybackPosition{elapsedTime, updateTime}` 进度）与 `setAVMetadata`（标题 + 时长）
+- 用「状态键」去重（`state|position|speed` 与 `title|duration`），仅在变化时发起 IPC 写，避免无效系统调用
+- 切集后宿主调用 `refreshMetadata()` 立即刷新元数据，不等下一个周期
+
+### 4. 生命周期跟随 PlayerPage
+
+- `aboutToAppear` → 创建服务并 `init()`（异步，失败仅记日志）
+- `aboutToDisappear` → `destroy()`（`off` 全部命令监听 + `destroy()` 会话）
+- 一个 UIAbility 仅允许一个 AVSession，本设计满足该约束
+
+### 5. 播控卡片拉起应用
+
+- 通过 `wantAgent` 配置 `setLaunchAbility`，bundleName 从 `context.applicationInfo.name` 动态获取，abilityName 为 `EntryAbility`
+- 失败不阻塞会话创建，仅记录日志
+
+### 备选方案
+
+- **在 `VideoPlayerController` 内直接创建会话**：耦合控制器与系统服务，且 controller 被多处复用，生命周期边界模糊，否决
+- **每帧同步播放状态**：IPC 开销大，1s 周期已满足媒体中心进度展示精度，否决
+
+## Risks / Trade-offs
+
+- **小艺指令路由依赖系统**：小艺把语音识别为媒体控制命令的前提是系统识别到「当前播放会话」；部分智慧屏版本或非标准场景下可能走「可见即可说」OCR 通道，行为不可控，属系统侧行为，应用侧无解
+- **一个 UIAbility 一个会话**：若未来出现多播放实例（如悬浮窗），需重新设计会话归属
+- **`setPlaybackState` 写频率**：1s 周期写对系统服务有一定 IPC 压力，已通过去重缓解
+- **API 差异**：`AVPlaybackState.position` 在 API 12+ 为 `PlaybackPosition` 对象结构（旧版为 number），已按当前 SDK（API 22）适配

--- a/openspec/changes/2026-08-21-avsession-voice-control/design.md
+++ b/openspec/changes/2026-08-21-avsession-voice-control/design.md
@@ -51,6 +51,15 @@
 - 通过 `wantAgent` 配置 `setLaunchAbility`，bundleName 从 `context.applicationInfo.name` 动态获取，abilityName 为 `EntryAbility`
 - 失败不阻塞会话创建，仅记录日志
 
+### 6. 媒体封面同步（mediaImage）
+
+- `AVMetadata.mediaImage` 支持 `PixelMap` 或 URI 字符串，用于系统媒体中心展示海报
+- 封面来源经 `PlayerPageParam` 新增的 4 个可选字段透传（`posterLocalPath` / `posterUrl` / `backdropLocalPath` / `backdropUrl`），由各播放入口（继续观看、电影/剧集/季详情、影视服务器、媒体库、播放历史）填写
+- 解析优先级：本地 backdrop → 本地 poster → 网络 backdrop → 网络 poster
+- 本地路径以 `file://` URI 直接上传（系统端可解析，零解码开销）；网络 URL 用 `@ohos.net.http` 下载 ArrayBuffer → `image.createImageSource` 解码为 480×270 PixelMap 后上传
+- 元数据去重键扩展为 `title|duration|mediaImage`（PixelMap 用固定标记，宿主替换封面后调 `refreshMetadata()` 强制刷新）
+- 切集 param 透传现有封面字段，`loadMediaImageForAvSession` 重新解析
+
 ### 备选方案
 
 - **在 `VideoPlayerController` 内直接创建会话**：耦合控制器与系统服务，且 controller 被多处复用，生命周期边界模糊，否决

--- a/openspec/changes/2026-08-21-avsession-voice-control/proposal.md
+++ b/openspec/changes/2026-08-21-avsession-voice-control/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+华为智慧屏用户期望用语音（小艺）直接控制第三方视频应用的播放/暂停，而不是依赖遥控器按键。当前应用未接入系统媒体播控服务（AVSession），小艺语音、遥控器播放键、系统媒体中心均无法控制播放器，与主流 TV 视频应用的用户体验存在差距。
+
+## What Changes
+
+- 新增 `AvSessionService`：创建并激活 AVSession（类型 `video`），作为系统媒体播控的 Provider
+- 注册固定播放控制命令监听：`play` / `pause` / `stop` / `seek` / `setSpeed`，将系统下发的命令桥接到 `VideoPlayerController`
+- 周期性同步播放状态（`AVPlaybackState`：播放/暂停/缓冲 + 进度位置）与媒体元数据（`AVMetadata`：标题、时长）到系统播控，供小艺/媒体中心展示
+- 通过 `setLaunchAbility` 配置点击系统播控卡片时拉起应用
+- 会话生命周期跟随 `PlayerPage`（进入创建、退出销毁），切集时刷新元数据
+- 适配 API 22 的 `PlaybackPosition { elapsedTime, updateTime }` 结构
+
+## Capabilities
+
+### New Capabilities
+- `avsession-media-control`: 应用作为系统媒体播控（AVSession）Provider，接收小艺语音/遥控器/媒体中心下发的播放控制命令并同步播放状态与元数据
+
+### Modified Capabilities
+<!-- 无既有能力的行为变化：本变更仅新增媒体播控接入，不改变现有播放内核、路由、续播等能力的行为。 -->
+
+## Impact
+
+- 新增代码：`entry/src/main/ets/services/avSession/AvSessionService.ets`
+- 修改代码：`entry/src/main/ets/pages/player/index.ets`（PlayerPage 集成，命令桥接 + 生命周期管理）
+- 依赖：`@kit.AVSessionKit`（API 12+，本项目 compatibleSdkVersion 19 支持）、`@kit.AbilityKit`（wantAgent）
+- 权限：无需新增权限声明
+- 行为影响：应用播放时成为系统可感知的媒体会话；播放器页面可见时，系统播控可下发控制命令

--- a/openspec/changes/2026-08-21-avsession-voice-control/specs/avsession-media-control/spec.md
+++ b/openspec/changes/2026-08-21-avsession-voice-control/specs/avsession-media-control/spec.md
@@ -1,0 +1,55 @@
+# avsession-media-control Specification
+
+## Purpose
+应用作为系统媒体播控（AVSession Kit）的 Provider 接入，使小艺语音、智慧屏遥控器播放键与系统媒体中心能够控制本应用的播放/暂停等操作，并把当前媒体信息同步到系统侧展示。
+
+## ADDED Requirements
+
+### Requirement: 播放器页面 SHALL 创建并激活媒体会话
+系统 SHALL 在播放器页面出现时创建一个类型为 video 的 AVSession 并激活，作为系统媒体播控的 Provider；一个 UIAbility 生命周期内仅维护一个会话。
+
+#### Scenario: 进入播放器页面
+- **WHEN** 用户进入播放器页面
+- **THEN** 系统 SHALL 创建并激活 AVSession
+- **AND** 会话失败创建或激活 SHALL 不影响播放器正常播放
+
+#### Scenario: 退出播放器页面
+- **WHEN** 用户退出播放器页面
+- **THEN** 系统 SHALL 注销命令监听并销毁 AVSession
+
+### Requirement: 系统播控命令 SHALL 控制播放器
+系统 SHALL 监听系统下发的固定播放控制命令，并将其映射到播放器控制：`play` → 播放、`pause` 与 `stop` → 暂停、`seek` → 跳转进度、`setSpeed` → 设置倍速。
+
+#### Scenario: 小艺语音暂停
+- **WHEN** 视频播放中，用户对小艺说「暂停」
+- **THEN** 系统 SHALL 收到 `pause` 命令并暂停当前视频
+
+#### Scenario: 小艺语音恢复播放
+- **WHEN** 视频处于暂停态，用户对小艺说「播放」或「继续播放」
+- **THEN** 系统 SHALL 收到 `play` 命令并恢复播放
+
+#### Scenario: 进度跳转
+- **WHEN** 系统下发 `seek` 命令且携带合法的毫秒进度值
+- **THEN** 系统 SHALL 将播放进度跳转到对应位置
+
+#### Scenario: 倍速设置
+- **WHEN** 系统下发 `setSpeed` 命令且携带合法的正数倍速
+- **THEN** 系统 SHALL 应用该倍速，不支持的值按播放器既有规则归一化
+
+### Requirement: 播放状态与元数据 SHALL 同步到系统播控
+系统 SHALL 周期性向 AVSession 同步播放状态（播放/暂停/缓冲、进度位置、倍速）与媒体元数据（标题、时长），使系统播控与媒体中心展示的信息保持准确。
+
+#### Scenario: 周期同步播放状态
+- **WHEN** 播放进行中
+- **THEN** 系统 SHALL 以不超过 1 秒的周期上报当前播放状态与进度位置
+
+#### Scenario: 切换媒体后更新元数据
+- **WHEN** 播放器切换到新的媒体（标题或时长变化）
+- **THEN** 系统 SHALL 更新 AVSession 元数据中的标题与时长
+
+### Requirement: 播控卡片 SHALL 可拉起应用
+系统 SHALL 为 AVSession 配置启动能力，使用户点击系统播控中的媒体卡片时拉起本应用。
+
+#### Scenario: 点击播控卡片
+- **WHEN** 用户在系统播控界面点击本应用的媒体卡片
+- **THEN** 系统 SHALL 启动本应用的 EntryAbility

--- a/openspec/changes/2026-08-21-avsession-voice-control/specs/avsession-media-control/spec.md
+++ b/openspec/changes/2026-08-21-avsession-voice-control/specs/avsession-media-control/spec.md
@@ -47,6 +47,25 @@
 - **WHEN** 播放器切换到新的媒体（标题或时长变化）
 - **THEN** 系统 SHALL 更新 AVSession 元数据中的标题与时长
 
+### Requirement: 媒体封面 SHALL 同步到系统播控
+系统 SHALL 在媒体存在封面或背景图时，将其以 PixelMap 或本地 URI 形式写入 AVSession 元数据的 mediaImage 字段，供系统媒体中心展示海报。封面来源解析顺序 SHALL 为：本地背景图 → 本地海报 → 网络背景图 → 网络海报；网络图片 SHALL 异步下载并解码为 PixelMap，下载或解码失败 SHALL 优雅降级为无封面，不影响播放。
+
+#### Scenario: 本地封面直接展示
+- **WHEN** 当前媒体存在本地海报或背景图路径
+- **THEN** 系统 SHALL 以 file:// URI 形式将该图片同步到 AVSession 元数据
+
+#### Scenario: 网络封面异步加载
+- **WHEN** 当前媒体仅有网络海报 URL
+- **THEN** 系统 SHALL 异步下载并解码为 PixelMap 后同步到 AVSession 元数据
+
+#### Scenario: 封面加载失败降级
+- **WHEN** 网络封面下载失败或当前媒体无任何封面
+- **THEN** 系统 SHALL 不设置封面，仅同步标题与时长，且播放不受影响
+
+#### Scenario: 切集后更新封面
+- **WHEN** 播放器切换到新的媒体（封面变化）
+- **THEN** 系统 SHALL 更新 AVSession 元数据中的封面
+
 ### Requirement: 播控卡片 SHALL 可拉起应用
 系统 SHALL 为 AVSession 配置启动能力，使用户点击系统播控中的媒体卡片时拉起本应用。
 

--- a/openspec/changes/2026-08-21-avsession-voice-control/tasks.md
+++ b/openspec/changes/2026-08-21-avsession-voice-control/tasks.md
@@ -1,0 +1,24 @@
+## 1. AVSession 服务封装
+
+- [x] 1.1 新增 `services/avSession/AvSessionService.ets`：`init()` 创建并激活 AVSession（`createAVSession(context, 'VidAll TV', 'video')` + `activate()`）
+- [x] 1.2 注册固定播放控制命令监听：`play` / `pause` / `stop` / `seek` / `setSpeed`，通过 `onCommand(cmd, args?)` 回调透出
+- [x] 1.3 实现状态同步：1s 定时器调用 `setAVPlaybackState`（播放/暂停/缓冲状态 + `PlaybackPosition{elapsedTime, updateTime}` + 倍速），标题/时长变化时调用 `setAVMetadata`
+- [x] 1.4 实现状态去重：`state|position|speed` 与 `title|duration` 键不变时不发起 IPC 写
+- [x] 1.5 实现 `setLaunchAbility`：通过 `wantAgent` 配置点击播控卡片拉起 `EntryAbility`（bundleName 取自 `context.applicationInfo.name`）
+- [x] 1.6 实现 `destroy()`：`off` 全部命令监听并 `destroy()` 会话，静默失败不抛异常
+
+## 2. PlayerPage 集成
+
+- [x] 2.1 `pages/player/index.ets` 新增 `avSessionService` 字段，`aboutToAppear` 调用 `initAvSession()` 创建服务
+- [x] 2.2 `initAvSession()` 注入 `onCommand` 回调：`play` → `controller.play()`、`pause`/`stop` → `controller.pause()`、`seek` → `controller.seek(args, 'avsession_seek')`、`setSpeed` → `controller.setPlaybackSpeed(args)`
+- [x] 2.3 `initAvSession()` 注入 `getState` 快照：从 controller 读取标题/`isPlaying`/`isLoading`/`currentTime`/`duration`/`playbackSpeed`
+- [x] 2.4 `aboutToDisappear` 调用 `avSessionService.destroy()` 并置空
+- [x] 2.5 切集（`applyPlayerPageParam`）后调用 `refreshMetadata()` 立即刷新元数据
+
+## 3. 构建与真机验证
+
+- [x] 3.1 `hvigorw assembleHap` 编译通过（BUILD SUCCESSFUL，无新增 ArkTS 警告）
+- [x] 3.2 hdc 安装到华为智慧屏 MateTV Pro（EDIS-790A，API 24）并启动应用
+- [ ] 3.3 真机语音验证：播放视频后对小艺说「暂停」「播放/继续播放」，确认播放器响应
+- [ ] 3.4 真机验证遥控器播放/暂停键与系统媒体中心显示（标题、进度）与拖动
+- [ ] 3.5 抓取 hilog 确认 `AVSession command: play/pause` 命令链路日志

--- a/openspec/changes/2026-08-21-avsession-voice-control/tasks.md
+++ b/openspec/changes/2026-08-21-avsession-voice-control/tasks.md
@@ -19,6 +19,16 @@
 
 - [x] 3.1 `hvigorw assembleHap` 编译通过（BUILD SUCCESSFUL，无新增 ArkTS 警告）
 - [x] 3.2 hdc 安装到华为智慧屏 MateTV Pro（EDIS-790A，API 24）并启动应用
-- [ ] 3.3 真机语音验证：播放视频后对小艺说「暂停」「播放/继续播放」，确认播放器响应
+- [x] 3.3 真机语音验证：播放视频后对小艺说「暂停」「播放/继续播放」，确认播放器响应
 - [ ] 3.4 真机验证遥控器播放/暂停键与系统媒体中心显示（标题、进度）与拖动
 - [ ] 3.5 抓取 hilog 确认 `AVSession command: play/pause` 命令链路日志
+
+## 4. 媒体封面同步
+
+- [x] 4.1 `AvSessionSyncState` 新增 `mediaImage`（PixelMap | file:// URI），`syncMetadataNow` 写入 `AVMetadata.mediaImage`
+- [x] 4.2 元数据去重键扩展为 `title|duration|mediaImage`（PixelMap 用固定标记 + 宿主强制刷新）
+- [x] 4.3 `PlayerPageParam` 新增 `posterLocalPath` / `posterUrl` / `backdropLocalPath` / `backdropUrl` 可选字段
+- [x] 4.4 `PlayerPage` 实现 `loadMediaImageForAvSession`：本地路径 → file:// URI；网络 URL → http 下载 + ImageSource 解码为 480×270 PixelMap；无封面优雅降级
+- [x] 4.5 切集 param（`buildMediaLibraryEpisodeSwitchParam` / `buildFileExplorerEpisodeSwitchParam`）透传封面字段
+- [x] 4.6 各播放入口透传封面：ContinueWatchCard / MovieDetailPage / SeriesDetailPage / SeasonDetailPage / ServerMediaDetailPage / ServerSeasonDetailPage / MediaLibraryTab / PlayHistoryPage
+- [ ] 4.7 真机验证：播放有海报的视频，确认系统媒体中心展示海报缩略图

--- a/openspec/changes/2026-08-21-avsession-voice-control/tasks.md
+++ b/openspec/changes/2026-08-21-avsession-voice-control/tasks.md
@@ -20,8 +20,8 @@
 - [x] 3.1 `hvigorw assembleHap` 编译通过（BUILD SUCCESSFUL，无新增 ArkTS 警告）
 - [x] 3.2 hdc 安装到华为智慧屏 MateTV Pro（EDIS-790A，API 24）并启动应用
 - [x] 3.3 真机语音验证：播放视频后对小艺说「暂停」「播放/继续播放」，确认播放器响应
-- [ ] 3.4 真机验证遥控器播放/暂停键与系统媒体中心显示（标题、进度）与拖动
-- [ ] 3.5 抓取 hilog 确认 `AVSession command: play/pause` 命令链路日志
+- [x] 3.4 真机验证遥控器播放/暂停键与系统媒体中心显示（标题、进度）与拖动
+- [x] 3.5 抓取 hilog 确认 `AVSession command: play/pause` 命令链路日志
 
 ## 4. 媒体封面同步
 
@@ -31,4 +31,4 @@
 - [x] 4.4 `PlayerPage` 实现 `loadMediaImageForAvSession`：本地路径 → file:// URI；网络 URL → http 下载 + ImageSource 解码为 480×270 PixelMap；无封面优雅降级
 - [x] 4.5 切集 param（`buildMediaLibraryEpisodeSwitchParam` / `buildFileExplorerEpisodeSwitchParam`）透传封面字段
 - [x] 4.6 各播放入口透传封面：ContinueWatchCard / MovieDetailPage / SeriesDetailPage / SeasonDetailPage / ServerMediaDetailPage / ServerSeasonDetailPage / MediaLibraryTab / PlayHistoryPage
-- [ ] 4.7 真机验证：播放有海报的视频，确认系统媒体中心展示海报缩略图
+- [x] 4.7 真机验证：播放有海报的视频，确认系统媒体中心展示海报缩略图


### PR DESCRIPTION
## 概述

接入 HarmonyOS **AVSession Kit（音视频播控服务）**，让华为智慧屏小艺语音、遥控器播放键、系统媒体中心能够控制本播放器的播放/暂停/进度/倍速，并在媒体中心展示当前视频标题与海报。

## 变更内容

### 1. 语音/播控控制（小艺语音操控播放/暂停）

- 新增 `services/avSession/AvSessionService.ets`：创建并激活 AVSession（类型 video），注册 `play`/`pause`/`stop`/`seek`/`setSpeed` 命令监听
- `PlayerPage` 集成：命令桥接到 `VideoPlayerController.play()/pause()/seek()/setPlaybackSpeed()`
- 1s 周期同步播放状态（`AVPlaybackState`，适配 API 22 的 `PlaybackPosition{elapsedTime, updateTime}`）与标题/时长元数据
- `setLaunchAbility`：点击播控卡片拉起应用；会话生命周期跟随播放页

### 2. 系统媒体中心封面展示

- `AVMetadata.mediaImage` 同步媒体海报：本地路径以 `file://` URI 直传，网络 URL 异步下载解码为 480×270 PixelMap
- `PlayerPageParam` 新增 `posterLocalPath`/`posterUrl`/`backdropLocalPath`/`backdropUrl` 字段
- 8 个播放入口透传封面：继续观看、电影/剧集/季详情页、影视服务器媒体/季详情、媒体库、播放历史
- 切集自动透传并重载封面；无封面/下载失败优雅降级

### 3. OpenSpec 文档

- `openspec/changes/2026-08-21-avsession-voice-control/`：proposal / specs（avsession-media-control，5 项需求）/ design / tasks
- 全部任务已真机验证通过（华为智慧屏 MateTV Pro，API 24）：语音播放/暂停、遥控器播控、媒体中心标题/进度/封面展示、命令链路日志

## 真机验证

- ✅ 小艺语音「暂停」「播放/继续播放」控制播放器
- ✅ 遥控器播放/暂停键、系统媒体中心标题/进度/拖动
- ✅ 系统媒体中心展示视频海报缩略图
- ✅ `hilog` 确认 `AVSession command: play/pause` 命令链路

## 兼容性

- 依赖 `@kit.AVSessionKit`（API 12+），项目 compatibleSdkVersion 19 满足
- 无需新增权限声明；接入失败不影响正常播放（优雅降级）