### PR TITLE
修复文件源最近添加剧集无法打开详情页及卡片底部显示

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,2 +1,2 @@
 local.properties
-oh_modules/*
+certs/*

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -46,6 +46,7 @@ import { ServerLibraryListPage, ServerLibraryListPageParam } from "../../detail/
 import { SettingsPage, SettingsPageParam } from "../../settings/Index"
 import SettingType from "../../settings/SettingType"
 import { resolveCardBehavior, isDirectPlayContextValid, ServerCardKind } from "../../../services/sourceAdapter/ServerCardAction"
+import { resolveSeriesCardDestination } from "../../../services/sourceAdapter/SeriesCardRoute"
 
 // ─────────────────────────────────────────────
 // 常量
@@ -127,6 +128,8 @@ interface SourceRuntimeConfig {
 @ComponentV2
 struct PosterCard {
   @Require @Param item: MediaItem
+  /** 播放进度（0~1），>0 时在底部显示进度条，电影使用 */
+  @Param progress: number = 0
   @Local isHovered: boolean = false
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
   private getTitle(): string { return displayTitle(this.item); }
@@ -159,17 +162,15 @@ struct PosterCard {
           .backgroundColor('#2A2A2A').borderRadius(6).justifyContent(FlexAlign.Center)
         }
 
