### PR TITLE
修复: 剧集近完播退出后继续播放应推进到下一集

### DIFF
--- a/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/SeriesDetailPage.ets
@@ -318,7 +318,9 @@ export struct SeriesDetailPage {
     // 使用新集级 key 格式查询（兼容旧格式），不再使用废弃的 seriesKey
     const mp = await db.getLatestMediaProgressBySeries(seriesProviderId);
     this.mediaProgress = mp;
-    this.hasActiveProgress = mp !== null && mp.positionMs > 0 && mp.durationMs > 0;
+    // 完播推进后，下一集以 position=0 写入，仍应视为「可继续」入口；
+    // 仅当 is_watched=1（已看完）或时长未知时视为无有效进度。
+    this.hasActiveProgress = mp !== null && mp.durationMs > 0 && (mp.isWatched ?? 0) !== 1;
     this.lastEpisode = null;
     this.lastEpisodeEntity = null;
 

--- a/entry/src/main/ets/pages/player/index.ets
+++ b/entry/src/main/ets/pages/player/index.ets
@@ -26,7 +26,8 @@ import { normalizePlayerBackend } from "../../services/playback/PlaybackBackendT
 import {
   PlaybackProgressService,
   PlaybackProgressContext,
-  PersistOutcome
+  PersistOutcome,
+  NextEpisodeHint
 } from "../../services/playbackProgress/PlaybackProgressService";
 import { PlaybackResumeDecision } from "../../services/playbackProgress/PlaybackResumeDecision";
 import { reportServerPlaybackStopped, reportServerPlaybackProgress } from "../../lib/ServerProgressReporter";
@@ -361,10 +362,47 @@ export struct PlayerPage {
         onResumeDialog: (posMs: number): void => {
           this.pendingSeekMs = posMs;
           this.showResumeDialog = true;
+        },
+        getNextEpisodeHint: (): NextEpisodeHint | null => {
+          return this.getNextEpisodeHintForNearEnd();
         }
       });
     }
     return this.progressService;
