### PR TITLE
优化: 弱语义文件名刮削时用父目录片名兜底

### DIFF
--- a/entry/src/main/ets/lib/MediaTypeClassifier.ets
+++ b/entry/src/main/ets/lib/MediaTypeClassifier.ets
@@ -41,6 +41,8 @@ export interface MediaTypeClassificationResult {
   mediaType: MediaTypeClassification;
   signals: MediaTypeClassificationSignal[];
   reason?: string;
+  /** 弱语义文件名场景下由父目录名兜底出的片名标题，供刮削层作为搜索词 */
+  fallbackTitle?: string;
 }
 
 interface PathSemanticKeywordRule {
@@ -409,6 +411,39 @@ function appendSignal(
   signals.push(signal);
 }
 
+/** 影片附属目录等不宜当作片名搜索的通用目录名（已归一化） */
+const GENERIC_DIRECTORY_TITLE_TOKENS: Set<string> = new Set([
+  'extras', 'extra', 'trailers', 'trailer', 'featurettes', 'featurette',
+  'samples', 'sample', 'behind the scenes', 'bonus', 'specials'
+]);
+
+/**
+ * 弱语义文件名场景下，从父目录名解析可用的兜底片名标题。
+ * 父目录若本身提供了路径语义信号（如"电影合集"）、自身弱语义、或属于影片附属通用目录，则不可用。
+ */
+function resolveParentDirectoryFallbackTitle(
+  input: MediaTypeClassificationInput,
+  pathSignalValues: Set<string>
+): string | undefined {
+  if (input.parentDirectoryName === undefined) {
+    return undefined;
+  }
+  const trimmed = input.parentDirectoryName.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  if (pathSignalValues.has(input.parentDirectoryName)) {
+    return undefined;
+  }
+  if (isWeakSemanticTitleText(trimmed)) {
+    return undefined;
+  }
+  if (GENERIC_DIRECTORY_TITLE_TOKENS.has(normalizeSemanticToken(trimmed))) {
+    return undefined;
+  }
+  return trimmed;
+}
+
 export function buildMediaTypeClassificationInput(
   fileName: string,
   filePath: string,
@@ -572,6 +607,22 @@ export function classifyMediaType(input: MediaTypeClassificationInput): MediaTyp
       60
     );
     return createMediaTypeClassificationResult('tv', signals, 'season-sibling-detected');
+  }
+
+  // 弱语义文件名（如"4K.mp4"）自身无标题证据：若路径存在纯 movie 证据且父目录名是可读片名
+  // （如"穿普拉达的女王2/4K.mp4"），以父目录名兜底判为 movie，刮削层用它替代文件名发起搜索。
+  if (hasWeakSemanticTitle && movieScore > 0 && tvScore === 0) {
+    const pathSignalValues = new Set<string>();
+    pathMatches.forEach((match: PathSemanticSignalMatch) => {
+      pathSignalValues.add(match.signal.value);
+    });
+    const fallbackTitle = resolveParentDirectoryFallbackTitle(input, pathSignalValues);
+    if (fallbackTitle !== undefined) {
+      appendSignal(signals, 'parent-directory', fallbackTitle, 'weak-filename-parent-title-fallback', 60);
+      const result = createMediaTypeClassificationResult('movie', signals, 'weak-filename-parent-directory-fallback');
+      result.fallbackTitle = fallbackTitle;
+      return result;
+    }
   }
 
   return createMediaTypeClassificationResult('unknown', signals, 'insufficient-evidence');

