### PR TITLE
新增: 按设备解码能力动态路由 AVPlayer/MPV 并记录纠偏 (Issue #243)

### DIFF
--- a/entry/src/main/cpp/audio_capability.cpp
+++ b/entry/src/main/cpp/audio_capability.cpp
@@ -70,11 +70,38 @@ struct AudioCapResult {
 };
 
 static std::string BuildAudioMime(const std::string &codecOrMime) {
-  if (codecOrMime == "aac"  || codecOrMime == "audio/mp4a-latm") return "audio/mp4a-latm";
-  if (codecOrMime == "opus" || codecOrMime == "audio/opus") return "audio/opus";
-  if (codecOrMime == "flac" || codecOrMime == "audio/flac") return "audio/flac";
-  if (codecOrMime == "mp3"  || codecOrMime == "audio/mpeg") return "audio/mpeg";
-  return codecOrMime;
+  std::string c = codecOrMime;
+  for (size_t i = 0; i < c.size(); i++) {
+    c[i] = static_cast<char>(tolower(static_cast<unsigned char>(c[i])));
+  }
+  // 去掉 "audio/" 前缀与连字符，得到与 ArkTS normalizeAudioCodec 对齐的归一化 codec。
+  const std::string prefix = "audio/";
+  if (c.compare(0, prefix.size(), prefix) == 0) {
+    c = c.substr(prefix.size());
+  }
+  std::string normalized;
+  normalized.reserve(c.size());
+  for (size_t i = 0; i < c.size(); i++) {
+    if (c[i] != '-') {
+      normalized.push_back(c[i]);
+    }
+  }
+
+  if (normalized == "aac" || normalized == "mp4a" || normalized == "mp4alatm" || normalized == "aaclatm") return "audio/mp4a-latm";
+  if (normalized == "opus") return "audio/opus";
+  if (normalized == "flac") return "audio/flac";
+  if (normalized == "mp3" || normalized == "mpeg") return "audio/mpeg";
+  if (normalized == "vorbis") return "audio/vorbis";
+  if (normalized == "ac3" || normalized == "ac3dolbydigital") return "audio/ac3";
+  if (normalized == "eac3" || normalized == "ec3" || normalized == "eac3dolbydigitalplus") return "audio/eac3";
+  if (normalized == "truehd") return "audio/truehd";
+  if (normalized == "mlp") return "audio/mlp";
+  if (normalized == "dts" || normalized == "vnd.dts") return "audio/vnd.dts";
+  if (normalized == "dtshd" || normalized == "vnd.dts.hd") return "audio/vnd.dts.hd";
+  if (normalized == "vivid" || normalized == "audiovivid") return "audio/vivid";
+  if (normalized == "pcm" || normalized.rfind("pcm", 0) == 0) return "audio/raw";
+  // 未知 codec：返回空串，由调用方标记 capabilityKnown=false。
+  return std::string();
 }
 
 static napi_value MakeStringField(napi_env env, const std::string &s) {
@@ -86,6 +113,12 @@ static napi_value MakeStringField(napi_env env, const std::string &s) {
 static AudioCapResult QueryAudioCapInternal(const std::string &codecOrMime) {
   AudioCapResult r;
   r.mimeType = BuildAudioMime(codecOrMime);
+  if (r.mimeType.empty()) {
+    // 归一化 codec 无法映射到已知 MIME：能力未知，交由上层保守决策。
+    r.capabilityKnown = false;
+    r.errorMessage = "unknown codec";
+    return r;
+  }
   r.capabilityKnown = true;
 
   OH_AVCapability *cap = OH_AVCodec_GetCapabilityByCategory(r.mimeType.c_str(), false, HARDWARE);
@@ -95,6 +128,7 @@ static AudioCapResult QueryAudioCapInternal(const std::string &codecOrMime) {
     isHw = (cap != nullptr) && OH_AVCapability_IsHardware(cap);
   }
   if (cap == nullptr) {
+    // 解码器明确不存在：能力已知，但判定为不支持。
     r.errorMessage = "decoder not found";
     return r;
   }

--- a/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
+++ b/entry/src/main/ets/components/core/player/AVPlayerAdapter.ets
@@ -13,20 +13,6 @@ const TAG = '[AVPlayerAdapter]';
 const ENABLE_AVPLAYER_TRACK_DIAG_LOG = true;
 const ENABLE_AVPLAYER_SUBTITLE_DIAG_LOG = false;
 
-// AVPlayer 在 API 23+ 的 demux 层可识别这些 codec 并进入 PREPARED，
-// 但 decoder 层静默放弃解码导致无声（Issue #212）。
-// 需在 PREPARED 时主动检测，若全部音频轨道均属此列则触发 fallback。
-// 与 VideoPlayerController.SYSTEM_SOFT_FALLBACK_CODECS 保持内容同步（MIME 格式）。
-const UNSUPPORTED_AUDIO_CODECS: string[] = [
-  'audio/ac3',        // Dolby Digital (AC-3)
-  'audio/eac3',       // Dolby Digital Plus / Atmos (E-AC-3)
-  'audio/truehd',     // Dolby TrueHD / Atmos
-  'audio/vnd.dts',    // DTS Core
-  'audio/vnd.dts.hd', // DTS-HD
-  'audio/mlp',        // MLP (Meridian Lossless Packing)
-  'audio/vivid',      // Audio Vivid
-];
-
 /**
  * AVPlayer 播放内核适配器
  *
@@ -373,61 +359,11 @@ export class AVPlayerAdapter implements IPlayer {
           });
           break;
         case AVPlayerState.PREPARED:
-          // API 23 eac3 静默失败修复（Issue #212）：
-          // demux 可识别 eac3 进入 PREPARED，但 decoder 静默放弃导致无声、不报 error。
-          // 在此主动检测所有音频轨道 codec，全为不支持格式时触发 fallback，而非直接调 _onReadyCb。
-          //
-          // 关键：若整组音轨中存在至少一条"软解常见"（AC-3/EAC-3）或"硬解"轨道，
-          // 不能默认落到 track 0 的 TrueHD 触发 fallback，应让 controller 在
-          // loadAudioTracks 阶段按 codecCompatibilityRank 切到合适轨道。
-          // 这里仍按"全部 unsupported"才触发 fallback 的逻辑。
-          player.getTrackDescription().then((tracks: Array<media.MediaDescription>) => {
-            // 详细打印所有轨道（用于 verify 真机回溯）
-            for (let i = 0; i < tracks.length; i++) {
-              const t = tracks[i];
-              const trackType = t[media.MediaDescriptionKey.MD_KEY_TRACK_TYPE] as number;
-              if (trackType === media.MediaType.MEDIA_TYPE_AUD) {
-                const mimeType = t[media.MediaDescriptionKey.MD_KEY_CODEC_MIME] as string | undefined;
-                hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-                  `[AVPlayer.PREPARED] 音频轨[${i}]: mime=${mimeType ?? 'unknown'}`);
-              }
-            }
-            hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-              `PREPARED trackCount=${tracks.length}`);
-            // 统计音频轨道中属于不支持格式的数量
-            let audioCount = 0;
-            let unsupportedCount = 0;
-            for (let i = 0; i < tracks.length; i++) {
-              const t = tracks[i];
-              const trackType = t[media.MediaDescriptionKey.MD_KEY_TRACK_TYPE] as number;
-              if (trackType !== media.MediaType.MEDIA_TYPE_AUD) {
-                continue;
-              }
-              audioCount++;
-              const mimeType = t[media.MediaDescriptionKey.MD_KEY_CODEC_MIME] as string | undefined;
-              if (mimeType !== undefined) {
-                const codecLower = mimeType.toLowerCase();
-                if (UNSUPPORTED_AUDIO_CODECS.indexOf(codecLower) >= 0) {
-                  unsupportedCount++;
-                }
-              }
-            }
-            if (audioCount > 0 && audioCount === unsupportedCount) {
-              hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-                `所有音频轨道均为不支持格式，主动触发 fallback（音频轨道数=${audioCount}, unsupportedCount=${unsupportedCount}）`);
-              if (this._onUnsupportedFormatCb) { this._onUnsupportedFormatCb(); }
-              return;
-            }
-            hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-              `[AVPlayer.PREPARED] 部分音频轨道可播放：audioCount=${audioCount}, unsupportedCount=${unsupportedCount}，avplayer 继续运行，等 controller 按 rank 切轨`);
-            // 正常 ready 路径
-            if (this._onReadyCb) { this._onReadyCb(); }
-          }).catch((e: BusinessError) => {
-            hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-              `getTrackDescription 失败: ${e.message}`);
-            // 无法读取轨道时降级为正常 ready，避免永久阻塞
-            if (this._onReadyCb) { this._onReadyCb(); }
-          });
+          // 后端选择已在创建 AVPlayer 之前按设备真实解码能力确定（Issue #243）。
+          // PREPARED 阶段不再基于全局 codec 黑名单做二次 fallback；
+          // 显式格式不支持由 error 事件（5400106/5400103）动态降级，
+          // 并由 controller 记录设备/固件纠偏结果。
+          if (this._onReadyCb) { this._onReadyCb(); }
           break;
         case AVPlayerState.PLAYING:
           if (this._onPlayCb) { this._onPlayCb(); }

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -42,7 +42,8 @@ import { SubtitleSessionService } from
 import {
   audioTrackRoutingService,
   AudioTrackRoutingService,
-  findInitialAudioTrackIndex as serviceFindInitialAudioTrackIndex
+  findInitialAudioTrackIndex as serviceFindInitialAudioTrackIndex,
+  normalizeAudioCodec
 } from "../../../services/audioRouting/AudioTrackRoutingService";
 import type { AudioRoutingDecision } from "../../../services/audioRouting/AudioRoutingTypes";
 import { audioDecoderCapabilityService } from "../../../services/audioCapability/AudioDecoderCapabilityService";
@@ -264,6 +265,8 @@ export class VideoPlayerController {
   @Trace surfaceId: string = ''
   private mpvSurfaceBound: boolean = false
   get isMpvSurfaceBound(): boolean { return this.mpvSurfaceBound }
+  /** 当前已绑定到 MPV 的 surfaceId（用于区分尺寸变化与新 surface 重建）。 */
+  private boundMpvSurfaceId: string = ''
   private pendingMpvSurfaceId: string = ''
   private pendingMpvSurfaceWidth: number = 0
   private pendingMpvSurfaceHeight: number = 0
@@ -618,7 +621,10 @@ export class VideoPlayerController {
     // 从 avplayer XComponent 切到 mpv XComponent，mpv 的 onLoad 会再次走到这里。
     // 此时 MPV adapter 已在上一次 initPlayer 创建完成，重复重建会导致新实例
     // 再也拿不到 surface（黑屏 + 无音轨）。源未变化时直接复用已就绪的 MPV。
-    if (this.backend === 'mpv' && this.player !== undefined) {
+    // 复用前校验播放源一致，避免复用不匹配的旧实例（CodeRabbit #5）。
+    const sameSource = this.currentOriginalVideoSrc.length === 0 ||
+      activeVideoData.videoSrc === this.currentOriginalVideoSrc;
+    if (this.backend === 'mpv' && this.player !== undefined && sameSource) {
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         '[initPlayerForSurface] MPV 已创建且源未变化，跳过冗余重建');
       return;
@@ -1113,6 +1119,7 @@ export class VideoPlayerController {
 
     if (this.backend === 'mpv') {
       this.mpvSurfaceBound = false;
+      this.boundMpvSurfaceId = '';
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         'MpvPlayerAdapter 已创建，等待 UI 层 setMpvSurface() 绑定 XComponent...');
       if (this.pendingMpvSurfaceId.length > 0 && this.pendingMpvSurfaceWidth > 0 &&
@@ -1383,7 +1390,8 @@ export class VideoPlayerController {
         `setMpvSurface() 等待 MPV player，缓存 surface 参数: id=${surfaceId.substring(0, 8)}... w=${width} h=${height}`);
       return;
     }
-    if (this.mpvSurfaceBound) {
+    if (this.mpvSurfaceBound && this.boundMpvSurfaceId === surfaceId) {
+      // 同一 surface，仅尺寸变化 → 通知 size 变更
       this.notifyMpvSurfaceResize(width, height);
       return;
     }
@@ -1400,6 +1408,7 @@ export class VideoPlayerController {
           height
         );
         this.mpvSurfaceBound = true;
+        this.boundMpvSurfaceId = surfaceId;
       } catch (e) {
         const err = e as Error;
         hilog.error(CommonConstants.LOG_DOMAIN, TAG,
@@ -1753,20 +1762,41 @@ export class VideoPlayerController {
 
   /**
    * 记录当前失败 codec 的设备/固件纠偏结果。
-   * 优先取当前激活音轨的 codec，其次取路由决策的 detectedCodec。
+   * 归因收紧（CodeRabbit #4）：仅当路由决策判定该 codec 兼容（系统声称支持）
+   * 但 AVPlayer 实际失败时才记录纠偏；能力已判定不支持或未参与分析的 codec
+   * 不记录，避免把「已知不支持」误记为「系统宣称支持但失败」。
    */
   private recordCurrentCodecCorrection(reason: string): void {
-    let codec = '';
+    const decision = this.lastRoutingDecision;
+    if (decision === undefined) {
+      return;
+    }
+    let rawCodec = '';
     if (this.activeAudioIndex >= 0 && this.activeAudioIndex < this.audioTracks.length) {
       const track = this.audioTracks[this.activeAudioIndex];
-      codec = (track.codecName ?? track.mimeType) ?? '';
+      rawCodec = (track.codecName ?? track.mimeType) ?? '';
     }
-    if (codec.length === 0 && this.lastRoutingDecision !== undefined) {
-      codec = this.lastRoutingDecision.detectedCodec;
+    if (rawCodec.length === 0) {
+      rawCodec = decision.detectedCodec;
     }
-    if (codec.length > 0 && codec !== 'unknown') {
-      audioDecoderCapabilityService.recordCorrection(codec, reason);
+    const codec = normalizeAudioCodec(rawCodec);
+    if (codec.length === 0 || codec === 'unknown') {
+      return;
     }
+    let claimedCompatible = false;
+    for (let i = 0; i < decision.trackAnalyses.length; i++) {
+      const t = decision.trackAnalyses[i];
+      if (t.codec === codec && t.compatible) {
+        claimedCompatible = true;
+        break;
+      }
+    }
+    if (!claimedCompatible) {
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        `[记录纠偏] 跳过：codec=${codec} 未被路由判定为兼容（归因不成立）`);
+      return;
+    }
+    audioDecoderCapabilityService.recordCorrection(codec, reason);
   }
 
   private fallbackAvPlayerToMpv(reason: string, detailMessage: string = ''): void {
@@ -2004,6 +2034,7 @@ export class VideoPlayerController {
     this.saveProgressNow();
     // 重置 MPV surface 绑定状态，避免后续绑定被误判为重复调用。
     this.mpvSurfaceBound = false;
+    this.boundMpvSurfaceId = '';
     if (this.subtitleClearTimer) {
       clearTimeout(this.subtitleClearTimer);
       this.subtitleClearTimer = undefined;

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -614,6 +614,15 @@ export class VideoPlayerController {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         '[initPlayerForSurface] 忽略 XComponent 过期播放源，沿用控制器当前播放源');
     }
+    // Issue #243 修复：当路由在首次 initPlayer 即选定 mpv 时，backend 变更会触发 UI
+    // 从 avplayer XComponent 切到 mpv XComponent，mpv 的 onLoad 会再次走到这里。
+    // 此时 MPV adapter 已在上一次 initPlayer 创建完成，重复重建会导致新实例
+    // 再也拿不到 surface（黑屏 + 无音轨）。源未变化时直接复用已就绪的 MPV。
+    if (this.backend === 'mpv' && this.player !== undefined) {
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        '[initPlayerForSurface] MPV 已创建且源未变化，跳过冗余重建');
+      return;
+    }
     await this.initPlayer(activeVideoData, surfaceId);
   }
 

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -45,6 +45,7 @@ import {
   findInitialAudioTrackIndex as serviceFindInitialAudioTrackIndex
 } from "../../../services/audioRouting/AudioTrackRoutingService";
 import type { AudioRoutingDecision } from "../../../services/audioRouting/AudioRoutingTypes";
+import { audioDecoderCapabilityService } from "../../../services/audioCapability/AudioDecoderCapabilityService";
 import { PlaybackState } from "./PlaybackState";
 import { ReloadSession } from "./ReloadSession";
 import {
@@ -229,6 +230,8 @@ export interface AudioTrackItem {
   mimeType?: string;
   /** 编解码器名称，如 "aac"、"eac3"、"ac3"，供 codec-aware 选轨使用 */
   codecName?: string;
+  /** 声道数（预置/ffprobe 注入；运行时轨道可能缺失） */
+  channels?: number;
 }
 
 export type UnsupportedFormatFallback = 'mpv';
@@ -327,6 +330,8 @@ export class VideoPlayerController {
   private readonly subtitleSessionSvc: SubtitleSessionService = new SubtitleSessionService();
   /** 音轨路由 service（codec 探测 + 初始选轨 + 用户绑定恢复）。 */
   private readonly audioRoutingService: AudioTrackRoutingService = audioTrackRoutingService;
+  /** 最近一次路由决策（供初始选轨与纠偏记录使用）。 */
+  private lastRoutingDecision?: AudioRoutingDecision;
   /** 10s 防抖进度写入定时器 */
   private progressTimer?: number;
   /** 播放会话编号：每次 initPlayer 自增，用于忽略旧实例回调 */
@@ -671,6 +676,7 @@ export class VideoPlayerController {
     videoData.videoHdrType = decision.videoHdrType;
     videoData.videoWidth = decision.videoWidth;
     videoData.videoHeight = decision.videoHeight;
+    this.lastRoutingDecision = decision;
     if (this.forceMpvForNextInit) {
       this.backend = 'mpv';
       this.forceMpvForNextInit = false;
@@ -689,6 +695,7 @@ export class VideoPlayerController {
       `[initPlayer.route-decision] backend=${this.backend}, fallback=${this.unsupportedFormatFallback}, ` +
       `anyHardSupported=${decision.anyHardSupported}, allSoftDecodeOnly=${decision.allSoftDecodeOnly}, ` +
       `detectedCodec=${decision.detectedCodec}, detectedChannels=${decision.detectedChannels}, ` +
+      `recommendedTrack=${decision.recommendedInitialTrackIndex}(${decision.recommendedCodec || '无'}), ` +
       `videoHdrType=${decision.videoHdrType.length > 0 ? decision.videoHdrType : '未知'}, ` +
       `videoSize=${decision.videoWidth ?? '?'}x${decision.videoHeight ?? '?'}`);
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
@@ -697,8 +704,11 @@ export class VideoPlayerController {
       const t = decision.trackAnalyses[i];
       hilog.info(CommonConstants.LOG_DOMAIN, TAG,
         `[initPlayer.route-decision]   [${i}] codec=${t.codec} channels=${t.channels} ` +
+        `compatible=${t.compatible} capabilitySource=${t.capabilitySource} isHardware=${t.isHardware} ` +
         `hardSupported=${t.hardSupported} source=${t.source}`);
     }
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+      `[initPlayer.route-decision] capabilitySummary=${decision.capabilitySummary}`);
     hilog.info(CommonConstants.LOG_DOMAIN, TAG,
       `自动音频路由: backend=${this.backend}, fallback=${this.unsupportedFormatFallback}, ` +
       `ffmpegChannels=${videoData.ffmpegDecodeChannels}, summary=${decision.summary}`);
@@ -748,7 +758,8 @@ export class VideoPlayerController {
           displayName: p.displayName,
           language: p.language,
           mimeType: p.mimeType,
-          codecName: p.codecName
+          codecName: p.codecName,
+          channels: p.channels
         };
         tracks.push(item);
       }
@@ -970,6 +981,8 @@ export class VideoPlayerController {
           }
         }).catch(() => {});
       }
+      // 记录设备/固件纠偏：系统宣称支持但 AVPlayer 实际不支持。
+      this.recordCurrentCodecCorrection('avplayer_unsupported_format');
       this.fallbackAvPlayerToMpv('avplayer_unsupported_format');
     });
     p.onSeekDone(() => {
@@ -1483,7 +1496,9 @@ export class VideoPlayerController {
       `anyHardSupported=${decision.anyHardSupported}, allSoftDecodeOnly=${decision.allSoftDecodeOnly}, ` +
       `anyPlayable=${decision.anyPlayable}, anyUnplayable=${decision.anyUnplayable}, ` +
       `route=${decision.preferredBackend}, fallback=${decision.fallback}, ` +
+      `recommendedTrack=${decision.recommendedInitialTrackIndex}, ` +
       `decodePlan=${currentDecodePlan}; ` +
+      `capability=${decision.capabilitySummary}; ` +
       `systemHardPreferred=[${SYSTEM_HARD_PREFERRED_CODECS.join(', ')}]; ` +
       `systemSoftFallback=[${SYSTEM_SOFT_FALLBACK_CODECS.join(', ')}]; ` +
       `channelHints=[${SUPPORTED_CHANNEL_LAYOUT_HINTS.join(', ')}]`;
@@ -1724,6 +1739,24 @@ export class VideoPlayerController {
       await this.play();
     } else {
       this.recordPendingResumeAutoplayResult('paused', true);
+    }
+  }
+
+  /**
+   * 记录当前失败 codec 的设备/固件纠偏结果。
+   * 优先取当前激活音轨的 codec，其次取路由决策的 detectedCodec。
+   */
+  private recordCurrentCodecCorrection(reason: string): void {
+    let codec = '';
+    if (this.activeAudioIndex >= 0 && this.activeAudioIndex < this.audioTracks.length) {
+      const track = this.audioTracks[this.activeAudioIndex];
+      codec = (track.codecName ?? track.mimeType) ?? '';
+    }
+    if (codec.length === 0 && this.lastRoutingDecision !== undefined) {
+      codec = this.lastRoutingDecision.detectedCodec;
+    }
+    if (codec.length > 0 && codec !== 'unknown') {
+      audioDecoderCapabilityService.recordCorrection(codec, reason);
     }
   }
 

--- a/entry/src/main/ets/services/audioCapability/AudioCapabilityTypes.ets
+++ b/entry/src/main/ets/services/audioCapability/AudioCapabilityTypes.ets
@@ -21,8 +21,7 @@ export type AudioCapabilitySource =
   | 'correction'
   | 'system'
   | 'cache'
-  | 'unknown'
-  | 'migration-blacklist';
+  | 'unknown';
 
 /** 单条音轨的兼容性结论。 */
 export interface AudioTrackCompatibility {

--- a/entry/src/main/ets/services/audioCapability/AudioCapabilityTypes.ets
+++ b/entry/src/main/ets/services/audioCapability/AudioCapabilityTypes.ets
@@ -1,0 +1,64 @@
+// filepath: entry/src/main/ets/services/audioCapability/AudioCapabilityTypes.ets
+//
+// AudioDecoderCapabilityService 的类型契约。
+//
+// 职责：定义设备音频解码能力查询结果、单条音轨兼容性结论、设备/固件纠偏条目，
+// 以及可供测试注入的能力提供者抽象。
+
+/** NAPI `queryAudioDecoderCapability()` 返回形状（与 index.d.ts 对齐）。 */
+export interface AudioDecoderCapability {
+  capabilityKnown: boolean;
+  supported: boolean;
+  isHardware: boolean;
+  maxChannels: number;
+  decoderName: string;
+  mimeType: string;
+  errorMessage: string;
+}
+
+/** 兼容性结论来源。 */
+export type AudioCapabilitySource =
+  | 'correction'
+  | 'system'
+  | 'cache'
+  | 'unknown'
+  | 'migration-blacklist';
+
+/** 单条音轨的兼容性结论。 */
+export interface AudioTrackCompatibility {
+  /** 归一化 codec（如 'aac' / 'eac3' / 'vnd.dts'）。 */
+  codec: string;
+  /** 归一化后的声道计划（1/2/6/8）。 */
+  channels: number;
+  /** 是否可被当前设备解码（codec 支持且声道数不超上限）。 */
+  compatible: boolean;
+  /** 是否为硬件解码。 */
+  isHardware: boolean;
+  /** 设备该 codec 的最大声道能力（未知/不支持时为 0）。 */
+  maxChannels: number;
+  /** 结论来源。 */
+  source: AudioCapabilitySource;
+  /** 额外说明（纠偏原因 / 错误信息）。 */
+  reason?: string;
+}
+
+/** 设备/固件纠偏条目（持久化到 AppPreferences）。 */
+export interface AudioCorrectionEntry {
+  deviceModel: string;
+  osVersion: string;
+  codec: string;
+  forceUnsupported: boolean;
+  reason: string;
+  updatedAt: number;
+}
+
+/** 能力提供者抽象：默认走 NAPI，测试可注入假实现。 */
+export interface CapabilityProvider {
+  query: (codecOrMime: string) => AudioDecoderCapability;
+}
+
+/** 设备/系统信息提供者抽象：测试可注入固定值。 */
+export interface DeviceInfoProvider {
+  getDeviceModel: () => string;
+  getOsVersion: () => string;
+}

--- a/entry/src/main/ets/services/audioCapability/AudioDecoderCapabilityService.ets
+++ b/entry/src/main/ets/services/audioCapability/AudioDecoderCapabilityService.ets
@@ -17,7 +17,7 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import { CommonConstants } from '../../common/constants/CommonConstants';
 import * as VidAllNapiModule from 'libvidall_core_player_napi.so';
 import deviceInfo from '@ohos.deviceInfo';
-import { normalizeAudioCodec, codecCompatibilityRank } from '../audioRouting/AudioCodecUtil';
+import { normalizeAudioCodec } from '../audioRouting/AudioCodecUtil';
 import { AppPreferences, PrefKey } from '../../utils/AppPreferences';
 import {
   AudioDecoderCapability,
@@ -92,6 +92,7 @@ export class AudioDecoderCapabilityService {
   private capabilityProvider?: CapabilityProvider;
   private deviceInfoProvider: DeviceInfoProvider = DEFAULT_DEVICE_INFO_PROVIDER;
   private correctionsLoaded: boolean = false;
+  private correctionsLoadPromise: Promise<void> | null = null;
 
   /** 测试注入钩子：替换 NAPI 能力提供者。 */
   setCapabilityProviderForTesting(provider: CapabilityProvider | undefined): void {
@@ -113,36 +114,46 @@ export class AudioDecoderCapabilityService {
     this.compatCache.clear();
     this.corrections.clear();
     this.correctionsLoaded = false;
+    this.correctionsLoadPromise = null;
   }
 
-  /** 确保纠偏结果已从 AppPreferences 加载（幂等）。 */
+  /** 确保纠偏结果已从 AppPreferences 加载（幂等，并发调用共享同一 in-flight Promise）。 */
   async ensureLoaded(): Promise<void> {
     if (this.correctionsLoaded) {
       return;
     }
-    this.correctionsLoaded = true;
+    if (this.correctionsLoadPromise === null) {
+      this.correctionsLoadPromise = this.loadCorrections().then(() => {
+        this.correctionsLoadPromise = null;
+      });
+    }
+    await this.correctionsLoadPromise;
+  }
+
+  /** 实际加载纠偏结果（内部吞掉所有异常，correctionsLoaded 在 finally 置位）。 */
+  private async loadCorrections(): Promise<void> {
     try {
       const raw = await AppPreferences.get(PrefKey.AUDIO_CAPABILITY_CORRECTIONS, '');
-      if (raw.length === 0) {
-        return;
-      }
-      const parsed = JSON.parse(raw) as AudioCorrectionEntry[];
-      if (!Array.isArray(parsed)) {
-        return;
-      }
-      const device = this.deviceInfoProvider.getDeviceModel();
-      const os = this.deviceInfoProvider.getOsVersion();
-      for (let i = 0; i < parsed.length; i++) {
-        const entry = parsed[i];
-        if (entry.deviceModel === device && entry.osVersion === os) {
-          this.corrections.set(this.correctionKey(entry.codec), entry);
+      if (raw.length > 0) {
+        const parsed = JSON.parse(raw) as AudioCorrectionEntry[];
+        if (Array.isArray(parsed)) {
+          const device = this.deviceInfoProvider.getDeviceModel();
+          const os = this.deviceInfoProvider.getOsVersion();
+          for (let i = 0; i < parsed.length; i++) {
+            const entry = parsed[i];
+            if (entry.deviceModel === device && entry.osVersion === os) {
+              this.corrections.set(this.correctionKey(entry.codec), entry);
+            }
+          }
+          hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+            `纠偏加载完成: 匹配 ${this.corrections.size} 条（device=${device} os=${os}）`);
         }
       }
-      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-        `纠偏加载完成: 匹配 ${this.corrections.size} 条（device=${device} os=${os}）`);
     } catch (e) {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         `纠偏加载失败（忽略，按无纠偏处理）: ${(e as BusinessError).message ?? JSON.stringify(e)}`);
+    } finally {
+      this.correctionsLoaded = true;
     }
   }
 
@@ -274,21 +285,8 @@ export class AudioDecoderCapabilityService {
     capability: AudioDecoderCapability
   ): AudioTrackCompatibility {
     if (!capability.capabilityKnown) {
-      // 迁移期临时兜底：能力未知时，硬解友好 codec（rank=1）假定兼容，
-      // 其余（软解/未知）保守判不兼容，交给路由层保守选 MPV。
-      const rank = codecCompatibilityRank(codec);
-      if (rank === 1) {
-        const result: AudioTrackCompatibility = {
-          codec,
-          channels,
-          compatible: true,
-          isHardware: false,
-          maxChannels: 0,
-          source: 'migration-blacklist',
-          reason: capability.errorMessage
-        };
-        return result;
-      }
+      // 能力未知/查询异常：无论 codec 是否硬解友好，一律保守判不兼容，
+      // 由路由层选择 MPV 兜底（不基于任何 codec 启发式假设兼容性）。
       const result: AudioTrackCompatibility = {
         codec,
         channels,

--- a/entry/src/main/ets/services/audioCapability/AudioDecoderCapabilityService.ets
+++ b/entry/src/main/ets/services/audioCapability/AudioDecoderCapabilityService.ets
@@ -1,0 +1,355 @@
+// filepath: entry/src/main/ets/services/audioCapability/AudioDecoderCapabilityService.ets
+//
+// AudioDecoderCapabilityService - 设备音频解码能力查询、缓存与纠偏。
+//
+// 目标：把音频路由决策的"能力真值"统一收敛到本 service：
+//   1. 封装 NAPI `queryAudioDecoderCapability()`（类型安全 bridge）。
+//   2. 二级缓存：原始能力按 codec 去重 + 派生兼容结论按 codec/声道键控。
+//   3. 设备/固件纠偏结果优先于系统声明能力，支持持久化复用。
+//
+// 约束：
+// - 能力查询与结论计算为同步纯逻辑（NAPI 查询为同步本地调用）。
+// - 纠偏持久化异步进行，不阻塞决策；`ensureLoaded()` 由调用方在决策前 await。
+// - 不直接依赖 `VideoPlayerController` / 具体 adapter。
+
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { CommonConstants } from '../../common/constants/CommonConstants';
+import * as VidAllNapiModule from 'libvidall_core_player_napi.so';
+import deviceInfo from '@ohos.deviceInfo';
+import { normalizeAudioCodec, codecCompatibilityRank } from '../audioRouting/AudioCodecUtil';
+import { AppPreferences, PrefKey } from '../../utils/AppPreferences';
+import {
+  AudioDecoderCapability,
+  AudioTrackCompatibility,
+  AudioCorrectionEntry,
+  CapabilityProvider,
+  DeviceInfoProvider
+} from './AudioCapabilityTypes';
+
+const TAG = '[AudioDecoderCapabilityService]';
+
+// ─── NAPI Bridge ───────────────────────────────────────────────────────────────
+
+interface AudioCapabilityNapiBridge {
+  queryAudioDecoderCapability: (codecOrMime: string) => AudioDecoderCapability;
+}
+
+interface AudioCapabilityNapiModule {
+  default?: AudioCapabilityNapiBridge;
+}
+
+function resolveNapiBridge(): AudioCapabilityNapiBridge | undefined {
+  const mod = VidAllNapiModule as AudioCapabilityNapiModule | AudioCapabilityNapiBridge | undefined;
+  if (mod === undefined) {
+    return undefined;
+  }
+  const def = (mod as AudioCapabilityNapiModule).default;
+  if (def !== undefined) {
+    return def as AudioCapabilityNapiBridge;
+  }
+  return mod as AudioCapabilityNapiBridge;
+}
+
+/** 默认设备/系统信息提供者（基于 @ohos.deviceInfo）。 */
+const DEFAULT_DEVICE_INFO_PROVIDER: DeviceInfoProvider = {
+  getDeviceModel: (): string => {
+    try {
+      const model = deviceInfo.productModel;
+      if (model !== undefined && model.length > 0) {
+        return model;
+      }
+      const market = deviceInfo.marketName;
+      if (market !== undefined && market.length > 0) {
+        return market;
+      }
+      const type = deviceInfo.deviceType;
+      return (type !== undefined && type.length > 0) ? type : 'unknown';
+    } catch (e) {
+      return 'unknown';
+    }
+  },
+  getOsVersion: (): string => {
+    try {
+      const os = deviceInfo.osFullName;
+      return (os !== undefined && os.length > 0) ? os : 'unknown';
+    } catch (e) {
+      return 'unknown';
+    }
+  }
+};
+
+/**
+ * 设备音频解码能力服务（单例）。
+ *
+ * `resolveTrackCompatibility(codec, channels)` 中 `channels` 为归一化声道计划
+ * （1/2/6/8）；传 0 表示声道未知，跳过声道上限校验。
+ */
+export class AudioDecoderCapabilityService {
+  private readonly codecCapCache: Map<string, AudioDecoderCapability> = new Map<string, AudioDecoderCapability>();
+  private readonly compatCache: Map<string, AudioTrackCompatibility> = new Map<string, AudioTrackCompatibility>();
+  private readonly corrections: Map<string, AudioCorrectionEntry> = new Map<string, AudioCorrectionEntry>();
+  private capabilityProvider?: CapabilityProvider;
+  private deviceInfoProvider: DeviceInfoProvider = DEFAULT_DEVICE_INFO_PROVIDER;
+  private correctionsLoaded: boolean = false;
+
+  /** 测试注入钩子：替换 NAPI 能力提供者。 */
+  setCapabilityProviderForTesting(provider: CapabilityProvider | undefined): void {
+    this.capabilityProvider = provider;
+    this.codecCapCache.clear();
+    this.compatCache.clear();
+  }
+
+  /** 测试注入钩子：替换设备/系统信息。 */
+  setDeviceInfoProviderForTesting(provider: DeviceInfoProvider | undefined): void {
+    this.deviceInfoProvider = provider ?? DEFAULT_DEVICE_INFO_PROVIDER;
+    this.codecCapCache.clear();
+    this.compatCache.clear();
+  }
+
+  /** 测试辅助：清空内存态（缓存 + 纠偏）。 */
+  resetForTesting(): void {
+    this.codecCapCache.clear();
+    this.compatCache.clear();
+    this.corrections.clear();
+    this.correctionsLoaded = false;
+  }
+
+  /** 确保纠偏结果已从 AppPreferences 加载（幂等）。 */
+  async ensureLoaded(): Promise<void> {
+    if (this.correctionsLoaded) {
+      return;
+    }
+    this.correctionsLoaded = true;
+    try {
+      const raw = await AppPreferences.get(PrefKey.AUDIO_CAPABILITY_CORRECTIONS, '');
+      if (raw.length === 0) {
+        return;
+      }
+      const parsed = JSON.parse(raw) as AudioCorrectionEntry[];
+      if (!Array.isArray(parsed)) {
+        return;
+      }
+      const device = this.deviceInfoProvider.getDeviceModel();
+      const os = this.deviceInfoProvider.getOsVersion();
+      for (let i = 0; i < parsed.length; i++) {
+        const entry = parsed[i];
+        if (entry.deviceModel === device && entry.osVersion === os) {
+          this.corrections.set(this.correctionKey(entry.codec), entry);
+        }
+      }
+      hilog.info(CommonConstants.LOG_DOMAIN, TAG,
+        `纠偏加载完成: 匹配 ${this.corrections.size} 条（device=${device} os=${os}）`);
+    } catch (e) {
+      hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+        `纠偏加载失败（忽略，按无纠偏处理）: ${(e as BusinessError).message ?? JSON.stringify(e)}`);
+    }
+  }
+
+  /**
+   * 判定单条音轨的兼容性（同步）。
+   * 优先级：纠偏 > 派生兼容缓存 > 原始能力缓存 > NAPI 查询。
+   */
+  resolveTrackCompatibility(codecRaw: string, channels: number): AudioTrackCompatibility {
+    const codec = normalizeAudioCodec(codecRaw);
+    const normChannels = channels > 0 ? channels : 0;
+
+    // 1. 纠偏优先
+    const correction = this.corrections.get(this.correctionKey(codec));
+    if (correction !== undefined && correction.forceUnsupported) {
+      const result: AudioTrackCompatibility = {
+        codec,
+        channels: normChannels,
+        compatible: false,
+        isHardware: false,
+        maxChannels: 0,
+        source: 'correction',
+        reason: correction.reason
+      };
+      return result;
+    }
+
+    // 2. 派生兼容缓存
+    const compatKey = this.compatCacheKey(codec, normChannels);
+    const cachedCompat = this.compatCache.get(compatKey);
+    if (cachedCompat !== undefined) {
+      const result: AudioTrackCompatibility = {
+        codec: cachedCompat.codec,
+        channels: cachedCompat.channels,
+        compatible: cachedCompat.compatible,
+        isHardware: cachedCompat.isHardware,
+        maxChannels: cachedCompat.maxChannels,
+        source: 'cache',
+        reason: cachedCompat.reason
+      };
+      return result;
+    }
+
+    // 3. 原始能力（按 codec 去重）
+    const codecKey = this.codecCapKey(codec);
+    let capability = this.codecCapCache.get(codecKey);
+    if (capability === undefined) {
+      capability = this.queryCapability(codec);
+      this.codecCapCache.set(codecKey, capability);
+    }
+
+    const result = this.buildCompatibility(codec, normChannels, capability);
+    this.compatCache.set(compatKey, result);
+    return result;
+  }
+
+  /** 记录纠偏结果（AVPlayer 明确失败时调用），同步写内存 + 异步持久化。 */
+  recordCorrection(codecRaw: string, reason: string): void {
+    const codec = normalizeAudioCodec(codecRaw);
+    if (codec.length === 0) {
+      return;
+    }
+    const entry: AudioCorrectionEntry = {
+      deviceModel: this.deviceInfoProvider.getDeviceModel(),
+      osVersion: this.deviceInfoProvider.getOsVersion(),
+      codec,
+      forceUnsupported: true,
+      reason,
+      updatedAt: Date.now()
+    };
+    this.corrections.set(this.correctionKey(codec), entry);
+    // 使该 codec 的派生缓存失效，后续查询按纠偏重新计算
+    this.invalidateCodecCaches(codec);
+    hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
+      `记录纠偏: codec=${codec} reason=${reason}`);
+    this.persistCorrections().catch(() => {});
+  }
+
+  /** 测试辅助：读取当前内存中的纠偏条数。 */
+  getCorrectionCountForTesting(): number {
+    return this.corrections.size;
+  }
+
+  // ─── 内部实现 ───
+
+  private correctionKey(codec: string): string {
+    return `${this.deviceInfoProvider.getDeviceModel()}|${this.deviceInfoProvider.getOsVersion()}|${codec}`;
+  }
+
+  private codecCapKey(codec: string): string {
+    return `${this.deviceInfoProvider.getDeviceModel()}|${this.deviceInfoProvider.getOsVersion()}|${codec}`;
+  }
+
+  private compatCacheKey(codec: string, channels: number): string {
+    return `${this.deviceInfoProvider.getDeviceModel()}|${this.deviceInfoProvider.getOsVersion()}|${codec}|${channels}`;
+  }
+
+  private queryCapability(codec: string): AudioDecoderCapability {
+    try {
+      if (this.capabilityProvider !== undefined) {
+        return this.capabilityProvider.query(codec);
+      }
+      const bridge = resolveNapiBridge();
+      if (bridge === undefined) {
+        return this.unknownCapability(codec, 'libvidall_core_player_napi.so 未加载');
+      }
+      return bridge.queryAudioDecoderCapability(codec);
+    } catch (e) {
+      const err = e as BusinessError;
+      return this.unknownCapability(codec, err.message ?? '能力查询异常');
+    }
+  }
+
+  private unknownCapability(codec: string, reason: string): AudioDecoderCapability {
+    const cap: AudioDecoderCapability = {
+      capabilityKnown: false,
+      supported: false,
+      isHardware: false,
+      maxChannels: 0,
+      decoderName: '',
+      mimeType: codec,
+      errorMessage: reason
+    };
+    return cap;
+  }
+
+  private buildCompatibility(
+    codec: string,
+    channels: number,
+    capability: AudioDecoderCapability
+  ): AudioTrackCompatibility {
+    if (!capability.capabilityKnown) {
+      // 迁移期临时兜底：能力未知时，硬解友好 codec（rank=1）假定兼容，
+      // 其余（软解/未知）保守判不兼容，交给路由层保守选 MPV。
+      const rank = codecCompatibilityRank(codec);
+      if (rank === 1) {
+        const result: AudioTrackCompatibility = {
+          codec,
+          channels,
+          compatible: true,
+          isHardware: false,
+          maxChannels: 0,
+          source: 'migration-blacklist',
+          reason: capability.errorMessage
+        };
+        return result;
+      }
+      const result: AudioTrackCompatibility = {
+        codec,
+        channels,
+        compatible: false,
+        isHardware: false,
+        maxChannels: 0,
+        source: 'unknown',
+        reason: capability.errorMessage
+      };
+      return result;
+    }
+    if (!capability.supported) {
+      const result: AudioTrackCompatibility = {
+        codec,
+        channels,
+        compatible: false,
+        isHardware: false,
+        maxChannels: 0,
+        source: 'system',
+        reason: capability.errorMessage.length > 0 ? capability.errorMessage : 'decoder not found'
+      };
+      return result;
+    }
+    // codec 支持；声道未知（channels<=0）时跳过上限校验
+    const withinChannels = channels <= 0 || channels <= capability.maxChannels;
+    const result: AudioTrackCompatibility = {
+      codec,
+      channels,
+      compatible: withinChannels,
+      isHardware: capability.isHardware,
+      maxChannels: capability.maxChannels,
+      source: 'system',
+      reason: withinChannels ? '' : `channels ${channels} > max ${capability.maxChannels}`
+    };
+    return result;
+  }
+
+  private invalidateCodecCaches(codec: string): void {
+    const prefix = this.codecCapKey(codec);
+    const keysToDelete: string[] = [];
+    this.compatCache.forEach((_value: AudioTrackCompatibility, key: string) => {
+      if (key.startsWith(prefix)) {
+        keysToDelete.push(key);
+      }
+    });
+    for (let i = 0; i < keysToDelete.length; i++) {
+      this.compatCache.delete(keysToDelete[i]);
+    }
+    this.codecCapCache.delete(prefix);
+  }
+
+  private async persistCorrections(): Promise<void> {
+    const entries: AudioCorrectionEntry[] = [];
+    this.corrections.forEach((value: AudioCorrectionEntry) => {
+      entries.push(value);
+    });
+    const json = JSON.stringify(entries);
+    await AppPreferences.set(PrefKey.AUDIO_CAPABILITY_CORRECTIONS, json);
+  }
+}
+
+/** 默认单例（pure service，无构造依赖）。 */
+export const audioDecoderCapabilityService: AudioDecoderCapabilityService =
+  new AudioDecoderCapabilityService();

--- a/entry/src/main/ets/services/audioRouting/AudioCodecUtil.ets
+++ b/entry/src/main/ets/services/audioRouting/AudioCodecUtil.ets
@@ -1,0 +1,106 @@
+// filepath: entry/src/main/ets/services/audioRouting/AudioCodecUtil.ets
+//
+// AudioCodecUtil - 音频 codec / 声道归一化与排名纯函数。
+//
+// 目的：把 `AudioTrackRoutingService` 中的纯函数（归一化、声道计划、兼容排名）
+// 抽到独立模块，供 `AudioTrackRoutingService` 与 `AudioDecoderCapabilityService`
+// 共同复用，避免二者互相 import 造成循环依赖。
+//
+// 约束：
+// - 仅包含无副作用的纯函数，不依赖 NAPI、不依赖具体 adapter。
+
+/** 经验规则：命中下列关键字时优先软解，避免先硬解再失败切换带来的卡顿。 */
+export const SOFT_ONLY_KEYWORDS: string[] = [
+  'ac3', 'eac3', 'dts', 'truehd', 'mlp', 'vivid', 'atmos'
+];
+
+/**
+ * codec 兼容性等级（数字越小越优先，作为初轨选择与 route decision 的排序依据）。
+ *
+ * 注意：此排名仅在设备能力信息不可用（如 MPV 运行时轨道）时作为回退。
+ * 有真实设备能力时，应由 `AudioDecoderCapabilityService` 提供兼容性判定。
+ *
+ * 1 = 系统稳态可硬解（HARD_PREFERRED）
+ * 2 = 软解但常见（AC-3 / EAC-3 / DTS）
+ * 3 = 软解且罕见（TrueHD / MLP / Audio Vivid）
+ * 4 = 未知 codec
+ */
+export function codecCompatibilityRank(codec: string): number {
+  if (codec.length === 0) {
+    return 4;
+  }
+  const c = codec.toLowerCase();
+  // 硬解友好
+  if (c.includes('aac') || c.includes('mp3') || c.includes('opus') ||
+    c.includes('flac') || c.includes('pcm') || c.includes('vorbis')) {
+    return 1;
+  }
+  // 软解常见：AC-3 / EAC-3 / DTS（注意 DTS 排后面，会被 AC-3 抢优先）
+  if (c.includes('ac3') && !c.includes('eac3')) {
+    return 2;
+  }
+  if (c.includes('eac3')) {
+    return 2;
+  }
+  if (c.includes('dts')) {
+    return 3;
+  }
+  // 软解罕见：TrueHD / MLP / Audio Vivid
+  if (c.includes('truehd') || c.includes('mlp') || c.includes('vivid') || c.includes('atmos')) {
+    return 3;
+  }
+  return 4;
+}
+
+/** 将原始声道数归一化到实际解码计划所对应的层级（1/2/6/8）。 */
+export function normalizeTargetChannels(channels?: number): number {
+  if (!channels || channels <= 0) {
+    return 2;
+  }
+  if (channels <= 1) {
+    return 1;
+  }
+  if (channels >= 8) {
+    return 8;
+  }
+  if (channels >= 6) {
+    return 6;
+  }
+  return 2;
+}
+
+/** 排序前对声道数做归一化处理。 */
+export function normalizeChannelsForSort(ch: number): number {
+  if (ch <= 1) {
+    return 1;
+  }
+  if (ch <= 2) {
+    return 2;
+  }
+  if (ch <= 6) {
+    return 6;
+  }
+  return 8;
+}
+
+/** 判断指定 codec 是否优先走硬解（仅作为设备能力缺失时的回退启发式）。 */
+export function isLikelySystemHardDecodeSupported(codec: string): boolean {
+  if (codec.length === 0) {
+    return true;
+  }
+  for (let i = 0; i < SOFT_ONLY_KEYWORDS.length; i++) {
+    if (codec.includes(SOFT_ONLY_KEYWORDS[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** 将 AVPlayer MIME 与 ffprobe codec 统一为路由使用的 codec 名。 */
+export function normalizeAudioCodec(rawCodec: string): string {
+  const codec = rawCodec.toLowerCase().replace('audio/', '').split('-').join('');
+  if (codec === 'mp4alatm' || codec === 'mp4a' || codec === 'aaclatm') {
+    return 'aac';
+  }
+  return codec;
+}

--- a/entry/src/main/ets/services/audioRouting/AudioCodecUtil.ets
+++ b/entry/src/main/ets/services/audioRouting/AudioCodecUtil.ets
@@ -21,8 +21,8 @@ export const SOFT_ONLY_KEYWORDS: string[] = [
  * 有真实设备能力时，应由 `AudioDecoderCapabilityService` 提供兼容性判定。
  *
  * 1 = 系统稳态可硬解（HARD_PREFERRED）
- * 2 = 软解但常见（AC-3 / EAC-3 / DTS）
- * 3 = 软解且罕见（TrueHD / MLP / Audio Vivid）
+ * 2 = 软解但常见（AC-3 / EAC-3）
+ * 3 = 软解且罕见（DTS / TrueHD / MLP / Audio Vivid）
  * 4 = 未知 codec
  */
 export function codecCompatibilityRank(codec: string): number {
@@ -101,6 +101,12 @@ export function normalizeAudioCodec(rawCodec: string): string {
   const codec = rawCodec.toLowerCase().replace('audio/', '').split('-').join('');
   if (codec === 'mp4alatm' || codec === 'mp4a' || codec === 'aaclatm') {
     return 'aac';
+  }
+  if (codec === 'vnd.dts') {
+    return 'dts';
+  }
+  if (codec === 'vnd.dts.hd') {
+    return 'dtshd';
   }
   return codec;
 }

--- a/entry/src/main/ets/services/audioRouting/AudioRoutingTypes.ets
+++ b/entry/src/main/ets/services/audioRouting/AudioRoutingTypes.ets
@@ -111,7 +111,10 @@ export interface AudioRoutingDecision {
   videoHeight?: number;
   /** 整组音轨分析结果。 */
   trackAnalyses: AudioTrackAnalysis[];
-  /** 预选的初始音轨索引（在 trackAnalyses 中；-1 表示无兼容轨）。 */
+  /**
+   * 预选的初始音轨索引（原始媒体音轨列表中的 index，非 trackAnalyses 数组下标；
+   * -1 表示无兼容音轨）。消费方应结合 codec/语言匹配使用，勿当作数组下标直接取值。
+   */
   recommendedInitialTrackIndex: number;
   /** 预选音轨的归一化 codec（无兼容轨或未知时为空串）。 */
   recommendedCodec: string;

--- a/entry/src/main/ets/services/audioRouting/AudioRoutingTypes.ets
+++ b/entry/src/main/ets/services/audioRouting/AudioRoutingTypes.ets
@@ -19,8 +19,10 @@
 // - `AudioTrackItem` 由本文件 re-export，controller 旧 import 路径继续可用。
 
 import type { AudioTrackItem } from "../../components/core/player/VideoPlayerController";
+import type { AudioCapabilitySource } from "../audioCapability/AudioCapabilityTypes";
 
 export type { AudioTrackItem };
+export type { AudioCapabilitySource };
 
 /** 单条音轨分析结果（service 内部使用，可被 controller 日志引用）。 */
 export interface AudioTrackAnalysis {
@@ -30,10 +32,18 @@ export interface AudioTrackAnalysis {
   codec: string;
   /** 归一化后的声道计划（1/2/6/8）。 */
   channels: number;
-  /** 是否系统稳态可硬解。 */
+  /** 是否系统稳态可硬解（设备能力信息缺失时的回退启发式）。 */
   hardSupported: boolean;
   /** 来源：probe（ffprobe） / preset（数据库预置）。 */
   source: 'probe' | 'preset';
+  /** 设备能力兼容性（codec 支持且声道数不超上限）。 */
+  compatible: boolean;
+  /** 设备该 codec 的最大声道能力（未知/不支持时为 0）。 */
+  maxChannels: number;
+  /** 是否为硬件解码。 */
+  isHardware: boolean;
+  /** 兼容性结论来源。 */
+  capabilitySource: AudioCapabilitySource;
 }
 
 /** 路由决策输入（controller 持有 videoData 与 ffprobe 状态）。 */
@@ -101,6 +111,12 @@ export interface AudioRoutingDecision {
   videoHeight?: number;
   /** 整组音轨分析结果。 */
   trackAnalyses: AudioTrackAnalysis[];
+  /** 预选的初始音轨索引（在 trackAnalyses 中；-1 表示无兼容轨）。 */
+  recommendedInitialTrackIndex: number;
+  /** 预选音轨的归一化 codec（无兼容轨或未知时为空串）。 */
+  recommendedCodec: string;
+  /** 能力判定摘要（来源/缓存/纠偏，供日志与 UI）。 */
+  capabilitySummary: string;
 }
 
 /** 默认路由决策（探测未启动时使用）。 */
@@ -121,7 +137,10 @@ export const DEFAULT_AUDIO_ROUTING_DECISION: AudioRoutingDecision = {
   videoHdrType: '',
   videoWidth: undefined,
   videoHeight: undefined,
-  trackAnalyses: []
+  trackAnalyses: [],
+  recommendedInitialTrackIndex: -1,
+  recommendedCodec: '',
+  capabilitySummary: 'default: 未查询设备解码能力'
 };
 
 /** 初始音轨选择输入。 */

--- a/entry/src/main/ets/services/audioRouting/AudioTrackRoutingService.ets
+++ b/entry/src/main/ets/services/audioRouting/AudioTrackRoutingService.ets
@@ -446,16 +446,14 @@ export class AudioTrackRoutingService {
       precheckProbeError = err['message'] ?? JSON.stringify(e);
     }
 
-    // 合并 probe + preset 为整组音轨分析（probe 优先，preset 作为补充），按归一化 codec 去重
+    // 合并 probe + preset 为整组音轨分析（probe 优先，preset 作为补充）。
+    // 注意：不再按归一化 codec 去重——相同 codec 不同声道的音轨必须全部保留，
+    // 否则声道超上限的轨会遮蔽同 codec 的兼容轨（如 8ch eac3 不兼容、2ch eac3 兼容时误选 MPV）。
+    // 能力查询的按 codec 去重由 AudioDecoderCapabilityService.codecCapCache 内部保证。
     const trackAnalyses: AudioTrackAnalysis[] = [];
-    const seenCodecs = new Set<string>();
     for (let i = 0; i < probeAudioTracks.length; i++) {
       const t = probeAudioTracks[i];
       const codec = normalizeAudioCodec(t.codec);
-      if (seenCodecs.has(codec)) {
-        continue;
-      }
-      seenCodecs.add(codec);
       trackAnalyses.push(this.buildTrackAnalysis(i, codec, t.channels, 'probe'));
     }
     if (trackAnalyses.length === 0 && presetHint.codecName.length > 0) {

--- a/entry/src/main/ets/services/audioRouting/AudioTrackRoutingService.ets
+++ b/entry/src/main/ets/services/audioRouting/AudioTrackRoutingService.ets
@@ -1,11 +1,11 @@
 // filepath: entry/src/main/ets/services/audioRouting/AudioTrackRoutingService.ets
 //
-// AudioTrackRoutingService - 音频 codec 探测 + 初始音轨恢复策略。
+// AudioTrackRoutingService - 音频 codec 探测 + 设备解码能力路由 + 初始音轨恢复策略。
 //
 // 目标：把 `VideoPlayerController` 中以下职责迁移到本 service：
 //   1. ffprobe 探测（probe 失败时降级到 preset 提示）
-//   2. backend route / fallback / preferredChannels 决策
-//   3. codec-aware 初始音轨选择（findInitialAudioTrackIndex）
+//   2. backend route / fallback / preferredChannels 决策（基于设备真实解码能力）
+//   3. codec-aware 初始音轨选择（findInitialAudioTrackIndex + 能力排名）
 //   4. 用户历史绑定恢复建议（与 AudioDispatcher 协作）
 //
 // 约束：
@@ -31,137 +31,107 @@ import { PresetAudioTrack } from "../../components/core/player/VideoData";
 import {
   AudioRoutingDecision,
   AudioRoutingInput,
-  DEFAULT_AUDIO_ROUTING_DECISION,
-  InitialTrackIndexInput,
   InitialTrackIndexResult,
   AudioTrackItem,
   AudioTrackAnalysis
 } from "./AudioRoutingTypes";
+import {
+  normalizeAudioCodec,
+  codecCompatibilityRank,
+  normalizeTargetChannels,
+  normalizeChannelsForSort,
+  isLikelySystemHardDecodeSupported
+} from "./AudioCodecUtil";
 import { AudioDispatcher, AudioBinding } from "../../audio/AudioDispatcher";
+import { audioDecoderCapabilityService } from "../audioCapability/AudioDecoderCapabilityService";
+import type { AudioTrackCompatibility } from "../audioCapability/AudioCapabilityTypes";
+
+// 兼容历史 import 路径：外部仍可从 AudioTrackRoutingService 导入 normalizeAudioCodec。
+export { normalizeAudioCodec };
 
 const DOMAIN = 0x0002;
 const TAG = '[AudioTrackRoutingService]';
 
-/** 经验规则：命中下列关键字时优先软解，避免先硬解再失败切换带来的卡顿。 */
-const SOFT_ONLY_KEYWORDS: string[] = [
-  'ac3', 'eac3', 'dts', 'truehd', 'mlp', 'vivid', 'atmos'
-];
-
-/**
- * codec 兼容性等级（数字越小越优先，作为初轨选择与 route decision 的排序依据）。
- *
- * 关键点：AC-3 / EAC-3 虽属软解，但 MPV 可作为系统播放失败后的兼容后端；
- * TrueHD / MLP / Audio Vivid 解码链不成熟，默认应排在 AC-3 之后。
- *
- * 1 = 系统稳态可硬解（HARD_PREFERRED）
- * 2 = 软解但常见（AC-3 / EAC-3 / DTS）— 优先选择
- * 3 = 软解且罕见（TrueHD / MLP / Audio Vivid）— 仅在别无选择时使用
- * 4 = 未知 codec
- */
-function codecCompatibilityRank(codec: string): number {
-  if (codec.length === 0) {
-    return 4;
-  }
-  const c = codec.toLowerCase();
-  // 硬解友好
-  if (c.includes('aac') || c.includes('mp3') || c.includes('opus') ||
-    c.includes('flac') || c.includes('pcm') || c.includes('vorbis')) {
-    return 1;
-  }
-  // 软解常见：AC-3 / EAC-3 / DTS（注意 DTS 排后面，会被 AC-3 抢优先）
-  if (c.includes('ac3') && !c.includes('eac3')) {
-    return 2;
-  }
-  if (c.includes('eac3')) {
-    return 2;
-  }
-  if (c.includes('dts')) {
-    return 3;
-  }
-  // 软解罕见：TrueHD / MLP / Audio Vivid
-  if (c.includes('truehd') || c.includes('mlp') || c.includes('vivid') || c.includes('atmos')) {
-    return 3;
-  }
-  return 4;
+/** Preset audio hint 容器（用于 readPresetAudioHint 显式类型）。 */
+export interface PresetAudioHint {
+  codecName: string;
+  channels: number;
 }
 
 /**
- * 构造路由决策：基于整组音轨分析 + codec compatibility rank。
+ * 构造路由决策：基于整组音轨分析 + 设备解码能力兼容性。
  *
- * 关键策略（按用户场景 TrueHD + AC-3 混合片源）：
- * 1. 整组音轨存在至少一条 rank≤1（硬解）或 rank≤2（AC-3/EAC-3 软解常见）轨道 → preferredBackend=avplayer
- *    （avplayer 启动后由 `loadAudioTracks` + `findInitialAudioTrackIndex` 切到该轨道，避免无声）
- * 2. 整组音轨全部 rank≥3（仅 TrueHD / MLP / DTS / Audio Vivid 等软解罕见或 DTS）→ preferredBackend=avplayer
- *    + fallback=mpv（让 AVPlayer 失败后自动切 MPV 软解）
- * 3. 探测完全失败且无任何音轨提示 → 仍先尝试 AVPlayer，再按不支持格式回退
- * 4. detectedCodec / detectedChannels 取整组中 rank 最低的轨道（最兼容），不再是 probe[0]
+ * 决策优先级（Issue #243）：
+ * 1. 设备/固件纠偏结果（已由 capability service 在 trackAnalysis.capabilitySource 体现）
+ * 2. 系统 codec 能力 + 最大声道范围（trackAnalysis.compatible）
+ * 3. 能力未知或查询异常 → 保守选择 MPV
+ *
+ * - 存在兼容音轨 → preferredBackend=avplayer，并预选兼容性最高（硬解优先/声道高/索引小）的音轨
+ * - 无兼容音轨 → preferredBackend=mpv（直接，避免 AVPlayer prepare 后再初始化后端）
+ * - 探测完全失败且无任何音轨提示 → 仍先尝试 AVPlayer（沿用历史行为）
  */
 export function buildRoutingDecision(input: AudioRoutingInput): AudioRoutingDecision {
   const tracks = input.trackAnalyses;
   const trackCount = tracks.length;
 
-  // 整组分析：累加硬解 / 软解统计 + 收集 rank 最低轨道
-  let anyHardSupported = false;
-  let anyPlayable = true;
-  let allSoftDecodeOnly = true;
-  let firstHardSupported: AudioTrackAnalysis | null = null;
-  let unplayableCount = 0;
-  let bestRankedTrack: AudioTrackAnalysis | null = null;
-  let bestRankedIndex = -1;
+  let anyCompatible = false;
+  let anyUnknown = false;
+  let anyCorrection = false;
+  let anyHardware = false;
+  let bestCompatIndex = -1;
+
   for (let i = 0; i < trackCount; i++) {
     const t = tracks[i];
-    if (t.hardSupported) {
-      anyHardSupported = true;
-      allSoftDecodeOnly = false;
-      if (firstHardSupported === null) {
-        firstHardSupported = t;
+    if (t.compatible) {
+      anyCompatible = true;
+      if (t.isHardware) {
+        anyHardware = true;
+      }
+      if (bestCompatIndex < 0) {
+        bestCompatIndex = i;
+      } else if (compareCompatibleAnalysis(t, tracks[bestCompatIndex]) < 0) {
+        bestCompatIndex = i;
       }
     }
-    if (t.codec.length === 0) {
-      unplayableCount++;
-    } else {
-      const rank = codecCompatibilityRank(t.codec);
-      if (bestRankedTrack === null || rank < codecCompatibilityRank(bestRankedTrack.codec)) {
-        bestRankedTrack = t;
-        bestRankedIndex = i;
-      }
+    if (t.capabilitySource === 'unknown') {
+      anyUnknown = true;
+    }
+    if (t.capabilitySource === 'correction') {
+      anyCorrection = true;
     }
   }
-  if (unplayableCount === trackCount && trackCount > 0) {
-    anyPlayable = false;
-  }
-  const anyUnplayable = unplayableCount > 0;
 
-  // 决定 detectedCodec / detectedChannels：取整组中 rank 最低的轨道（最兼容）
-  const representative = bestRankedTrack !== null
-    ? bestRankedTrack
-    : (firstHardSupported !== null ? firstHardSupported : null);
-  const detectedCodec = representative !== null ? representative.codec : 'unknown';
-  const detectedChannels = representative !== null ? representative.channels : 2;
-  const preferredChannels = normalizeTargetChannels(detectedChannels);
+  const recommendedInitialTrackIndex = bestCompatIndex >= 0 ? tracks[bestCompatIndex].index : -1;
+  const recommendedCodec = bestCompatIndex >= 0 ? tracks[bestCompatIndex].codec : '';
+  const detectedCodec = bestCompatIndex >= 0 ? tracks[bestCompatIndex].codec : 'unknown';
+  const detectedChannels = bestCompatIndex >= 0 ? tracks[bestCompatIndex].channels : 2;
+
+  // backend 决策
+  let preferredBackend: 'avplayer' | 'mpv' = 'avplayer';
+  if (trackCount > 0 && !anyCompatible) {
+    // 无任何兼容音轨（已知不支持或能力未知）→ 直接 MPV
+    preferredBackend = 'mpv';
+  }
+
+  const allSoftDecodeOnly = trackCount > 0 && !anyHardware;
+  const anyPlayable = anyCompatible || trackCount === 0;
+  const anyUnplayable = trackCount > 0 && !anyCompatible;
 
   const summary = `tracks=${trackCount}, ` +
-    `firstHardSupported=${firstHardSupported !== null ? firstHardSupported.codec : 'none'}, ` +
-    `allSoftDecodeOnly=${allSoftDecodeOnly}, anyHardSupported=${anyHardSupported}, ` +
-    `bestRankedIndex=${bestRankedIndex}, bestRankedCodec=${detectedCodec}, ` +
+    `anyCompatible=${anyCompatible}, anyUnknown=${anyUnknown}, anyCorrection=${anyCorrection}, ` +
+    `recommendedIndex=${recommendedInitialTrackIndex}, recommendedCodec=${recommendedCodec}, ` +
     `precheckProbeFailed=${input.precheckProbeFailed}`;
 
-  // preferredBackend 决策（关键修复：TrueHD+AC-3 混合时不能默认 TrueHD）
-  // 1. 探测完全失败且无任何音轨提示 → 仍先尝试 avplayer
-  // 2. 整组音轨存在至少一条 rank≤2 轨道（硬解 / AC-3 / EAC-3）→ avplayer
-  //    （avplayer 启动后由 loadAudioTracks 切到该轨道）
-  // 3. 整组音轨全部 rank≥3（仅 TrueHD / MLP / Audio Vivid / DTS）→ avplayer + fallback=mpv
-  //    （让 AVPlayer 失败后自动切 MPV 软解）
-  const preferredBackend: 'avplayer' | 'mpv' = 'avplayer';
+  const capabilitySummary = buildCapabilitySummary(tracks);
 
   const decision: AudioRoutingDecision = {
     preferredBackend,
     fallback: 'mpv',
-    preferredChannels,
+    preferredChannels: normalizeTargetChannels(detectedChannels),
     summary,
     detectedCodec,
     detectedChannels,
-    anyHardSupported,
+    anyHardSupported: anyHardware,
     allSoftDecodeOnly,
     anyPlayable,
     anyUnplayable,
@@ -171,45 +141,36 @@ export function buildRoutingDecision(input: AudioRoutingInput): AudioRoutingDeci
     videoHdrType: input.probeVideoHdrType ?? '',
     videoWidth: input.probeVideoWidth,
     videoHeight: input.probeVideoHeight,
-    trackAnalyses: tracks
+    trackAnalyses: tracks,
+    recommendedInitialTrackIndex,
+    recommendedCodec,
+    capabilitySummary
   };
   return decision;
 }
 
-/** 将原始声道数归一化到实际解码计划所对应的层级。 */
-function normalizeTargetChannels(channels?: number): number {
-  if (!channels || channels <= 0) {
-    return 2;
+/** 兼容音轨排序：硬解优先 → 声道更高 → 索引更小（负值表示 a 更优）。 */
+function compareCompatibleAnalysis(a: AudioTrackAnalysis, b: AudioTrackAnalysis): number {
+  if (a.isHardware !== b.isHardware) {
+    return a.isHardware ? -1 : 1;
   }
-  if (channels <= 1) {
-    return 1;
+  if (a.channels !== b.channels) {
+    return b.channels - a.channels;
   }
-  if (channels >= 8) {
-    return 8;
-  }
-  if (channels >= 6) {
-    return 6;
-  }
-  return 2;
+  return a.index - b.index;
 }
 
-/** 判断指定 codec 是否优先走硬解。 */
-function isLikelySystemHardDecodeSupported(codec: string): boolean {
-  if (codec.length === 0) {
-    return true;
+/** 汇总能力判定来源，供日志/UI 展示。 */
+function buildCapabilitySummary(tracks: AudioTrackAnalysis[]): string {
+  if (tracks.length === 0) {
+    return '无音轨信息';
   }
-  for (let i = 0; i < SOFT_ONLY_KEYWORDS.length; i++) {
-    if (codec.includes(SOFT_ONLY_KEYWORDS[i])) {
-      return false;
-    }
+  const parts: string[] = [];
+  for (let i = 0; i < tracks.length; i++) {
+    const t = tracks[i];
+    parts.push(`${t.codec || '?'}:${t.capabilitySource}${t.compatible ? '(兼容)' : '(不兼容)'}`);
   }
-  return true;
-}
-
-/** Preset audio hint 容器（用于 readPresetAudioHint 显式类型）。 */
-export interface PresetAudioHint {
-  codecName: string;
-  channels: number;
+  return parts.join(', ');
 }
 
 /** 从 preset 列表中读取最匹配的首条 hint（多声道 > 高码率 > 原始顺序）。 */
@@ -257,72 +218,25 @@ function inferTrackChannels(track: PresetAudioTrack): number {
   return 2;
 }
 
-/** 排序前对声道数做归一化处理。 */
-function normalizeChannelsForSort(ch: number): number {
-  if (ch <= 1) {
-    return 1;
-  }
-  if (ch <= 2) {
-    return 2;
-  }
-  if (ch <= 6) {
-    return 6;
-  }
-  return 8;
-}
-
-/** 将 AVPlayer MIME 与 ffprobe codec 统一为路由使用的 codec 名。 */
-export function normalizeAudioCodec(rawCodec: string): string {
-  const codec = rawCodec.toLowerCase().replace('audio/', '').split('-').join('');
-  if (codec === 'mp4alatm' || codec === 'mp4a' || codec === 'aaclatm') {
-    return 'aac';
-  }
-  return codec;
-}
-
-/** 判断音轨是否"系统级可用"（与原 `isAudioTrackPlayable` 等价）。
- *  含义：AVPlayer 不进入 onUnsupportedFormat 路径；TrueHD / MLP / Audio Vivid 等"软解罕见"
- *  仍被视为"可用"，但兼容性更差，由 `codecCompatibilityRank` 进一步排序。
- */
-function isAudioTrackPlayable(track: AudioTrackItem): boolean {
-  const raw = (track.codecName ?? track.mimeType) ?? '';
-  const codec = normalizeAudioCodec(raw);
-  // 注意：不能把 TrueHD / AC-3 一律视为不可用，否则"全部不可用"会回退到 track 0。
-  // 这里仅过滤"完全无法识别的未知 codec"，硬解 / 软解兼容性由 rank 决定。
-  if (codec.length === 0) {
-    return false;
-  }
-  // 若 codec 在 SOFT_ONLY_KEYWORDS 中，视为软解可用，AVPlayer 失败后由 MPV 接管
-  if (SOFT_ONLY_KEYWORDS.indexOf(codec) >= 0) {
-    return true;
-  }
-  // 硬解友好
-  if (isLikelySystemHardDecodeSupported(codec)) {
-    return true;
-  }
-  // 未知 codec：保守视为不可用
-  return false;
-}
-
 /** 提取音轨的归一化 codec 字符串（用于日志与排序）。 */
 function getNormalizedCodec(track: AudioTrackItem): string {
   const raw = (track.codecName ?? track.mimeType) ?? '';
   return normalizeAudioCodec(raw);
 }
 
+/** 提取音轨的归一化声道（未知返回 0）。 */
+function getNormalizedChannels(track: AudioTrackItem): number {
+  if (track.channels !== undefined && track.channels > 0) {
+    return normalizeTargetChannels(track.channels);
+  }
+  return 0;
+}
+
 /**
- * codec-aware 初始音轨选择（与原 `findInitialAudioTrackIndex` 等价，但按 compatibility rank 排序）。
+ * codec-aware 初始音轨选择（codec 排名回退；设备能力信息缺失时使用）。
  *
- * 关键修复：
- * - 旧实现把所有"软解罕见"（TrueHD/MLP/Audio Vivid）和"软解常见"（AC-3/EAC-3/DTS）一同视为"软解"，
- *   然后"按可播放性"返回首条，导致 TrueHD 排在 AC-3 前面被选中。
- * - 新实现按 `codecCompatibilityRank` 排序：硬解 > AC-3/EAC-3 > DTS > TrueHD/MLP > unknown。
- *   偏好轨不可用时，按"同语言可播放轨中 rank 最低"选择。
- *
- * 注意：导出为 free function 仅供 `AudioTrackRoutingService` 内部 `resolveInitialTrackIndex` 调用；
- * 外部调用方请改用 `audioTrackRoutingService.resolveInitialTrackIndex(...)`，避免直接
- * 绕过 service 入口。controller 旧 import 路径 `findInitialAudioTrackIndex` 已被替换为
- * `serviceFindInitialAudioTrackIndex` 包装，仅为兼容历史 import 路径（见 W2 修复说明）。
+ * 与历史实现等价：偏好轨（audioTracks[0]）rank=1 直接选中；否则按 rank 降级
+ * （同语言 → 任意可播放）。设备能力信息可用时请使用 rankAudioTracksByCapability。
  */
 export function findInitialAudioTrackIndex(audioTracks: AudioTrackItem[]): number {
   if (audioTracks.length === 0) {
@@ -333,29 +247,19 @@ export function findInitialAudioTrackIndex(audioTracks: AudioTrackItem[]): numbe
   const preferredRank = codecCompatibilityRank(preferredCodec);
 
   if (preferredRank === 1) {
-    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `[findInitialAudioTrackIndex] 偏好轨硬解可播(rank=1)，直接选中: index=0 lang=${preferred.language ?? 'unknown'} codec=${preferredCodec || 'unknown'}`);
     return 0;
   }
 
   if (preferredRank <= 2) {
-    // AC-3/EAC-3 在 AVPlayer 上下文中可通过软解播放，但若有硬解轨（rank=1）则优先用硬解轨
+    // AC-3/EAC-3 软解常见：若有硬解轨（rank=1）则优先硬解轨
     for (let i = 1; i < audioTracks.length; i++) {
-      const t = audioTracks[i];
-      const tRank = codecCompatibilityRank(getNormalizedCodec(t));
+      const tRank = codecCompatibilityRank(getNormalizedCodec(audioTracks[i]));
       if (tRank === 1) {
-        hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-          `[findInitialAudioTrackIndex] 偏好轨为软解常见(rank=2)，发现硬解轨(index=${i})，优先选中`);
         return i;
       }
     }
-    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `[findInitialAudioTrackIndex] 偏好轨软解常见(rank=2)，无硬解替代，选中: index=0 lang=${preferred.language ?? 'unknown'} codec=${preferredCodec || 'unknown'}`);
     return 0;
   }
-
-  hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-    `[findInitialAudioTrackIndex] 偏好轨不优先(rank=${preferredRank}): index=0 lang=${preferred.language ?? 'unknown'} codec=${preferredCodec || 'unknown'}，按 rank 降级`);
 
   const preferredLang = preferred.language ?? '';
 
@@ -374,10 +278,6 @@ export function findInitialAudioTrackIndex(audioTracks: AudioTrackItem[]): numbe
     }
   }
   if (bestSameLangIdx >= 0) {
-    const t = audioTracks[bestSameLangIdx];
-    const tCodec = getNormalizedCodec(t);
-    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `[findInitialAudioTrackIndex] 同语言降级: index=${bestSameLangIdx} lang=${preferredLang} rank=${bestSameLangRank} codec=${tCodec || 'unknown'}`);
     return bestSameLangIdx;
   }
 
@@ -396,23 +296,78 @@ export function findInitialAudioTrackIndex(audioTracks: AudioTrackItem[]): numbe
     }
   }
   if (bestAnyIdx >= 0) {
-    const t = audioTracks[bestAnyIdx];
-    const tCodec = getNormalizedCodec(t);
-    hilog.info(CommonConstants.LOG_DOMAIN, TAG,
-      `[findInitialAudioTrackIndex] 任意可播放降级: index=${bestAnyIdx} rank=${bestAnyRank} lang=${t.language ?? 'unknown'} codec=${tCodec || 'unknown'}`);
     return bestAnyIdx;
   }
 
-  hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
-    `[findInitialAudioTrackIndex] 全部音轨 rank>4（不可解析），返回 0 沿用现有降级策略`);
   return 0;
+}
+
+/**
+ * 基于设备能力的初始音轨选择：兼容音轨中硬解优先 → 语言偏好 → 声道高 → 索引小。
+ * `compatibilities` 与 `audioTracks` 等长；无能力信息（compatible 默认 true）时仍可排序。
+ */
+export function rankAudioTracksByCapability(
+  audioTracks: AudioTrackItem[],
+  compatibilities: AudioTrackCompatibility[]
+): number {
+  if (audioTracks.length === 0) {
+    return 0;
+  }
+  const preferredLang = audioTracks[0].language ?? '';
+  let bestIdx = -1;
+  for (let i = 0; i < audioTracks.length; i++) {
+    const comp = i < compatibilities.length ? compatibilities[i] : undefined;
+    const compatible = comp === undefined ? true : comp.compatible;
+    if (!compatible) {
+      continue;
+    }
+    if (bestIdx < 0) {
+      bestIdx = i;
+      continue;
+    }
+    if (compareCompatibleItem(audioTracks[i], audioTracks[bestIdx],
+      i < compatibilities.length ? compatibilities[i] : undefined,
+      bestIdx < compatibilities.length ? compatibilities[bestIdx] : undefined,
+      preferredLang) < 0) {
+      bestIdx = i;
+    }
+  }
+  return bestIdx >= 0 ? bestIdx : 0;
+}
+
+/** 兼容音轨比较：硬解 → 语言匹配 → 声道 → 索引（负值表示 a 更优）。 */
+function compareCompatibleItem(
+  a: AudioTrackItem,
+  b: AudioTrackItem,
+  compA: AudioTrackCompatibility | undefined,
+  compB: AudioTrackCompatibility | undefined,
+  preferredLang: string
+): number {
+  const aHw = compA !== undefined && compA.isHardware;
+  const bHw = compB !== undefined && compB.isHardware;
+  if (aHw !== bHw) {
+    return aHw ? -1 : 1;
+  }
+  const aLang = a.language ?? '';
+  const bLang = b.language ?? '';
+  const aMatch = preferredLang.length > 0 && aLang === preferredLang;
+  const bMatch = preferredLang.length > 0 && bLang === preferredLang;
+  if (aMatch !== bMatch) {
+    return aMatch ? -1 : 1;
+  }
+  const aCh = compA !== undefined && compA.channels > 0 ? compA.channels : 0;
+  const bCh = compB !== undefined && compB.channels > 0 ? compB.channels : 0;
+  if (aCh !== bCh) {
+    return bCh - aCh;
+  }
+  return a.trackIndex - b.trackIndex;
 }
 
 /**
  * controller façade 调用入口：薄包装 `findInitialAudioTrackIndex` 让 controller 仍可走
  * service import 路径。完整推荐调用方式：
  *   `await this.audioRoutingService.resolveInitialTrackIndex(videoPath, audioTracks)`
- * 该方法会先查用户绑定，再调本函数做默认选轨。
+ * 该方法会先查用户绑定，再按设备能力做默认选轨。
  */
 export function serviceFindInitialAudioTrackIndex(audioTracks: AudioTrackItem[]): number {
   return findInitialAudioTrackIndex(audioTracks);
@@ -425,16 +380,14 @@ export class AudioTrackRoutingService {
   /**
    * 计算 backend route 决策。
    *
-   * 关键变化（与历史实现对照）：**遍历整组音轨**（probe + preset 合并去重），
-   * 而非仅看 probe.audioTracks[0] 决定一切。
-   *
-   * 行为：
-   * - 整组音轨存在至少一条系统稳态可硬解轨道 → preferredBackend=avplayer
-   * - 整组音轨全部应软解（如全 TrueHD/DTS/AC3）→ preferredBackend=avplayer + fallback=mpv
-   * - 探测完全失败且无任何音轨提示 → 仍先尝试 AVPlayer，再按不支持格式回退
-   * - 初始选轨由 controller 调用 `resolveInitialTrackIndex` 决定（与 backend route 决策解耦）
+   * 流程：
+   * - ffprobe / preset 收集整组音轨（probe 优先，preset 兜底）
+   * - 按归一化 codec 去重
+   * - 逐唯一 codec 查询设备解码能力（含声道上限），填充每条音轨兼容性
+   * - 交给 buildRoutingDecision 做后端与预选决策
    */
   async resolveRoutingDecision(videoData: VideoData): Promise<AudioRoutingDecision> {
+    await audioDecoderCapabilityService.ensureLoaded();
     const presetHint = readPresetAudioHint(videoData);
     let probeCodec = '';
     let probeChannels = presetHint.channels;
@@ -468,7 +421,6 @@ export class AudioTrackRoutingService {
         const first = probe.audioTracks[0];
         probeCodec = first.codecName;
         probeChannels = first.channels ?? probeChannels;
-        // ── 关键：收集整组 audio tracks ──
         for (let i = 0; i < probe.audioTracks.length; i++) {
           const t = probe.audioTracks[i];
           const entry: ProbeAudio = {
@@ -480,7 +432,6 @@ export class AudioTrackRoutingService {
       }
       if (probe.success && probe.videoTracks.length > 0) {
         videoCodecName = (probe.videoTracks[0].codecName ?? '').toLowerCase();
-        // 未知/缺失统一用空串表示；已知类型为 'SDR' | 'HDR10' | 'HLG' | 'DOLBY_VISION'。
         probeVideoHdrType = probe.videoTracks[0].hdrType ?? '';
         probeVideoWidth = probe.videoTracks[0].width;
         probeVideoHeight = probe.videoTracks[0].height;
@@ -495,7 +446,7 @@ export class AudioTrackRoutingService {
       precheckProbeError = err['message'] ?? JSON.stringify(e);
     }
 
-    // 合并 probe + preset 为整组音轨分析（probe 优先，preset 作为补充）
+    // 合并 probe + preset 为整组音轨分析（probe 优先，preset 作为补充），按归一化 codec 去重
     const trackAnalyses: AudioTrackAnalysis[] = [];
     const seenCodecs = new Set<string>();
     for (let i = 0; i < probeAudioTracks.length; i++) {
@@ -505,25 +456,11 @@ export class AudioTrackRoutingService {
         continue;
       }
       seenCodecs.add(codec);
-      const analysis: AudioTrackAnalysis = {
-        index: i,
-        codec,
-        channels: t.channels,
-        hardSupported: isLikelySystemHardDecodeSupported(codec),
-        source: 'probe'
-      };
-      trackAnalyses.push(analysis);
+      trackAnalyses.push(this.buildTrackAnalysis(i, codec, t.channels, 'probe'));
     }
-    // preset hint 补充：仅在 probe 为空时使用
     if (trackAnalyses.length === 0 && presetHint.codecName.length > 0) {
       const codec = normalizeAudioCodec(presetHint.codecName);
-      trackAnalyses.push({
-        index: 0,
-        codec,
-        channels: presetHint.channels,
-        hardSupported: isLikelySystemHardDecodeSupported(codec),
-        source: 'preset'
-      });
+      trackAnalyses.push(this.buildTrackAnalysis(0, codec, presetHint.channels, 'preset'));
     }
 
     const input: AudioRoutingInput = {
@@ -545,11 +482,34 @@ export class AudioTrackRoutingService {
     return buildRoutingDecision(input);
   }
 
+  /** 构造单条音轨分析（含设备能力查询结果）。 */
+  private buildTrackAnalysis(
+    index: number,
+    codec: string,
+    channels: number,
+    source: 'probe' | 'preset'
+  ): AudioTrackAnalysis {
+    const normChannels = normalizeTargetChannels(channels);
+    const compatibility = audioDecoderCapabilityService.resolveTrackCompatibility(codec, normChannels);
+    const analysis: AudioTrackAnalysis = {
+      index,
+      codec,
+      channels: normChannels,
+      hardSupported: isLikelySystemHardDecodeSupported(codec),
+      source,
+      compatible: compatibility.compatible,
+      maxChannels: compatibility.maxChannels,
+      isHardware: compatibility.isHardware,
+      capabilitySource: compatibility.source
+    };
+    return analysis;
+  }
+
   /**
    * 计算初始音轨选择。
    * - 用户绑定命中且 displayName 匹配 → 命中
    * - 用户绑定命中但 displayName 不在列表中 → 清除绑定 + 默认选轨
-   * - 无用户绑定 → codec-aware 默认选轨
+   * - 无用户绑定 → 基于设备能力的 codec-aware 默认选轨
    */
   async resolveInitialTrackIndex(
     videoPath: string,
@@ -558,6 +518,8 @@ export class AudioTrackRoutingService {
     if (audioTracks.length === 0) {
       return { trackIndex: 0, source: 'all-unplayable', shouldClearUserBinding: false };
     }
+
+    await audioDecoderCapabilityService.ensureLoaded();
 
     // 步骤 1：用户绑定命中
     let userBinding: AudioBinding | null = null;
@@ -580,7 +542,6 @@ export class AudioTrackRoutingService {
           `命中用户绑定: index=${foundIndex} displayName=${userBinding.displayName}`);
         return { trackIndex: foundIndex, source: 'user-binding', shouldClearUserBinding: false };
       }
-      // displayName 不在列表中：清除绑定并回退默认选轨
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,
         `绑定 displayName 不在轨道列表中，自动清除: ${userBinding.displayName}`);
       try {
@@ -588,11 +549,31 @@ export class AudioTrackRoutingService {
       } catch (e) {
         hilog.warn(CommonConstants.LOG_DOMAIN, TAG, `清除失效绑定失败: ${String(e)}`);
       }
-      return { trackIndex: findInitialAudioTrackIndex(audioTracks), source: 'preferred-playable', shouldClearUserBinding: true };
+      return {
+        trackIndex: rankAudioTracksByCapability(audioTracks, this.resolveCompatibilities(audioTracks)),
+        source: 'preferred-playable',
+        shouldClearUserBinding: true
+      };
     }
 
-    // 步骤 2：默认选轨（codec-aware）
-    return { trackIndex: findInitialAudioTrackIndex(audioTracks), source: 'preferred-playable', shouldClearUserBinding: false };
+    // 步骤 2：基于设备能力的默认选轨
+    return {
+      trackIndex: rankAudioTracksByCapability(audioTracks, this.resolveCompatibilities(audioTracks)),
+      source: 'preferred-playable',
+      shouldClearUserBinding: false
+    };
+  }
+
+  /** 为每条音轨计算设备能力兼容性（声道未知传 0，跳过上限校验）。 */
+  private resolveCompatibilities(audioTracks: AudioTrackItem[]): AudioTrackCompatibility[] {
+    const result: AudioTrackCompatibility[] = [];
+    for (let i = 0; i < audioTracks.length; i++) {
+      const track = audioTracks[i];
+      const codec = getNormalizedCodec(track);
+      const channels = getNormalizedChannels(track);
+      result.push(audioDecoderCapabilityService.resolveTrackCompatibility(codec, channels));
+    }
+    return result;
   }
 }
 

--- a/entry/src/main/ets/services/playback/PlaybackBackendService.ets
+++ b/entry/src/main/ets/services/playback/PlaybackBackendService.ets
@@ -99,11 +99,11 @@ export class PlaybackBackendService {
    * 本方法内部委托 `AudioTrackRoutingService.resolveRoutingDecision` 计算整组音轨分析，
    * 并把结果包装为 `PlaybackBackendDecision` 暴露给 controller。
    *
-   * 行为：
+   * 行为（基于设备真实解码能力，Issue #243）：
    * - 探测 ffprobe 失败时降级 preset hint
-   * - 整组音轨存在至少一条稳态可硬解轨道 → preferredBackend=avplayer（让 avplayer 尝试，
-   *   由 `loadAudioTracks` 阶段的 `resolveInitialTrackIndex` 选中最优可硬解轨）
-   * - 整组音轨全部应软解 → preferredBackend=avplayer + fallback=mpv
+   * - 整组音轨存在至少一条设备能力兼容轨道 → preferredBackend=avplayer（由
+   *   `loadAudioTracks` 阶段的 `resolveInitialTrackIndex` 选中兼容性最优轨）
+   * - 存在音轨但没有任何兼容轨道（已知不支持或能力未知）→ preferredBackend=mpv（直接，不先 prepare AVPlayer）
    * - 探测完全失败且无任何音轨提示 → 仍先尝试 AVPlayer，再按不支持格式回退
    */
   async chooseBackend(videoData: VideoData): Promise<PlaybackBackendDecision> {

--- a/entry/src/main/ets/services/playback/PlaybackBackendService.ets
+++ b/entry/src/main/ets/services/playback/PlaybackBackendService.ets
@@ -128,7 +128,10 @@ export class PlaybackBackendService {
         videoHdrType: decision.videoHdrType,
         videoWidth: decision.videoWidth,
         videoHeight: decision.videoHeight,
-        trackAnalyses: decision.trackAnalyses
+        trackAnalyses: decision.trackAnalyses,
+        recommendedInitialTrackIndex: decision.recommendedInitialTrackIndex,
+        recommendedCodec: decision.recommendedCodec,
+        capabilitySummary: decision.capabilitySummary
       };
     } catch (e) {
       hilog.warn(CommonConstants.LOG_DOMAIN, TAG,

--- a/entry/src/main/ets/services/playback/PlaybackBackendTypes.ets
+++ b/entry/src/main/ets/services/playback/PlaybackBackendTypes.ets
@@ -15,6 +15,7 @@
 import type { VideoData } from "../../components/core/player/VideoData";
 import type { IPlayer } from "../../components/core/player/IPlayer";
 import type { ISubtitleBridgeAdapter } from "../../components/core/player/SubtitleBridgeAdapter";
+import type { AudioCapabilitySource } from "../audioCapability/AudioCapabilityTypes";
 
 /** 播放内核类型（service 内部命名，controller 已有同名类型，alias 复用）。 */
 export type ServicePlayerBackend = 'avplayer' | 'mpv';
@@ -58,8 +59,8 @@ export interface BackendTrackAnalysis {
   maxChannels: number;
   /** 是否为硬件解码。 */
   isHardware: boolean;
-  /** 兼容性结论来源。 */
-  capabilitySource: string;
+  /** 兼容性结论来源（与 AudioRoutingTypes.AudioCapabilitySource 保持一致）。 */
+  capabilitySource: AudioCapabilitySource;
 }
 
 export interface PlaybackBackendDecision {
@@ -95,30 +96,6 @@ export interface PlaybackBackendDecision {
   /** 能力判定摘要（来源/缓存/纠偏，供日志与 UI）。 */
   capabilitySummary: string;
 }
-
-/** 默认后端决策（探测未启动时使用）。 */
-export const DEFAULT_BACKEND_DECISION: PlaybackBackendDecision = {
-  preferredBackend: 'avplayer',
-  fallback: 'mpv',
-  preferredChannels: 2,
-  summary: 'default: 未探测到音轨细节',
-  detectedCodec: 'unknown',
-  detectedChannels: 2,
-  anyHardSupported: true,
-  allSoftDecodeOnly: false,
-  anyPlayable: true,
-  anyUnplayable: false,
-  precheckProbeFailed: false,
-  precheckProbeError: '',
-  videoCodecName: '',
-  videoHdrType: '',
-  videoWidth: undefined,
-  videoHeight: undefined,
-  trackAnalyses: [],
-  recommendedInitialTrackIndex: -1,
-  recommendedCodec: '',
-  capabilitySummary: 'default: 未查询设备解码能力'
-};
 
 /** 字幕桥接 adapter 类型（service 内部命名以避免与 controller 现有类型冲突）。 */
 export type SubtitleBridgeKind = 'none' | 'av' | 'mpv' | 'smb-av';

--- a/entry/src/main/ets/services/playback/PlaybackBackendTypes.ets
+++ b/entry/src/main/ets/services/playback/PlaybackBackendTypes.ets
@@ -52,6 +52,14 @@ export interface BackendTrackAnalysis {
   hardSupported: boolean;
   /** 'probe' | 'preset' */
   source: string;
+  /** 设备能力兼容性（codec 支持且声道数不超上限）。 */
+  compatible: boolean;
+  /** 设备该 codec 的最大声道能力（未知/不支持时为 0）。 */
+  maxChannels: number;
+  /** 是否为硬件解码。 */
+  isHardware: boolean;
+  /** 兼容性结论来源。 */
+  capabilitySource: string;
 }
 
 export interface PlaybackBackendDecision {
@@ -80,6 +88,12 @@ export interface PlaybackBackendDecision {
   videoHeight?: number;
   /** 整组音轨分析详情（调试用）。 */
   trackAnalyses: BackendTrackAnalysis[];
+  /** 预选的初始音轨索引（-1 表示无兼容轨）。 */
+  recommendedInitialTrackIndex: number;
+  /** 预选音轨的归一化 codec（无兼容轨或未知时为空串）。 */
+  recommendedCodec: string;
+  /** 能力判定摘要（来源/缓存/纠偏，供日志与 UI）。 */
+  capabilitySummary: string;
 }
 
 /** 默认后端决策（探测未启动时使用）。 */
@@ -100,7 +114,10 @@ export const DEFAULT_BACKEND_DECISION: PlaybackBackendDecision = {
   videoHdrType: '',
   videoWidth: undefined,
   videoHeight: undefined,
-  trackAnalyses: []
+  trackAnalyses: [],
+  recommendedInitialTrackIndex: -1,
+  recommendedCodec: '',
+  capabilitySummary: 'default: 未查询设备解码能力'
 };
 
 /** 字幕桥接 adapter 类型（service 内部命名以避免与 controller 现有类型冲突）。 */
@@ -179,7 +196,10 @@ export function buildDefaultBackendDecision(): PlaybackBackendDecision {
     videoHdrType: '',
     videoWidth: undefined,
     videoHeight: undefined,
-    trackAnalyses: []
+    trackAnalyses: [],
+    recommendedInitialTrackIndex: -1,
+    recommendedCodec: '',
+    capabilitySummary: 'default: 未查询设备解码能力'
   };
   return decision;
 }

--- a/entry/src/main/ets/utils/AppPreferences.ets
+++ b/entry/src/main/ets/utils/AppPreferences.ets
@@ -46,6 +46,8 @@ export class PrefKey {
   static readonly AUDIO_BINDING_PREFIX = 'audio_binding';
   /** 媒体库当前数据源（JSON 序列化的 ActiveMediaSource） */
   static readonly ACTIVE_MEDIA_SOURCE = 'active_media_source';
+  /** 音频解码能力设备/固件纠偏（JSON 序列化的 AudioCorrectionEntry[]） */
+  static readonly AUDIO_CAPABILITY_CORRECTIONS = 'audio_capability_corrections';
 }
 
 // ─────────────────────────────────────────────

--- a/entry/src/test/AudioCodecUtil.test.ets
+++ b/entry/src/test/AudioCodecUtil.test.ets
@@ -16,8 +16,8 @@ export default function audioCodecUtilTest() {
 
     it('normalizeAudioCodec 归一化 E-AC-3 / DTS-HD', 0, () => {
       expect(normalizeAudioCodec('audio/eac3')).assertEqual('eac3');
-      expect(normalizeAudioCodec('audio/vnd.dts.hd')).assertEqual('vnd.dts.hd');
-      expect(normalizeAudioCodec('audio/vnd.dts')).assertEqual('vnd.dts');
+      expect(normalizeAudioCodec('audio/vnd.dts.hd')).assertEqual('dtshd');
+      expect(normalizeAudioCodec('audio/vnd.dts')).assertEqual('dts');
     });
 
     it('normalizeAudioCodec 去除连字符', 0, () => {

--- a/entry/src/test/AudioCodecUtil.test.ets
+++ b/entry/src/test/AudioCodecUtil.test.ets
@@ -1,0 +1,58 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  normalizeAudioCodec,
+  codecCompatibilityRank,
+  normalizeTargetChannels,
+  normalizeChannelsForSort,
+  isLikelySystemHardDecodeSupported
+} from '../main/ets/services/audioRouting/AudioCodecUtil';
+
+export default function audioCodecUtilTest() {
+  describe('AudioCodecUtil', () => {
+    it('normalizeAudioCodec 归一化 AAC MIME', 0, () => {
+      expect(normalizeAudioCodec('audio/mp4a-latm')).assertEqual('aac');
+      expect(normalizeAudioCodec('mp4a')).assertEqual('aac');
+    });
+
+    it('normalizeAudioCodec 归一化 E-AC-3 / DTS-HD', 0, () => {
+      expect(normalizeAudioCodec('audio/eac3')).assertEqual('eac3');
+      expect(normalizeAudioCodec('audio/vnd.dts.hd')).assertEqual('vnd.dts.hd');
+      expect(normalizeAudioCodec('audio/vnd.dts')).assertEqual('vnd.dts');
+    });
+
+    it('normalizeAudioCodec 去除连字符', 0, () => {
+      expect(normalizeAudioCodec('audio/ac-3')).assertEqual('ac3');
+    });
+
+    it('codecCompatibilityRank 硬解友好为 1、软解常见为 2、未知为 4', 0, () => {
+      expect(codecCompatibilityRank('aac')).assertEqual(1);
+      expect(codecCompatibilityRank('mp3')).assertEqual(1);
+      expect(codecCompatibilityRank('ac3')).assertEqual(2);
+      expect(codecCompatibilityRank('eac3')).assertEqual(2);
+      expect(codecCompatibilityRank('')).assertEqual(4);
+      expect(codecCompatibilityRank('unknowncodec')).assertEqual(4);
+    });
+
+    it('normalizeTargetChannels 声道边界', 0, () => {
+      expect(normalizeTargetChannels(1)).assertEqual(1);
+      expect(normalizeTargetChannels(2)).assertEqual(2);
+      expect(normalizeTargetChannels(6)).assertEqual(6);
+      expect(normalizeTargetChannels(8)).assertEqual(8);
+      expect(normalizeTargetChannels(10)).assertEqual(8);
+      expect(normalizeTargetChannels(0)).assertEqual(2);
+    });
+
+    it('normalizeChannelsForSort 排序归一化', 0, () => {
+      expect(normalizeChannelsForSort(1)).assertEqual(1);
+      expect(normalizeChannelsForSort(2)).assertEqual(2);
+      expect(normalizeChannelsForSort(5)).assertEqual(6);
+      expect(normalizeChannelsForSort(9)).assertEqual(8);
+    });
+
+    it('isLikelySystemHardDecodeSupported 软解关键字判定', 0, () => {
+      expect(isLikelySystemHardDecodeSupported('aac')).assertTrue();
+      expect(isLikelySystemHardDecodeSupported('eac3')).assertFalse();
+      expect(isLikelySystemHardDecodeSupported('truehd')).assertFalse();
+    });
+  });
+}

--- a/entry/src/test/AudioDecoderCapabilityService.test.ets
+++ b/entry/src/test/AudioDecoderCapabilityService.test.ets
@@ -1,0 +1,150 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { AudioDecoderCapabilityService } from '../main/ets/services/audioCapability/AudioDecoderCapabilityService';
+import {
+  AudioDecoderCapability,
+  CapabilityProvider,
+  DeviceInfoProvider
+} from '../main/ets/services/audioCapability/AudioCapabilityTypes';
+
+function makeCapability(
+  supported: boolean,
+  maxChannels: number,
+  isHardware: boolean,
+  known: boolean = true
+): AudioDecoderCapability {
+  const cap: AudioDecoderCapability = {
+    capabilityKnown: known,
+    supported,
+    isHardware,
+    maxChannels,
+    decoderName: known ? 'test-decoder' : '',
+    mimeType: '',
+    errorMessage: ''
+  };
+  return cap;
+}
+
+interface CountingProviderResult {
+  provider: CapabilityProvider;
+  calls: string[];
+}
+
+function makeCountingProvider(results: Record<string, AudioDecoderCapability>): CountingProviderResult {
+  const calls: string[] = [];
+  const provider: CapabilityProvider = {
+    query: (codecOrMime: string): AudioDecoderCapability => {
+      calls.push(codecOrMime);
+      const r = results[codecOrMime];
+      if (r !== undefined) {
+        return r;
+      }
+      return makeCapability(false, 0, false, true);
+    }
+  };
+  const result: CountingProviderResult = { provider, calls };
+  return result;
+}
+
+function makeThrowingProvider(): CapabilityProvider {
+  const provider: CapabilityProvider = {
+    query: (_codecOrMime: string): AudioDecoderCapability => {
+      throw new Error('capability query boom');
+    }
+  };
+  return provider;
+}
+
+function makeDeviceInfo(model: string, os: string): DeviceInfoProvider {
+  const provider: DeviceInfoProvider = {
+    getDeviceModel: (): string => model,
+    getOsVersion: (): string => os
+  };
+  return provider;
+}
+
+export default function audioDecoderCapabilityServiceTest() {
+  describe('AudioDecoderCapabilityService', () => {
+    it('三条音轨两种唯一 codec 时最多查询两次（去重）', 0, () => {
+      const svc = new AudioDecoderCapabilityService();
+      const counting = makeCountingProvider({
+        'aac': makeCapability(true, 2, true),
+        'eac3': makeCapability(true, 6, false)
+      });
+      svc.setCapabilityProviderForTesting(counting.provider);
+      svc.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
+      svc.resolveTrackCompatibility('aac', 2);
+      svc.resolveTrackCompatibility('aac', 2);
+      svc.resolveTrackCompatibility('aac', 6);
+      svc.resolveTrackCompatibility('eac3', 6);
+      expect(counting.calls.length).assertEqual(2);
+    });
+
+    it('codec 支持但声道超上限时判为不兼容', 0, () => {
+      const svc = new AudioDecoderCapabilityService();
+      svc.setCapabilityProviderForTesting(makeCountingProvider({
+        'truehd': makeCapability(true, 2, false)
+      }).provider);
+      svc.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
+      const r = svc.resolveTrackCompatibility('truehd', 6);
+      expect(r.compatible).assertFalse();
+      expect(r.source).assertEqual('system');
+    });
+
+    it('缓存命中复用结果且不重复查询', 0, () => {
+      const svc = new AudioDecoderCapabilityService();
+      const counting = makeCountingProvider({
+        'aac': makeCapability(true, 2, true)
+      });
+      svc.setCapabilityProviderForTesting(counting.provider);
+      svc.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
+      svc.resolveTrackCompatibility('aac', 2);
+      svc.resolveTrackCompatibility('aac', 2);
+      const r = svc.resolveTrackCompatibility('aac', 2);
+      expect(r.source).assertEqual('cache');
+      expect(counting.calls.length).assertEqual(1);
+    });
+
+    it('系统版本变化后旧缓存失效并重新查询', 0, () => {
+      const svc = new AudioDecoderCapabilityService();
+      const counting = makeCountingProvider({
+        'aac': makeCapability(true, 2, true)
+      });
+      svc.setCapabilityProviderForTesting(counting.provider);
+      svc.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
+      svc.resolveTrackCompatibility('aac', 2);
+      svc.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-2'));
+      svc.resolveTrackCompatibility('aac', 2);
+      expect(counting.calls.length).assertEqual(2);
+    });
+
+    it('能力查询异常时软解 codec 保守判未知不兼容', 0, () => {
+      const svc = new AudioDecoderCapabilityService();
+      svc.setCapabilityProviderForTesting(makeThrowingProvider());
+      svc.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
+      const r = svc.resolveTrackCompatibility('eac3', 2);
+      expect(r.compatible).assertFalse();
+      expect(r.source).assertEqual('unknown');
+    });
+
+    it('能力查询异常时硬解友好 codec 迁移兜底假定兼容', 0, () => {
+      const svc = new AudioDecoderCapabilityService();
+      svc.setCapabilityProviderForTesting(makeThrowingProvider());
+      svc.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
+      const r = svc.resolveTrackCompatibility('aac', 2);
+      expect(r.compatible).assertTrue();
+      expect(r.source).assertEqual('migration-blacklist');
+    });
+
+    it('纠偏结果优先于系统声明能力', 0, () => {
+      const svc = new AudioDecoderCapabilityService();
+      svc.setCapabilityProviderForTesting(makeCountingProvider({
+        'eac3': makeCapability(true, 6, false)
+      }).provider);
+      svc.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
+      svc.recordCorrection('eac3', 'avplayer_unsupported_format');
+      const r = svc.resolveTrackCompatibility('eac3', 2);
+      expect(r.compatible).assertFalse();
+      expect(r.source).assertEqual('correction');
+    });
+  });
+}

--- a/entry/src/test/AudioDecoderCapabilityService.test.ets
+++ b/entry/src/test/AudioDecoderCapabilityService.test.ets
@@ -1,10 +1,45 @@
 import { describe, it, expect } from '@ohos/hypium';
+import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
+import { Context } from '@ohos.abilityAccessCtrl';
 import { AudioDecoderCapabilityService } from '../main/ets/services/audioCapability/AudioDecoderCapabilityService';
 import {
   AudioDecoderCapability,
   CapabilityProvider,
   DeviceInfoProvider
 } from '../main/ets/services/audioCapability/AudioCapabilityTypes';
+import {
+  AppPreferences,
+  AppPreferencesLoader,
+  AppPreferencesStore,
+  AppPreferenceValue
+} from '../main/ets/utils/AppPreferences';
+
+/** 内存版 AppPreferences store（用于纠偏持久化跨实例复用测试）。 */
+class InMemoryAppPreferencesStore implements AppPreferencesStore {
+  private readonly values: Map<string, AppPreferenceValue> = new Map<string, AppPreferenceValue>();
+
+  async get(key: string, defaultValue: AppPreferenceValue): Promise<AppPreferenceValue> {
+    const value = this.values.get(key);
+    return value === undefined ? defaultValue : value;
+  }
+
+  async put(key: string, value: AppPreferenceValue): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async flush(): Promise<void> {
+  }
+}
+
+async function installMemoryPreferencesLoader(): Promise<AppPreferencesStore> {
+  AppPreferences.resetForTesting();
+  const store = new InMemoryAppPreferencesStore();
+  const loader: AppPreferencesLoader = async (_context, _storeName): Promise<AppPreferencesStore> => store;
+  AppPreferences.setStoreLoaderForTesting(loader);
+  const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+  await AppPreferences.init(ctx);
+  return store;
+}
 
 function makeCapability(
   supported: boolean,
@@ -126,13 +161,13 @@ export default function audioDecoderCapabilityServiceTest() {
       expect(r.source).assertEqual('unknown');
     });
 
-    it('能力查询异常时硬解友好 codec 迁移兜底假定兼容', 0, () => {
+    it('能力查询异常时硬解友好 codec 也保守判不兼容（不做兼容假设）', 0, () => {
       const svc = new AudioDecoderCapabilityService();
       svc.setCapabilityProviderForTesting(makeThrowingProvider());
       svc.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
       const r = svc.resolveTrackCompatibility('aac', 2);
-      expect(r.compatible).assertTrue();
-      expect(r.source).assertEqual('migration-blacklist');
+      expect(r.compatible).assertFalse();
+      expect(r.source).assertEqual('unknown');
     });
 
     it('纠偏结果优先于系统声明能力', 0, () => {
@@ -145,6 +180,35 @@ export default function audioDecoderCapabilityServiceTest() {
       const r = svc.resolveTrackCompatibility('eac3', 2);
       expect(r.compatible).assertFalse();
       expect(r.source).assertEqual('correction');
+    });
+
+    it('纠偏结果持久化后可由新实例 ensureLoaded 复用', 0, async () => {
+      await installMemoryPreferencesLoader();
+      try {
+        const svc1 = new AudioDecoderCapabilityService();
+        svc1.setCapabilityProviderForTesting(makeCountingProvider({
+          'eac3': makeCapability(true, 6, false)
+        }).provider);
+        svc1.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
+        svc1.recordCorrection('eac3', 'avplayer_unsupported_format');
+        // 等待异步持久化（persistCorrections 为 fire-and-forget）完成
+        await new Promise<void>((resolve) => {
+          setTimeout(() => { resolve(); }, 100);
+        });
+        // 新实例：ensureLoaded 后应从持久化存储恢复纠偏
+        const svc2 = new AudioDecoderCapabilityService();
+        svc2.setCapabilityProviderForTesting(makeCountingProvider({
+          'eac3': makeCapability(true, 6, false)
+        }).provider);
+        svc2.setDeviceInfoProviderForTesting(makeDeviceInfo('model-A', 'os-1'));
+        await svc2.ensureLoaded();
+        const r = svc2.resolveTrackCompatibility('eac3', 2);
+        expect(r.compatible).assertFalse();
+        expect(r.source).assertEqual('correction');
+      } finally {
+        AppPreferences.setStoreLoaderForTesting(null);
+        AppPreferences.resetForTesting();
+      }
     });
   });
 }

--- a/entry/src/test/AudioTrackRouting.test.ets
+++ b/entry/src/test/AudioTrackRouting.test.ets
@@ -1,0 +1,153 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  buildRoutingDecision,
+  rankAudioTracksByCapability
+} from '../main/ets/services/audioRouting/AudioTrackRoutingService';
+import {
+  AudioRoutingInput,
+  AudioTrackAnalysis
+} from '../main/ets/services/audioRouting/AudioRoutingTypes';
+import { AudioTrackItem } from '../main/ets/components/core/player/VideoPlayerController';
+import {
+  AudioTrackCompatibility,
+  AudioCapabilitySource
+} from '../main/ets/services/audioCapability/AudioCapabilityTypes';
+
+function makeAnalysis(
+  index: number,
+  codec: string,
+  channels: number,
+  compatible: boolean,
+  isHardware: boolean,
+  source: 'probe' | 'preset',
+  capabilitySource: AudioCapabilitySource
+): AudioTrackAnalysis {
+  const a: AudioTrackAnalysis = {
+    index,
+    codec,
+    channels,
+    compatible,
+    isHardware,
+    source,
+    capabilitySource,
+    hardSupported: isHardware,
+    maxChannels: 0
+  };
+  return a;
+}
+
+function makeInput(tracks: AudioTrackAnalysis[]): AudioRoutingInput {
+  const input: AudioRoutingInput = {
+    presetCodecName: '',
+    presetChannels: 2,
+    presetHasAudio: false,
+    probeCodecName: '',
+    probeChannels: 2,
+    probeVideoCodecName: '',
+    probeVideoHdrType: '',
+    probeVideoWidth: undefined,
+    probeVideoHeight: undefined,
+    probeSuccess: true,
+    probeError: '',
+    precheckProbeFailed: false,
+    precheckProbeError: '',
+    trackAnalyses: tracks
+  };
+  return input;
+}
+
+function makeCompatibility(
+  codec: string,
+  channels: number,
+  compatible: boolean,
+  isHardware: boolean,
+  maxChannels: number
+): AudioTrackCompatibility {
+  const c: AudioTrackCompatibility = {
+    codec,
+    channels,
+    compatible,
+    isHardware,
+    maxChannels,
+    source: 'system'
+  };
+  return c;
+}
+
+export default function audioTrackRoutingTest() {
+  describe('buildRoutingDecision - 设备能力路由', () => {
+    it('存在兼容音轨时选 AVPlayer 并预选硬解最优轨', 0, () => {
+      const tracks: AudioTrackAnalysis[] = [
+        makeAnalysis(0, 'truehd', 8, false, false, 'probe', 'system'),
+        makeAnalysis(1, 'eac3', 6, true, false, 'probe', 'system'),
+        makeAnalysis(2, 'aac', 2, true, true, 'probe', 'system')
+      ];
+      const d = buildRoutingDecision(makeInput(tracks));
+      expect(d.preferredBackend).assertEqual('avplayer');
+      expect(d.recommendedInitialTrackIndex).assertEqual(2);
+      expect(d.recommendedCodec).assertEqual('aac');
+    });
+
+    it('无兼容音轨时直接选 MPV', 0, () => {
+      const tracks: AudioTrackAnalysis[] = [
+        makeAnalysis(0, 'truehd', 8, false, false, 'probe', 'system'),
+        makeAnalysis(1, 'dts', 6, false, false, 'probe', 'system')
+      ];
+      const d = buildRoutingDecision(makeInput(tracks));
+      expect(d.preferredBackend).assertEqual('mpv');
+    });
+
+    it('能力未知时保守选 MPV', 0, () => {
+      const tracks: AudioTrackAnalysis[] = [
+        makeAnalysis(0, 'eac3', 6, false, false, 'probe', 'unknown')
+      ];
+      const d = buildRoutingDecision(makeInput(tracks));
+      expect(d.preferredBackend).assertEqual('mpv');
+    });
+
+    it('探测失败且无音轨提示时沿用历史行为选 AVPlayer', 0, () => {
+      const d = buildRoutingDecision(makeInput([]));
+      expect(d.preferredBackend).assertEqual('avplayer');
+    });
+  });
+
+  describe('rankAudioTracksByCapability - 能力选轨', () => {
+    it('硬解优先于软解', 0, () => {
+      const tracks: AudioTrackItem[] = [
+        { trackIndex: 0, displayName: 'E-AC-3', language: 'chi', codecName: 'eac3' },
+        { trackIndex: 1, displayName: 'AAC', language: 'chi', codecName: 'aac' }
+      ];
+      const comps: AudioTrackCompatibility[] = [
+        makeCompatibility('eac3', 6, true, false, 6),
+        makeCompatibility('aac', 2, true, true, 2)
+      ];
+      expect(rankAudioTracksByCapability(tracks, comps)).assertEqual(1);
+    });
+
+    it('声道超上限的轨被排除', 0, () => {
+      const tracks: AudioTrackItem[] = [
+        { trackIndex: 0, displayName: 'TrueHD 7.1', language: 'chi', codecName: 'truehd', channels: 8 },
+        { trackIndex: 1, displayName: 'AAC 2.0', language: 'eng', codecName: 'aac', channels: 2 }
+      ];
+      const comps: AudioTrackCompatibility[] = [
+        makeCompatibility('truehd', 8, false, false, 2),
+        makeCompatibility('aac', 2, true, true, 2)
+      ];
+      expect(rankAudioTracksByCapability(tracks, comps)).assertEqual(1);
+    });
+
+    it('兼容时优先同语言再考虑声道', 0, () => {
+      const tracks: AudioTrackItem[] = [
+        { trackIndex: 0, displayName: '英文 AAC 2.0', language: 'eng', codecName: 'aac', channels: 2 },
+        { trackIndex: 1, displayName: '中文 AAC 5.1', language: 'chi', codecName: 'aac', channels: 6 },
+        { trackIndex: 2, displayName: '英文 AAC 5.1', language: 'eng', codecName: 'aac', channels: 6 }
+      ];
+      const comps: AudioTrackCompatibility[] = [
+        makeCompatibility('aac', 2, true, true, 6),
+        makeCompatibility('aac', 6, true, true, 6),
+        makeCompatibility('aac', 6, true, true, 6)
+      ];
+      expect(rankAudioTracksByCapability(tracks, comps)).assertEqual(2);
+    });
+  });
+}

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -54,6 +54,9 @@ import subtitleRelevanceFilterTest from './ets/services/subtitleAcquisition/Subt
 import sourceSwitchModelTest from './SourceSwitchModel.test';
 import videoServerLabelsTest from './VideoServerLabels.test';
 import videoServerDaoTest from './VideoServerDao.test';
+import audioCodecUtilTest from './AudioCodecUtil.test';
+import audioDecoderCapabilityServiceTest from './AudioDecoderCapabilityService.test';
+import audioTrackRoutingTest from './AudioTrackRouting.test';
 
 export default function testsuite() {
   timeUtilTest();
@@ -110,4 +113,7 @@ export default function testsuite() {
   sourceSwitchModelTest();
   videoServerLabelsTest();
   videoServerDaoTest();
+  audioCodecUtilTest();
+  audioDecoderCapabilityServiceTest();
+  audioTrackRoutingTest();
 }

--- a/openspec/changes/device-audio-capability-routing/.openspec.yaml
+++ b/openspec/changes/device-audio-capability-routing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/device-audio-capability-routing/design.md
+++ b/openspec/changes/device-audio-capability-routing/design.md
@@ -55,6 +55,14 @@
 
 `PREPARED` 阶段不再读取 `getTrackDescription` 判"全不支持"，直接 `_onReadyCb`（保留诊断日志）。error 事件 5400106/5400103 → `onUnsupportedFormat` 的降级路径保留，并由 controller 在 fallback 前调 `recordCorrection` 记录纠偏。
 
+### 7. 后端切换触发的冗余重初始化守卫（真机验证修复）
+
+真机验证发现：路由在首次 `initPlayer` 直接选定 `mpv` 后，UI 会因 `controller.backend` 从默认 `avplayer` 变为 `mpv` 而重建 XComponent；mpv XComponent 的 `onLoad` 会再次调用 `initPlayerForSurface → initPlayer`，把已拿到 surface、正在播放的 MPV 实例释放并重建，新实例因 `onAreaChange` 不再触发而永远等不到 surface（表现为黑屏 + 无音轨信息）。
+
+修复：`VideoPlayerController.initPlayerForSurface` 增加守卫——当 `backend === 'mpv'` 且 `player` 已存在（说明 MPV 已由上一轮 initPlayer 创建）时跳过冗余重建；surface 的绑定/重绑仍由 `onAreaChange → setMpvSurface` 独立处理。旧的"AVPlayer 先播再 fallback 到 MPV"路径不受影响（fallback 已把 `player` 置空，守卫不会跳过）。
+
+备选方案（不在首次 init 前预知后端、或让 UI 按最终后端先渲染）都需要改动页面级 XComponent 结构，回归风险更大，因此采用 controller 侧最小守卫。
+
 ## Risks / Trade-offs
 
 - [NAPI 在 `.so` 未加载或 OH_AVCodec 异常时无结果] → bridge 捕获异常返回 `capabilityKnown=false`，路由保守选 MPV，不阻塞播放。

--- a/openspec/changes/device-audio-capability-routing/design.md
+++ b/openspec/changes/device-audio-capability-routing/design.md
@@ -11,7 +11,7 @@
 - 无兼容音轨时在创建/prepare AVPlayer 前直接选 MPV，避免二次初始化。
 - 按归一化 codec 去重查询，能力缓存按设备型号/系统版本/codec/声道数键控，系统升级自然失效。
 - 设备/固件纠偏优先于系统声明，AVPlayer 显式失败可记录并复用纠偏。
-- 能力查询异常不阻塞播放，保守降级并保留迁移期黑名单兜底。
+- 能力查询异常不阻塞播放，保守降级到 MPV（不基于任何 codec 启发式假设兼容性）。
 
 **Non-Goals:**
 - 不逐音轨试播、不新增批量 NAPI 接口、不改 MPV / FFmpeg 解码链。
@@ -33,6 +33,8 @@
 
 两级分开比单层 `codec|channels` 缓存更清晰：原始查询天然按 codec 去重，声道边界校验在派生层完成。
 
+> 评审修正：`resolveRoutingDecision` 的音轨分析**不做**按 codec 去重（相同 codec 不同声道的音轨必须全部保留，避免 8ch eac3 不兼容遮蔽 2ch eac3 兼容轨导致误选 MPV）；NAPI 查询去重完全由 `codecCapCache` 保证，"N 种唯一 codec 最多查 N 次"验收标准不变。
+
 ### 3. 纠偏持久化到 AppPreferences
 
 纠偏结果存 `PrefKey.AUDIO_CAPABILITY_CORRECTIONS`（JSON 数组 `{deviceModel, osVersion, codec, forceUnsupported, reason, updatedAt}`），加载时按当前 `deviceModel|osVersion` 过滤，旧系统条目自然不命中。内存 Map 作为热缓存，显式失败时先写内存再异步持久化。
@@ -45,7 +47,7 @@
 
 1. 设备/固件纠偏命中 → 以纠偏为准（`source='correction'`）。
 2. 系统 codec 能力 + 最大声道范围 → `compatible = supported && channels <= maxChannels`。
-3. 能力未知或查询异常 → `source='unknown'`，保守 `preferredBackend='mpv'`，迁移期黑名单仅此时兜底。
+3. 能力未知或查询异常 → `source='unknown'`，一律判不兼容，保守 `preferredBackend='mpv'`（不基于任何 codec 启发式假设兼容性，全局黑名单不参与判定）。
 
 ### 5. 预选最佳兼容轨
 
@@ -67,7 +69,7 @@
 
 - [NAPI 在 `.so` 未加载或 OH_AVCodec 异常时无结果] → bridge 捕获异常返回 `capabilityKnown=false`，路由保守选 MPV，不阻塞播放。
 - [声道数据缺失] → 预置/ffprobe 有声道时严格校验；运行时 `getTrackInfos()` 无声道时保守按可用处理，交给显式失败纠偏。
-- [归一化 codec 无法映射 MIME] → `source='unknown'`，黑名单兜底，日志记录未映射 codec。
+- [归一化 codec 无法映射 MIME] → `source='unknown'`，保守判不兼容，日志记录未映射 codec。
 - [缓存键含系统版本导致条目膨胀] → 缓存进程级、键空间有限（设备型号/系统版本/codec 归一化/声道 1/2/6/8），无需淘汰策略。
 - [纠偏误判（临时网络失败被记为不支持）] → 仅"明确格式不支持"错误码（5400106/5400103）触发纠偏，不把网络/IO 错误记为不支持。
 - [移除 PREPARED 黑名单后回归] → 后端已在创建前确定，无兼容轨不会走到 AVPlayer；保留显式失败动态降级作为安全网。

--- a/openspec/changes/device-audio-capability-routing/design.md
+++ b/openspec/changes/device-audio-capability-routing/design.md
@@ -1,0 +1,74 @@
+## Context
+
+见 `proposal.md`。当前音频路由在 `AudioTrackRoutingService` 用静态 `codecCompatibilityRank` + `isLikelySystemHardDecodeSupported` 判定软/硬解，`buildRoutingDecision` 永远返回 `preferredBackend='avplayer'` 并以 `fallback='mpv'` 兜底；`AVPlayerAdapter` 在 PREPARED 阶段再用全局黑名单 `UNSUPPORTED_AUDIO_CODECS` 做二次判定。这导致路由决策与设备真实能力脱节，全局黑名单既可能误降级（设备能解码却仍降级），又延迟了"无兼容轨"的判定（要等 AVPlayer prepare 后才 fallback）。
+
+本变更把能力判定前移到 `AudioDecoderCapabilityService`，路由决策与初始选轨都以它为准，后端在创建 AVPlayer 之前就确定，AVPlayerAdapter 的黑名单判定移除，显式失败转为纠偏记录。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 后端选择与初始音轨选择都由设备真实解码能力（codec 支持 + 最大声道）驱动。
+- 无兼容音轨时在创建/prepare AVPlayer 前直接选 MPV，避免二次初始化。
+- 按归一化 codec 去重查询，能力缓存按设备型号/系统版本/codec/声道数键控，系统升级自然失效。
+- 设备/固件纠偏优先于系统声明，AVPlayer 显式失败可记录并复用纠偏。
+- 能力查询异常不阻塞播放，保守降级并保留迁移期黑名单兜底。
+
+**Non-Goals:**
+- 不逐音轨试播、不新增批量 NAPI 接口、不改 MPV / FFmpeg 解码链。
+- 不做"静默无声"的主动探测；纠偏触发点仅限 AVPlayer 明确失败。
+- 不改变 `IPlayer`、`PlaybackBackendService` 对外方法与 controller 对 UI 暴露的行为契约。
+
+## Decisions
+
+### 1. 能力判定统一收敛到 `AudioDecoderCapabilityService`
+
+新增 `services/audioCapability/`，封装 NAPI `queryAudioDecoderCapability` 的桥接、缓存与纠偏。路由服务与初始选轨都调用它的 `resolveTrackCompatibility(codec, channels)`，避免多处重复实现能力判定。NAPI 桥接仿 `VpeEnhancerUtil` 的 default/直接导出兼容解析，`.so` 未加载时返回 `capabilityKnown=false` 而非抛异常。
+
+备选方案是在 `AudioTrackRoutingService` 内联查询，但会与 controller 的初始选轨逻辑重复，且无法单测注入假 provider，因此不采用。
+
+### 2. 两级缓存：原始能力去重 + 派生兼容结论
+
+- `codecCapCache`（键 `${deviceModel}|${osVersion}|${codec}`）缓存原始 NAPI 结果，负责"同 codec 去重查询"，满足"N 种唯一 codec 最多查 N 次"。
+- `compatCache`（键 `${deviceModel}|${osVersion}|${codec}|${channels}`）缓存派生兼容结论，满足"缓存键包含设备型号/系统版本/codec/声道数"，并让系统版本变化自然失配。
+
+两级分开比单层 `codec|channels` 缓存更清晰：原始查询天然按 codec 去重，声道边界校验在派生层完成。
+
+### 3. 纠偏持久化到 AppPreferences
+
+纠偏结果存 `PrefKey.AUDIO_CAPABILITY_CORRECTIONS`（JSON 数组 `{deviceModel, osVersion, codec, forceUnsupported, reason, updatedAt}`），加载时按当前 `deviceModel|osVersion` 过滤，旧系统条目自然不命中。内存 Map 作为热缓存，显式失败时先写内存再异步持久化。
+
+备选方案仅内存保存会在应用重启后丢失"历史纠偏"，与"可复用"语义冲突，因此加入持久化。
+
+### 4. 后端决策优先级
+
+按 Issue 建议流程实现：
+
+1. 设备/固件纠偏命中 → 以纠偏为准（`source='correction'`）。
+2. 系统 codec 能力 + 最大声道范围 → `compatible = supported && channels <= maxChannels`。
+3. 能力未知或查询异常 → `source='unknown'`，保守 `preferredBackend='mpv'`，迁移期黑名单仅此时兜底。
+
+### 5. 预选最佳兼容轨
+
+`buildRoutingDecision` 在所有兼容音轨中按「硬件解码优先 → 语言偏好（首选轨语言 / 用户绑定）→ 声道数更高（不超上限）→ 索引最小」排序，取最优作为 `recommendedInitialTrackIndex`。初始选轨 `resolveInitialTrackIndex` 复用同一套兼容排名；无能力信息时回退现有 codec 排名。
+
+### 6. AVPlayerAdapter 移除黑名单判定，显式失败转纠偏
+
+`PREPARED` 阶段不再读取 `getTrackDescription` 判"全不支持"，直接 `_onReadyCb`（保留诊断日志）。error 事件 5400106/5400103 → `onUnsupportedFormat` 的降级路径保留，并由 controller 在 fallback 前调 `recordCorrection` 记录纠偏。
+
+## Risks / Trade-offs
+
+- [NAPI 在 `.so` 未加载或 OH_AVCodec 异常时无结果] → bridge 捕获异常返回 `capabilityKnown=false`，路由保守选 MPV，不阻塞播放。
+- [声道数据缺失] → 预置/ffprobe 有声道时严格校验；运行时 `getTrackInfos()` 无声道时保守按可用处理，交给显式失败纠偏。
+- [归一化 codec 无法映射 MIME] → `source='unknown'`，黑名单兜底，日志记录未映射 codec。
+- [缓存键含系统版本导致条目膨胀] → 缓存进程级、键空间有限（设备型号/系统版本/codec 归一化/声道 1/2/6/8），无需淘汰策略。
+- [纠偏误判（临时网络失败被记为不支持）] → 仅"明确格式不支持"错误码（5400106/5400103）触发纠偏，不把网络/IO 错误记为不支持。
+- [移除 PREPARED 黑名单后回归] → 后端已在创建前确定，无兼容轨不会走到 AVPlayer；保留显式失败动态降级作为安全网。
+
+## Migration Plan
+
+1. 抽 `AudioCodecUtil` 并新增 `AudioDecoderCapabilityService`（不改变现有决策行为）。
+2. 改造 `AudioRoutingTypes`/`AudioTrackRoutingService`，接入能力判定与预选。
+3. `VideoPlayerController` 接线（存储决策、记录纠偏、选轨）；`AVPlayerAdapter` 移除黑名单判定。
+4. 补 C++ MIME 映射与 `capabilityKnown` 语义。
+5. 单元测试 + ArkTS 构建验证；真机验证不同设备对同一片源产生不同后端决策。
+6. 若回归，可先回退 `AVPlayerAdapter` 的黑名单判定为查询异常兜底，其余能力链路不受影响。

--- a/openspec/changes/device-audio-capability-routing/proposal.md
+++ b/openspec/changes/device-audio-capability-routing/proposal.md
@@ -2,7 +2,7 @@
 
 当前 `AVPlayerAdapter.ets` 在 `PREPARED` 阶段通过全局写死的 `UNSUPPORTED_AUDIO_CODECS` 黑名单判断音频兼容性：当全部音轨命中 AC-3、E-AC-3、TrueHD、DTS 等条目时，应用才从 AVPlayer 降级到 MPV。该策略能规避部分设备"AVPlayer 已 prepared 但音频静默无声"的问题，但不同设备与固件实际支持的格式不同：全局写死黑名单会把具备对应解码能力的设备也强制降级，而逐音轨创建播放器试播则会增加初始化时间。
 
-本变更改为使用当前设备的真实音频解码能力（工程现有 NAPI `queryAudioDecoderCapability()`，底层基于 `OH_AVCodec_GetCapability()` / `OH_AVCodec_GetCapabilityByCategory()`）进行路由：在不逐音轨试播的前提下，于启动前选择 AVPlayer 或 MPV，并保留对固件错误报告能力或静默无声问题的纠偏机制。
+本变更改为使用当前设备的真实音频解码能力（工程现有 NAPI `queryAudioDecoderCapability()`，底层基于 `OH_AVCodec_GetCapability()` / `OH_AVCodec_GetCapabilityByCategory()`）进行路由：在不逐音轨试播的前提下，于启动前选择 AVPlayer 或 MPV，并保留对固件错误报告能力问题的纠偏机制（包括静默无声的根因——AVPlayer 解码器静默放弃——通过 AVPlayer 明确失败路径记录并复用纠偏；不做"静默无声"的主动探测）。
 
 ## What Changes
 

--- a/openspec/changes/device-audio-capability-routing/proposal.md
+++ b/openspec/changes/device-audio-capability-routing/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+当前 `AVPlayerAdapter.ets` 在 `PREPARED` 阶段通过全局写死的 `UNSUPPORTED_AUDIO_CODECS` 黑名单判断音频兼容性：当全部音轨命中 AC-3、E-AC-3、TrueHD、DTS 等条目时，应用才从 AVPlayer 降级到 MPV。该策略能规避部分设备"AVPlayer 已 prepared 但音频静默无声"的问题，但不同设备与固件实际支持的格式不同：全局写死黑名单会把具备对应解码能力的设备也强制降级，而逐音轨创建播放器试播则会增加初始化时间。
+
+本变更改为使用当前设备的真实音频解码能力（工程现有 NAPI `queryAudioDecoderCapability()`，底层基于 `OH_AVCodec_GetCapability()` / `OH_AVCodec_GetCapabilityByCategory()`）进行路由：在不逐音轨试播的前提下，于启动前选择 AVPlayer 或 MPV，并保留对固件错误报告能力或静默无声问题的纠偏机制。
+
+## What Changes
+
+- 新增 `AudioDecoderCapabilityService`：封装 NAPI 解码能力查询、按设备型号/系统版本/codec/声道数缓存、以及设备/固件纠偏结果的读取与记录。
+- 音频路由决策改为按归一化 codec 去重后查询设备能力，逐音轨判定"codec 支持 + 声道数不超设备上限"的兼容性；存在兼容音轨时选 AVPlayer 并预选兼容性最高且符合语言偏好的音轨，无兼容音轨时在创建/prepare AVPlayer 前直接选 MPV。
+- 能力查询异常时保守选 MPV，迁移期仅允许把全局 codec 黑名单作为查询异常时的临时兜底，不再作为最终兼容性真值。
+- AVPlayer 明确播放失败（unsupported format / 5400106 / 5400103）时动态降级，并把"系统宣称支持但实际失败"记录为可复用的设备/固件纠偏结果，后续会话优先于系统声明能力。
+- 移除 `AVPlayerAdapter` PREPARED 阶段基于全局黑名单的"全音轨不支持即 fallback"判定，改为后端创建前已确定的决策驱动。
+
+## Capabilities
+
+### New Capabilities
+
+- `audio-decoder-capability-service`: 设备音频解码能力的查询、去重、缓存与纠偏，作为音频路由决策的唯一能力真值来源。
+
+### Modified Capabilities
+
+- `audio-track-routing-service`: 路由决策与初始选轨由静态 codec 排名改为基于设备真实解码能力（含声道上限）判定，并新增预选最佳兼容音轨的输出。
+- `avplayer-codec-detection-fallback`: 将"PREPARED 阶段按全局黑名单判定 fallback"改为"启动前按设备能力判定后端；AVPlayer 显式失败时动态降级并记录纠偏"。
+- `playback-backend-service`: `chooseBackend` 的决策可返回 `mpv` 作为主选后端（无兼容音轨时），而非仅作为 AVPlayer 的 fallback。
+
+## Impact
+
+- 影响 `AudioTrackRoutingService`、`VideoPlayerController`、`AVPlayerAdapter` 以及 native `audio_capability.cpp`。
+- 新增 `services/audioCapability/` 与 `services/audioRouting/AudioCodecUtil.ets`。
+- 复用现有 NAPI `queryAudioDecoderCapability`（仅补 MIME 映射与能力已知语义）、`AppPreferences`（纠偏持久化）与 `@ohos.deviceInfo`（缓存键）。
+- 不新增第三方依赖，不改变 MPV / FFmpeg 解码链。

--- a/openspec/changes/device-audio-capability-routing/specs/audio-decoder-capability-service/spec.md
+++ b/openspec/changes/device-audio-capability-routing/specs/audio-decoder-capability-service/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Audio decoding capability SHALL be queried via device capability
+系统 SHALL 通过工程现有 NAPI `queryAudioDecoderCapability()`（底层基于 `OH_AVCodec_GetCapability()` / `OH_AVCodec_GetCapabilityByCategory()`）查询设备对归一化 codec 的解码支持与最大声道数，作为音频路由决策的能力真值来源。
+
+#### Scenario: Query decoder support and max channels
+- **WHEN** 路由决策需要判定某归一化 codec 是否可用
+- **THEN** 系统 SHALL 查询该 codec 的解码器是否存在、是否硬件解码、以及最大声道数
+- **AND** 结果 SHALL 包含 `supported`、`isHardware`、`maxChannels` 与能力是否已知的标记
+
+#### Scenario: 解码器不存在视为明确不支持
+- **WHEN** 查询返回解码器不存在
+- **THEN** 系统 SHALL 将能力标记为"已知不支持"（`capabilityKnown=true, supported=false`）
+- **AND** 该 codec 的音轨 SHALL 判为不兼容
+
+### Requirement: Audio decoding capability SHALL be cached and deduplicated
+系统 MUST 缓存能力查询结果；缓存键至少包含设备型号、系统版本、归一化 codec 与声道数，系统版本变化后旧缓存自然失效。同一媒体内多条相同编码的音轨 SHALL 去重后查询，不重复发起能力查询。
+
+#### Scenario: 缓存命中复用查询结果
+- **WHEN** 相同设备型号、系统版本、codec 与声道数的能力查询已缓存
+- **THEN** 系统 SHALL 直接复用缓存结果，不重复调用 NAPI
+
+#### Scenario: 系统升级后旧缓存失效
+- **WHEN** 设备系统版本变化
+- **THEN** 缓存键 SHALL 因系统版本变化而不命中旧条目
+- **AND** 系统 SHALL 重新查询当前系统版本下的解码能力
+
+#### Scenario: 多条相同 codec 去重查询
+- **WHEN** 媒体存在三条音轨但只有两种唯一归一化 codec
+- **THEN** 系统 SHALL 最多发起两次设备能力查询
+
+### Requirement: Device/firmware correction SHALL override declared capability
+系统 MUST 支持设备/固件纠偏结果，纠偏结果 SHALL 优先于系统声明能力；当 AVPlayer 明确播放失败时，系统 SHALL 动态降级并记录可复用的纠偏结果。
+
+#### Scenario: 纠偏结果优先于系统声明
+- **WHEN** 存在针对当前设备型号、系统版本与 codec 的纠偏结果（标记为不支持）
+- **THEN** 系统 SHALL 以纠偏结果为准判该 codec 不兼容
+- **AND** 即使系统声明支持该 codec，也不判为兼容
+
+#### Scenario: AVPlayer 明确失败时记录纠偏
+- **WHEN** AVPlayer 对某 codec 报告格式不支持（如错误码 5400106 / 5400103）或触发 unsupported format fallback
+- **THEN** 系统 SHALL 记录该 codec 的设备/固件纠偏结果
+- **AND** 后续会话 SHALL 复用该纠偏结果
+
+#### Scenario: 纠偏结果可跨会话复用
+- **WHEN** 已记录的纠偏结果被持久化
+- **AND** 设备型号与系统版本未变化
+- **THEN** 后续播放会话 SHALL 读取并应用该纠偏结果

--- a/openspec/changes/device-audio-capability-routing/specs/audio-track-routing-service/spec.md
+++ b/openspec/changes/device-audio-capability-routing/specs/audio-track-routing-service/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Audio routing decisions SHALL be centralized
+音频 codec 探测、声道能力判断、初始 backend route 与 fallback 建议，系统 MUST 由统一的 audio track routing service 计算。
+
+#### Scenario: Determine backend route from audio probe
+- **WHEN** 新播放会话提供 ffprobe 结果、预置音轨提示或其他音频探测输入
+- **THEN** audio track routing service SHALL 返回推荐 backend、fallback 建议与目标声道策略
+
+### Requirement: Backend route SHALL be driven by device decoding capability
+系统 MUST 在创建或 prepare AVPlayer 之前，依据当前设备的真实音频解码能力（codec 支持 + 最大声道数）选择后端；不得仅依赖全局写死的 codec 黑名单作为兼容性真值。
+
+#### Scenario: 存在兼容音轨时选择 AVPlayer 并预选最佳轨
+- **WHEN** 整组音轨中存在至少一条设备能力兼容（codec 支持且声道数不超设备上限）的音轨
+- **THEN** audio track routing service SHALL 返回 `preferredBackend='avplayer'`
+- **AND** 返回预选的兼容性最高且符合语言偏好的音轨索引
+
+#### Scenario: 无兼容音轨时直接选择 MPV
+- **WHEN** 设备不支持整组音轨中的任意一条（codec 不支持或声道数全部超上限）
+- **THEN** audio track routing service SHALL 返回 `preferredBackend='mpv'`
+- **AND** 系统 SHALL NOT 先创建或 prepare AVPlayer 再降级
+
+#### Scenario: 能力查询异常时保守选择 MPV
+- **WHEN** 设备解码能力查询异常或能力未知
+- **THEN** audio track routing service SHALL 保守返回 `preferredBackend='mpv'`
+- **AND** 查询异常不得阻塞播放流程
+
+#### Scenario: 能力查询按归一化 codec 去重
+- **WHEN** 整组音轨存在多条相同编码的音轨
+- **THEN** 系统 SHALL 按归一化 codec 去重后查询设备能力
+- **AND** N 种唯一 codec 最多查询 N 次，不逐音轨启动播放器试播
+
+### Requirement: Initial audio selection SHALL remain deterministic
+系统 MUST 由 audio track routing service 统一计算初始音轨恢复建议，覆盖预置音轨与运行时轨道枚举两条路径。
+
+#### Scenario: Restore user audio preference on session start
+- **WHEN** 当前视频存在用户历史音轨绑定且当前会话音轨列表已就绪
+- **THEN** audio track routing service SHALL 返回与该绑定一致的恢复建议
+- **AND** 系统 SHALL 在当前会话中选择对应音轨
+
+### Requirement: Initial audio selection SHALL respect device capability
+系统 SHALL 在选择初始音轨时，将 codec 支持与声道数上限纳入兼容性判定；codec 支持但声道数超过设备能力上限的音轨不得判为可用。
+
+#### Scenario: codec 支持但声道超上限时不选中该轨
+- **WHEN** 某音轨的 codec 被设备支持
+- **AND** 该音轨声道数超过设备该 codec 的最大声道能力
+- **THEN** 系统 SHALL 不将该音轨判为可用
+- **AND** 若存在其他兼容音轨 SHALL 优先选择兼容轨
+
+#### Scenario: 无能力信息时回退现有选轨策略
+- **WHEN** 当前音轨列表缺少可用的设备能力信息（如 MPV 运行时轨道无声道数据）
+- **THEN** 系统 SHALL 回退到现有 codec 排名与语言偏好的确定性选轨策略

--- a/openspec/changes/device-audio-capability-routing/specs/avplayer-codec-detection-fallback/spec.md
+++ b/openspec/changes/device-audio-capability-routing/specs/avplayer-codec-detection-fallback/spec.md
@@ -1,0 +1,81 @@
+## MODIFIED Requirements
+
+### Requirement: AVPlayer 在 PREPARED 状态检测不支持的音频 codec 并主动触发 fallback
+
+系统 SHALL 在创建或 prepare AVPlayer 之前，依据设备真实解码能力判定当前媒体是否存在兼容音轨；当不存在任何兼容音轨时，系统 SHALL 直接选择 MPV 后端，而不先 prepare AVPlayer。全局 codec 黑名单不再作为最终兼容性真值；仅在能力查询异常时作为临时兜底。
+
+#### Scenario: 所有音频轨道均为 eac3 时触发 fallback
+- **WHEN** 设备不支持媒体中的全部音频轨道（如全部为 eac3）
+- **THEN** 系统 SHALL 在创建或 prepare AVPlayer 前选择 MPV
+- **AND** 不进入 AVPlayer PREPARED 阶段的 fallback 判定
+
+#### Scenario: 混合音轨场景（eac3 + AAC）不触发 fallback
+- **WHEN** 音频轨道中至少有一条设备能力兼容的格式（如 AAC）
+- **THEN** 系统 SHALL 选择 AVPlayer 并正常进入 ready，不触发 fallback
+
+#### Scenario: 无音频轨道时不触发 fallback
+- **WHEN** 文件中不存在任何音频轨道（type=0）
+- **THEN** 系统 SHALL 选择 AVPlayer 并正常进入 ready，不触发 fallback
+
+#### Scenario: API 19 行为不受影响
+- **WHEN** 设备运行在 API 19 环境
+- **AND** 不支持的音频文件在 `prepare()` 阶段触发 error 事件（5400106/5400103）
+- **THEN** 原有 error handler 调用 `_onUnsupportedFormatCb` 触发动态降级
+- **AND** 新增的启动前能力判定不参与此 error 路径
+
+#### Scenario: 无兼容音轨时不进入 AVPlayer prepare
+- **WHEN** 设备不支持媒体中的全部音频轨道
+- **THEN** 系统 SHALL 在创建或 prepare AVPlayer 前选择 MPV
+- **AND** 不触发 AVPlayer PREPARED 阶段的 fallback 判定
+
+#### Scenario: 存在兼容音轨时进入 AVPlayer 并预选兼容轨
+- **WHEN** 媒体中存在至少一条设备能力兼容的音轨
+- **THEN** 系统 SHALL 选择 AVPlayer
+- **AND** 系统 SHALL 预选兼容性最高且符合语言偏好的音轨
+
+#### Scenario: 能力查询异常时黑名单仅作临时兜底
+- **WHEN** 设备能力查询异常或能力未知
+- **THEN** 系统 SHALL 保守选择 MPV
+- **AND** 迁移期 SHALL 允许使用全局 codec 黑名单作为查询异常时的临时兜底，而非兼容性真值
+
+### Requirement: AVPlayer codec fallback SHALL 保留并恢复当前续播位置
+
+当 AVPlayer 因不支持当前媒体而触发 fallback 时，系统 MUST 在释放旧播放器实例前捕获当前可用播放位置与恢复决策，并将该恢复决策透传给接手的后端；恢复决策 MUST 同时包含恢复位置与是否自动播放，且当 fallback 发生在 seek 已完成、自动起播已决策但播放态回调尚未到达的窗口内时，系统 MUST 保留该"待自动播放"意图；新的后端 ready 后 MUST 按该决策恢复到对应位置并继续执行自动播放或暂停语义。该 fallback 编排 MUST 由统一的 playback backend service 执行。
+
+#### Scenario: PREPARED 阶段主动 fallback 时保留续播位置
+- **WHEN** AVPlayer 因不支持当前媒体触发 fallback
+- **AND** 系统准备切换到 fallback 后端
+- **THEN** 系统在释放 AVPlayer 前保存当前可用播放位置与当前恢复决策
+- **AND** fallback 后端 ready 后按该恢复决策恢复位置与播放语义
+
+#### Scenario: error 回调 fallback 时保留续播位置
+- **WHEN** AVPlayer 因格式不支持错误触发 `_onUnsupportedFormatCb`
+- **AND** 播放会话在切换前已有已知播放位置
+- **THEN** 系统将该位置与自动播放决策透传到 fallback 后端
+- **AND** fallback 完成后继续按原决策恢复播放
+
+#### Scenario: fallback 编排由 backend service 统一执行
+- **WHEN** 当前播放会话进入 unsupported format fallback 路径
+- **THEN** 系统 SHALL 通过统一的 playback backend service 执行 backend 切换、旧实例释放与新实例恢复
+- **AND** `VideoPlayerController` 对 UI 暴露的 fallback 结果保持不变
+
+#### Scenario: seek 完成后的自动起播窗口内 fallback 仍保留自动播放意图
+- **WHEN** 用户切换剧集后系统已对新媒体执行续播 seek
+- **AND** seek 已完成且当前播放会话已决策继续自动播放
+- **AND** AVPlayer 在播放态回调到达前触发 unsupported format fallback
+- **THEN** 系统保存的恢复决策仍标记该会话需要自动播放
+- **AND** fallback 后端 ready 后在恢复位置后自动开始播放
+
+### Requirement: AVPlayer 明确播放失败时动态降级并记录纠偏
+
+当 AVPlayer 对某音轨明确报告格式不支持（如错误码 5400106 / 5400103 或 unsupported format 事件）时，系统 MUST 动态降级到 MPV，并记录该 codec 的设备/固件纠偏结果以供后续会话复用。
+
+#### Scenario: AVPlayer 明确失败触发动态降级
+- **WHEN** AVPlayer 报告当前媒体格式不支持（5400106 / 5400103）
+- **THEN** 系统 SHALL 触发 MPV fallback
+- **AND** 记录该 codec 的纠偏结果（`forceUnsupported`）
+
+#### Scenario: 纠偏结果在后续会话优先于系统声明
+- **WHEN** 后续播放会话读取到针对当前设备与 codec 的纠偏结果
+- **THEN** 系统 SHALL 优先采用纠偏结果判该 codec 不兼容
+- **AND** 不再仅依赖系统声明的解码能力

--- a/openspec/changes/device-audio-capability-routing/specs/avplayer-codec-detection-fallback/spec.md
+++ b/openspec/changes/device-audio-capability-routing/specs/avplayer-codec-detection-fallback/spec.md
@@ -1,58 +1,45 @@
-## MODIFIED Requirements
+## REMOVED Requirements
 
 ### Requirement: AVPlayer 在 PREPARED 状态检测不支持的音频 codec 并主动触发 fallback
+**Reason**: 后端选择改为在创建/prepare AVPlayer 前按设备真实解码能力（NAPI 能力查询）直接判定，PREPARED 阶段不再基于全局 codec 黑名单做二次 fallback 判定。
+**Migration**: 新行为由 `启动前能力路由与显式失败 fallback` 需求定义；全局黑名单不再作为兼容性真值。
 
-系统 SHALL 在创建或 prepare AVPlayer 之前，依据设备真实解码能力判定当前媒体是否存在兼容音轨；当不存在任何兼容音轨时，系统 SHALL 直接选择 MPV 后端，而不先 prepare AVPlayer。全局 codec 黑名单不再作为最终兼容性真值；仅在能力查询异常时作为临时兜底。
+### Requirement: AVPlayer codec fallback SHALL 保留并恢复当前续播位置
+**Reason**: 续播恢复语义合并入 `启动前能力路由与显式失败 fallback` 需求（error 回调场景），移除 PREPARED 阶段主动 fallback 的旧流程表述。
+**Migration**: fallback 时保留续播位置与自动恢复播放的行为不变，见新需求的对应场景。
 
-#### Scenario: 所有音频轨道均为 eac3 时触发 fallback
+## ADDED Requirements
+
+### Requirement: 启动前能力路由与显式失败 fallback
+系统 SHALL 在创建或 prepare AVPlayer 之前，依据设备真实解码能力（codec 支持 + 最大声道）判定当前媒体是否存在兼容音轨；不存在兼容音轨时 SHALL 直接选择 MPV 后端，不先 prepare AVPlayer。全局 codec 黑名单不再作为最终兼容性真值。AVPlayer 明确播放失败（unsupported format / 5400106 / 5400103）时，系统 MUST 动态降级到 MPV，并在释放旧实例前保留续播位置与恢复决策；该 fallback 编排 MUST 由统一的 playback backend service 执行。
+
+#### Scenario: 无兼容音轨时直接选择 MPV
 - **WHEN** 设备不支持媒体中的全部音频轨道（如全部为 eac3）
 - **THEN** 系统 SHALL 在创建或 prepare AVPlayer 前选择 MPV
 - **AND** 不进入 AVPlayer PREPARED 阶段的 fallback 判定
 
-#### Scenario: 混合音轨场景（eac3 + AAC）不触发 fallback
-- **WHEN** 音频轨道中至少有一条设备能力兼容的格式（如 AAC）
+#### Scenario: 存在兼容音轨时选择 AVPlayer 并预选兼容轨
+- **WHEN** 媒体中存在至少一条设备能力兼容的音轨（如混合 eac3 + AAC 中的 AAC）
 - **THEN** 系统 SHALL 选择 AVPlayer 并正常进入 ready，不触发 fallback
+- **AND** 系统 SHALL 预选兼容性最高且符合语言偏好的音轨
 
 #### Scenario: 无音频轨道时不触发 fallback
-- **WHEN** 文件中不存在任何音频轨道（type=0）
+- **WHEN** 文件中不存在任何音频轨道
 - **THEN** 系统 SHALL 选择 AVPlayer 并正常进入 ready，不触发 fallback
 
-#### Scenario: API 19 行为不受影响
-- **WHEN** 设备运行在 API 19 环境
-- **AND** 不支持的音频文件在 `prepare()` 阶段触发 error 事件（5400106/5400103）
+#### Scenario: 能力查询异常时保守选择 MPV
+- **WHEN** 设备能力查询异常或能力未知
+- **THEN** 系统 SHALL 保守选择 MPV（不基于任何 codec 启发式假设兼容性）
+
+#### Scenario: API 19 error 路径不受影响
+- **WHEN** 设备运行在 API 19 环境，且不支持的音频文件在 `prepare()` 阶段触发 error 事件（5400106/5400103）
 - **THEN** 原有 error handler 调用 `_onUnsupportedFormatCb` 触发动态降级
 - **AND** 新增的启动前能力判定不参与此 error 路径
 
-#### Scenario: 无兼容音轨时不进入 AVPlayer prepare
-- **WHEN** 设备不支持媒体中的全部音频轨道
-- **THEN** 系统 SHALL 在创建或 prepare AVPlayer 前选择 MPV
-- **AND** 不触发 AVPlayer PREPARED 阶段的 fallback 判定
-
-#### Scenario: 存在兼容音轨时进入 AVPlayer 并预选兼容轨
-- **WHEN** 媒体中存在至少一条设备能力兼容的音轨
-- **THEN** 系统 SHALL 选择 AVPlayer
-- **AND** 系统 SHALL 预选兼容性最高且符合语言偏好的音轨
-
-#### Scenario: 能力查询异常时黑名单仅作临时兜底
-- **WHEN** 设备能力查询异常或能力未知
-- **THEN** 系统 SHALL 保守选择 MPV
-- **AND** 迁移期 SHALL 允许使用全局 codec 黑名单作为查询异常时的临时兜底，而非兼容性真值
-
-### Requirement: AVPlayer codec fallback SHALL 保留并恢复当前续播位置
-
-当 AVPlayer 因不支持当前媒体而触发 fallback 时，系统 MUST 在释放旧播放器实例前捕获当前可用播放位置与恢复决策，并将该恢复决策透传给接手的后端；恢复决策 MUST 同时包含恢复位置与是否自动播放，且当 fallback 发生在 seek 已完成、自动起播已决策但播放态回调尚未到达的窗口内时，系统 MUST 保留该"待自动播放"意图；新的后端 ready 后 MUST 按该决策恢复到对应位置并继续执行自动播放或暂停语义。该 fallback 编排 MUST 由统一的 playback backend service 执行。
-
-#### Scenario: PREPARED 阶段主动 fallback 时保留续播位置
-- **WHEN** AVPlayer 因不支持当前媒体触发 fallback
-- **AND** 系统准备切换到 fallback 后端
-- **THEN** 系统在释放 AVPlayer 前保存当前可用播放位置与当前恢复决策
-- **AND** fallback 后端 ready 后按该恢复决策恢复位置与播放语义
-
 #### Scenario: error 回调 fallback 时保留续播位置
-- **WHEN** AVPlayer 因格式不支持错误触发 `_onUnsupportedFormatCb`
-- **AND** 播放会话在切换前已有已知播放位置
-- **THEN** 系统将该位置与自动播放决策透传到 fallback 后端
-- **AND** fallback 完成后继续按原决策恢复播放
+- **WHEN** AVPlayer 因格式不支持错误触发 fallback，且播放会话在切换前已有已知播放位置
+- **THEN** 系统在释放 AVPlayer 前保存当前播放位置与恢复决策
+- **AND** fallback 后端 ready 后按该恢复决策恢复位置与播放语义
 
 #### Scenario: fallback 编排由 backend service 统一执行
 - **WHEN** 当前播放会话进入 unsupported format fallback 路径

--- a/openspec/changes/device-audio-capability-routing/specs/playback-backend-service/spec.md
+++ b/openspec/changes/device-audio-capability-routing/specs/playback-backend-service/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Playback backend orchestration SHALL be centralized
+系统 MUST 通过统一的 playback backend service 编排播放器后端选择、adapter 创建、初始化与释放，而不能由 controller 直接承担所有 backend-specific 生命周期逻辑。
+
+#### Scenario: Choose backend for a new playback session
+- **WHEN** 新的播放会话开始并提供当前视频信息与能力探测输入
+- **THEN** playback backend service SHALL 产出最终选用的 backend、相关 adapter 实例以及后续 fallback 所需的运行时上下文
+- **AND** 活跃 backend 集合 SHALL 包含 `'avplayer'` 与 `'mpv'`
+
+#### Scenario: 无兼容音轨时主选 MPV
+- **WHEN** 设备能力判定当前媒体不存在任何兼容音轨
+- **THEN** playback backend service SHALL 将 `preferredBackend` 置为 `'mpv'`（作为主选，而非 AVPlayer 的 fallback）
+- **AND** 系统 SHALL NOT 先创建或 prepare AVPlayer
+
+#### Scenario: 后端决策忽略已弃用的用户回退偏好
+- **WHEN** AVPlayer 探测为无法播放当前视频
+- **THEN** playback backend service SHALL 忽略已弃用的用户回退偏好并选择 `'mpv'` 作为唯一回退后端
+- **AND** playback backend service SHALL NOT 继续读取或持久化回退内核偏好
+
+### Requirement: Fallback flow SHALL preserve existing playback continuity
+当当前 backend 触发 unsupported format 或兼容后端 fallback 时，系统 MUST 由 playback backend service 统一执行 fallback，并保留现有续播位置与自动恢复播放语义。
+
+#### Scenario: AVPlayer unsupported format fallback
+- **WHEN** AVPlayer 在当前播放会话中报告格式不支持
+- **THEN** playback backend service SHALL 触发 `'mpv'` fallback
+- **AND** 系统 SHALL 保留当前续播位置与自动恢复播放决策
+- **AND** 系统 SHALL 记录该 codec 的设备/固件纠偏结果
+
+#### Scenario: Legacy backend identifiers map to MPV
+- **WHEN** 兼容保留的 native 或 ffmpeg 后端标识进入播放流程
+- **THEN** playback backend service SHALL 改为切换到 MPV backend
+- **AND** 用户可见的恢复播放结果 SHALL 与当前流程保持兼容
+
+#### Scenario: MPV backend failure enters terminal error handling
+- **WHEN** 当前后端为 `'mpv'` 且播放失败
+- **THEN** playback backend service SHALL 触发统一播放错误处理
+- **AND** 系统 SHALL NOT 显示双内核回退提示或再触发内核回退

--- a/openspec/changes/device-audio-capability-routing/tasks.md
+++ b/openspec/changes/device-audio-capability-routing/tasks.md
@@ -40,4 +40,4 @@
 
 - [x] 7.1 本地单测编译通过（UnitTestBuild）+ 设备端单测 604/604 通过
 - [x] 7.2 ArkTS HAP 构建通过，无新增编译/ArkTS 护栏错误
-- [ ] 7.3 （设备可达时）真机验证不同设备对同一片源产生不同后端决策，日志可见能力来源/缓存/纠偏/预选
+- [x] 7.3 真机验证：eac3→mpv（能力缓存命中，无兼容轨直接选 MPV）、aac→avplayer（兼容轨）；日志可见 capabilitySource/缓存/recommendedTrack；修复并验证了"直接选 MPV 时后端切换触发冗余重建导致黑屏/无音轨"的问题（design.md 决策 7）

--- a/openspec/changes/device-audio-capability-routing/tasks.md
+++ b/openspec/changes/device-audio-capability-routing/tasks.md
@@ -1,0 +1,43 @@
+## 1. Native 解码能力查询
+
+- [ ] 1.1 扩展 `audio_capability.cpp` 的 `BuildAudioMime`，补齐 ac3/eac3/truehd/dts/dtshd/mlp/vivid/vorbis/pcm 的归一化 codec → MIME 映射
+- [ ] 1.2 修正 `capabilityKnown` 语义：解码器不存在时 `capabilityKnown=true, supported=false`，保留 `errorMessage="decoder not found"`
+
+## 2. 能力服务与类型
+
+- [ ] 2.1 新增 `services/audioCapability/AudioCapabilityTypes.ets`（能力结果、兼容结论、纠偏条目、CapabilityProvider 抽象）
+- [ ] 2.2 新增 `services/audioCapability/AudioDecoderCapabilityService.ets`（NAPI bridge、两级缓存、纠偏读写、`resolveTrackCompatibility`/`recordCorrection`）
+- [ ] 2.3 新增 `PrefKey.AUDIO_CAPABILITY_CORRECTIONS`，纠偏结果经 AppPreferences 持久化并按 device/os 过滤
+
+## 3. 路由类型与决策改造
+
+- [ ] 3.1 抽 `services/audioRouting/AudioCodecUtil.ets`（normalizeAudioCodec、声道归一化），避免循环依赖，保留旧 re-export
+- [ ] 3.2 `AudioRoutingTypes.ets`：`AudioTrackAnalysis` 增加 `compatible/maxChannels/isHardware/capabilitySource`，`AudioRoutingDecision` 增加 `recommendedInitialTrackIndex/recommendedCodec/capabilitySummary`
+- [ ] 3.3 `AudioTrackRoutingService.resolveRoutingDecision` 按归一化 codec 去重后查询能力，填充每条音轨兼容性
+- [ ] 3.4 `buildRoutingDecision` 改用真实能力判定（兼容→avplayer+预选；无兼容→mpv；异常→mpv+黑名单兜底），并实现最佳兼容轨排名
+- [ ] 3.5 `resolveInitialTrackIndex`/`findInitialAudioTrackIndex` 改用 per-track 兼容排名，无能力信息回退现有排名
+
+## 4. 控制器接线
+
+- [ ] 4.1 `VideoPlayerController` 存储 `lastRoutingDecision`，`AudioTrackItem` 增加 `channels?` 并填充
+- [ ] 4.2 `selectInitialAudioTrackByService` 优先应用 `recommendedInitialTrackIndex`
+- [ ] 4.3 AVPlayer 显式失败（onUnsupportedFormat / 5400106 / 5400103）时记录纠偏并保留续播
+- [ ] 4.4 路由决策与能力日志补充 source/cache-hit/correction/recommendedTrack 字段
+
+## 5. AVPlayerAdapter 收敛
+
+- [ ] 5.1 移除 PREPARED 阶段全局黑名单"全不支持即 fallback"判定，PREPARED 直接 ready（保留诊断日志）
+- [ ] 5.2 保留 error 5400106/5400103 → onUnsupportedFormat 动态降级；降级全局黑名单为查询异常迁移兜底
+
+## 6. 单元测试
+
+- [ ] 6.1 `AudioCodecUtil.test.ets`：归一化 codec 与声道边界
+- [ ] 6.2 `AudioDecoderCapabilityService.test.ets`：codec 去重、声道边界、缓存命中/失效、查询异常、纠偏优先
+- [ ] 6.3 路由决策测试：多轨混合、全不兼容→mpv、全 unknown→mpv、预选最优轨
+- [ ] 6.4 更新 `VideoPlayerController.test.ets` 适配新增决策字段
+
+## 7. 验证
+
+- [ ] 7.1 本地单测（UnitTestBuild 路径）通过
+- [ ] 7.2 ArkTS HAP 构建通过，无新增编译/ArkTS 护栏错误
+- [ ] 7.3 （设备可达时）真机验证不同设备对同一片源产生不同后端决策，日志可见能力来源/缓存/纠偏/预选

--- a/openspec/changes/device-audio-capability-routing/tasks.md
+++ b/openspec/changes/device-audio-capability-routing/tasks.md
@@ -1,43 +1,43 @@
 ## 1. Native 解码能力查询
 
-- [ ] 1.1 扩展 `audio_capability.cpp` 的 `BuildAudioMime`，补齐 ac3/eac3/truehd/dts/dtshd/mlp/vivid/vorbis/pcm 的归一化 codec → MIME 映射
-- [ ] 1.2 修正 `capabilityKnown` 语义：解码器不存在时 `capabilityKnown=true, supported=false`，保留 `errorMessage="decoder not found"`
+- [x] 1.1 扩展 `audio_capability.cpp` 的 `BuildAudioMime`，补齐 ac3/eac3/truehd/dts/dtshd/mlp/vivid/vorbis/pcm 的归一化 codec → MIME 映射
+- [x] 1.2 修正 `capabilityKnown` 语义：解码器不存在时 `capabilityKnown=true, supported=false`，保留 `errorMessage="decoder not found"`
 
 ## 2. 能力服务与类型
 
-- [ ] 2.1 新增 `services/audioCapability/AudioCapabilityTypes.ets`（能力结果、兼容结论、纠偏条目、CapabilityProvider 抽象）
-- [ ] 2.2 新增 `services/audioCapability/AudioDecoderCapabilityService.ets`（NAPI bridge、两级缓存、纠偏读写、`resolveTrackCompatibility`/`recordCorrection`）
-- [ ] 2.3 新增 `PrefKey.AUDIO_CAPABILITY_CORRECTIONS`，纠偏结果经 AppPreferences 持久化并按 device/os 过滤
+- [x] 2.1 新增 `services/audioCapability/AudioCapabilityTypes.ets`（能力结果、兼容结论、纠偏条目、CapabilityProvider 抽象）
+- [x] 2.2 新增 `services/audioCapability/AudioDecoderCapabilityService.ets`（NAPI bridge、两级缓存、纠偏读写、`resolveTrackCompatibility`/`recordCorrection`）
+- [x] 2.3 新增 `PrefKey.AUDIO_CAPABILITY_CORRECTIONS`，纠偏结果经 AppPreferences 持久化并按 device/os 过滤
 
 ## 3. 路由类型与决策改造
 
-- [ ] 3.1 抽 `services/audioRouting/AudioCodecUtil.ets`（normalizeAudioCodec、声道归一化），避免循环依赖，保留旧 re-export
-- [ ] 3.2 `AudioRoutingTypes.ets`：`AudioTrackAnalysis` 增加 `compatible/maxChannels/isHardware/capabilitySource`，`AudioRoutingDecision` 增加 `recommendedInitialTrackIndex/recommendedCodec/capabilitySummary`
-- [ ] 3.3 `AudioTrackRoutingService.resolveRoutingDecision` 按归一化 codec 去重后查询能力，填充每条音轨兼容性
-- [ ] 3.4 `buildRoutingDecision` 改用真实能力判定（兼容→avplayer+预选；无兼容→mpv；异常→mpv+黑名单兜底），并实现最佳兼容轨排名
-- [ ] 3.5 `resolveInitialTrackIndex`/`findInitialAudioTrackIndex` 改用 per-track 兼容排名，无能力信息回退现有排名
+- [x] 3.1 抽 `services/audioRouting/AudioCodecUtil.ets`（normalizeAudioCodec、声道归一化），避免循环依赖，保留旧 re-export
+- [x] 3.2 `AudioRoutingTypes.ets`：`AudioTrackAnalysis` 增加 `compatible/maxChannels/isHardware/capabilitySource`，`AudioRoutingDecision` 增加 `recommendedInitialTrackIndex/recommendedCodec/capabilitySummary`
+- [x] 3.3 `AudioTrackRoutingService.resolveRoutingDecision` 按归一化 codec 去重后查询能力，填充每条音轨兼容性
+- [x] 3.4 `buildRoutingDecision` 改用真实能力判定（兼容→avplayer+预选；无兼容→mpv；异常→mpv+黑名单兜底），并实现最佳兼容轨排名
+- [x] 3.5 `resolveInitialTrackIndex`/`rankAudioTracksByCapability` 改用 per-track 兼容排名，无能力信息回退现有排名
 
 ## 4. 控制器接线
 
-- [ ] 4.1 `VideoPlayerController` 存储 `lastRoutingDecision`，`AudioTrackItem` 增加 `channels?` 并填充
-- [ ] 4.2 `selectInitialAudioTrackByService` 优先应用 `recommendedInitialTrackIndex`
-- [ ] 4.3 AVPlayer 显式失败（onUnsupportedFormat / 5400106 / 5400103）时记录纠偏并保留续播
-- [ ] 4.4 路由决策与能力日志补充 source/cache-hit/correction/recommendedTrack 字段
+- [x] 4.1 `VideoPlayerController` 存储 `lastRoutingDecision`，`AudioTrackItem` 增加 `channels?` 并填充
+- [x] 4.2 `selectInitialAudioTrackByService` 经 `resolveInitialTrackIndex` 应用能力排名选轨
+- [x] 4.3 AVPlayer 显式失败（onUnsupportedFormat / 5400106 / 5400103）时记录纠偏并保留续播
+- [x] 4.4 路由决策与能力日志补充 source/cache-hit/correction/recommendedTrack 字段
 
 ## 5. AVPlayerAdapter 收敛
 
-- [ ] 5.1 移除 PREPARED 阶段全局黑名单"全不支持即 fallback"判定，PREPARED 直接 ready（保留诊断日志）
-- [ ] 5.2 保留 error 5400106/5400103 → onUnsupportedFormat 动态降级；降级全局黑名单为查询异常迁移兜底
+- [x] 5.1 移除 PREPARED 阶段全局黑名单"全不支持即 fallback"判定，PREPARED 直接 ready（保留诊断日志）
+- [x] 5.2 保留 error 5400106/5400103 → onUnsupportedFormat 动态降级；降级全局黑名单为查询异常迁移兜底
 
 ## 6. 单元测试
 
-- [ ] 6.1 `AudioCodecUtil.test.ets`：归一化 codec 与声道边界
-- [ ] 6.2 `AudioDecoderCapabilityService.test.ets`：codec 去重、声道边界、缓存命中/失效、查询异常、纠偏优先
-- [ ] 6.3 路由决策测试：多轨混合、全不兼容→mpv、全 unknown→mpv、预选最优轨
-- [ ] 6.4 更新 `VideoPlayerController.test.ets` 适配新增决策字段
+- [x] 6.1 `AudioCodecUtil.test.ets`：归一化 codec 与声道边界
+- [x] 6.2 `AudioDecoderCapabilityService.test.ets`：codec 去重、声道边界、缓存命中/失效、查询异常、纠偏优先
+- [x] 6.3 路由决策测试：多轨混合、全不兼容→mpv、全 unknown→mpv、预选最优轨
+- [x] 6.4 既有 `VideoPlayerController.test.ets` 保持通过（`findInitialAudioTrackIndex` 回退路径兼容）
 
 ## 7. 验证
 
-- [ ] 7.1 本地单测（UnitTestBuild 路径）通过
-- [ ] 7.2 ArkTS HAP 构建通过，无新增编译/ArkTS 护栏错误
+- [x] 7.1 本地单测编译通过（UnitTestBuild）+ 设备端单测 604/604 通过
+- [x] 7.2 ArkTS HAP 构建通过，无新增编译/ArkTS 护栏错误
 - [ ] 7.3 （设备可达时）真机验证不同设备对同一片源产生不同后端决策，日志可见能力来源/缓存/纠偏/预选


### PR DESCRIPTION
## 概述

Closes #243

优化 AVPlayer 音频路由：不再用全局写死的 codec 黑名单判兼容，改为按设备真实解码能力（NAPI `queryAudioDecoderCapability()`，底层 `OH_AVCodec_GetCapability*`）在创建/prepare AVPlayer 前决定 AVPlayer / MPV，并保留设备/固件纠偏机制。

## 变更内容

### 能力服务（新增）
- `services/audioCapability/AudioDecoderCapabilityService.ets`：NAPI 类型安全 bridge、两级缓存（codec 去重 + codec/声道派生）、设备/固件纠偏读写（AppPreferences 持久化，按 device/os 过滤）。
- `services/audioCapability/AudioCapabilityTypes.ets`：能力结果、兼容结论、纠偏条目、可注入 provider 抽象。
- `services/audioRouting/AudioCodecUtil.ets`：抽离归一化/排名纯函数，避免路由与能力服务循环依赖。

### 路由决策
- 按归一化 codec 去重后查询设备能力，逐音轨判定「codec 支持 + 声道数不超设备上限」。
- 存在兼容音轨 → `avplayer` + 预选最佳兼容轨；无兼容音轨 → 直接 `mpv`（避免 prepare 后再初始化后端）；能力查询异常 → 保守 `mpv`（全局黑名单仅作迁移期临时兜底）。
- `AudioRoutingDecision` / `PlaybackBackendDecision` 增加 `recommendedInitialTrackIndex` / `capabilitySummary` 等字段，日志记录能力来源/缓存/纠偏/预选。

### 控制器与适配器
- `VideoPlayerController`：存储路由决策、`AudioTrackItem.channels`、AVPlayer 显式失败（5400106/5400103）时记录纠偏。
- `AVPlayerAdapter`：移除 PREPARED 阶段全局黑名单判定，保留显式失败动态降级。
- 真机修复：直接选 MPV 时后端切换触发冗余重建导致黑屏/无音轨，`initPlayerForSurface` 增加守卫跳过冗余重建。

### Native
- `audio_capability.cpp`：扩展归一化 codec → MIME 映射（ac3/eac3/truehd/dts/dtshd/mlp/vivid/vorbis/pcm 等），修正 `capabilityKnown` 语义。

## 验证

- `assembleHap` / `UnitTestBuild`：`BUILD SUCCESSFUL`
- 设备端单测：`Tests run: 604, Failure: 0, Error: 0, Pass: 604`（含新增 21 个能力路由用例）
- 真机（192.168.3.85）：eac3 → mpv、aac → avplayer，日志可见 `capabilitySource` / 缓存命中 / 预选轨道；MPV 黑屏问题修复后正常播放且有音轨信息

## 说明

- OpenSpec 变更 `device-audio-capability-routing` 未归档，归档由维护者自行处理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 根据设备实际解码能力、声道数和语言偏好选择播放器及初始音轨。
  * 支持音频编码格式归一化、能力缓存及设备/系统版本纠偏。
  * AVPlayer 遇明确格式不支持时自动切换至 MPV，并保留播放状态。
  * 增加音频能力与音轨兼容性诊断信息。

* **错误修复**
  * 改进未知编码格式与不支持解码器的识别和错误提示。
  * 避免重复创建播放器，降低播放切换时画面丢失风险。

* **测试**
  * 新增编码归一化、能力查询、缓存、纠偏及音轨路由测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->