+  }
+
+  /**
+   * 近完播时计算下一集提示，用于把「继续播放」指针推进到下一集。
+   *
+   * 仅在 media_library 上下文且存在下一集（hasNext）时生效；
+   * 电影 / 最后一集 / 文件浏览上下文均返回 null，此时仅标记当前集已看完。
+   */
+  private getNextEpisodeHintForNearEnd(): NextEpisodeHint | null {
+    const pc = this.videoPlayerController.playbackContext;
+    if (pc === undefined || pc.contextType !== 'media_library') {
+      return null;
+    }
+    const mlc = pc as MediaLibraryContext;
+    if (!mlc.hasNext) {
+      return null;
+    }
+    const nextIndex = mlc.currentIndex + 1;
+    if (nextIndex < 0 || nextIndex >= mlc.items.length) {
+      return null;
+    }
+    const nextItem = mlc.items[nextIndex];
+    const seriesProviderId = this.currentPageParam?.seriesProviderId ?? '';
+    const season = nextItem.seasonNumber ?? 0;
+    const episode = nextItem.episodeNumber ?? 0;
+    if (seriesProviderId.length === 0 || season <= 0 || episode <= 0) {
+      return null;
+    }
+    return {
+      mediaKey: MediaProgressStore.episodeKey(seriesProviderId, season, episode),
+      season,
+      episode,
+      durationMs: nextItem.durationMs ?? 0
+    };
   }
 
   aboutToAppear(): void {

--- a/entry/src/main/ets/services/playbackProgress/PlaybackProgressService.ets
+++ b/entry/src/main/ets/services/playbackProgress/PlaybackProgressService.ets
@@ -65,6 +65,26 @@ export interface PlaybackProgressServiceOptions {
    * page 端在此设置 `showResumeDialog = true` 与 `pendingSeekMs`。
    */
   onResumeDialog?: (positionMs: number) => void;
+  /**
+   * near-end（完播）时获取下一集提示，用于把「继续播放」指针推进到下一集。
+   * 返回 null 表示无下一集（电影 / 最后一集 / 文件浏览上下文等），此时仅标记当前集已看完。
+   */
+  getNextEpisodeHint?: () => NextEpisodeHint | null;
+}
+
+/**
+ * 下一集的媒体级进度提示。
+ *
+ * 由 page 基于当前播放上下文（media_library）计算：
+ * - `mediaKey`：下一集的集级进度 key（`media_progress_episode_tmdb_{seriesTmdbId}_s{sn}_e{en}`）
+ * - `season` / `episode`：下一集的季号 / 集号
+ * - `durationMs`：下一集的时长（未知时写 0，卡片会暂不展示）
+ */
+export interface NextEpisodeHint {
+  mediaKey: string;
+  season: number;
+  episode: number;
+  durationMs: number;
 }
 
 /**
@@ -259,6 +279,18 @@ export class PlaybackProgressService {
     }
     if (MediaProgressStore.isNearEnd(posMs, durMs)) {
       await MediaProgressStore.clear(ctx.mediaKey).catch(() => {});
+      // 完播后把「继续播放」指针推进到下一集（position=0，未开始）。
+      // 幂等：重复触发（切后台 / 退出 / 定时）会用 position=0 覆盖写入，无副作用。
+      const nextHint = this.options.getNextEpisodeHint?.();
+      if (nextHint !== null && nextHint !== undefined) {
+        await MediaProgressStore.save(
+          nextHint.mediaKey,
+          0,
+          nextHint.durationMs,
+          nextHint.season,
+          nextHint.episode
+        ).catch(() => {});
+      }
       return 'cleared';
     }
     if (posMs > 0 && durMs > 0) {

--- a/entry/src/main/ets/stores/media/MediaLibraryModel.ets
+++ b/entry/src/main/ets/stores/media/MediaLibraryModel.ets
@@ -220,10 +220,14 @@ export class MediaLibraryModel {
       const top20: MediaProgressEntry[] = [];
       for (const entry of allEntries) {
         if (top20.length >= 20) { break; }
-        if (entry.positionMs <= 0 || entry.durationMs <= 0) { continue; }
-        if ((entry.positionMs / entry.durationMs) < 0.95) {
-          top20.push(entry);
-        }
+        if (entry.durationMs <= 0) { continue; }
+        const ratio = entry.positionMs / entry.durationMs;
+        // 剧集集级（episode key）允许「未开始」（positionMs == 0）进入列表，
+        // 用于把近完播后推进的下一集以 0% 状态展示；电影 / 旧整剧格式仍要求已播放。
+        const isEpisodeKey = entry.mediaKey.startsWith('media_progress_episode_tmdb_');
+        if (entry.positionMs === 0 && !isEpisodeKey) { continue; }
+        if (ratio >= 0.95) { continue; }
+        top20.push(entry);
       }
 
       // 从已加载的 recentlyAdded 构建两张查找 Map


### PR DESCRIPTION
## 为什么改

剧集某一集（如第6集）播放到近完播时退出播放器，旧逻辑只把该集标记为「已看」，但不会把「继续播放」指针推进到下一集。首页「继续播放」栏会过滤掉已完播（比例≥95%）的条目，而下一集又没有进度记录，导致整部剧从「继续播放」彻底消失、进度丢失。

期望行为：标记当前集已看的同时，若存在下一集，则把进度指针设为下一集，使下一集以未开始（0%）状态出现在「继续播放」卡片上。

## 方案说明

本次把「完播后推进下一集」收口到已有的播放进度持久化流程，用「下一集媒体级进度（position=0）」作为推进指针：

- **PlaybackProgressService**：`persistNow()` 的 near-end 分支在 `markAsWatched` 后，通过新增的 `getNextEpisodeHint` 回调写入下一集 `media_progress`（`position=0` + 下一集时长）。写入是幂等的，切后台 / 退出 / 定时重复触发无副作用。
- **PlayerPage**：注入 `getNextEpisodeHintForNearEnd()`，基于 `playbackContext`（media_library）+ `currentIndex+1` 解析下一集。电影、最后一集、文件浏览上下文返回 `null`，不推进。
- **MediaLibraryModel**：`loadContinueWatching` 放宽过滤，允许 `position==0` 的剧集集级条目进入列表，使未开始的下一集以 0% 展示；仍按 `ratio>=0.95` 剔除已完播条目。
- **SeriesDetailPage**：`hasActiveProgress` 改为依据 `is_watched!=1 && durationMs>0` 判定，避免 next-up 条目（position=0）被误判为无进度导致「继续」入口消失。

## 需要留意

- 若下一集的 `durationMs` 缺失（尚未探测），写入的 `duration=0`，卡片会暂不展示，用户实际播放下一集后会补齐 —— 已作降级处理。
- 「推进下一集」仅限定在**同季内**（基于当前 media_library 上下文的 `currentIndex+1`），跨季（季末最后一部）暂不推进。
- 电影 / 文件浏览上下文 / 最后一集行为不变。

## 验证

- `assembleHap` 干净构建通过（`BUILD SUCCESSFUL`），仅有仓库既有 warning。
- 已安装到局域网电视（`192.168.3.85:5555`）并启动运行，进程存活。