### PR TITLE
修复 Jellyfin 剧集横图加载失败

### DIFF
--- a/entry/src/main/ets/lib/JellyfinClient.ets
+++ b/entry/src/main/ets/lib/JellyfinClient.ets
@@ -842,13 +842,17 @@ export class JellyfinClient {
     if (backdropTags !== undefined && backdropTags.length > 0) {
       backdropUrl = `${this.buildBaseUrl()}/Items/${id}/Images/Backdrop?maxWidth=1280&quality=90&tag=${backdropTags[0]}&api_key=${token}`;
     }
+    if (isEpisode && backdropUrl.length === 0) {
+      const parentBackdropId = String(item['ParentBackdropItemId'] ?? '');
+      const parentBackdropTags = item['ParentBackdropImageTags'] as Array<string> | undefined;
+      if (parentBackdropId.length > 0 && parentBackdropTags !== undefined && parentBackdropTags.length > 0) {
+        backdropUrl = `${this.buildBaseUrl()}/Items/${parentBackdropId}/Images/Backdrop?fillWidth=700&fillHeight=394&quality=96&tag=${parentBackdropTags[0]}&api_key=${token}`;
+      }
+    }
     if (isEpisode && backdropUrl.length === 0 && seriesId.length > 0) {
-      // 16:9 缩略图：用剧集的 Thumb（与 Jellyfin Web 的继续观看/接下来一致）
       const seriesThumbTag = item['SeriesThumbImageTag'];
       if (typeof seriesThumbTag === 'string' && seriesThumbTag.length > 0) {
         backdropUrl = `${this.buildBaseUrl()}/Items/${seriesId}/Images/Thumb?fillWidth=700&fillHeight=394&quality=96&tag=${seriesThumbTag}&api_key=${token}`;
-      } else {
-        backdropUrl = `${this.buildBaseUrl()}/Items/${seriesId}/Images/Thumb?fillWidth=700&fillHeight=394&quality=96&api_key=${token}`;
       }
     }
 


### PR DESCRIPTION
## 背景

Jellyfin 媒体库首页的“继续观看”和“接下来”中，部分剧集卡片会显示为空白。相关 JPEG 日志只是硬件解码不可用后的软件回退提示，实际原因是客户端在剧集缺少自身 Backdrop 时请求了不存在的系列 Thumb。

## 修改内容

- 剧集没有自身 Backdrop 时，使用配对的 `ParentBackdropItemId` 和 `ParentBackdropImageTags` 加载父级横图。
- 仅在 `SeriesThumbImageTag` 有效时请求系列 Thumb，避免构造必然失败的无 tag 图片地址。
- 保留现有海报作为最终回退，形成“条目 Backdrop -> 父级 Backdrop -> 有效系列 Thumb -> 海报”的选择顺序。

## 验证

- `git diff --check` 通过。
- `devecocli build --modules entry@default` 构建成功，日志包含 `BUILD SUCCESSFUL`。
- signed HAP 已安装并启动至华为智慧屏 MateTV Pro。
- 真机截图确认“继续观看”和“接下来”中的问题剧集横图均恢复显示。
- 验证期间未发现相关 Jellyfin 图片加载失败或 JPEG 解码错误日志。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化剧集背景图显示：当剧集缺少直接背景图时，优先使用父级条目的背景图。
  - 改进背景图回退顺序，确保父级背景图不可用时再使用剧集缩略图。
  - 避免生成缺少必要标签的无效图片地址。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->