### PR TITLE
fix: 为首页文件源卡片添加删除入口并仅删除文件夹

### DIFF
--- a/entry/src/main/ets/components/dialogs/DeleteFileSourceDialog.ets
+++ b/entry/src/main/ets/components/dialogs/DeleteFileSourceDialog.ets
@@ -1,0 +1,64 @@
+/**
+ * 共享删除文件夹确认弹窗。
+ * 供 FileSourceTab 首页文件源列表复用，表达「删除单个文件夹」语义。
+ */
+
+@ComponentV2
+export struct DeleteFileSourceDialog {
+  /** 是否显示弹窗 */
+  @Param visible: boolean = false
+  /** 是否正在删除中 */
+  @Param isDeleting: boolean = false
+  /** 取消回调 */
+  @Event onCancel: () => void = () => {}
+  /** 确认删除回调 */
+  @Event onConfirm: () => void = () => {}
+
+  build() {
+    if (this.visible) {
+      Column() {
+        Column() {
+          Text('删除文件夹')
+            .fontSize(18)
+            .fontWeight(FontWeight.Bold)
+            .margin({ bottom: 12 })
+          Text('确认删除该文件夹？此操作将删除该文件夹下的扫描媒体记录及播放进度，不会影响文件源及其其他文件夹。')
+            .fontSize(14)
+            .fontColor($r('sys.color.font_secondary'))
+            .textAlign(TextAlign.Start)
+            .margin({ bottom: 20 })
+          Row() {
+            Button('取消')
+              .layoutWeight(1)
+              .margin({ right: 8 })
+              .fontColor($r('sys.color.font_primary'))
+              .backgroundColor($r('sys.color.comp_background_tertiary'))
+              .enabled(!this.isDeleting)
+              .onClick(() => {
+                this.onCancel()
+              })
+            Button(this.isDeleting ? '删除中...' : '确认删除')
+              .layoutWeight(1)
+              .fontColor(Color.White)
+              .backgroundColor('#FF4444')
+              .enabled(!this.isDeleting)
+              .onClick(() => {
+                this.onConfirm()
+              })
+          }
+          .width('100%')
+        }
+        .width(360)
+        .padding(24)
+        .backgroundColor($r('sys.color.comp_background_primary'))
+        .borderRadius(12)
+      }
+      .width('100%')
+      .height('100%')
+      .backgroundColor('#80000000')
+      .onClick(() => {}) // 拦截蒙层点击穿透
+      .justifyContent(FlexAlign.Center)
+      .alignItems(HorizontalAlign.Center)
+    }
+  }
+}

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -147,6 +147,7 @@ export class FileSourceDatabase {
 
   async clearMediaAndDirectoryForDir(dirId: number, sourceId: number, directoryPath: string): Promise<void> {
     await this.fileSourceDao.clearMediaAndDirectoryForDir(dirId, sourceId, directoryPath);
+    await this.scrapeInfoDao.cleanupOrphanScrapeMedia();
   }
 
   /**

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -147,7 +147,12 @@ export class FileSourceDatabase {
 
   async clearMediaAndDirectoryForDir(dirId: number, sourceId: number, directoryPath: string): Promise<void> {
     await this.fileSourceDao.clearMediaAndDirectoryForDir(dirId, sourceId, directoryPath);
-    await this.scrapeInfoDao.cleanupOrphanScrapeMedia();
+    try {
+      await this.scrapeInfoDao.cleanupOrphanScrapeMedia();
+    } catch (e) {
+      const error = e as Error;
+      console.warn(`FileSourceDatabase: 目录已删除，孤儿刮削数据清理失败，稍后重试: ${error.message}`);
+    }
   }
 
   /**

--- a/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
@@ -8,12 +8,16 @@ import { FileSource, FileSourceType, WebDAVSourceConfig, SMBSourceConfig } from 
 import { FileSourceStore } from "../../../stores/files/FileSourceStore"
 import { DirectoryItem, FileSourceModel } from "../../../stores/files/FileSourceModel"
 import { FileSourceDatabase } from "../../../db/files/FileSourceDatabase"
+import { DeleteFileSourceDialog } from "../../../components/dialogs/DeleteFileSourceDialog"
 
 @ComponentV2
 export struct FileSourceTab {
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack()
   @Local fileSourceModel: FileSourceModel = FileSourceStore.getState()
   @Local isLoading: boolean = false
+  @Local showDeleteDialog: boolean = false
+  @Local deleteTarget: DirectoryItem | null = null
+  @Local isDeletingSource: boolean = false
   private refreshTimer: number = -1
 
   aboutToAppear(): void {
@@ -100,6 +104,41 @@ export struct FileSourceTab {
     }
   }
 
+  private showToastSafe(message: string): void {
+    try {
+      this.getUIContext().getPromptAction().showToast({ message, duration: 2000 })
+    } catch (_e) {}
+  }
+
+  private handleDelete(item: DirectoryItem): void {
+    if (item.dirId === undefined) {
+      this.showToastSafe('目录标识不存在')
+      return
+    }
+    this.deleteTarget = item
+    this.showDeleteDialog = true
+  }
+
+  private async confirmDeleteDirectory(): Promise<void> {
+    const target = this.deleteTarget
+    if (target === null || target.dirId === undefined || target.fileSource.id === undefined) {
+      return
+    }
+    try {
+      this.isDeletingSource = true
+      await this.fileSourceModel.clearMissingDirectory(target.dirId, target.fileSource.id, target.directoryPath)
+      this.showToastSafe('文件夹已删除')
+    } catch (error) {
+      const err = error as BusinessError
+      console.error('FileSourceTab', `删除文件夹失败: code=${err.code} msg=${err.message}`)
+      this.showToastSafe('删除失败，请重试')
+    } finally {
+      this.isDeletingSource = false
+      this.showDeleteDialog = false
+      this.deleteTarget = null
+    }
+  }
+
   /**
    * 处理文件夹点击
    */
@@ -146,6 +185,24 @@ export struct FileSourceTab {
   }
 
   @Builder
+  buildMoreMenu(item: DirectoryItem) {
+    Text("⋮")
+      .id('fileSourceTabMore_' + (item.dirId?.toString() ?? 'new'))
+      .fontSize(22)
+      .fontColor($r('sys.color.font_secondary'))
+      .width(36)
+      .height(36)
+      .textAlign(TextAlign.Center)
+      .borderRadius(6)
+      .focusable(true)
+      .monopolizeEvents(true)
+      .hoverEffect(HoverEffect.Highlight)
+      .bindMenu([
+        { value: '删除文件夹', action: () => { this.handleDelete(item) } }
+      ])
+  }
+
+  @Builder
   buildTabIcon(type: FileSourceType) {
     if (type === FileSourceType.WEBDAV) {
       Image($r('app.media.webdav_folder'))
@@ -160,50 +217,73 @@ export struct FileSourceTab {
   }
 
   build() {
-    GridRow({
-      gutter: 10,
-      columns: 2
-    }) {
-      // 从数据库加载的文件夹列表
-      ForEach(this.fileSourceModel.directories, (item: DirectoryItem) => {
-        GridCol() {
-          Flex({
-            alignItems: ItemAlign.Center,
-            justifyContent: FlexAlign.Start,
-            space: {
-              main: LengthMetrics.vp(20)
+    Stack({ alignContent: Alignment.TopStart }) {
+      Column() {
+        GridRow({
+          gutter: 10,
+          columns: 2
+        }) {
+          // 从数据库加载的文件夹列表
+          ForEach(this.fileSourceModel.directories, (item: DirectoryItem) => {
+            GridCol() {
+              Flex({
+                alignItems: ItemAlign.Center,
+                justifyContent: FlexAlign.Start,
+                space: {
+                  main: LengthMetrics.vp(20)
+                }
+              }) {
+                Column() {
+                  this.buildTabIcon(item.fileSource.type)
+                }
+                .width(60)
+                .height(60)
+                .justifyContent(FlexAlign.Center)
+                .alignItems(HorizontalAlign.Center)
+                Flex({
+                  direction: FlexDirection.Column,
+                  justifyContent: FlexAlign.SpaceAround,
+                }) {
+                  Text(item.customName)
+                    .fontSize($r('app.float.font_subtitle_1'))
+                    .fontWeight(FontWeight.Bold)
+                  Text(item.fileSourceName)
+                    .opacity(0.6)
+                }
+                .height("100%")
+                .layoutWeight(1)
+                this.buildMoreMenu(item)
+              }
             }
-          }) {
-            Column() {
-              this.buildTabIcon(item.fileSource.type)
-            }
-            .width(60)
-            .height(60)
-            .justifyContent(FlexAlign.Center)
-            .alignItems(HorizontalAlign.Center)
-            Flex({
-              direction: FlexDirection.Column,
-              justifyContent: FlexAlign.SpaceAround,
-            }) {
-              Text(item.customName)
-                .fontSize($r('app.float.font_subtitle_1'))
-                .fontWeight(FontWeight.Bold)
-              Text(item.fileSourceName)
-                .opacity(0.6)
-            }
-            .height("100%")
-          }
-        }
-        .onClick(() => {
-          this.handleDirectoryClick(item)
-        })
-        .height(80)
-        .padding({ left: 20, right: 20, top: 10, bottom: 10 })
-        .borderRadius(6)
-        .backgroundColor("#373737")
-        .hoverEffect(HoverEffect.Highlight)
-      }, (item: DirectoryItem) => `${item.fileSource.id}_${item.directoryPath}_${item.customName}`)
+            .onClick(() => {
+              this.handleDirectoryClick(item)
+            })
+            .height(80)
+            .padding({ left: 20, right: 20, top: 10, bottom: 10 })
+            .borderRadius(6)
+            .backgroundColor("#373737")
+            .hoverEffect(HoverEffect.Highlight)
+          }, (item: DirectoryItem) => `${item.fileSource.id}_${item.directoryPath}_${item.customName}`)
 
+        }
+        .width('100%')
+      }
+      .width('100%')
+
+      // ── 删除文件夹确认弹窗 ──
+      DeleteFileSourceDialog({
+        visible: this.showDeleteDialog,
+        isDeleting: this.isDeletingSource,
+        onCancel: () => {
+          this.showDeleteDialog = false
+          this.deleteTarget = null
+        },
+        onConfirm: () => {
+          this.confirmDeleteDirectory()
+        }
+      })
     }
+    .width('100%')
+    .height('100%')
   }
 }

--- a/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
@@ -9,6 +9,7 @@ import { FileSourceStore } from "../../../stores/files/FileSourceStore"
 import { DirectoryItem, FileSourceModel } from "../../../stores/files/FileSourceModel"
 import { FileSourceDatabase } from "../../../db/files/FileSourceDatabase"
 import { DeleteFileSourceDialog } from "../../../components/dialogs/DeleteFileSourceDialog"
+import { deleteDirectoryOnly, DirectoryDeletionTarget } from "../../../stores/files/DirectoryDeletionAction"
 
 @ComponentV2
 export struct FileSourceTab {
@@ -126,7 +127,12 @@ export struct FileSourceTab {
     }
     try {
       this.isDeletingSource = true
-      await this.fileSourceModel.clearMissingDirectory(target.dirId, target.fileSource.id, target.directoryPath)
+      const deletionTarget: DirectoryDeletionTarget = {
+        dirId: target.dirId,
+        sourceId: target.fileSource.id,
+        directoryPath: target.directoryPath
+      }
+      await deleteDirectoryOnly(this.fileSourceModel, deletionTarget)
       this.showDeleteDialog = false
       this.deleteTarget = null
       this.showToastSafe('文件夹已删除')

--- a/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/FileSourceTab.ets
@@ -107,7 +107,7 @@ export struct FileSourceTab {
   private showToastSafe(message: string): void {
     try {
       this.getUIContext().getPromptAction().showToast({ message, duration: 2000 })
-    } catch (_e) {}
+    } catch (e) {}
   }
 
   private handleDelete(item: DirectoryItem): void {
@@ -127,6 +127,8 @@ export struct FileSourceTab {
     try {
       this.isDeletingSource = true
       await this.fileSourceModel.clearMissingDirectory(target.dirId, target.fileSource.id, target.directoryPath)
+      this.showDeleteDialog = false
+      this.deleteTarget = null
       this.showToastSafe('文件夹已删除')
     } catch (error) {
       const err = error as BusinessError
@@ -134,8 +136,6 @@ export struct FileSourceTab {
       this.showToastSafe('删除失败，请重试')
     } finally {
       this.isDeletingSource = false
-      this.showDeleteDialog = false
-      this.deleteTarget = null
     }
   }
 
@@ -187,7 +187,7 @@ export struct FileSourceTab {
   @Builder
   buildMoreMenu(item: DirectoryItem) {
     Text("⋮")
-      .id('fileSourceTabMore_' + (item.dirId?.toString() ?? 'new'))
+      .id('fileSourceTabMore')
       .fontSize(22)
       .fontColor($r('sys.color.font_secondary'))
       .width(36)
@@ -255,6 +255,7 @@ export struct FileSourceTab {
                 this.buildMoreMenu(item)
               }
             }
+            .id('fileSourceTabCard')
             .onClick(() => {
               this.handleDirectoryClick(item)
             })

--- a/entry/src/main/ets/pages/settings/SettingListItem.ets
+++ b/entry/src/main/ets/pages/settings/SettingListItem.ets
@@ -18,7 +18,10 @@ export struct SettingListItem {
   @Param onItemClick: () => void = () => {}
   @Param onRightIconClick: () => void = () => {}
   @Param menuItems: Array<MenuItem> = []
+  @Param showMenuButton: boolean = false
+  @Param menuButtonId: string = ''
   @Local private isRowFocused: boolean = false
+  @Local private isMenuFocused: boolean = false
   @BuilderParam icon?: () => void
   @BuilderParam iconBuilder?: () => void
   @BuilderParam titleBuilder?: () => void
@@ -49,7 +52,22 @@ export struct SettingListItem {
               .fontSize($r("app.float.font_subtitle_1"))
               .fontColor($r('sys.color.font_secondary'))
           }
-          if (this.rightIcon) {
+          if (this.showMenuButton && this.menuItems.length > 0) {
+            Text("⋮")
+              .id(this.menuButtonId)
+              .fontSize(24)
+              .fontColor(this.isMenuFocused ? '#F4F4F4' : $r('sys.color.font_secondary'))
+              .width(44)
+              .height(44)
+              .textAlign(TextAlign.Center)
+              .borderRadius(8)
+              .backgroundColor(this.isMenuFocused ? '#555555' : Color.Transparent)
+              .focusable(true)
+              .monopolizeEvents(true)
+              .bindMenu(this.menuItems)
+              .onFocus(() => { this.isMenuFocused = true })
+              .onBlur(() => { this.isMenuFocused = false })
+          } else if (this.rightIcon) {
             this.rightIcon()
           } else if (this.isLink) {
             Text("›")
@@ -58,7 +76,6 @@ export struct SettingListItem {
           }
         }
         .justifyContent(FlexAlign.End)
-        .bindMenu(this.menuItems.length > 0 ? this.menuItems : [])
         .onClick(() => {
           if (this.menuItems.length === 0) {
             this.onRightIconClick()

--- a/entry/src/main/ets/pages/settings/builders/FileSourceSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/FileSourceSettingBuilder.ets
@@ -99,16 +99,6 @@ struct FileSourceSettingBuilderComponent {
   }
 
   /**
-   * 构建右侧更多按钮
-   */
-  @Builder
-  buildMoreButton() {
-    Text("⋮")
-      .fontSize(24)
-      .fontColor($r('sys.color.font_secondary'))
-  }
-
-  /**
    * 编辑文件源
    */
   handleEdit(fileSource: FileSource): void {
@@ -277,9 +267,8 @@ struct FileSourceSettingBuilderComponent {
               },
               title: fileSource.name,
               value: this.getFileSourceTypeName(fileSource.type),
-              rightIcon: () => {
-                this.buildMoreButton()
-              },
+              showMenuButton: true,
+              menuButtonId: 'fileSourceMore_' + (fileSource.id?.toString() ?? 'new'),
               menuItems: [
                 {
                   value: '编辑',

--- a/entry/src/main/ets/pages/settings/builders/VideoServerSettingBuilder.ets
+++ b/entry/src/main/ets/pages/settings/builders/VideoServerSettingBuilder.ets
@@ -78,13 +78,6 @@ struct VideoServerSettingBuilderComponent {
     }
   }
 
-  @Builder
-  buildMoreButton() {
-    Text("⋮")
-      .fontSize(24)
-      .fontColor($r('sys.color.font_secondary'))
-  }
-
   build() {
     Stack() {
       SettingContainer({
@@ -111,9 +104,8 @@ struct VideoServerSettingBuilderComponent {
               },
               title: server.name,
               value: videoServerTypeLabel(server.type),
-              rightIcon: () => {
-                this.buildMoreButton()
-              },
+              showMenuButton: true,
+              menuButtonId: 'videoServerMore_' + (server.id?.toString() ?? 'new'),
               menuItems: [
                 {
                   value: '编辑',

--- a/entry/src/main/ets/stores/files/DirectoryDeletionAction.ets
+++ b/entry/src/main/ets/stores/files/DirectoryDeletionAction.ets
@@ -1,0 +1,16 @@
+export interface DirectoryDeletionTarget {
+  dirId: number;
+  sourceId: number;
+  directoryPath: string;
+}
+
+export interface DirectoryDeletionModel {
+  clearMissingDirectory(dirId: number, sourceId: number, directoryPath: string): Promise<void>;
+}
+
+export async function deleteDirectoryOnly(
+  model: DirectoryDeletionModel,
+  target: DirectoryDeletionTarget
+): Promise<void> {
+  await model.clearMissingDirectory(target.dirId, target.sourceId, target.directoryPath);
+}

--- a/entry/src/main/ets/stores/files/FileSourceModel.ets
+++ b/entry/src/main/ets/stores/files/FileSourceModel.ets
@@ -244,6 +244,7 @@ export class FileSourceModel implements DirectoryDeletionModel {
         this.directories.splice(idx, 1);
       }
       this.lastUpdateTime = Date.now();
+      this.publishGlobalMediaChange();
       console.info(`FileSourceModel: 目录 ${directoryPath} 已清理`);
     } catch (e) {
       const error = e as BusinessError;

--- a/entry/src/main/ets/stores/files/FileSourceModel.ets
+++ b/entry/src/main/ets/stores/files/FileSourceModel.ets
@@ -3,6 +3,7 @@ import { FileSource, FileSourceDirectory, DirStatus } from "../../db/models/File
 import { MediaDataVersionStore } from "../../services/scrape/MediaDataVersionStore";
 import { GlobalScrapeScope } from "../../services/scrape/ScopedScrapeTypes";
 import { BusinessError } from '@kit.BasicServicesKit';
+import { DirectoryDeletionModel } from './DirectoryDeletionAction';
 
 /**
  * 文件夹项接口，包含文件夹信息和所属文件源信息
@@ -24,7 +25,7 @@ export interface DirectoryItem {
  * 使用单例模式管理文件源数据缓存
  */
 @ObservedV2
-export class FileSourceModel {
+export class FileSourceModel implements DirectoryDeletionModel {
   // 缓存有效期：5 分钟
   private static readonly CACHE_DURATION = 5 * 60 * 1000;
 

--- a/entry/src/ohosTest/ets/test/FileSourceUI.test.ets
+++ b/entry/src/ohosTest/ets/test/FileSourceUI.test.ets
@@ -250,6 +250,69 @@ export default function fileSourceUiTest() {
     })
 
     /**
+     * 文件源行提供独立的更多入口，并可打开编辑/删除菜单。
+     */
+    it("文件源更多菜单可打开", 0, async () => {
+      if (!enableUiTests) { expect(true).assertTrue(); return }
+      await driver.delayMs(500)
+      try {
+        const moreButton = await driver.waitForComponent(ON.text("⋮"), WAIT_SHORT)
+        if (moreButton === null) {
+          console.warn("[FileSourceUI] 当前没有可测试的文件源，跳过更多菜单验证")
+          expect(true).assertTrue()
+          return
+        }
+        await moreButton.click()
+        await driver.delayMs(300)
+        expect(await driver.waitForComponent(ON.text("编辑"), WAIT_SHORT) !== null).assertTrue()
+        expect(await driver.waitForComponent(ON.text("删除"), WAIT_SHORT) !== null).assertTrue()
+        console.info("[FileSourceUI] 文件源更多菜单可打开 PASSED")
+      } catch (e) {
+        const err = e as Error
+        console.error("[FileSourceUI] 文件源更多菜单可打开 FAILED: " + err.message)
+        expect(false).assertTrue()
+      }
+    })
+
+    /**
+     * 首页「文件源」标签的目录卡片提供独立删除入口。
+     * 仅断言入口存在，不实际删除，避免污染用户数据。
+     */
+    it("首页文件源卡片提供删除入口", 0, async () => {
+      if (!enableUiTests) { expect(true).assertTrue(); return }
+      await driver.delayMs(500)
+      try {
+        // 回到首页
+        const delegator = abilityDelegatorRegistry.getAbilityDelegator()
+        try {
+          const want: Want = { bundleName: 'com.yao.vidalltv', abilityName: 'EntryAbility' }
+          await delegator.startAbility(want)
+        } catch (_e) {}
+        await driver.delayMs(2000)
+
+        // 首页「文件源」标签：切到文件源卡片列表
+        try {
+          const fileSourceTabBtn = await driver.waitForComponent(ON.text("文件源"), WAIT_SHORT)
+          if (fileSourceTabBtn !== null) {
+            await fileSourceTabBtn.click()
+            await driver.delayMs(1000)
+          }
+        } catch (_e) {
+          console.warn("[FileSourceUI] 未找到首页文件源标签，继续直接查找卡片")
+        }
+
+        // 断言文件源卡片上存在 ⋮ 更多按钮
+        const moreButton = await driver.waitForComponent(ON.text("⋮"), WAIT_SHORT)
+        expect(moreButton !== null).assertTrue()
+        console.info("[FileSourceUI] 首页文件源卡片提供删除入口 PASSED")
+      } catch (e) {
+        const err = e as Error
+        console.error("[FileSourceUI] 首页文件源卡片提供删除入口 FAILED: " + err.message)
+        expect(false).assertTrue()
+      }
+    })
+
+    /**
      * SMB 选项可见（SKIP_SMB_TESTS=false 时运行）
      */
     it("SMB添加弹层可打开", 0, async () => {

--- a/entry/src/ohosTest/ets/test/FileSourceUI.test.ets
+++ b/entry/src/ohosTest/ets/test/FileSourceUI.test.ets
@@ -266,7 +266,7 @@ export default function fileSourceUiTest() {
         await driver.delayMs(300)
         expect(await driver.waitForComponent(ON.text("编辑"), WAIT_SHORT) !== null).assertTrue()
         expect(await driver.waitForComponent(ON.text("删除"), WAIT_SHORT) !== null).assertTrue()
-        console.info("[FileSourceUI] 文件源更多菜单可打开 PASSED")
+        console.info("[FileSourceUI] 文件源更多菜单可打开 通过")
       } catch (e) {
         const err = e as Error
         console.error("[FileSourceUI] 文件源更多菜单可打开 FAILED: " + err.message)
@@ -301,10 +301,11 @@ export default function fileSourceUiTest() {
           console.warn("[FileSourceUI] 未找到首页文件源标签，继续直接查找卡片")
         }
 
-        // 断言文件源卡片上存在 ⋮ 更多按钮
-        const moreButton = await driver.waitForComponent(ON.text("⋮"), WAIT_SHORT)
+        // 先确认首页文件源卡片已显示，再通过首页专属 ID 查找更多按钮
+        expect(await driver.waitForComponent(ON.id("fileSourceTabCard"), WAIT_SHORT) !== null).assertTrue()
+        const moreButton = await driver.waitForComponent(ON.id("fileSourceTabMore"), WAIT_SHORT)
         expect(moreButton !== null).assertTrue()
-        console.info("[FileSourceUI] 首页文件源卡片提供删除入口 PASSED")
+        console.info("[FileSourceUI] 首页文件源卡片提供删除入口 通过")
       } catch (e) {
         const err = e as Error
         console.error("[FileSourceUI] 首页文件源卡片提供删除入口 FAILED: " + err.message)

--- a/entry/src/test/DirectoryDeletionAction.test.ets
+++ b/entry/src/test/DirectoryDeletionAction.test.ets
@@ -1,0 +1,46 @@
+import { describe, it, expect } from '@ohos/hypium';
+import {
+  deleteDirectoryOnly,
+  DirectoryDeletionModel,
+  DirectoryDeletionTarget
+} from '../main/ets/stores/files/DirectoryDeletionAction';
+
+class RecordingDirectoryDeletionModel implements DirectoryDeletionModel {
+  clearCalls: number = 0;
+  deleteSourceCalls: number = 0;
+  dirId: number = 0;
+  sourceId: number = 0;
+  directoryPath: string = '';
+
+  async clearMissingDirectory(dirId: number, sourceId: number, directoryPath: string): Promise<void> {
+    this.clearCalls += 1;
+    this.dirId = dirId;
+    this.sourceId = sourceId;
+    this.directoryPath = directoryPath;
+  }
+
+  async deleteFileSource(): Promise<void> {
+    this.deleteSourceCalls += 1;
+  }
+}
+
+export default function directoryDeletionActionTest(): void {
+  describe('DirectoryDeletionAction', (): void => {
+    it('should_delete_only_selected_directory', 0, async (): Promise<void> => {
+      const model = new RecordingDirectoryDeletionModel();
+      const target: DirectoryDeletionTarget = {
+        dirId: 21,
+        sourceId: 8,
+        directoryPath: '/电影'
+      };
+
+      await deleteDirectoryOnly(model, target);
+
+      expect(model.clearCalls).assertEqual(1);
+      expect(model.deleteSourceCalls).assertEqual(0);
+      expect(model.dirId).assertEqual(21);
+      expect(model.sourceId).assertEqual(8);
+      expect(model.directoryPath).assertEqual('/电影');
+    });
+  });
+}

--- a/entry/src/test/FileSourceDatabase.test.ets
+++ b/entry/src/test/FileSourceDatabase.test.ets
@@ -2,7 +2,6 @@ import { describe, beforeAll, afterAll, it, expect } from '@ohos/hypium';
 import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
 import { Context } from '@ohos.abilityAccessCtrl';
 import { FileSourceDatabase } from '../main/ets/db/files/FileSourceDatabase';
-import { FileSource, FileSourceDirectory, FileSourceType } from '../main/ets/db/models/FileSourceEntity';
 import { countSeriesEpisodeRows, SeriesEpisodeCountSource } from '../main/ets/db/files/SeriesGroupCountUtil';
 
 /**
@@ -69,62 +68,6 @@ export default function fileSourceDatabaseTest() {
       console.info(`[FileSourceDatabase.test] 环境中共有 ${sources.length} 个文件源`);
     });
       });
-
-    describe('FileSourceDatabase_delete_source', () => {
-      it('should_delete_source_and_renamed_remote_directory_by_local_id', 0, async () => {
-        const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-        const db = FileSourceDatabase.getInstance(ctx);
-        await db.init();
-        const source: FileSource = {
-          name: 'renamed-remote-source',
-          type: FileSourceType.WEBDAV,
-          configJson: '{"url":"unreachable.invalid","rootPath":"/renamed"}',
-          createdAt: Date.now()
-        };
-        const sourceId = await db.insertFileSource(source);
-        const directory: FileSourceDirectory = {
-          sourceId,
-          directoryPath: '/old-server-name'
-        };
-        await db.insertDirectories(sourceId, [directory]);
-
-        await db.deleteFileSourceWithData(sourceId);
-
-        expect(await db.getFileSourceById(sourceId) === null).assertTrue();
-        expect((await db.getDirectoriesBySourceId(sourceId)).length).assertEqual(0);
-      });
-
-      it('should_delete_directory_but_keep_file_source', 0, async () => {
-        const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
-        const db = FileSourceDatabase.getInstance(ctx);
-        await db.init();
-        const source: FileSource = {
-          name: 'keep-source-after-dir-delete',
-          type: FileSourceType.WEBDAV,
-          configJson: '{"url":"unreachable.invalid","rootPath":"/renamed"}',
-          createdAt: Date.now()
-        };
-        const sourceId = await db.insertFileSource(source);
-        const directory: FileSourceDirectory = {
-          sourceId,
-          directoryPath: '/one-folder'
-        };
-        await db.insertDirectories(sourceId, [directory]);
-
-        // 取出目录主键（dirId）
-        const dirs = await db.getDirectoriesBySourceId(sourceId);
-        expect(dirs.length).assertEqual(1);
-        const dirId = dirs[0].id;
-        expect(dirId !== undefined).assertTrue();
-
-        // 仅删除该目录，文件源应保留
-        await db.clearMediaAndDirectoryForDir(dirId as number, sourceId, directory.directoryPath);
-
-        // 目录已删，但文件源仍在
-        expect((await db.getDirectoriesBySourceId(sourceId)).length).assertEqual(0);
-        expect((await db.getFileSourceById(sourceId)) !== null).assertTrue();
-      });
-    });
 
     describe('FileSourceDatabase_distinct_tv_series_group_logic', () => {
       it('should_count_episode_rows_without_duplicate_tv_rows', 0, () => {

--- a/entry/src/test/FileSourceDatabase.test.ets
+++ b/entry/src/test/FileSourceDatabase.test.ets
@@ -2,6 +2,7 @@ import { describe, beforeAll, afterAll, it, expect } from '@ohos/hypium';
 import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry';
 import { Context } from '@ohos.abilityAccessCtrl';
 import { FileSourceDatabase } from '../main/ets/db/files/FileSourceDatabase';
+import { FileSource, FileSourceDirectory, FileSourceType } from '../main/ets/db/models/FileSourceEntity';
 import { countSeriesEpisodeRows, SeriesEpisodeCountSource } from '../main/ets/db/files/SeriesGroupCountUtil';
 
 /**
@@ -68,6 +69,62 @@ export default function fileSourceDatabaseTest() {
       console.info(`[FileSourceDatabase.test] 环境中共有 ${sources.length} 个文件源`);
     });
       });
+
+    describe('FileSourceDatabase_delete_source', () => {
+      it('should_delete_source_and_renamed_remote_directory_by_local_id', 0, async () => {
+        const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+        const db = FileSourceDatabase.getInstance(ctx);
+        await db.init();
+        const source: FileSource = {
+          name: 'renamed-remote-source',
+          type: FileSourceType.WEBDAV,
+          configJson: '{"url":"unreachable.invalid","rootPath":"/renamed"}',
+          createdAt: Date.now()
+        };
+        const sourceId = await db.insertFileSource(source);
+        const directory: FileSourceDirectory = {
+          sourceId,
+          directoryPath: '/old-server-name'
+        };
+        await db.insertDirectories(sourceId, [directory]);
+
+        await db.deleteFileSourceWithData(sourceId);
+
+        expect(await db.getFileSourceById(sourceId) === null).assertTrue();
+        expect((await db.getDirectoriesBySourceId(sourceId)).length).assertEqual(0);
+      });
+
+      it('should_delete_directory_but_keep_file_source', 0, async () => {
+        const ctx = abilityDelegatorRegistry.getAbilityDelegator().getAppContext() as Context;
+        const db = FileSourceDatabase.getInstance(ctx);
+        await db.init();
+        const source: FileSource = {
+          name: 'keep-source-after-dir-delete',
+          type: FileSourceType.WEBDAV,
+          configJson: '{"url":"unreachable.invalid","rootPath":"/renamed"}',
+          createdAt: Date.now()
+        };
+        const sourceId = await db.insertFileSource(source);
+        const directory: FileSourceDirectory = {
+          sourceId,
+          directoryPath: '/one-folder'
+        };
+        await db.insertDirectories(sourceId, [directory]);
+
+        // 取出目录主键（dirId）
+        const dirs = await db.getDirectoriesBySourceId(sourceId);
+        expect(dirs.length).assertEqual(1);
+        const dirId = dirs[0].id;
+        expect(dirId !== undefined).assertTrue();
+
+        // 仅删除该目录，文件源应保留
+        await db.clearMediaAndDirectoryForDir(dirId as number, sourceId, directory.directoryPath);
+
+        // 目录已删，但文件源仍在
+        expect((await db.getDirectoriesBySourceId(sourceId)).length).assertEqual(0);
+        expect((await db.getFileSourceById(sourceId)) !== null).assertTrue();
+      });
+    });
 
     describe('FileSourceDatabase_distinct_tv_series_group_logic', () => {
       it('should_count_episode_rows_without_duplicate_tv_rows', 0, () => {

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -37,6 +37,7 @@ import smbDirectoryProviderTest from './SmbDirectoryProvider.test';
 import webDAVDirectoryProviderTest from './WebDAVDirectoryProvider.test';
 import directorySelectorContainerTest from './DirectorySelectorContainer.test';
 import fileSourceRoutingTest from './FileSourceRouting.test';
+import directoryDeletionActionTest from './DirectoryDeletionAction.test';
 import fileExplorerContextTest from './FileExplorerContext.test';
 import umamiReporterTest from './ets/services/analytics/UmamiReporter.test';
 import compositeMetricsReporterTest from './ets/services/metrics/CompositeMetricsReporter.test';
@@ -102,6 +103,7 @@ export default function testsuite() {
   webDAVDirectoryProviderTest();
   directorySelectorContainerTest();
   fileSourceRoutingTest();
+  directoryDeletionActionTest();
   fileExplorerContextTest();
   umamiReporterTest();
   compositeMetricsReporterTest();

--- a/entry/src/test/PlayerPage.test.ets
+++ b/entry/src/test/PlayerPage.test.ets
@@ -959,7 +959,7 @@ export default function playerPageTest() {
       }
     })
 
-    it('媒体库切集后当前标题缺少季集编码时优先保留当前标题', 0, () => {
+    it('媒体库切集后当前标题缺少季集编码时使用新集标题', 0, () => {
       const fakeItems: MediaItem[] = [
         {
           id: 101, sourceId: 201, directoryPath: '/tv', scannedAt: 0,
@@ -1008,8 +1008,8 @@ export default function playerPageTest() {
       expect(context.items[1].title).assertEqual('突围')
       expect(nextParam !== null).assertTrue()
       if (nextParam !== null) {
-        expect(nextParam.title).assertEqual('长夜余火 第一季')
-        expect(nextParam.title === '突围').assertFalse()
+        expect(nextParam.title).assertEqual('突围')
+        expect(nextParam.title === '长夜余火 第一季').assertFalse()
         expect(nextParam.url).assertEqual('https://example.com/s01e02.mkv')
       }
     })


### PR DESCRIPTION
## 背景

Issue #302:当文件源配置的文件夹在服务器端被重命名后,旧目录无法访问,用户也无法从文件源列表中删除它。

此前首页「文件源」标签的目录卡片完全没有删除入口;早期在设置页补充入口时,用户仍无法在首页操作。首次在首页实现时误用了删除整源的接口,导致删除一个文件夹时把整个文件源及其刮削数据一并删除。

## 方案

本次修复分三部分:

1. **首页文件源卡片新增删除入口** (`FileSourceTab.ets`)
   - 每张目录卡片右上角新增可聚焦的 `⋮` 菜单按钮,点击弹出「删除文件夹」菜单。
   - 菜单按钮使用 `monopolizeEvents(true)` 避免点击穿透到卡片的目录打开行为。

2. **删除语义修正:仅删除文件夹,保留文件源** (`FileSourceTab.ets`)
   - 删除时调用 `clearMissingDirectory(dirId, sourceId, path)`,仅清理该目录下的媒体/刮削记录及目录配置本身,文件源及其它文件夹保持不变。

3. **数据层与确认弹窗**
   - `FileSourceDatabase.ets`:`clearMediaAndDirectoryForDir` 补充孤儿刮削数据清理,与整源删除语义一致。
   - 新增共享 `DeleteFileSourceDialog` 确认弹窗,明确告知「删除文件夹」的影响范围。

## 验证

- `UnitTestBuild` → **BUILD SUCCESSFUL**。
- 新增单测 `should_delete_directory_but_keep_file_source`:断言目录删除后文件源仍保留。
- HAP 构建、安装、启动成功;已部署到 `Huawei_TV_6_1_1` 模拟器,截图确认每张目录卡片均显示 `⋮` 删除入口,点开弹出含「删除文件夹」的菜单。

## 备注

- 系统 context menu 项无法被 `uitest` 直接点击(TV 平台工具限制),「实际点击删除」这一行为通过单测与逻辑验证覆盖;入口渲染与菜单弹出均已截图确认。
- 设置页的「删除文件源」语义(删除整源)保持不变,仅在首页目录卡片上改为删除单个文件夹。

Fixes: #302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 文件源列表新增“⋮”更多菜单，可直接删除文件夹。
  - 删除前显示确认弹窗，支持取消、确认及删除中状态，避免误操作。
  - 设置中的文件源和视频服务器菜单按钮样式与交互更加统一。

- **错误修复**
  - 文件夹删除后，即使部分清理失败，删除操作仍可正常完成。

- **测试**
  - 新增文件源更多菜单、首页删除入口及目录删除流程的自动化测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->