### PR TITLE
新增: 支持遥控器左右键加速快进快退

### DIFF
--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -14,6 +14,7 @@ struct VideoControls {
   @Require @Param dialogController: CustomDialogController
   @Require @Param openSettings: () => void
   @Param onOpenSubtitleSelector: () => void = () => {}
+  @Param onRemoteKey: (event: KeyEvent) => void = (_event: KeyEvent) => {}
   closeTimer?: number
   seekTimer?: number
   private AUTO_CLOSE_TIMEOUT = 5000
@@ -592,6 +593,9 @@ struct VideoControls {
       }
     }
     .hitTestBehavior(HitTestMode.Transparent)
+    .onKeyEvent((event: KeyEvent) => {
+      this.onRemoteKey(event)
+    })
     .onClick(async () => {
       await this.videoController.toggle()
       this.enableAutoHide()
@@ -755,6 +759,7 @@ export struct VideoControlsDialog {
   @Require videoController: VideoPlayerController
   @Require onOpenSettings: () => void
   onOpenSubtitleSelector: () => void = () => {}
+  onRemoteKey: (event: KeyEvent) => void = (_event: KeyEvent) => {}
   @State opacityValue: number = 0;
 
   aboutToAppear(): void {
@@ -772,7 +777,8 @@ export struct VideoControlsDialog {
       videoController: this.videoController,
       dialogController: this.controller,
       openSettings: this.onOpenSettings,
-      onOpenSubtitleSelector: this.onOpenSubtitleSelector
+      onOpenSubtitleSelector: this.onOpenSubtitleSelector,
+      onRemoteKey: this.onRemoteKey
     })
       .opacity(this.opacityValue)
   }

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -15,6 +15,7 @@ struct VideoControls {
   @Require @Param openSettings: () => void
   @Param onOpenSubtitleSelector: () => void = () => {}
   @Param onRemoteKey: (event: KeyEvent) => void = (_event: KeyEvent) => {}
+  @Param onRemoteAxis: (event: AxisEvent) => void = (_event: AxisEvent) => {}
   closeTimer?: number
   seekTimer?: number
   private AUTO_CLOSE_TIMEOUT = 5000
@@ -529,6 +530,11 @@ struct VideoControls {
                   }
                 }
               })
