### PR TITLE
修复模拟器 AGC 登录初始化与诊断

### DIFF
--- a/entry/src/main/ets/components/account/LoginDialog.ets
+++ b/entry/src/main/ets/components/account/LoginDialog.ets
@@ -2,6 +2,7 @@ import { LoginWithHuaweiIDButton, loginComponentManager } from '@kit.AccountKit'
 import { common } from '@kit.AbilityKit'
 import { BusinessError } from '@kit.BasicServicesKit'
 import { AccountService } from '../../services/account/AccountService'
+import { ERROR_AGC_NOT_INITIALIZED } from '../../services/account/AgcCloudAuthService'
 import { HuaweiAuthProvider } from '../../services/account/providers/HuaweiAuthProvider'
 import { AccountModel } from '../../stores/account/AccountModel'
 
@@ -44,12 +45,16 @@ export struct LoginDialog {
 
   private handleLoginError(error: Error): void {
     const businessError = error as BusinessError
+    console.warn(`[LoginDialog] 华为登录失败 code=${businessError.code ?? -1}`)
     if (businessError.code === 1001502012) {
       this.accountModel.setLoginError('已取消登录，你可以重新选择华为账号登录')
       return
     }
+    if (businessError.code === ERROR_AGC_NOT_INITIALIZED) {
+      this.accountModel.setLoginError('登录服务初始化失败，请重启应用后重试')
+      return
+    }
     this.accountModel.setLoginError('登录失败，请检查网络后重试')
-    console.warn(`[LoginDialog] 华为登录失败 code=${businessError.code ?? -1}`)
   }
 
   private getHuaweiController(): loginComponentManager.LoginWithHuaweiIDButtonController {

--- a/entry/src/main/ets/services/account/AgcCloudAuthService.ets
+++ b/entry/src/main/ets/services/account/AgcCloudAuthService.ets
@@ -5,11 +5,11 @@ import { hilog } from '@kit.PerformanceAnalysisKit';
 import buffer from '@ohos.buffer';
 import auth, { AuthUser, HwIdCredentialInfo, SignInParam } from '@hw-agconnect/auth';
 
-const AGC_CONFIG_FILE: string = 'agc_config.json';
+const AGC_CONFIG_FILE: string = 'agconnect-services.json';
 const CLOUD_DB_SCHEMA_FILE: string = 'schema.json';
 const LOG_DOMAIN: number = 0x0000;
 const TAG: string = 'AgcCloudAuth';
-const ERROR_NOT_INITIALIZED: number = 10001;
+export const ERROR_AGC_NOT_INITIALIZED: number = 10001;
 const ERROR_SESSION_MISSING: number = 10002;
 const ERROR_AUTHENTICATION_FAILED: number = 10003;
 
@@ -40,7 +40,7 @@ export class AgcCloudAuthService {
 
   async authenticateHuaweiAccount(): Promise<void> {
     if (!this.initialized) {
-      throw new AgcAuthenticationError(ERROR_NOT_INITIALIZED, 'AGC Authentication 尚未初始化');
+      throw new AgcAuthenticationError(ERROR_AGC_NOT_INITIALIZED, 'AGC Authentication 尚未初始化');
     }
 
     const credentialInfo: HwIdCredentialInfo = { kind: 'hwid' };

--- a/entry/src/main/ets/services/account/repo/CloudBindingRepository.ets
+++ b/entry/src/main/ets/services/account/repo/CloudBindingRepository.ets
@@ -1,6 +1,21 @@
+import { BusinessError } from '@kit.BasicServicesKit';
 import { cloudDatabase } from '@kit.CloudFoundationKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
 import { AccountBinding } from '../../../db/models/AccountBinding';
 import { CLOUD_ZONE_NAME } from '../CloudAccountConfig';
+
+const LOG_DOMAIN: number = 0x0000;
+const TAG: string = 'CloudBindingRepo';
+
+class CloudBindingRepositoryError extends Error implements BusinessError {
+  code: number;
+
+  constructor(code: number, message: string) {
+    super(message);
+    this.name = 'CloudBindingRepositoryError';
+    this.code = code;
+  }
+}
 
 /**
  * AccountBinding 表的 Cloud DB 读写。
@@ -19,10 +34,17 @@ export class CloudBindingRepository {
     const queryCondition = new cloudDatabase.DatabaseQuery(AccountBinding);
     queryCondition.equalTo('platform', platform);
     queryCondition.equalTo('platformUserId', platformUserId);
-    const results: AccountBinding[] = await zone.query(queryCondition);
-    if (results.length === 0) {
-      return null;
+    try {
+      const results: AccountBinding[] = await zone.query(queryCondition);
+      if (results.length === 0) {
+        return null;
+      }
+      return results[0];
+    } catch (e) {
+      const error = e as BusinessError;
+      hilog.error(LOG_DOMAIN, TAG, '查询 AccountBinding 失败 code=%{public}d message=%{public}s',
+        error.code ?? -1, error.message ?? 'Cloud DB 查询失败');
+      throw new CloudBindingRepositoryError(error.code ?? -1, error.message ?? 'Cloud DB 查询失败');
     }
-    return results[0];
   }
 }


### PR DESCRIPTION
## 背景

模拟器和真机登录曾因 AGC 配置资源名错误而停在本地初始化阶段，且统一的网络错误提示无法区分初始化失败与 Cloud DB 鉴权失败，增加了排障成本。

## 改动

- 使用官方资源名 `agconnect-services.json` 初始化 AGC Authentication。
- 导出并复用未初始化错误码，为登录界面提供准确的重启提示。
- 为 AccountBinding 云查询保留业务错误码与消息，并增加不包含账号、令牌或配置内容的安全诊断日志。

## 验证

- 当前 worktree HAP 构建成功。
- 真机覆盖安装后登录恢复。
- 在 AGC 注册模拟器 Cloud Foundation 调试凭据后，模拟器完整登录成功。
- Cloud DB 的 AccountBinding/UserAccount 查询及后续 Upsert 均成功，`401:205525007` 不再出现。
- `git diff --check` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化华为账号登录失败提示：当登录服务初始化失败时，现显示明确的错误信息，并建议重启应用后重试。
  - 改进云端账号绑定查询的异常处理，错误发生时提供更稳定、清晰的反馈。
  - 优化登录错误日志记录，便于更准确地追踪问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->