--- a/entry/src/main/ets/lib/MediaTypeClassifier.ets
+++ b/entry/src/main/ets/lib/MediaTypeClassifier.ets
@@ -419,7 +419,8 @@ const GENERIC_DIRECTORY_TITLE_TOKENS: Set<string> = new Set([
 
 /**
  * 弱语义文件名场景下，从父目录名解析可用的兜底片名标题。
- * 父目录若本身提供了路径语义信号（如"电影合集"）、自身弱语义、或属于影片附属通用目录，则不可用。
+ * 父目录若本身提供了路径语义信号（如"电影合集"）、自身弱语义、属于影片附属通用目录、
+ * 或本身是季目录段（如"长剧第二季"，实为剧集集数文件），则不可用。
  */
 function resolveParentDirectoryFallbackTitle(
   input: MediaTypeClassificationInput,
@@ -436,6 +437,10 @@ function resolveParentDirectoryFallbackTitle(
     return undefined;
   }
   if (isWeakSemanticTitleText(trimmed)) {
+    return undefined;
+  }
+  if (isSeasonDirectorySegment(trimmed)) {
+    // "长剧第二季"这类季目录段下放的多是剧集集数文件，父目录名不能当电影片名搜索。
     return undefined;
   }
   if (GENERIC_DIRECTORY_TITLE_TOKENS.has(normalizeSemanticToken(trimmed))) {

--- a/entry/src/main/ets/lib/ScrapeClient.ets
+++ b/entry/src/main/ets/lib/ScrapeClient.ets
@@ -239,10 +239,14 @@ export function resolveMovieSearchTerms(parsed: ParsedFileName, overrideTitle?: 
   let title = parsed.title;
   let year = parsed.year;
   if (overrideTitle !== undefined && overrideTitle.trim().length > 0) {
-    const overridden = parseFileName(overrideTitle);
-    title = overridden.title.length > 0 ? overridden.title : overrideTitle.trim();
-    if (overridden.year !== undefined) {
-      year = overridden.year;
+    const normalizedOverrideTitle = overrideTitle.trim();
+    const overridden = parseFileName(normalizedOverrideTitle);
+    title = overridden.title.length > 0 ? overridden.title : normalizedOverrideTitle;
+    // parseFileName 会把无扩展名标题末尾的 ".2021" 当扩展名截断导致年份丢失，
+    // 此时改用 extractSearchYear 从原始兜底标题直接提取年份（如 "Dune.2021" → 2021）。
+    const overrideYear = overridden.year ?? extractSearchYear(normalizedOverrideTitle);
+    if (overrideYear !== undefined) {
+      year = overrideYear;
     }
   }
   const terms: MovieSearchTerms = { title, year };

--- a/entry/src/main/ets/lib/ScrapeClient.ets
+++ b/entry/src/main/ets/lib/ScrapeClient.ets
@@ -227,6 +227,29 @@ export function buildSearchTitles(title: string): string[] {
 }
 
 /**
+ * 解析电影搜索词：默认取文件名解析结果；传入兜底标题（如父目录片名，可含年份）时以其替代，
+ * 并复用 parseFileName 从兜底标题中提取干净标题与年份（如"穿普拉达的女王2 (2011)"）。
+ */
+interface MovieSearchTerms {
+  title: string;
+  year?: number;
+}
+
+export function resolveMovieSearchTerms(parsed: ParsedFileName, overrideTitle?: string): MovieSearchTerms {
+  let title = parsed.title;
+  let year = parsed.year;
+  if (overrideTitle !== undefined && overrideTitle.trim().length > 0) {
+    const overridden = parseFileName(overrideTitle);
+    title = overridden.title.length > 0 ? overridden.title : overrideTitle.trim();
+    if (overridden.year !== undefined) {
+      year = overridden.year;
+    }
+  }
+  const terms: MovieSearchTerms = { title, year };
+  return terms;
+}
+
+/**
  * 从刮削结果 rawJson 中提取 IMDb ID（格式 tt + 数字）。
  * 电影详情 rawJson 直接含 `imdb_id`；剧集详情含 `external_ids.imdb_id`。
  * 解析失败或缺失返回空字符串。
@@ -833,16 +856,17 @@ export class ScrapeClient {
   }
 
   /** 搜索电影候选，按文件名解析出的标题优先级合并去重。 */
-  async searchMovieCandidates(fileName: string): Promise<MovieScrapeResult[]> {
+  async searchMovieCandidates(fileName: string, overrideTitle?: string): Promise<MovieScrapeResult[]> {
     const parsed = parseFileName(fileName);
+    const searchTerms = resolveMovieSearchTerms(parsed, overrideTitle);
     const merged: MovieScrapeResult[] = [];
     const seen = new Set<string>();
     await this.acquire();
     try {
       for (const provider of this.getActiveProviders()) {
-        for (const title of buildSearchTitles(parsed.title)) {
+        for (const title of buildSearchTitles(searchTerms.title)) {
           try {
-            const results = await provider.searchMovie(title, parsed.year, 'zh-CN');
+            const results = await provider.searchMovie(title, searchTerms.year, 'zh-CN');
             for (const result of results) {
               const key = `${result.provider}:${result.providerId}`;
               if (!seen.has(key)) {
@@ -929,16 +953,20 @@ export class ScrapeClient {
     }
   }
 
-  /** 搜索电影，返回第一个命中的详情 */
-  async autoScrapeMovie(fileName: string): Promise<MovieScrapeResult | null> {
+  /** 搜索电影，返回第一个命中的详情
+   * @param overrideTitle 可选，兜底搜索标题。弱语义文件名（如"4K.mp4"）场景下由分类器提供的父目录片名，
+   * 传入后以该标题（可含年份）替代文件名解析结果发起 TMDB 搜索。
+   */
+  async autoScrapeMovie(fileName: string, overrideTitle?: string): Promise<MovieScrapeResult | null> {
     const parsed = parseFileName(fileName);
+    const searchTerms = resolveMovieSearchTerms(parsed, overrideTitle);
     await this.acquire();
     try {
       for (const provider of this.getActiveProviders()) {
         try {
-          const searchTitles = buildSearchTitles(parsed.title);
+          const searchTitles = buildSearchTitles(searchTerms.title);
           for (const candidate of searchTitles) {
-            const results = await provider.searchMovie(candidate, parsed.year, 'zh-CN');
+            const results = await provider.searchMovie(candidate, searchTerms.year, 'zh-CN');
             if (results.length > 0) {
               console.info(`[ScrapeClient] autoScrapeMovie 命中候选标题="${candidate}" providerId=${results[0].providerId}`);
               return await provider.fetchMovieDetail(results[0].providerId, 'zh-CN');

--- a/entry/src/main/ets/services/scrape/ScopedScrapeService.ets
+++ b/entry/src/main/ets/services/scrape/ScopedScrapeService.ets
@@ -53,6 +53,8 @@ interface ScrapeMediaGroup {
   targets: ScopedScrapeVideo[];
   searchFileName: string;
   seriesHint?: string;
+  /** 弱语义文件名场景下由分类器提供的父目录片名兜底标题 */
+  fallbackTitle?: string;
 }
 
 export interface ScopedScrapeExecutor {
@@ -350,7 +352,8 @@ export class ScopedScrapeService implements ScopedScrapeExecutor {
           mediaType: classification.mediaType,
           targets: [target],
           searchFileName: video.fileName,
-          seriesHint
+          seriesHint,
+          fallbackTitle: classification.fallbackTitle
         };
         groups.push(group);
         groupMap.set(key, group);
@@ -361,7 +364,7 @@ export class ScopedScrapeService implements ScopedScrapeExecutor {
 
   private async searchCandidates(client: ScrapeClient, group: ScrapeMediaGroup): Promise<ScrapeCandidate[]> {
     if (group.mediaType === 'movie') {
-      const results = await client.searchMovieCandidates(group.searchFileName);
+      const results = await client.searchMovieCandidates(group.searchFileName, group.fallbackTitle);
       return results.map((result: MovieScrapeResult): ScrapeCandidate => this.movieCandidate(result));
     }
     if (group.mediaType === 'tv') {

--- a/entry/src/main/ets/utils/VideoScrapeProcessor.ets
+++ b/entry/src/main/ets/utils/VideoScrapeProcessor.ets
@@ -223,7 +223,10 @@ export async function processVideoScrape(
 
   if (classification.mediaType === 'movie') {
     try {
-      const movie = await scrapeClient.autoScrapeMovie(fileName);
+      if (classification.fallbackTitle !== undefined) {
+        console.info(`${logPrefix} 文件名弱语义，使用父目录片名兜底搜索 fallbackTitle="${classification.fallbackTitle}"`);
+      }
+      const movie = await scrapeClient.autoScrapeMovie(fileName, classification.fallbackTitle);
       if (!movie) {
         console.warn(`${logPrefix} 电影刮削无结果 ${fileName}`);
         return { success: false, category: FAILURE_CATEGORY_NO_MATCH };

--- a/entry/src/test/MediaTypeClassifierContract.test.ets
+++ b/entry/src/test/MediaTypeClassifierContract.test.ets
@@ -38,6 +38,13 @@ const weakSemanticRegressionSamples: WeakSemanticRegressionSample[] = [
     expectedMediaType: 'movie'
   },
   {
+    name: '弱语义电影样本：父目录片名可兜底为 movie',
+    fileName: '4K.mp4',
+    filePath: '/Videos/Movies/穿普拉达的女王2/4K.mp4',
+    expectedMediaType: 'movie',
+    expectedReason: 'weak-filename-parent-directory-fallback'
+  },
+  {
     name: '弱语义 unknown 样本：无足够路径线索时保持保守',
     fileName: '22 4K.mp4',
     filePath: '/下载/未整理/22 4K.mp4',
@@ -176,6 +183,25 @@ export default function mediaTypeClassifierContractTest() {
       expect(explicitFalseClassification.reason).assertEqual('insufficient-evidence');
       expect(omittedClassification.mediaType).assertEqual('unknown');
       expect(omittedClassification.reason).assertEqual('insufficient-evidence');
+    });
+
+    it('should fall back to parent directory title for weak filename under movie path', 0, () => {
+      const classification = classifyVideoScrapeTarget(
+        '4K.mp4',
+        '/Videos/Movies/穿普拉达的女王2/4K.mp4'
+      );
+
+      expect(classification.mediaType).assertEqual('movie');
+      expect(classification.reason).assertEqual('weak-filename-parent-directory-fallback');
+      expect(classification.fallbackTitle).assertEqual('穿普拉达的女王2');
+    });
+
+    it('should keep weak filename unknown when parent directory is a generic movie keyword segment', 0, () => {
+      const classification = classifyVideoScrapeTarget('4K.mp4', '/电影合集/4K.mp4');
+
+      expect(classification.mediaType).assertEqual('unknown');
+      expect(classification.reason).assertEqual('insufficient-evidence');
+      expect(classification.fallbackTitle).assertUndefined();
     });
 
     // ─── #254 中文季号后缀目录名 ───

--- a/entry/src/test/MediaTypeClassifierContract.test.ets
+++ b/entry/src/test/MediaTypeClassifierContract.test.ets
@@ -12,7 +12,7 @@ import {
   stripSeasonSuffixFromDirectoryName,
   isSeasonDirectorySegment
 } from '../main/ets/lib/MediaTypeClassifier';
-import { parseFileName } from '../main/ets/lib/ScrapeClient';
+import { parseFileName, resolveMovieSearchTerms } from '../main/ets/lib/ScrapeClient';
 import { classifyVideoScrapeTarget } from '../main/ets/utils/VideoScannerHelpers';
 
 interface WeakSemanticRegressionSample {
@@ -185,7 +185,7 @@ export default function mediaTypeClassifierContractTest() {
       expect(omittedClassification.reason).assertEqual('insufficient-evidence');
     });
 
-    it('should fall back to parent directory title for weak filename under movie path', 0, () => {
+    it('电影路径下弱语义文件名用父目录片名兜底为 movie', 0, () => {
       const classification = classifyVideoScrapeTarget(
         '4K.mp4',
         '/Videos/Movies/穿普拉达的女王2/4K.mp4'
@@ -196,12 +196,31 @@ export default function mediaTypeClassifierContractTest() {
       expect(classification.fallbackTitle).assertEqual('穿普拉达的女王2');
     });
 
-    it('should keep weak filename unknown when parent directory is a generic movie keyword segment', 0, () => {
+    it('父目录为通用电影关键词段时弱语义文件名保持 unknown', 0, () => {
       const classification = classifyVideoScrapeTarget('4K.mp4', '/电影合集/4K.mp4');
 
       expect(classification.mediaType).assertEqual('unknown');
       expect(classification.reason).assertEqual('insufficient-evidence');
       expect(classification.fallbackTitle).assertUndefined();
+    });
+
+    it('父目录为季目录段时弱语义文件名不兜底为 movie', 0, () => {
+      const classification = classifyVideoScrapeTarget(
+        '4K.mp4',
+        '/电影/长剧第二季/4K.mp4'
+      );
+
+      expect(classification.mediaType).assertEqual('unknown');
+      expect(classification.reason).assertEqual('insufficient-evidence');
+      expect(classification.fallbackTitle).assertUndefined();
+    });
+
+    it('兜底标题末尾形如 .2021 的年份不被当扩展名丢失', 0, () => {
+      const parsed = parseFileName('4K.mp4');
+      const terms = resolveMovieSearchTerms(parsed, 'Dune.2021');
+
+      expect(terms.title).assertEqual('Dune');
+      expect(terms.year).assertEqual(2021);
     });
 
     // ─── #254 中文季号后缀目录名 ───


### PR DESCRIPTION
## 背景

`/Videos/Movies/穿普拉达的女王2/4K.mp4` 无法刮削出元数据。经模拟器实测定位根因：文件名为 `4K.mp4` 这类弱语义名称，分类器判定 unknown 后直接跳过刮削，TMDB 零请求。目录名本身已能表达片名，应当可以被利用。

## 方案

在 `classifyMediaType` 尾部新增兜底分支：当文件名弱语义、路径存在 movie 证据（movieScore > 0）且 tvScore = 0 时，取父目录名作为兜底标题判为 movie，并将该标题经 `fallbackTitle` 透传到刮削阶段；`autoScrapeMovie` 新增 overrideTitle 参数作为 TMDB 搜索词（复用 parseFileName 提取干净标题与年份，兼容"穿普拉达的女王2 (2011)"式目录名）。

防误判守卫（重点审查项）：

- season-sibling 电视剧分支在前：`/电影/庆余年第二季/4K.mp4` 仍判 tv
- 仅 tvScore = 0 才兜底：`/下载/未整理/01.mkv` 等通用目录场景不受影响
- 父目录名本身是路径信号值（如"电影合集"直接命中关键词）时不兜底，保持 unknown（与 openspec 既有规格一致）
- Extras / trailers / bonus 等通用附属目录名进黑名单，防误搜

## 验证

- 契约测试新增 2 个用例：`/Videos/Movies/穿普拉达的女王2/4K.mp4` 兜底命中、`/电影合集/4K.mp4` 保持 unknown；既有回归样本（季数文件名、数字标题等）全部兼容
- `assembleHap` 构建通过（exit 0）
- 模拟器真机验证：覆盖重扫后日志显示「文件名弱语义，使用父目录片名兜底搜索 fallbackTitle="穿普拉达的女王2"」→ TMDB 命中 providerId=1314481 → 落库 `{type=movie, title=穿普拉达的女王2, rating=7.1, poster=Y}`，条目从 unknown 成功转为 movie

## 影响范围

仅影响"文件名弱语义 + 路径有明确 movie 证据"的场景；正常强语义文件名与电视剧目录行为不变。增量扫描对 unknown 条目会自动重试刮削，存量数据无需覆盖模式即可修复。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 改进弱语义视频文件名的识别：当电影目录名称包含具体片名时，可自动使用父目录名称进行分类和搜索。
  * 电影信息抓取支持使用父目录片名作为搜索标题，并保留年份等有效信息。

* **错误修复**
  * 减少 `4K.mp4` 等缺少有效片名的电影文件被误判或无法刮削的问题。
  * 对“电影合集”等通用目录名称保持谨慎，不进行错误分类。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->