+              .onAxisEvent((event: AxisEvent) => {
+                // 控件打开后 Slider 通常位于输入命中层，继续转发并延长显示时间。
+                this.enableAutoHide()
+                this.onRemoteAxis(event)
+              })
               .onFocus(() => {
                 this.sliderFocused = true
                 this.sliderHovered = true
@@ -595,6 +601,10 @@ struct VideoControls {
     .hitTestBehavior(HitTestMode.Transparent)
     .onKeyEvent((event: KeyEvent) => {
       this.onRemoteKey(event)
+    })
+    .onAxisEvent((event: AxisEvent) => {
+      this.enableAutoHide()
+      this.onRemoteAxis(event)
     })
     .onClick(async () => {
       await this.videoController.toggle()
@@ -760,6 +770,7 @@ export struct VideoControlsDialog {
   @Require onOpenSettings: () => void
   onOpenSubtitleSelector: () => void = () => {}
   onRemoteKey: (event: KeyEvent) => void = (_event: KeyEvent) => {}
+  onRemoteAxis: (event: AxisEvent) => void = (_event: AxisEvent) => {}
   @State opacityValue: number = 0;
 
   aboutToAppear(): void {
@@ -778,7 +789,8 @@ export struct VideoControlsDialog {
       dialogController: this.controller,
       openSettings: this.onOpenSettings,
       onOpenSubtitleSelector: this.onOpenSubtitleSelector,
-      onRemoteKey: this.onRemoteKey
+      onRemoteKey: this.onRemoteKey,
+      onRemoteAxis: this.onRemoteAxis
     })
       .opacity(this.opacityValue)
   }

--- a/entry/src/main/ets/components/core/player/VideoControls.ets
+++ b/entry/src/main/ets/components/core/player/VideoControls.ets
@@ -530,11 +530,6 @@ struct VideoControls {
                   }
                 }
               })
-              .onAxisEvent((event: AxisEvent) => {
-                // 控件打开后 Slider 通常位于输入命中层，继续转发并延长显示时间。
-                this.enableAutoHide()
-                this.onRemoteAxis(event)
-              })
               .onFocus(() => {
                 this.sliderFocused = true
                 this.sliderHovered = true
@@ -600,6 +595,7 @@ struct VideoControls {
     }
     .hitTestBehavior(HitTestMode.Transparent)
     .onKeyEvent((event: KeyEvent) => {
+      this.enableAutoHide()
       this.onRemoteKey(event)
     })
     .onAxisEvent((event: AxisEvent) => {

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -9,6 +9,7 @@ import { SubtitleParserFactory, ParsedSubtitle, SubtitleSegment } from "./Subtit
 import { millisecondsToTime } from "../../../utils/TimeUtil"
 import { PlaybackContextItem } from "./PlaybackContext"
 import { resolveRenderFitForAspectRatioMode } from "./VideoPlayerLayoutUtil"
+import { KeyCode } from '@kit.InputKit'
 
 @ComponentV2
 export struct VideoPlayer {
@@ -30,6 +31,13 @@ export struct VideoPlayer {
    * onWillDismiss 拦截返回键时调用：若处于搜索结果视图则退回轨道列表（返回 true），否则返回 false。
    */
   private subtitleTryHideSearch: (() => boolean) | undefined = undefined
+
+  private lastKeyDirection: 'forward' | 'backward' | '' = ''
+  private lastKeyAt: number = 0
+  private keyAccelerationLevel: number = 0
+  private static readonly KEY_ACCELERATION_WINDOW_MS: number = 1000
+  private static readonly KEY_STEP_MS: number = 10000
+  private static readonly KEY_MAX_STEP_MS: number = 60000
 
   // ASS 解析结果缓存：相同 raw 文本不重复解析（#17 AC）
   private _lastRawText: string = ''
@@ -70,6 +78,40 @@ export struct VideoPlayer {
 
   private resetInitMode(): void {
     this.initMode = ''
+  }
+
+  private handleKeySeek(direction: 'forward' | 'backward'): void {
+    const now = Date.now()
+    if (direction === this.lastKeyDirection && now - this.lastKeyAt <= VideoPlayer.KEY_ACCELERATION_WINDOW_MS) {
+      this.keyAccelerationLevel = Math.min(this.keyAccelerationLevel + 1, 5)
+    } else {
+      this.keyAccelerationLevel = 0
+    }
+    this.lastKeyDirection = direction
+    this.lastKeyAt = now
+    const stepMs = Math.min(
+      VideoPlayer.KEY_STEP_MS * (this.keyAccelerationLevel + 1),
+      VideoPlayer.KEY_MAX_STEP_MS
+    )
+    if (direction === 'forward') {
+      this.controller.forward(stepMs)
+    } else {
+      this.controller.backward(stepMs)
+    }
+    this.controlsDialogController.open()
+  }
+
+  private handleRemoteKey(event: KeyEvent): void {
+    if (event.type !== KeyType.Down) {
+      return
+    }
+    if (event.keyCode === KeyCode.KEYCODE_DPAD_LEFT) {
+      this.handleKeySeek('backward')
+      event.stopPropagation()
+    } else if (event.keyCode === KeyCode.KEYCODE_DPAD_RIGHT) {
+      this.handleKeySeek('forward')
+      event.stopPropagation()
+    }
   }
 
   private isPlaybackCompletedState(): boolean {
@@ -488,16 +530,10 @@ export struct VideoPlayer {
             await this.controller.pause()
             this.controlsDialogController.open()
           })
-          .gesture(
-            SwipeGesture()
-              .onAction((event: SwipeGestureEvent) => {
-                if (!this.controlsOpened) {
-                  this.controlsDialogController.open()
-                } else {
-                  console.log('swipe direction: ' + JSON.stringify(event))
-                }
-              })
-          )
+          .focusable(true)
+          .onKeyEvent((event: KeyEvent) => {
+            this.handleRemoteKey(event)
+          })
           .width("100%")
           .height("100%")
           .renderFit(this.toRenderFit(this.aspectRatioMode))
@@ -553,16 +589,10 @@ export struct VideoPlayer {
             await this.controller.pause()
             this.controlsDialogController.open()
           })
-          .gesture(
-            SwipeGesture()
-              .onAction((event: SwipeGestureEvent) => {
-                if (!this.controlsOpened) {
-                  this.controlsDialogController.open()
-                } else {
-                  console.log('swipe direction: ' + JSON.stringify(event))
-                }
-              })
-          )
+          .focusable(true)
+          .onKeyEvent((event: KeyEvent) => {
+            this.handleRemoteKey(event)
+          })
           .width("100%")
           .height("100%")
           .renderFit(this.toRenderFit(this.aspectRatioMode))
@@ -588,6 +618,9 @@ export struct VideoPlayer {
 
   aboutToDisappear(): void {
     emitter.off(PlayerEvents.COMPLETED.eventId)
+    this.lastKeyDirection = ''
+    this.lastKeyAt = 0
+    this.keyAccelerationLevel = 0
   }
 
 }

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -111,6 +111,10 @@ export struct VideoPlayer {
     } else if (event.keyCode === KeyCode.KEYCODE_DPAD_RIGHT) {
       this.handleKeySeek('forward')
       event.stopPropagation()
+    } else if (event.keyCode === KeyCode.KEYCODE_DPAD_DOWN && !this.controlsOpened) {
+      // 播放中画面持有焦点时，向下键用于唤起播放控件。
+      this.controlsDialogController.open()
+      event.stopPropagation()
     }
   }
 
@@ -156,6 +160,9 @@ export struct VideoPlayer {
       onOpenSubtitleSelector: () => {
         this.controlsDialogController.close()
         this.subtitleSelectorDialogController.open()
+      },
+      onRemoteKey: (event: KeyEvent) => {
+        this.handleRemoteKey(event)
       }
     }),
     customStyle: true,
@@ -605,12 +612,20 @@ export struct VideoPlayer {
     .width('100%')
     .height('100%')
     .backgroundColor(Color.Black)
+    .focusable(true)
+    .id('videoPlayerRoot')
+    .onKeyEvent((event: KeyEvent) => {
+      this.handleRemoteKey(event)
+    })
   }
 
   aboutToAppear(): void {
     this.backendMode = this.controller.backend
     this.aspectRatioMode = this.controller.aspectRatioMode
     this.initMode = ''
+    setTimeout(() => {
+      focusControl.requestFocus('videoPlayerRoot')
+    }, 0)
     emitter.on(PlayerEvents.COMPLETED, () => {
         this.controlsDialogController.open()
     })

--- a/entry/src/main/ets/components/core/player/VideoPlayer.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayer.ets
@@ -38,6 +38,9 @@ export struct VideoPlayer {
   private static readonly KEY_ACCELERATION_WINDOW_MS: number = 1000
   private static readonly KEY_STEP_MS: number = 10000
   private static readonly KEY_MAX_STEP_MS: number = 60000
+  private static readonly AXIS_REPEAT_INTERVAL_MS: number = 250
+  private static readonly AXIS_DIRECTION_THRESHOLD: number = 0.01
+  private lastAxisSeekAt: number = 0
 
   // ASS 解析结果缓存：相同 raw 文本不重复解析（#17 AC）
   private _lastRawText: string = ''
@@ -80,6 +83,15 @@ export struct VideoPlayer {
     this.initMode = ''
   }
 
+  private showControls(): void {
+    if (this.controlsOpened) {
+      return
+    }
+    // 先置位，避免 Dialog 完成出现动画前的连续轴事件重复 open 并叠加遮罩。
+    this.controlsOpened = true
+    this.controlsDialogController.open()
+  }
+
   private handleKeySeek(direction: 'forward' | 'backward'): void {
     const now = Date.now()
     if (direction === this.lastKeyDirection && now - this.lastKeyAt <= VideoPlayer.KEY_ACCELERATION_WINDOW_MS) {
@@ -93,12 +105,13 @@ export struct VideoPlayer {
       VideoPlayer.KEY_STEP_MS * (this.keyAccelerationLevel + 1),
       VideoPlayer.KEY_MAX_STEP_MS
     )
+    console.info(`[VideoPlayer] 执行${direction === 'forward' ? '快进' : '快退'}: step=${stepMs} current=${this.controller.currentTime}`)
     if (direction === 'forward') {
       this.controller.forward(stepMs)
     } else {
       this.controller.backward(stepMs)
     }
-    this.controlsDialogController.open()
+    this.showControls()
   }
 
   private handleRemoteKey(event: KeyEvent): void {
@@ -113,9 +126,27 @@ export struct VideoPlayer {
       event.stopPropagation()
     } else if (event.keyCode === KeyCode.KEYCODE_DPAD_DOWN && !this.controlsOpened) {
       // 播放中画面持有焦点时，向下键用于唤起播放控件。
-      this.controlsDialogController.open()
+      this.showControls()
       event.stopPropagation()
     }
+  }
+
+  private handleRemoteAxis(event: AxisEvent): void {
+    if (event.action !== AxisAction.BEGIN && event.action !== AxisAction.UPDATE) {
+      return
+    }
+    const horizontal = event.getHorizontalAxisValue()
+    if (Math.abs(horizontal) <= VideoPlayer.AXIS_DIRECTION_THRESHOLD) {
+      return
+    }
+    const now = Date.now()
+    if (event.action === AxisAction.UPDATE &&
+      now - this.lastAxisSeekAt < VideoPlayer.AXIS_REPEAT_INTERVAL_MS) {
+      return
+    }
+    this.lastAxisSeekAt = now
+    // MateTV 的水平轴正值对应遥控器左键，负值对应右键。
+    this.handleKeySeek(horizontal > 0 ? 'backward' : 'forward')
   }
 
   private isPlaybackCompletedState(): boolean {
@@ -163,6 +194,9 @@ export struct VideoPlayer {
       },
       onRemoteKey: (event: KeyEvent) => {
         this.handleRemoteKey(event)
+      },
+      onRemoteAxis: (event: AxisEvent) => {
+        this.handleRemoteAxis(event)
       }
     }),
     customStyle: true,
@@ -537,9 +571,12 @@ export struct VideoPlayer {
             await this.controller.pause()
             this.controlsDialogController.open()
           })
-          .focusable(true)
+          .focusable(false)
           .onKeyEvent((event: KeyEvent) => {
             this.handleRemoteKey(event)
+          })
+          .onAxisEvent((event: AxisEvent) => {
+            this.handleRemoteAxis(event)
           })
           .width("100%")
           .height("100%")
@@ -596,9 +633,12 @@ export struct VideoPlayer {
             await this.controller.pause()
             this.controlsDialogController.open()
           })
-          .focusable(true)
+          .focusable(false)
           .onKeyEvent((event: KeyEvent) => {
             this.handleRemoteKey(event)
+          })
+          .onAxisEvent((event: AxisEvent) => {
+            this.handleRemoteAxis(event)
           })
           .width("100%")
           .height("100%")
@@ -617,6 +657,9 @@ export struct VideoPlayer {
     .onKeyEvent((event: KeyEvent) => {
       this.handleRemoteKey(event)
     })
+    .onAxisEvent((event: AxisEvent) => {
+      this.handleRemoteAxis(event)
+    })
   }
 
   aboutToAppear(): void {
@@ -625,7 +668,7 @@ export struct VideoPlayer {
     this.initMode = ''
     setTimeout(() => {
       focusControl.requestFocus('videoPlayerRoot')
-    }, 0)
+    }, 100)
     emitter.on(PlayerEvents.COMPLETED, () => {
         this.controlsDialogController.open()
     })
@@ -636,6 +679,7 @@ export struct VideoPlayer {
     this.lastKeyDirection = ''
     this.lastKeyAt = 0
     this.keyAccelerationLevel = 0
+    this.lastAxisSeekAt = 0
   }
 
 }

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -2112,11 +2112,13 @@ export class VideoPlayerController {
   }
 
   async forward(milliseconds: number): Promise<void> {
-    this.seek(this.currentTime + milliseconds);
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG, `[remote-seek] 快进: step=${milliseconds} current=${this.currentTime}`)
+    this.seek(this.currentTime + milliseconds)
   }
 
   async backward(milliseconds: number): Promise<void> {
-    this.seek(this.currentTime - milliseconds);
+    hilog.info(CommonConstants.LOG_DOMAIN, TAG, `[remote-seek] 快退: step=${milliseconds} current=${this.currentTime}`)
+    this.seek(this.currentTime - milliseconds)
   }
 
   // ─── 字幕定时器 ───

--- a/entry/src/main/ets/components/core/player/VideoPlayerController.ets
+++ b/entry/src/main/ets/components/core/player/VideoPlayerController.ets
@@ -905,6 +905,10 @@ export class VideoPlayerController {
       if (currentSessionId !== this.playbackSessionId) {
         return;
       }
+      // seek 完成前底层仍可能上报旧播放位置，不能覆盖界面上的乐观目标进度。
+      if (this.isSeeking) {
+        return;
+      }
       const backwardDelta = this.lastTimeUpdateMs - currentTime;
       const shouldWarnRollback = this.lastTimeUpdateMs >= 0 &&
         !this.isSeeking &&
@@ -1034,7 +1038,7 @@ export class VideoPlayerController {
         }
         this.player?.seek(this.timeToSeek);
         this.timeToSeek = -1;
-        this.isSeeking = false;
+        // 队列中的最新目标仍在 seek，等待下一次 onSeekDone 后再恢复播放。
         return;
       }
       const shouldContinuePendingReadyAfterSeek = this.resumeSession.trackInitAfterSeek;


### PR DESCRIPTION
## 背景

TV 播放器此前无法稳定响应遥控器左右方向键，且华为智慧屏会将长按方向键主要作为 AxisEvent 投递，导致常规 KeyEvent 处理无效。连续定位时还存在控件遮罩重复叠加和旧播放位置回调引发进度条来回跳动的问题。

## 实现

- 同时支持 KeyEvent 与 AxisEvent，兼容不同 TV 遥控器输入方式。
- 左键快退、右键快进；同方向连续输入时步长从 10 秒逐步加速至 60 秒。
- 定位时自动显示播放控件，并刷新自动隐藏计时，确保长按期间控件持续可见。
- 统一控件打开状态，避免 Dialog 动画期间重复打开造成遮罩叠加。
- 连续 seek 期间忽略底层旧时间回调，并在最终 seek 完成前保持定位状态，避免进度条回跳。

## 验证

- `git diff --check` 通过。
- `devecocli build` 构建成功。
- 已在华为智慧屏 MateTV Pro（API 24）安装并启动验证。
- 已验证左右方向、10-60 秒加速、控件持续显示、遮罩不叠加及连续定位进度稳定。

## 风险

不同 TV 设备可能采用不同的遥控器事件投递方式，因此保留 KeyEvent 兼容路径，并为智慧屏补充 AxisEvent 处理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持使用遥控器左右按键及水平轴进行快进、快退，并提供连续加速操作。
  * 按下遥控器向下键可唤起播放控制栏，播放页面会自动获取焦点。
  * 优化遥控器事件传递，提升播放器控件的交互体验。

* **问题修复**
  * 修复连续拖动或跳转时播放进度显示被旧位置覆盖的问题。
  * 优化连续快进、快退操作，确保播放进度与操作结果保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->