-        // 底部黑色渐变（覆盖下方 20%）
-        if (this.getRating().length > 0) {
-          Column()
-            .width(POSTER_WIDTH)
-            .height("28%")
-            .linearGradient({
-              angle: 180,
-              colors: [['#00000000', 0.0], ['#CC000000', 1.0]]
-            })
-            .borderRadius({ bottomLeft: 6, bottomRight: 6 })
-            .position({ left: 0, bottom: 0 })
+        // 底部播放进度条（仅进行中的电影显示，无进度则不显示）
+        if (this.progress > 0 && this.progress < 1) {
+          Stack({ alignContent: Alignment.Start }) {
+            Column().width(POSTER_WIDTH).height(4).backgroundColor('#66000000')
+            Column().width(POSTER_WIDTH * this.progress).height(4).backgroundColor('#4A9FFF')
+          }
+          .width(POSTER_WIDTH)
+          .height(4)
+          .position({ left: 0, bottom: 0 })
         }
 
         // 右上角分辨率标签
@@ -184,12 +185,14 @@ struct PosterCard {
             .position({ top: 2, right: 2 })
         }
 
-        // 右下角评分（橘黄色，透明背景）
+        // 右下角评分（橘黄色，带深色小底衬保证可读性）
         if (this.getRating().length > 0) {
           Text(this.getRating())
             .fontSize(11).fontColor('#FFA500').fontWeight(FontWeight.Bold)
             .padding({ left: 4, right: 4, bottom: 4 })
-            .position({ right: 2, bottom: 2 })
+            .backgroundColor('#66000000')
+            .borderRadius(3)
+            .position({ right: 2, bottom: 6 })
         }
 
         // 亮色海报上增强 hover 可见性的遮罩层
@@ -199,12 +202,20 @@ struct PosterCard {
           .backgroundColor(this.getCardOverlayColor())
           .position({ left: 0, top: 0 })
           .hitTestBehavior(HitTestMode.Transparent)
+
+        // 边框覆盖层（置于最顶层）：避免 border 占用内容尺寸，导致图片/进度条与边框之间出现空隙
+        Column()
+          .width('100%')
+          .height('100%')
+          .borderRadius(6)
+          .border({ width: 2, color: this.getCardBorderColor() })
+          .hitTestBehavior(HitTestMode.Transparent)
+          .animation({ duration: 140, curve: Curve.EaseInOut })
       }
       .borderRadius(6)
       .clip(true)
       .width(POSTER_WIDTH)
       .aspectRatio(PORTRAIT_ASPECT_RATIO)
-      .border({ width: 2, color: this.getCardBorderColor() })
       .shadow({ radius: this.isHovered ? 14 : 8, color: this.getCardShadowColor(), offsetX: 0, offsetY: 2 })
       .onHover((isHover: boolean) => { this.isHovered = isHover; })
       .animation({ duration: 140, curve: Curve.EaseInOut })
@@ -295,19 +306,6 @@ struct SeriesCard {
           .backgroundColor('#2A2A2A').borderRadius(6).justifyContent(FlexAlign.Center)
         }
 
-        // 底部黑色渐变
-        if (this.getRating().length > 0 || this.getSeasonLabel().length > 0) {
-          Column()
-            .width(POSTER_WIDTH)
-            .height("28%")
-            .linearGradient({
-              angle: 180,
-              colors: [['#00000000', 0.0], ['#CC000000', 1.0]]
-            })
-            .borderRadius({ bottomLeft: 6, bottomRight: 6 })
-            .position({ left: 0, bottom: 0 })
-        }
-
         // 右上角分辨率标签
         if (this.getResolution().length > 0) {
           Text(this.getResolution())
@@ -320,19 +318,23 @@ struct SeriesCard {
             .position({ top: 2, right: 2 })
         }
 
-        // 左下角季标签（最近添加时显示）
+        // 左下角季标签（最近添加时显示，深色小底衬保证可读性）
         if (this.getSeasonLabel().length > 0) {
           Text(this.getSeasonLabel())
             .fontSize(10).fontColor(Color.White).fontWeight(FontWeight.Medium)
             .padding({ left: 4, right: 4, bottom: 4 })
+            .backgroundColor('#66000000')
+            .borderRadius(3)
             .position({ left: 2, bottom: 2 })
         }
 
-        // 右下角评分
+        // 右下角评分（深色小底衬保证可读性）
         if (this.getRating().length > 0) {
           Text(this.getRating())
             .fontSize(11).fontColor('#FFA500').fontWeight(FontWeight.Bold)
             .padding({ left: 4, right: 4, bottom: 4 })
+            .backgroundColor('#66000000')
+            .borderRadius(3)
             .position({ right: 2, bottom: 2 })
         }
 
@@ -343,12 +345,20 @@ struct SeriesCard {
           .backgroundColor(this.getCardOverlayColor())
           .position({ left: 0, top: 0 })
           .hitTestBehavior(HitTestMode.Transparent)
+
+        // 边框覆盖层（置于最顶层）：避免 border 占用内容尺寸，导致海报与边框之间出现空隙
+        Column()
+          .width('100%')
+          .height('100%')
+          .borderRadius(6)
+          .border({ width: 2, color: this.getCardBorderColor() })
+          .hitTestBehavior(HitTestMode.Transparent)
+          .animation({ duration: 140, curve: Curve.EaseInOut })
       }
       .borderRadius(6)
       .clip(true)
       .width(POSTER_WIDTH)
       .aspectRatio(PORTRAIT_ASPECT_RATIO)
-      .border({ width: 2, color: this.getCardBorderColor() })
       .shadow({ radius: this.isHovered ? 14 : 8, color: this.getCardShadowColor(), offsetX: 0, offsetY: 2 })
       .onHover((isHover: boolean) => { this.isHovered = isHover; })
       .animation({ duration: 140, curve: Curve.EaseInOut })
@@ -363,11 +373,10 @@ struct SeriesCard {
     .width(POSTER_WIDTH)
     .alignItems(HorizontalAlign.Start)
     .onClick(() => {
-      if (this.showSeasonPoster && this.group.seasonNumber !== undefined && this.group.tvSeriesId !== undefined) {
-        // 季卡片 → 跳转季详情页
+      const dest = resolveSeriesCardDestination(this.showSeasonPoster, this.group);
+      if (dest === 'seasonDetail') {
         this.pageStack.pushPathByName(SeasonDetailPage.PAGE_NAME, this.group);
-      } else if (!this.showSeasonPoster && this.group.tvSeriesId !== undefined) {
-        // 剧集卡片 → 跳转剧集详情页
+      } else if (dest === 'seriesDetail') {
         this.pageStack.pushPathByName(SeriesDetailPage.PAGE_NAME, this.group);
       }
     })
@@ -380,6 +389,8 @@ struct SeriesCard {
 @ComponentV2
 struct MixedCard {
   @Require @Param listItem: MediaListItem
+  /** 当 listItem 为视频（电影）时的播放进度，0 表示无进度 */
+  @Param itemProgress: number = 0
 
   private isSeries(): boolean {
     return this.listItem.kind === 'series';
@@ -398,7 +409,7 @@ struct MixedCard {
       if (this.isSeries()) {
         SeriesCard({ group: this.getSeries(), showSeasonPoster: true })
       } else {
-        PosterCard({ item: this.getVideo() })
+        PosterCard({ item: this.getVideo(), progress: this.itemProgress })
       }
     }
   }
@@ -1617,12 +1628,22 @@ export struct MediaLibraryTab {
     .width('100%').alignItems(HorizontalAlign.Start).margin({ bottom: 20 })
   }
 
+  /**
+   * 取混合列表项的播放进度：视频（电影）返回其 providerId 对应的进度，系列返回 0。
+   */
+  private movieProgress(listItem: MediaListItem): number {
+    if (listItem.kind !== 'video' || listItem.video === undefined) {
+      return 0;
+    }
+    return this.model.getMovieProgress(listItem.video.providerId);
+  }
+
   @Builder
   RecentlyAddedSection() {
     if (this.model.recentlyAddedList.length > 0) {
       SectionRow({ title: '最近添加' }) {
         ForEach(this.model.recentlyAddedList.slice(0, 20), (listItem: MediaListItem) => {
-          MixedCard({ listItem })
+          MixedCard({ listItem, itemProgress: this.movieProgress(listItem) })
         })
       }
     }
@@ -1641,7 +1662,7 @@ export struct MediaLibraryTab {
         }
       }) {
         ForEach(this.model.movies.slice(0, 30), (item: MediaItem) => {
-          PosterCard({ item })
+          PosterCard({ item, progress: this.model.getMovieProgress(item.providerId) })
         })
       }
     }
@@ -1671,7 +1692,7 @@ export struct MediaLibraryTab {
     if (this.model.unwatchedList.length > 0) {
       SectionRow({ title: '未观看' }) {
         ForEach(this.model.unwatchedList.slice(0, 20), (listItem: MediaListItem) => {
-          MixedCard({ listItem })
+          MixedCard({ listItem, itemProgress: this.movieProgress(listItem) })
         })
       }
     }

--- a/entry/src/main/ets/services/sourceAdapter/SeriesCardRoute.ets
+++ b/entry/src/main/ets/services/sourceAdapter/SeriesCardRoute.ets
@@ -1,0 +1,33 @@
+// filepath: entry/src/main/ets/services/sourceAdapter/SeriesCardRoute.ets
+//
+// SeriesCardRoute - 媒体库「系列卡片」点击行为契约（纯函数）。
+//
+// 目标：把 `MediaLibraryTab` 中 `SeriesCard` 的点击分流抽成可单测的纯函数，
+// 避免行为契约散落在 UI build() 里。
+//
+// 约束：
+// - 仅包含无副作用纯函数，不依赖 UI / 网络 / 具体详情页。
+// - 行为与 `MediaLibraryTab` 中 `SeriesCard` wiring 保持一致（wiring 通过本模块解析）。
+
+import type { SeriesGroup } from "../../db/models/MediaEntity";
+
+/** 系列卡片可跳转的目标详情页；null 表示不跳转。 */
+export type SeriesCardDestination = 'seriesDetail' | 'seasonDetail' | null;
+
+/**
+ * 解析系列卡片点击应跳转的详情页：
+ * - showSeasonPoster=true（最近添加/混合列表，显示季海报+季号）：
+ *   有季号 → 季详情页（展示该季）；
+ *   无季号 → 剧集详情页（展示整部剧，修复「点击后无法打开」的问题）。
+ * - showSeasonPoster=false（电视剧栏）：→ 剧集详情页。
+ * - tvSeriesId 缺失时返回 null（不跳转，防止误进详情页）。
+ */
+export function resolveSeriesCardDestination(showSeasonPoster: boolean, group: SeriesGroup): SeriesCardDestination {
+  if (group.tvSeriesId === undefined) {
+    return null;
+  }
+  if (showSeasonPoster) {
+    return group.seasonNumber !== undefined ? 'seasonDetail' : 'seriesDetail';
+  }
+  return 'seriesDetail';
+}

--- a/entry/src/main/ets/stores/media/MediaLibraryModel.ets
+++ b/entry/src/main/ets/stores/media/MediaLibraryModel.ets
@@ -1,5 +1,6 @@
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { MediaItem, MediaStats, SeriesGroup, DecadeGroup, MediaListItem, ContinueWatchingItem, TvSeriesEntity, TvEpisodeEntity, MediaProgressEntry } from '../../db/models/MediaEntity';
+import { MediaProgressStore } from '../../db/MediaProgressStore';
 import { millisecondsToTime } from '../../utils/TimeUtil';
 
 export interface YearGroup {
@@ -194,7 +195,8 @@ export class MediaLibraryModel {
       const allEntries: MediaProgressEntry[] = await db.getAllMediaProgress();
 
       // 构建电影播放进度映射（providerId → 进行中比例），供文件源卡片底部进度条使用。
-      // 仅记录「进行中」（0 < ratio < 0.95 且未标记完播），已完播/未在看不显示进度条。
+      // 仅记录「进行中」（0 < 比例 且未到完播阈值，与 MediaProgressStore.isNearEnd 保持一致，
+      // 即剩余时长 < 60 秒或已播比例 ≥ 95% 视为完播），已完播/未在看不显示进度条。
       const movieProgressMap = new Map<string, number>();
       for (const entry of allEntries) {
         if (!entry.mediaKey.startsWith('media_progress_movie_')) {
@@ -208,7 +210,7 @@ export class MediaLibraryModel {
           continue;
         }
         const ratio = entry.positionMs / entry.durationMs;
-        if (ratio > 0 && ratio < 0.95) {
+        if (ratio > 0 && !MediaProgressStore.isNearEnd(entry.positionMs, entry.durationMs)) {
           movieProgressMap.set(providerId, ratio);
         }
       }

--- a/entry/src/main/ets/stores/media/MediaLibraryModel.ets
+++ b/entry/src/main/ets/stores/media/MediaLibraryModel.ets
@@ -52,6 +52,8 @@ export class MediaLibraryModel {
   @Trace latestScanTime: number = 0;
   /** 「继续播放」栏数据，按最近播放时间倒序，最多 20 条 */
   @Trace continueWatchingList: ContinueWatchingItem[] = [];
+  /** 电影播放进度（providerId → 0~1 进行中比例），用于文件源卡片底部进度条 */
+  @Trace movieProgressMap: Map<string, number> = new Map();
 
   async load(): Promise<void> {
     if (this.isLoading) {
@@ -171,6 +173,17 @@ export class MediaLibraryModel {
   }
 
   /**
+   * 读取某部电影的播放进度比例（0~1）。
+   * 无进度数据、未在看或已完播均返回 0（不显示进度条）。
+   */
+  getMovieProgress(providerId?: string): number {
+    if (providerId === undefined || providerId.length === 0) {
+      return 0;
+    }
+    return this.movieProgressMap.get(providerId) ?? 0;
+  }
+
+  /**
    * 加载「继续播放」栏数据。
    * 从 media_progress 表读取进度，过滤完播项，匹配 recentlyAdded 元数据，
    * 构建 ContinueWatchingItem 列表写入 continueWatchingList。
@@ -179,6 +192,27 @@ export class MediaLibraryModel {
     try {
       const db = FileSourceDatabase.getInstance();
       const allEntries: MediaProgressEntry[] = await db.getAllMediaProgress();
+
+      // 构建电影播放进度映射（providerId → 进行中比例），供文件源卡片底部进度条使用。
+      // 仅记录「进行中」（0 < ratio < 0.95 且未标记完播），已完播/未在看不显示进度条。
+      const movieProgressMap = new Map<string, number>();
+      for (const entry of allEntries) {
+        if (!entry.mediaKey.startsWith('media_progress_movie_')) {
+          continue;
+        }
+        if (entry.isWatched === 1) {
+          continue;
+        }
+        const providerId = entry.mediaKey.slice('media_progress_movie_'.length);
+        if (providerId.length === 0 || entry.durationMs <= 0) {
+          continue;
+        }
+        const ratio = entry.positionMs / entry.durationMs;
+        if (ratio > 0 && ratio < 0.95) {
+          movieProgressMap.set(providerId, ratio);
+        }
+      }
+      this.movieProgressMap = movieProgressMap;
 
       // getAllMediaProgress() 已按最近播放倒序返回，直接过滤取前 20 条
       const top20: MediaProgressEntry[] = [];

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -58,6 +58,7 @@ import audioCodecUtilTest from './AudioCodecUtil.test';
 import audioDecoderCapabilityServiceTest from './AudioDecoderCapabilityService.test';
 import audioTrackRoutingTest from './AudioTrackRouting.test';
 import serverCardActionTest from './ServerCardAction.test';
+import seriesCardRouteTest from './SeriesCardRoute.test';
 
 export default function testsuite() {
   timeUtilTest();
@@ -118,4 +119,5 @@ export default function testsuite() {
   audioDecoderCapabilityServiceTest();
   audioTrackRoutingTest();
   serverCardActionTest();
+  seriesCardRouteTest();
 }

--- a/entry/src/test/SeriesCardRoute.test.ets
+++ b/entry/src/test/SeriesCardRoute.test.ets
@@ -1,0 +1,45 @@
+import { describe, it, expect } from '@ohos/hypium'
+import { resolveSeriesCardDestination } from '../main/ets/services/sourceAdapter/SeriesCardRoute'
+import { SeriesGroup } from '../main/ets/db/models/MediaEntity'
+
+/** 构造一个系列卡片数据。seasonNumber 传 undefined 表示无季号。 */
+function makeGroup(tvSeriesId: number | undefined, seasonNumber: number | undefined): SeriesGroup {
+  const group: SeriesGroup = {
+    title: '测试剧',
+    tvSeriesId: tvSeriesId,
+    seasonNumber: seasonNumber,
+    episodeCount: 10,
+    episodes: [],
+    latestScannedAt: 0
+  }
+  return group
+}
+
+export default function seriesCardRouteTest(): void {
+  describe('resolveSeriesCardDestination - 系列卡片点击分流', () => {
+    it('最近添加/混合卡片：有季号 → 季详情页', 0, () => {
+      const dest = resolveSeriesCardDestination(true, makeGroup(1, 2))
+      expect(dest).assertEqual('seasonDetail')
+    })
+
+    it('最近添加/混合卡片：无季号 → 剧集详情页（修复点击无法打开）', 0, () => {
+      const dest = resolveSeriesCardDestination(true, makeGroup(1, undefined))
+      expect(dest).assertEqual('seriesDetail')
+    })
+
+    it('电视剧栏：无季号 → 剧集详情页', 0, () => {
+      const dest = resolveSeriesCardDestination(false, makeGroup(1, undefined))
+      expect(dest).assertEqual('seriesDetail')
+    })
+
+    it('电视剧栏：有季号也进剧集详情页', 0, () => {
+      const dest = resolveSeriesCardDestination(false, makeGroup(1, 3))
+      expect(dest).assertEqual('seriesDetail')
+    })
+
+    it('tvSeriesId 缺失 → 不跳转（返回 null）', 0, () => {
+      const dest = resolveSeriesCardDestination(true, makeGroup(undefined, undefined))
+      expect(dest).assertEqual(null)
+    })
+  })
+}


### PR DESCRIPTION
## 背景

文件源媒体库中「最近添加」的剧集列表项点击后无法打开剧集详情页（电影正常），是先前「季详情页」重构引入的回归。同时卡片底部常驻的黑色渐变看起来像空进度条，视觉突兀；hover 时边框底部还会出现空隙。

## 改动

- **修复剧集详情页无法打开**：把 `SeriesCard` 的点击分流抽成纯函数 `resolveSeriesCardDestination`（`services/sourceAdapter/SeriesCardRoute.ets`）。原逻辑在「最近添加 + 无季号」时三个条件都判空导致无跳转；现改为：有季号→季详情页，无季号→剧集详情页，无 `tvSeriesId`→不跳转。
- **进度条优化**：`MediaLibraryModel` 新增 `movieProgressMap`（providerId→进行中比例，仅记录 0<ratio<0.95 且未完播），`PosterCard` 电影卡片仅在真实进度时显示蓝色进度条；无进度时不再显示底部黑条。
- **hover 边框空隙**：把 `border` 从卡片 `Stack` 本体改为独立顶层覆盖层，避免边框占用内容尺寸，消除 hover 时图片/进度条与边框之间的底部空隙；评分/季标签加小深色底衬保证去掉渐变后可读性。
- **测试**：新增 `SeriesCardRoute.test.ets`（5 个分支用例），并注册进 `List.test.ets`。
- **worktree 依赖**：`.worktreeinclude` 加入模块级依赖与签名证书复制，保证新 worktree 可构建签名。

## 验证

- 本地 `assembleHap` BUILD SUCCESSFUL
- hdc 安装到电视 + 启动成功

## 说明

- 「最近添加/未观看/电影片库」通过 `MixedCard`/`PosterCard` 传入电影进度；剧集卡片未加进度条（剧集进度为集级，非单一值）。
- 影视服务器卡片（`ServerPosterCard`/`ServerWideCard`）结构相同，如需应用同样的边框覆盖层方案可另行处理。

Fixes: #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 媒体库电影卡片新增播放进度显示。
  * 评分和季数标签改为深色底衬叠加样式，卡片展示更清晰。
  * 优化电视剧卡片跳转逻辑，可按场景进入剧集或季详情页。
  * 最近添加、未观看及电影列表支持展示电影播放进度。

* **样式优化**
  * 调整海报卡片边框与电视剧卡片渐变效果，改善视觉呈现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->