### PR TITLE
修复 Jellyfin 选集重复及跨季混排

### DIFF
--- a/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
+++ b/entry/src/main/ets/components/core/player/EpisodeListPanel.ets
@@ -127,8 +127,15 @@ export function buildEpisodeAnchorRanges(totalCount: number): EpisodeAnchorRange
   return result
 }
 
-export function buildEpisodeContinuousListItems(items: PlaybackContextItem[]): PlaybackContextItem[] {
-  return items
+export function buildEpisodeContinuousListItems(items: PlaybackContextItem[], currentIndex: number = -1): PlaybackContextItem[] {
+  if (currentIndex < 0 || currentIndex >= items.length) {
+    return items
+  }
+  const currentSeasonNumber = items[currentIndex].seasonNumber
+  if (currentSeasonNumber === undefined) {
+    return items
+  }
+  return items.filter((item: PlaybackContextItem): boolean => item.seasonNumber === currentSeasonNumber)
 }
 
 export function getEpisodeItemRenderKey(item: PlaybackContextItem): string {
@@ -261,9 +268,9 @@ export struct EpisodeListPanel {
   private waveTimerId: number | undefined = undefined
 
   aboutToAppear(): void {
-    const currentIdx = this.context.currentIndex
-    this.focusedCardIndex = Math.max(0, Math.min(currentIdx, this.context.items.length - 1))
-    this.pageBarFocusedIndex = getEpisodeAnchorIndexForItem(currentIdx, this.context.items.length)
+    const currentIdx = this.getCurrentListIndex()
+    this.focusedCardIndex = Math.max(0, Math.min(currentIdx, this.getListItems().length - 1))
+    this.pageBarFocusedIndex = getEpisodeAnchorIndexForItem(currentIdx, this.getListItems().length)
     this.startWaveAnimation()
   }
 
@@ -274,7 +281,7 @@ export struct EpisodeListPanel {
   // ── 数据辅助方法 ───────────────────────────────────────────────────────────
 
   private getAnchorRanges(): EpisodeAnchorRange[] {
-    return buildEpisodeAnchorRanges(this.context.items.length)
+    return buildEpisodeAnchorRanges(this.getListItems().length)
   }
 
   private getTotalAnchors(): number {
@@ -282,28 +289,37 @@ export struct EpisodeListPanel {
   }
 
   private getListItems(): PlaybackContextItem[] {
-    return buildEpisodeContinuousListItems(this.context.items)
+    return buildEpisodeContinuousListItems(this.context.items, this.context.currentIndex)
+  }
+
+  private getCurrentListIndex(): number {
+    const items = this.getListItems()
+    if (this.context.currentIndex < 0 || this.context.currentIndex >= this.context.items.length) {
+      return -1
+    }
+    const currentItem = this.context.items[this.context.currentIndex]
+    return items.indexOf(currentItem)
   }
 
   private scrollToAnchor(groupIndex: number): void {
-    if (this.context.items.length === 0) {
+    if (this.getListItems().length === 0) {
       return
     }
     const total = this.getTotalAnchors()
     if (groupIndex < 0 || groupIndex >= total) {
       return
     }
-    const request = buildEpisodeAnchorScrollRequest(groupIndex, this.context.items.length)
+    const request = buildEpisodeAnchorScrollRequest(groupIndex, this.getListItems().length)
     this.scroller.scrollToIndex(request.index, request.smooth, request.align)
     this.focusedCardIndex = request.index
     this.pageBarFocusedIndex = groupIndex
   }
 
   private scrollToCurrentItem(): void {
-    if (this.context.items.length === 0) {
+    if (this.getListItems().length === 0) {
       return
     }
-    const request = buildEpisodeInitialScrollRequest(this.context.currentIndex, this.context.items.length)
+    const request = buildEpisodeInitialScrollRequest(this.getCurrentListIndex(), this.getListItems().length)
     this.scroller.scrollToIndex(request.index, request.smooth, request.align)
   }
 
@@ -316,7 +332,10 @@ export struct EpisodeListPanel {
   }
 
   private isCurrentItem(item: PlaybackContextItem): boolean {
-    return item.index === this.context.currentIndex
+    if (this.context.currentIndex < 0 || this.context.currentIndex >= this.context.items.length) {
+      return false
+    }
+    return item === this.context.items[this.context.currentIndex]
   }
 
   private buildAnchorIndexRange(): number[] {
@@ -339,7 +358,7 @@ export struct EpisodeListPanel {
   private getPageTabStyleState(pageIdx: number): EpisodePageTabStyleState {
     return getEpisodePageTabStyleState(
       this.isPageBarFocused && this.pageBarFocusedIndex === pageIdx,
-      getEpisodeAnchorIndexForItem(this.context.currentIndex, this.context.items.length) === pageIdx,
+      getEpisodeAnchorIndexForItem(this.getCurrentListIndex(), this.getListItems().length) === pageIdx,
       this.hoveredPageBarIndex === pageIdx
     )
   }

--- a/entry/src/main/ets/utils/ServerEpisodePlaybackContextUtil.ets
+++ b/entry/src/main/ets/utils/ServerEpisodePlaybackContextUtil.ets
@@ -32,9 +32,15 @@ export async function buildServerEpisodeContextFromCatalog(serverType: VideoServ
   }
   const seasons = await client.getSeasons(seriesId);
   const episodes: VideoServerEpisode[] = [];
+  const episodeIds: Set<string> = new Set();
   for (let index: number = 0; index < seasons.length; index += 1) {
     const seasonEpisodes = await client.getEpisodes(seriesId, seasons[index].id);
-    seasonEpisodes.forEach((episode: VideoServerEpisode) => episodes.push(episode));
+    seasonEpisodes.forEach((episode: VideoServerEpisode) => {
+      if (episode.id.length > 0 && !episodeIds.has(episode.id)) {
+        episodeIds.add(episode.id);
+        episodes.push(episode);
+      }
+    });
   }
   const result: ServerBuildItemsResult = buildServerPlaybackItems(
     serverType, serverId, seriesId, episodes, currentItemId);

--- a/entry/src/test/EpisodeListPanel.test.ets
+++ b/entry/src/test/EpisodeListPanel.test.ets
@@ -47,6 +47,29 @@ export default function EpisodeListPanelTest() {
       expect(listItems[14].episodeNumber).assertEqual(15)
     })
 
+    it('服务器剧集仅展示当前播放项所在季且保留原始条目引用', 0, () => {
+      const items: PlaybackContextItem[] = [
+        { videoPath: 's1e1', title: 'S1E1', index: 0, seasonNumber: 1, episodeNumber: 1 },
+        { videoPath: 's1e2', title: 'S1E2', index: 1, seasonNumber: 1, episodeNumber: 2 },
+        { videoPath: 's2e1', title: 'S2E1', index: 2, seasonNumber: 2, episodeNumber: 1 }
+      ]
+
+      const listItems: PlaybackContextItem[] = buildEpisodeContinuousListItems(items, 2)
+
+      expect(listItems.length).assertEqual(1)
+      expect(listItems[0] === items[2]).assertTrue()
+      expect(listItems[0].episodeNumber).assertEqual(1)
+    })
+
+    it('文件列表条目没有季号时仍展示完整上下文', 0, () => {
+      const items: PlaybackContextItem[] = makeItems(8)
+
+      const listItems: PlaybackContextItem[] = buildEpisodeContinuousListItems(items, 3)
+
+      expect(listItems.length).assertEqual(8)
+      expect(listItems[3] === items[3]).assertTrue()
+    })
+
     it('连续列表渲染 key 使用全局唯一值，滚动后不复用局部索引', 0, () => {
       const items: PlaybackContextItem[] = makeItems(15)
 

--- a/entry/src/test/ets/ServerEpisodePlaybackContextUtilTest.ets
+++ b/entry/src/test/ets/ServerEpisodePlaybackContextUtilTest.ets
@@ -101,6 +101,26 @@ export default function serverEpisodePlaybackContextUtilTest() {
       }
     });
 
+    it('跨季返回相同 episode id 时保序去重且当前项定位正确', 0, async () => {
+      const client = buildTwoSeasonCatalog();
+      client.episodesBySeasonId.set('season-2', [
+        makeEpisode('jf-s1e1', 0, 1),
+        makeEpisode('jf-s2e1', 2, 1)
+      ]);
+
+      const context = await buildServerEpisodeContextFromCatalog(
+        VideoServerType.JELLYFIN, 11, 'series-1', 'jf-s2e1', client);
+
+      expect(context !== null).assertTrue();
+      if (context !== null) {
+        expect(context.items.length).assertEqual(3);
+        expect(context.currentIndex).assertEqual(2);
+        expect((context.items[0] as ServerPlaybackContextItem).serverItemId).assertEqual('jf-s1e1');
+        expect((context.items[1] as ServerPlaybackContextItem).serverItemId).assertEqual('jf-s1e2');
+        expect((context.items[2] as ServerPlaybackContextItem).serverItemId).assertEqual('jf-s2e1');
+      }
+    });
+
     it('当前项不在目录返回的集列表中时返回 null（安全退化单集播放）', 0, async () => {
       const context = await buildServerEpisodeContextFromCatalog(
         VideoServerType.EMBY, 3, 'series-1', 'missing-item', buildTwoSeasonCatalog());


### PR DESCRIPTION
## 背景

Jellyfin 部分剧集目录会在不同季返回相同 episode，导致播放器选集出现同一集重复；全剧上下文直接展示时，跨季相同集号也难以区分。

## 改动

- 构建服务器剧集播放上下文时按非空 episode ID 保序去重，保留首次出现的条目。
- 选集面板仅展示当前播放项所在季，并将焦点、锚点、滚动和当前项判断统一到过滤后的局部列表。
- 保留全剧播放上下文，因此跨季自动连播行为不变；无季号的文件列表仍展示完整上下文。
- 增加跨季重复 ID、当前季过滤及文件列表兼容性的聚焦测试。

## 验证

- `assembleHap`：通过，日志包含 `BUILD SUCCESSFUL`。
- `UnitTestBuild`：通过，日志包含 `BUILD SUCCESSFUL`。
- 新增的 3 个设备端测试均通过。
- TV 模拟器 `Huawei_TV_6_1_1` 构建、安装及启动成功。
- 全量设备端测试仍有 1 个与本次改动无关的既有 `PlayerPage` 标题断言失败。
- 仓库未配置独立 lint/format 命令；`git diff --check` 通过。

Fixes: #305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 播放剧集列表现在会优先展示当前播放剧集所在季的内容，并保持播放定位与滚动状态准确。
  - 无季号的内容仍会展示完整列表。

- **问题修复**
  - 跨季剧集列表会自动去除重复或无效剧集，避免重复播放项并确保当前剧集定位正确。

- **测试**
  - 新增针对分季筛选、无季号内容及跨季重复剧集处理的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->