### PR TITLE
修复: 统一搜索来源上下文与范围语义（#315）

### DIFF
--- a/entry/src/main/ets/db/models/MediaEntity.ets
+++ b/entry/src/main/ets/db/models/MediaEntity.ets
@@ -1,3 +1,4 @@
+import { SearchScope } from '../../models/search/SearchScope';
 /**
  * 媒体实体定义 — DB v3
  *
@@ -270,6 +271,7 @@ export interface ContinueWatchingItem {
 // ─────────────────────────────────────────────
 
 export interface MediaItem {
+  searchScope?: SearchScope;
   // videos
   id: number;
   sourceId: number;
@@ -320,6 +322,7 @@ export interface MediaListItem {
 }
 
 export interface SeriesGroup {
+  searchScope?: SearchScope;
   title: string;
   /** tv_series 表主键，用于详情页加载剧集数据 */
   tvSeriesId?: number;

--- a/entry/src/main/ets/models/search/SearchScope.ets
+++ b/entry/src/main/ets/models/search/SearchScope.ets
@@ -1,6 +1,6 @@
 import { VideoServer, VideoServerType } from '../../db/models/VideoServerEntity';
 
-/** Local WebDAV/SMB configurations share one scope. Cloud drives are not included. */
+/** 本地 WebDAV/SMB 配置共享同一范围，不包含网盘。 */
 export interface SearchScope {
   kind: 'localFiles' | 'videoServer' | 'unavailable';
   key: string;
@@ -9,7 +9,7 @@ export interface SearchScope {
   serverType?: VideoServerType;
 }
 
-/** Route/persisted input is untrusted; keys and labels are always rebuilt. */
+/** 路由及持久化输入不可信，必须重新生成来源键与显示名称。 */
 export interface SearchScopeIdentity {
   kind: string;
   key?: string;
@@ -68,7 +68,7 @@ export function resolveSearchScope(identity: SearchScopeIdentity, servers: Video
   return scope;
 }
 
-/** Copy identity explicitly: ArkTS does not allow structural assignment between these interfaces. */
+/** 显式复制身份，避免 ArkTS 不允许的跨接口结构赋值。 */
 export function toSearchScopeIdentity(scope: SearchScope): SearchScopeIdentity {
   const identity: SearchScopeIdentity = {
     kind: scope.kind, serverId: scope.serverId, serverType: scope.serverType
@@ -76,7 +76,7 @@ export function toSearchScopeIdentity(scope: SearchScope): SearchScopeIdentity {
   return identity;
 }
 
-/** Missing scope on legacy routes means current source, never global/local fallback. */
+/** 旧路由缺少范围时使用当前来源，禁止回退全局或本地。 */
 export function resolveSearchRoute(param: SearchRouteParam | string | null | undefined,
   currentScope: SearchScope, servers: VideoServer[]): ResolvedSearchRoute {
   let scope = currentScope;
@@ -91,7 +91,7 @@ export function resolveSearchRoute(param: SearchRouteParam | string | null | und
   return route;
 }
 
-/** Only implemented capabilities are exposed. Server search is deliberately unavailable. */
+/** 只暴露已实现的能力，暂不开放服务器搜索。 */
 export function getSearchCapabilities(scope: SearchScope): SearchCapabilities {
   const local = scope.kind === 'localFiles';
   const capabilities: SearchCapabilities = {

--- a/entry/src/main/ets/models/search/SearchScope.ets
+++ b/entry/src/main/ets/models/search/SearchScope.ets
@@ -1,0 +1,97 @@
+import { VideoServer, VideoServerType } from '../../db/models/VideoServerEntity';
+
+/** Local WebDAV/SMB configurations share one scope. Cloud drives are not included. */
+export interface SearchScope {
+  kind: 'localFiles' | 'videoServer' | 'unavailable';
+  key: string;
+  label: string;
+  serverId?: number;
+  serverType?: VideoServerType;
+}
+
+/** Route/persisted input is untrusted; keys and labels are always rebuilt. */
+export interface SearchScopeIdentity {
+  kind: string;
+  key?: string;
+  serverId?: number;
+  serverType?: VideoServerType;
+}
+
+export interface SearchRouteParam {
+  scope?: SearchScopeIdentity;
+  keyword?: string;
+}
+
+export interface ResolvedSearchRoute {
+  scope: SearchScope;
+  keyword: string;
+}
+
+export interface SearchCapabilities {
+  localSearch: boolean;
+  serverSearch: boolean;
+  localHistory: boolean;
+  localSuggestions: boolean;
+  localDetail: boolean;
+  inputModes: string[];
+  hint: string;
+}
+
+export function createLocalSearchScope(): SearchScope {
+  const scope: SearchScope = { kind: 'localFiles', key: 'local-files', label: '本地文件源' };
+  return scope;
+}
+
+export function createUnavailableSearchScope(): SearchScope {
+  const scope: SearchScope = { kind: 'unavailable', key: 'unavailable', label: '来源不可用' };
+  return scope;
+}
+
+export function resolveSearchScope(identity: SearchScopeIdentity, servers: VideoServer[]): SearchScope {
+  if (identity === null || identity === undefined) { return createUnavailableSearchScope(); }
+  if (identity.kind === 'localFiles' || identity.kind === 'fileSource') {
+    return createLocalSearchScope();
+  }
+  if (identity.kind !== 'videoServer' || identity.serverId === undefined || !Number.isInteger(identity.serverId) ||
+    (identity.serverId ?? 0) <= 0) { return createUnavailableSearchScope(); }
+  const server = servers.find((item: VideoServer) => item.id === identity.serverId);
+  if (server === undefined ||
+    (server.type !== VideoServerType.JELLYFIN && server.type !== VideoServerType.EMBY &&
+      server.type !== VideoServerType.PLEX) ||
+    (identity.serverType !== undefined && identity.serverType !== server.type)) {
+    return createUnavailableSearchScope();
+  }
+  const scope: SearchScope = {
+    kind: 'videoServer', key: `video-server:${server.type}:${server.id}`,
+    label: server.name, serverId: server.id, serverType: server.type
+  };
+  return scope;
+}
+
+/** Missing scope on legacy routes means current source, never global/local fallback. */
+export function resolveSearchRoute(param: SearchRouteParam | string | null | undefined,
+  currentScope: SearchScope, servers: VideoServer[]): ResolvedSearchRoute {
+  let scope = currentScope;
+  let keyword = '';
+  if (typeof param === 'string') {
+    keyword = param;
+  } else if (param !== null && param !== undefined) {
+    if (param.scope !== undefined) { scope = resolveSearchScope(param.scope, servers); }
+    keyword = typeof param.keyword === 'string' ? param.keyword : '';
+  }
+  const route: ResolvedSearchRoute = { scope: resolveSearchScope(scope, servers), keyword };
+  return route;
+}
+
+/** Only implemented capabilities are exposed. Server search is deliberately unavailable. */
+export function getSearchCapabilities(scope: SearchScope): SearchCapabilities {
+  const local = scope.kind === 'localFiles';
+  const capabilities: SearchCapabilities = {
+    localSearch: local, serverSearch: false, localHistory: local,
+    localSuggestions: local, localDetail: local,
+    inputModes: local ? ['initials', 'pinyin', 'chinese'] : [],
+    hint: local ? '支持首字母、全拼、中文片名搜索' :
+      scope.kind === 'videoServer' ? '当前影视服务器暂不支持搜索' : '来源不可用，请返回重新选择来源'
+  };
+  return capabilities;
+}

--- a/entry/src/main/ets/models/search/SearchScope.ets
+++ b/entry/src/main/ets/models/search/SearchScope.ets
@@ -68,6 +68,14 @@ export function resolveSearchScope(identity: SearchScopeIdentity, servers: Video
   return scope;
 }
 
+/** Copy identity explicitly: ArkTS does not allow structural assignment between these interfaces. */
+export function toSearchScopeIdentity(scope: SearchScope): SearchScopeIdentity {
+  const identity: SearchScopeIdentity = {
+    kind: scope.kind, serverId: scope.serverId, serverType: scope.serverType
+  };
+  return identity;
+}
+
 /** Missing scope on legacy routes means current source, never global/local fallback. */
 export function resolveSearchRoute(param: SearchRouteParam | string | null | undefined,
   currentScope: SearchScope, servers: VideoServer[]): ResolvedSearchRoute {
@@ -79,7 +87,7 @@ export function resolveSearchRoute(param: SearchRouteParam | string | null | und
     if (param.scope !== undefined) { scope = resolveSearchScope(param.scope, servers); }
     keyword = typeof param.keyword === 'string' ? param.keyword : '';
   }
-  const route: ResolvedSearchRoute = { scope: resolveSearchScope(scope, servers), keyword };
+  const route: ResolvedSearchRoute = { scope: resolveSearchScope(toSearchScopeIdentity(scope), servers), keyword };
   return route;
 }
 

--- a/entry/src/main/ets/pages/home/index.ets
+++ b/entry/src/main/ets/pages/home/index.ets
@@ -50,8 +50,8 @@ export struct HomePage {
   private async loadSourceState(): Promise<void> {
     try {
       await this.videoServerModel.loadVideoServers(true)
-      // 仅在服务器列表成功加载后再恢复数据源，避免临时数据库错误时用不完整列表误判服务器已删除而回退文件源
-      await this.sourceSwitchModel.load(this.videoServerModel.videoServers.map(s => s.id ?? -1))
+      // 仅在服务器列表成功加载后再恢复数据源，避免临时数据库错误时用不完整列表误判服务器已删除
+      await this.sourceSwitchModel.load(this.videoServerModel.videoServers)
     } catch (error) {
       console.warn('[HomePage] 加载数据源状态失败', (error as BusinessError).message ?? String(error))
     }

--- a/entry/src/main/ets/pages/home/tabs/VideoServerTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/VideoServerTab.ets
@@ -30,7 +30,7 @@ export struct VideoServerTab {
       this.isLoading = true
       await this.videoServerModel.loadVideoServers(true)
       // 校验当前源仍有效（服务器被删则回退文件源）
-      await this.sourceSwitchModel.load(this.videoServerModel.videoServers.map(s => s.id ?? -1))
+      await this.sourceSwitchModel.load(this.videoServerModel.videoServers)
     } catch (error) {
       console.error('VideoServerTab: 加载服务器失败', (error as BusinessError).message ?? String(error))
     } finally {

--- a/entry/src/main/ets/pages/home/topbar/index.ets
+++ b/entry/src/main/ets/pages/home/topbar/index.ets
@@ -1,3 +1,5 @@
+import { VideoServerStore } from '../../../stores/servers/VideoServerStore'
+import { SearchRouteParam, toSearchScopeIdentity } from '../../../models/search/SearchScope'
 import { IBestButton, IBestDivider, IBestIcon, IBestToast } from "@ibestservices/ibest-ui"
 import { LengthMetrics } from "@kit.ArkUI"
 import { LucideCloudDownload, LucideServer } from "lucide"
@@ -83,7 +85,11 @@ export struct HomeTopBar {
           btnBorderColor: Color.Transparent,
           iconBuilder: (): void => this.settingIBestIconBuilder('search'),
           onBtnClick: () => {
-            this.pageStack.pushPathByName(SearchWorkspacePage.PAGE_NAME, null)
+            const param: SearchRouteParam = {
+              scope: toSearchScopeIdentity(
+                this.sourceSwitchModel.getSearchScope(VideoServerStore.getState().videoServers))
+            }
+            this.pageStack.pushPathByName(SearchWorkspacePage.PAGE_NAME, param)
           }
         }).bindTips('搜索')
 

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -311,6 +311,8 @@ export struct MediaResultPage {
   // 路由初始参数，用于 resetAll() 恢复入口语义
   private initialMediaType: string = '';
   private initialGenre: string = '';
+  private initialRating: number = 0;
+  private initialYearLabel: string = '';
   private initialPageTitle: string = '搜索结果';
 
   aboutToDisappear(): void {
@@ -415,8 +417,8 @@ export struct MediaResultPage {
   private resetAll(): void {
     this.filterMediaType = this.initialMediaType;
     this.filterGenre = this.initialGenre;
-    this.filterYearLabel = '';
-    this.filterRating = 0;
+    this.filterYearLabel = this.initialYearLabel;
+    this.filterRating = this.initialRating;
     this.filterProgress = '';
     this.filterRegion = '';
     this.filterSort = 'composite';
@@ -821,6 +823,8 @@ export struct MediaResultPage {
         // 保存入口初始值，resetAll() 时恢复入口语义而非全部清空
         this.initialMediaType = this.filterMediaType;
         this.initialGenre = this.filterGenre;
+        this.initialRating = this.filterRating;
+        this.initialYearLabel = this.filterYearLabel;
         this.initialPageTitle = this.pageTitle;
       }
       this.loadGenreOptions().catch((): void => {});

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -1,3 +1,6 @@
+import { SearchScope, SearchRouteParam, createUnavailableSearchScope, resolveSearchRoute, getSearchCapabilities } from '../../models/search/SearchScope';
+import { SourceSwitchModel } from '../../stores/media/SourceSwitchModel';
+import { VideoServerStore } from '../../stores/servers/VideoServerStore';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { MediaItem, SeriesGroup, SearchMediaOptions } from '../../db/models/MediaEntity';
 import { MovieDetailPage } from '../detail/MovieDetailPage';
@@ -7,7 +10,7 @@ import { SeriesDetailPage } from '../detail/SeriesDetailPage';
 // Page param interface (for external route navigation)
 // ─────────────────────────────────────────────────────────────────────────────
 
-export interface MediaResultPageParam {
+export interface MediaResultPageParam extends SearchRouteParam {
   keyword?: string;
   mediaType?: string;
   genre?: string;
@@ -156,12 +159,16 @@ function scoreText(r: number | undefined): string {
 @ComponentV2
 struct ResultPosterCard {
   @Require @Param item: MediaItem;
+  @Require @Param scope: SearchScope;
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
   @Local isFocused: boolean = false;
 
   private navigateToDetail(): void {
+    if (!getSearchCapabilities(this.scope).localDetail) { return; }
+    this.item.searchScope = this.scope;
     if (this.item.tvSeriesId !== undefined) {
       const group: SeriesGroup = {
+        searchScope: this.scope,
         title: itemTitle(this.item),
         tvSeriesId: this.item.tvSeriesId,
         posterUrl: this.item.posterUrl,
@@ -281,6 +288,7 @@ export struct MediaResultPage {
   // ── Page state ────────────────────────────────────────────────────────────
   @Local pageTitle: string = '\u641C\u7D22\u7ED3\u679C';
   @Local keyword: string = '';
+  @Local scope: SearchScope = createUnavailableSearchScope();
 
   // ── Filter state ──────────────────────────────────────────────────────────
   @Local filterMediaType: string = '';    // '' | 'movie' | 'tv'
@@ -297,13 +305,17 @@ export struct MediaResultPage {
   @Local isLoading: boolean = false;
   @Local totalCount: number = 0;
 
-  private db: FileSourceDatabase = FileSourceDatabase.getInstance();
+  private db: FileSourceDatabase | null = null;
   // 竞态保护：每次发起新请求时递增，回调中比对版本号，过期则丢弃
   private searchGeneration: number = 0;
   // 路由初始参数，用于 resetAll() 恢复入口语义
   private initialMediaType: string = '';
   private initialGenre: string = '';
   private initialPageTitle: string = '搜索结果';
+
+  aboutToDisappear(): void {
+    this.searchGeneration++;
+  }
 
   private getWatchProgressFilter(): 'unseen' | 'partial' | 'done' | undefined {
     if (this.filterProgress === 'unseen') { return 'unseen'; }
@@ -325,6 +337,7 @@ export struct MediaResultPage {
   // ── Data operations ───────────────────────────────────────────────────────
 
   private async doSearch(): Promise<void> {
+    if (!getSearchCapabilities(this.scope).localSearch || this.db === null) { return; }
     const generation = ++this.searchGeneration;
     this.isLoading = true;
     try {
@@ -377,6 +390,7 @@ export struct MediaResultPage {
   // ── Filter option getters ─────────────────────────────────────────────────
 
   private async loadGenreOptions(): Promise<void> {
+    if (!getSearchCapabilities(this.scope).localSearch || this.db === null) { return; }
     let mt: 'movie' | 'tv' | undefined = undefined;
     if (this.filterMediaType === 'movie') { mt = 'movie'; }
     else if (this.filterMediaType === 'tv') { mt = 'tv'; }
@@ -742,7 +756,7 @@ export struct MediaResultPage {
       Grid() {
         ForEach(this.results, (item: MediaItem) => {
           GridItem() {
-            ResultPosterCard({ item: item })
+            ResultPosterCard({ item: item, scope: this.scope })
           }
         }, (item: MediaItem) => String(item.id))
       }
@@ -761,7 +775,12 @@ export struct MediaResultPage {
         Column({ space: 20 }) {
           // 标题栏随内容整体滚动
           this.buildHeader()
-          this.buildFilterPanel()
+          Text(this.scope.label).fontSize(24).fontColor(C_TEXT_TITLE)
+          if (getSearchCapabilities(this.scope).localSearch) {
+            this.buildFilterPanel()
+          } else {
+            Text(getSearchCapabilities(this.scope).hint).fontSize(18).fontColor(C_SECONDARY)
+          }
           // summary：有筛选条件时显示当前条件
           if (this.filterMediaType !== '' || this.filterGenre !== '' || this.filterYearLabel !== '' || this.filterRating > 0 || this.filterProgress !== '') {
             Text(this.summaryText())
@@ -769,7 +788,9 @@ export struct MediaResultPage {
               .fontColor(C_SECONDARY)
               .width('100%')
           }
-          this.buildResultGrid()
+          if (getSearchCapabilities(this.scope).localSearch) {
+            this.buildResultGrid()
+          }
         }
         .width('100%')
         .padding(20)
@@ -781,12 +802,22 @@ export struct MediaResultPage {
       .backgroundColor(C_PAGE_BG)
     }
     .onReady((context: NavDestinationContext) => {
-      const param = context.pathInfo.param as MediaResultPageParam;
-      if (param !== undefined && param !== null) {
+      const param = context.pathInfo.param as MediaResultPageParam | string | null | undefined;
+      const servers = VideoServerStore.getState().videoServers;
+      const route = resolveSearchRoute(param, SourceSwitchModel.getState().getSearchScope(servers), servers);
+      this.scope = route.scope;
+      this.keyword = route.keyword;
+      this.searchGeneration++;
+      this.results = [];
+      this.genreOptions = [];
+      if (!getSearchCapabilities(this.scope).localSearch) { return; }
+      this.db = FileSourceDatabase.getInstance();
+      if (param !== undefined && param !== null && typeof param !== 'string') {
         this.pageTitle = param.pageTitle ?? '搜索结果';
-        this.keyword = param.keyword ?? '';
         this.filterMediaType = param.mediaType ?? '';
         this.filterGenre = param.genre ?? '';
+        this.filterRating = param.minRating ?? 0;
+        this.filterYearLabel = param.decadeYear ?? '';
         // 保存入口初始值，resetAll() 时恢复入口语义而非全部清空
         this.initialMediaType = this.filterMediaType;
         this.initialGenre = this.filterGenre;

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -1,3 +1,6 @@
+import { SearchScope, SearchRouteParam, createUnavailableSearchScope, resolveSearchRoute, getSearchCapabilities } from '../../models/search/SearchScope';
+import { SourceSwitchModel } from '../../stores/media/SourceSwitchModel';
+import { VideoServerStore } from '../../stores/servers/VideoServerStore';
 import { MediaItem, SearchHistoryEntry, SeriesGroup } from '../../db/models/MediaEntity';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 
@@ -324,6 +327,7 @@ struct SearchWorkspacePage {
 
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
 
+  @Local scope: SearchScope = createUnavailableSearchScope();
   @Local searchText: string = '';
   @Local searchResults: MediaItem[] = [];
   @Local historyList: SearchHistoryEntry[] = [];
@@ -337,16 +341,22 @@ struct SearchWorkspacePage {
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
-  aboutToAppear(): void {
-    try {
-      this.db = FileSourceDatabase.getInstance();
-      this.loadHistory();
-    } catch (e) {
-      // Preview 沙箱：native DB 不可用，静默降级
-    }
+  private initializeRoute(param: SearchRouteParam | string | null | undefined): void {
+    const servers = VideoServerStore.getState().videoServers;
+    const route = resolveSearchRoute(param, SourceSwitchModel.getState().getSearchScope(servers), servers);
+    this.scope = route.scope;
+    this.searchText = route.keyword;
+    this.searchGeneration++;
+    this.searchResults = [];
+    this.historyList = [];
+    if (!getSearchCapabilities(this.scope).localSearch) { return; }
+    this.db = FileSourceDatabase.getInstance();
+    this.loadHistory();
+    this.scheduleSearch();
   }
 
   aboutToDisappear(): void {
+    this.searchGeneration++;
     if (this.searchDebounceTimer !== -1) {
       clearTimeout(this.searchDebounceTimer);
     }
@@ -355,7 +365,7 @@ struct SearchWorkspacePage {
   // ── Data helpers ──────────────────────────────────────────────────────────
 
   private loadHistory(): void {
-    if (this.db === null) { return; }
+    if (!getSearchCapabilities(this.scope).localHistory || this.db === null) { return; }
     this.db.getSearchHistory(20)
       .then((list: SearchHistoryEntry[]) => {
         this.historyList = list;
@@ -365,6 +375,9 @@ struct SearchWorkspacePage {
 
 
   private scheduleSearch(): void {
+    this.searchGeneration++;
+    this.isSearching = false;
+    if (!getSearchCapabilities(this.scope).localSearch) { return; }
     if (this.searchDebounceTimer !== -1) {
       clearTimeout(this.searchDebounceTimer);
       this.searchDebounceTimer = -1;
@@ -381,6 +394,7 @@ struct SearchWorkspacePage {
 
   /** 本地预览搜索（仅实时展示结果，不保存历史、不跳转） */
   private async executeSearch(): Promise<void> {
+    if (!getSearchCapabilities(this.scope).localSearch || this.db === null) { return; }
     const kw: string = this.searchText.trim();
     if (kw.length === 0) {
       this.searchResults = [];
@@ -418,6 +432,7 @@ struct SearchWorkspacePage {
 
   /** 执行搜索并保存历史 */
   private executeSearchWithHistory(): void {
+    if (!getSearchCapabilities(this.scope).localHistory) { return; }
     const kw: string = this.searchText.trim();
     if (kw.length === 0) { return; }
     if (this.db !== null) {
@@ -447,22 +462,25 @@ struct SearchWorkspacePage {
   }
 
   private deleteHistory(keyword: string): void {
-    if (this.db === null) { return; }
+    if (!getSearchCapabilities(this.scope).localHistory || this.db === null) { return; }
     this.db.deleteSearchHistory(keyword)
       .then(() => { this.loadHistory(); })
       .catch(() => {});
   }
 
   private clearAllHistory(): void {
-    if (this.db === null) { return; }
+    if (!getSearchCapabilities(this.scope).localHistory || this.db === null) { return; }
     this.db.clearSearchHistory()
       .then(() => { this.historyList = []; })
       .catch(() => {});
   }
 
   private navigateToDetail(item: MediaItem): void {
+    if (!getSearchCapabilities(this.scope).localDetail) { return; }
+    item.searchScope = this.scope;
     if (item.tvSeriesId !== undefined) {
       const group: SeriesGroup = {
+        searchScope: this.scope,
         title: item.title ?? '',
         tvSeriesId: item.tvSeriesId,
         posterUrl: item.posterUrl,
@@ -732,10 +750,14 @@ struct SearchWorkspacePage {
       Scroll() {
         Column({ space: 20 }) {
           this.buildBackRow()
-          this.buildSearchBar()
-          this.buildKeyboard()
-          this.buildHistory()
-          this.buildResultsPreview()
+          Text(this.scope.label).fontSize(24).fontColor(C_TEXT_TITLE)
+          Text(getSearchCapabilities(this.scope).hint).fontSize(18).fontColor(C_SECONDARY)
+          if (getSearchCapabilities(this.scope).localSearch) {
+            this.buildSearchBar()
+            this.buildKeyboard()
+            this.buildHistory()
+            this.buildResultsPreview()
+          }
         }
         .width('100%')
         .alignItems(HorizontalAlign.Start)
@@ -749,6 +771,9 @@ struct SearchWorkspacePage {
       .align(Alignment.TopStart)
       .backgroundColor(C_PAGE_BG)
     }
+    .onReady((context: NavDestinationContext) => {
+      this.initializeRoute(context.pathInfo.param as SearchRouteParam | string | null | undefined);
+    })
     .hideTitleBar(true)
     .onBackPressed(() => {
       this.pageStack.pop();

--- a/entry/src/main/ets/stores/media/SourceSwitchModel.ets
+++ b/entry/src/main/ets/stores/media/SourceSwitchModel.ets
@@ -29,7 +29,7 @@ export class SourceSwitchModel {
     return SourceSwitchModel.instance;
   }
 
-  private sourceLoaded: boolean = false;
+  @Trace private sourceLoaded: boolean = false;
 
   @Trace activeSource: ActiveMediaSource = { kind: 'fileSource' };
 
@@ -97,13 +97,13 @@ export class SourceSwitchModel {
             serverType: server.type, name: server.name };
           return;
         }
-        // Preserve the invalid identity: search must not silently query local data.
+        // 保留无效身份，禁止搜索静默回退本地数据。
         this.activeSource = { kind: 'videoServer', serverId, serverType: parsed.serverType, name: '来源不可用' };
         return;
       }
       this.activeSource = parsed.kind === 'fileSource' ? { kind: 'fileSource' } :
         { kind: 'videoServer', name: '来源不可用' };
-    } catch {
+    } catch (e) {
       this.activeSource = { kind: 'videoServer', name: '来源不可用' };
     } finally {
       this.sourceLoaded = true;

--- a/entry/src/main/ets/stores/media/SourceSwitchModel.ets
+++ b/entry/src/main/ets/stores/media/SourceSwitchModel.ets
@@ -1,5 +1,6 @@
+import { SearchScopeIdentity, SearchScope, resolveSearchScope, createUnavailableSearchScope } from '../../models/search/SearchScope';
 import { AppPreferences, PrefKey } from '../../utils/AppPreferences';
-import { VideoServer } from '../../db/models/VideoServerEntity';
+import { VideoServer, VideoServerType } from '../../db/models/VideoServerEntity';
 
 /**
  * 媒体库当前数据源描述。
@@ -9,6 +10,7 @@ import { VideoServer } from '../../db/models/VideoServerEntity';
 export interface ActiveMediaSource {
   kind: 'fileSource' | 'videoServer';
   serverId?: number;
+  serverType?: VideoServerType;
   name?: string;
 }
 
@@ -26,6 +28,8 @@ export class SourceSwitchModel {
     }
     return SourceSwitchModel.instance;
   }
+
+  private sourceLoaded: boolean = false;
 
   @Trace activeSource: ActiveMediaSource = { kind: 'fileSource' };
 
@@ -49,6 +53,7 @@ export class SourceSwitchModel {
   }
 
   async setFileSource(): Promise<void> {
+    this.sourceLoaded = true;
     this.activeSource = { kind: 'fileSource' };
     await this.persist();
   }
@@ -57,7 +62,8 @@ export class SourceSwitchModel {
     if (server.id === undefined) {
       return;
     }
-    this.activeSource = { kind: 'videoServer', serverId: server.id, name: server.name };
+    this.sourceLoaded = true;
+    this.activeSource = { kind: 'videoServer', serverId: server.id, serverType: server.type, name: server.name };
     await this.persist();
   }
 
@@ -66,16 +72,16 @@ export class SourceSwitchModel {
    */
   async syncServerName(server: VideoServer): Promise<void> {
     if (this.activeSource.kind === 'videoServer' && this.activeSource.serverId === server.id) {
-      this.activeSource = { kind: 'videoServer', serverId: server.id, name: server.name };
+      this.activeSource = { kind: 'videoServer', serverId: server.id, serverType: server.type, name: server.name };
       await this.persist();
     }
   }
 
   /**
-   * 从偏好加载当前源。若指向的服务器已不存在则回退到文件源。
-   * @param existingServerIds 当前已加载的服务器 ID 集合
+   * 从偏好加载当前源。从已加载配置恢复类型；删除的服务器保留为不可用身份。
+   * @param servers 当前已加载的服务器配置
    */
-  async load(existingServerIds: number[]): Promise<void> {
+  async load(servers: VideoServer[]): Promise<void> {
     try {
       const raw = await AppPreferences.get(PrefKey.ACTIVE_MEDIA_SOURCE, '');
       if (raw.length === 0) {
@@ -85,19 +91,33 @@ export class SourceSwitchModel {
       const parsed = JSON.parse(raw) as ActiveMediaSource;
       if (parsed.kind === 'videoServer') {
         const serverId = parsed.serverId;
-        if (serverId !== undefined && existingServerIds.includes(serverId)) {
-          this.activeSource = parsed;
+        const server = servers.find((item: VideoServer) => item.id === serverId);
+        if (server !== undefined && (parsed.serverType === undefined || parsed.serverType === server.type)) {
+          this.activeSource = { kind: 'videoServer', serverId: server.id,
+            serverType: server.type, name: server.name };
           return;
         }
-        // 服务器已删除，回退文件源
-        this.activeSource = { kind: 'fileSource' };
-        await this.persist();
+        // Preserve the invalid identity: search must not silently query local data.
+        this.activeSource = { kind: 'videoServer', serverId, serverType: parsed.serverType, name: '来源不可用' };
         return;
       }
-      this.activeSource = { kind: 'fileSource' };
+      this.activeSource = parsed.kind === 'fileSource' ? { kind: 'fileSource' } :
+        { kind: 'videoServer', name: '来源不可用' };
     } catch {
-      this.activeSource = { kind: 'fileSource' };
+      this.activeSource = { kind: 'videoServer', name: '来源不可用' };
+    } finally {
+      this.sourceLoaded = true;
     }
+  }
+
+  getSearchScope(servers: VideoServer[]): SearchScope {
+    if (!this.sourceLoaded) { return createUnavailableSearchScope(); }
+    const identity: SearchScopeIdentity = {
+      kind: this.activeSource.kind,
+      serverId: this.activeSource.serverId,
+      serverType: this.activeSource.serverType
+    };
+    return resolveSearchScope(identity, servers);
   }
 
   private async persist(): Promise<void> {

--- a/entry/src/main/ets/stores/servers/VideoServerModel.ets
+++ b/entry/src/main/ets/stores/servers/VideoServerModel.ets
@@ -2,7 +2,6 @@ import { FileSourceDatabase } from "../../db/files/FileSourceDatabase";
 import { VideoServer, VideoServerType } from "../../db/models/VideoServerEntity";
 import { BusinessError } from "@kit.BasicServicesKit";
 import SettingType from "../../pages/settings/SettingType";
-import { SourceSwitchModel } from "../media/SourceSwitchModel";
 
 /**
  * 影视服务器缓存管理类。
@@ -129,21 +128,12 @@ export class VideoServerModel {
   }
 
   /**
-   * 删除影视服务器并处理当前源回退（统一删除流程）。
-   * 若被删除的服务器恰好是当前激活源，自动回退到文件源。
-   * 源回退的持久化失败不中断删除流程（服务器已删除不可恢复，
-   * 残余的无效源引用会在下次 load() 时自动回退）。
+   * 统一删除入口，保留原方法名以兼容调用方。
+   * 保留当前源及持久化身份：已删除服务器由范围解析判为不可用，
+   * 只有用户主动选择文件源才允许本地搜索；删除非当前源不改变选择。
    */
   async deleteVideoServerWithFallback(id: number): Promise<void> {
     await this.deleteVideoServer(id);
-    const sourceSwitch = SourceSwitchModel.getState();
-    if (sourceSwitch.getActiveServerId() === id) {
-      try {
-        await sourceSwitch.setFileSource();
-      } catch (e) {
-        console.warn('VideoServerModel: 源回退持久化失败，将在下次加载时自动恢复', (e as BusinessError).message ?? String(e));
-      }
-    }
   }
 
   /**

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -1,3 +1,4 @@
+import searchScopeTest from './SearchScope.test';
 import timeUtilTest from './TimeUtil.test';
 import playbackContextTest from './ets/PlaybackContextTest';
 import settingsControllerTest from './SettingsController.test';
@@ -122,6 +123,7 @@ export default function testsuite() {
   subtitleLanguageFilterTest();
   subtitleRelevanceFilterTest();
   sourceSwitchModelTest();
+  searchScopeTest();
   videoServerLabelsTest();
   videoServerDaoTest();
   audioCodecUtilTest();

--- a/entry/src/test/SearchScope.test.ets
+++ b/entry/src/test/SearchScope.test.ets
@@ -7,13 +7,13 @@ export default function searchScopeTest() {
     { id: 1, type: VideoServerType.JELLYFIN, name: 'A', configJson: '{}', createdAt: 1 },
     { id: 2, type: VideoServerType.PLEX, name: 'B', configJson: '{}', createdAt: 1 }
   ];
-  describe('SearchScope', () => {
-    it('aggregates local configurations', 0, () => {
+  describe('搜索来源范围', () => {
+    it('聚合本地文件源配置', 0, () => {
       expect(createLocalSearchScope().key).assertEqual('local-files');
       expect(createLocalSearchScope().label).assertEqual('本地文件源');
       expect(getSearchCapabilities(createLocalSearchScope()).localSearch).assertTrue();
     });
-    it('restores legacy server identity from configuration', 0, () => {
+    it('从配置恢复旧服务器身份', 0, () => {
       const scope = resolveSearchScope({ kind: 'videoServer', serverId: 1 } as SearchScopeIdentity, servers);
       expect(scope.key).assertEqual('video-server:jellyfin:1');
       expect(scope.label).assertEqual('A');
@@ -21,16 +21,16 @@ export default function searchScopeTest() {
       expect(getSearchCapabilities(scope).serverSearch).assertEqual(false);
       expect(getSearchCapabilities(scope).inputModes.length).assertEqual(0);
     });
-    it('separates server instances and types', 0, () => {
+    it('隔离服务器实例与类型', 0, () => {
       expect(resolveSearchScope({ kind: 'videoServer', serverId: 2 } as SearchScopeIdentity, servers).key)
         .assertEqual('video-server:plex:2');
     });
-    it('rebuilds untrusted keys', 0, () => {
+    it('重新生成不可信来源键', 0, () => {
       const scope = resolveSearchScope({ kind: 'videoServer', serverId: 1,
         serverType: VideoServerType.JELLYFIN, key: 'local-files' } as SearchScopeIdentity, servers);
       expect(scope.key).assertEqual('video-server:jellyfin:1');
     });
-    it('rejects deleted and mismatched servers without local fallback', 0, () => {
+    it('删除或类型不匹配时禁止回退本地', 0, () => {
       const deleted = resolveSearchScope({ kind: 'videoServer', serverId: 99 } as SearchScopeIdentity, servers);
       const mismatch = resolveSearchScope({ kind: 'videoServer', serverId: 1,
         serverType: VideoServerType.PLEX } as SearchScopeIdentity, servers);
@@ -39,20 +39,20 @@ export default function searchScopeTest() {
       expect(getSearchCapabilities(deleted).localSearch).assertEqual(false);
       expect(getSearchCapabilities(deleted).localHistory).assertEqual(false);
     });
-    it('legacy null and keyword routes follow current server', 0, () => {
+    it('旧空值与关键词路由跟随当前服务器', 0, () => {
       const current = resolveSearchScope({ kind: 'videoServer', serverId: 1 } as SearchScopeIdentity, servers);
       expect(resolveSearchRoute(null, current, servers).scope.key).assertEqual(current.key);
       const route = resolveSearchRoute('hello', current, servers);
       expect(route.scope.key).assertEqual(current.key);
       expect(route.keyword).assertEqual('hello');
     });
-    it('explicit scope survives active source changes and round trip', 0, () => {
+    it('显式范围在切源与序列化后保持身份', 0, () => {
       const route = resolveSearchRoute({ scope: { kind: 'videoServer', serverId: 2 } } as SearchRouteParam,
         createLocalSearchScope(), servers);
       expect(resolveSearchRoute(JSON.parse(JSON.stringify(route)) as SearchRouteParam, createLocalSearchScope(), servers)
         .scope.key).assertEqual('video-server:plex:2');
     });
-    it('invalid explicit scope never falls back to local', 0, () => {
+    it('无效显式范围禁止回退本地', 0, () => {
       expect(resolveSearchRoute({ scope: { kind: 'bad' } } as SearchRouteParam, createLocalSearchScope(), servers)
         .scope.kind).assertEqual('unavailable');
     });

--- a/entry/src/test/SearchScope.test.ets
+++ b/entry/src/test/SearchScope.test.ets
@@ -1,0 +1,60 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { SearchScopeIdentity, SearchRouteParam, createLocalSearchScope, resolveSearchScope, resolveSearchRoute, getSearchCapabilities } from '../main/ets/models/search/SearchScope';
+import { VideoServer, VideoServerType } from '../main/ets/db/models/VideoServerEntity';
+
+export default function searchScopeTest() {
+  const servers: VideoServer[] = [
+    { id: 1, type: VideoServerType.JELLYFIN, name: 'A', configJson: '{}', createdAt: 1 },
+    { id: 2, type: VideoServerType.PLEX, name: 'B', configJson: '{}', createdAt: 1 }
+  ];
+  describe('SearchScope', () => {
+    it('aggregates local configurations', 0, () => {
+      expect(createLocalSearchScope().key).assertEqual('local-files');
+      expect(createLocalSearchScope().label).assertEqual('本地文件源');
+      expect(getSearchCapabilities(createLocalSearchScope()).localSearch).assertTrue();
+    });
+    it('restores legacy server identity from configuration', 0, () => {
+      const scope = resolveSearchScope({ kind: 'videoServer', serverId: 1 } as SearchScopeIdentity, servers);
+      expect(scope.key).assertEqual('video-server:jellyfin:1');
+      expect(scope.label).assertEqual('A');
+      expect(getSearchCapabilities(scope).localHistory).assertEqual(false);
+      expect(getSearchCapabilities(scope).serverSearch).assertEqual(false);
+      expect(getSearchCapabilities(scope).inputModes.length).assertEqual(0);
+    });
+    it('separates server instances and types', 0, () => {
+      expect(resolveSearchScope({ kind: 'videoServer', serverId: 2 } as SearchScopeIdentity, servers).key)
+        .assertEqual('video-server:plex:2');
+    });
+    it('rebuilds untrusted keys', 0, () => {
+      const scope = resolveSearchScope({ kind: 'videoServer', serverId: 1,
+        serverType: VideoServerType.JELLYFIN, key: 'local-files' } as SearchScopeIdentity, servers);
+      expect(scope.key).assertEqual('video-server:jellyfin:1');
+    });
+    it('rejects deleted and mismatched servers without local fallback', 0, () => {
+      const deleted = resolveSearchScope({ kind: 'videoServer', serverId: 99 } as SearchScopeIdentity, servers);
+      const mismatch = resolveSearchScope({ kind: 'videoServer', serverId: 1,
+        serverType: VideoServerType.PLEX } as SearchScopeIdentity, servers);
+      expect(deleted.kind).assertEqual('unavailable');
+      expect(mismatch.kind).assertEqual('unavailable');
+      expect(getSearchCapabilities(deleted).localSearch).assertEqual(false);
+      expect(getSearchCapabilities(deleted).localHistory).assertEqual(false);
+    });
+    it('legacy null and keyword routes follow current server', 0, () => {
+      const current = resolveSearchScope({ kind: 'videoServer', serverId: 1 } as SearchScopeIdentity, servers);
+      expect(resolveSearchRoute(null, current, servers).scope.key).assertEqual(current.key);
+      const route = resolveSearchRoute('hello', current, servers);
+      expect(route.scope.key).assertEqual(current.key);
+      expect(route.keyword).assertEqual('hello');
+    });
+    it('explicit scope survives active source changes and round trip', 0, () => {
+      const route = resolveSearchRoute({ scope: { kind: 'videoServer', serverId: 2 } } as SearchRouteParam,
+        createLocalSearchScope(), servers);
+      expect(resolveSearchRoute(JSON.parse(JSON.stringify(route)) as SearchRouteParam, createLocalSearchScope(), servers)
+        .scope.key).assertEqual('video-server:plex:2');
+    });
+    it('invalid explicit scope never falls back to local', 0, () => {
+      expect(resolveSearchRoute({ scope: { kind: 'bad' } } as SearchRouteParam, createLocalSearchScope(), servers)
+        .scope.kind).assertEqual('unavailable');
+    });
+  });
+}

--- a/entry/src/test/SourceSwitchModel.test.ets
+++ b/entry/src/test/SourceSwitchModel.test.ets
@@ -3,6 +3,7 @@ import abilityDelegatorRegistry from '@ohos.app.ability.abilityDelegatorRegistry
 import { Context } from '@ohos.abilityAccessCtrl';
 import {
   AppPreferences,
+  PrefKey,
   AppPreferencesLoader,
   AppPreferencesStore
 } from '../main/ets/utils/AppPreferences';
@@ -64,7 +65,7 @@ export default function sourceSwitchModelTest() {
       const model = new SourceSwitchModel();
       model.setVideoServer(makeServer(3, 'Home'));
       expect(model.getDisplayName()).assertEqual('Home');
-      expect(model.isFileSource()).assertFalse();
+      expect(model.isFileSource()).assertEqual(false);
       expect(model.getActiveServerId()).assertEqual(3);
     });
 
@@ -78,25 +79,52 @@ export default function sourceSwitchModelTest() {
 
     it('load 恢复已持久化的服务器源', 0, async () => {
       const model = new SourceSwitchModel();
-      model.setVideoServer(makeServer(5, 'NAS'));
+      await model.setVideoServer(makeServer(5, 'NAS'));
       const restored = new SourceSwitchModel();
-      await restored.load([5]);
+      await restored.load([makeServer(5, 'NAS')]);
       expect(restored.getDisplayName()).assertEqual('NAS');
       expect(restored.getActiveServerId()).assertEqual(5);
     });
 
-    it('load 时服务器已删除则回退文件源', 0, async () => {
+    it('load 时服务器已删除则禁止本地搜索', 0, async () => {
       const model = new SourceSwitchModel();
-      model.setVideoServer(makeServer(9, '已删除'));
+      await model.setVideoServer(makeServer(9, '已删除'));
       const restored = new SourceSwitchModel();
-      await restored.load([1, 2]);
-      expect(restored.isFileSource()).assertTrue();
-      expect(restored.getDisplayName()).assertEqual('文件源');
+      await restored.load([makeServer(1, 'A'), makeServer(2, 'B')]);
+      expect(restored.isFileSource()).assertEqual(false);
+      expect(restored.getSearchScope([]).kind).assertEqual('unavailable');
+    });
+
+    it('旧偏好仅 serverId 从配置恢复类型与名称', 0, async () => {
+      await store.put(PrefKey.ACTIVE_MEDIA_SOURCE, '{"kind":"videoServer","serverId":5}');
+      const model = new SourceSwitchModel();
+      const servers: VideoServer[] = [makeServer(5, 'Current')];
+      await model.load(servers);
+      expect(model.activeSource.serverType).assertEqual(VideoServerType.JELLYFIN);
+      expect(model.getDisplayName()).assertEqual('Current');
+      expect(model.getSearchScope(servers).key).assertEqual('video-server:jellyfin:5');
+    });
+
+    it('未加载与损坏偏好不恢复本地搜索', 0, async () => {
+      const model = new SourceSwitchModel();
+      expect(model.getSearchScope([]).kind).assertEqual('unavailable');
+      await store.put(PrefKey.ACTIVE_MEDIA_SOURCE, 'bad-json');
+      await model.load([]);
+      expect(model.getSearchScope([]).kind).assertEqual('unavailable');
+    });
+
+    it('持久化类型与现配置不匹配时不可用', 0, async () => {
+      await store.put(PrefKey.ACTIVE_MEDIA_SOURCE,
+        '{"kind":"videoServer","serverId":5,"serverType":"plex"}');
+      const model = new SourceSwitchModel();
+      const servers: VideoServer[] = [makeServer(5, 'Changed')];
+      await model.load(servers);
+      expect(model.getSearchScope(servers).kind).assertEqual('unavailable');
     });
 
     it('load 无持久化值时默认文件源', 0, async () => {
       const model = new SourceSwitchModel();
-      await model.load([1, 2]);
+      await model.load([makeServer(1, 'A'), makeServer(2, 'B')]);
       expect(model.isFileSource()).assertTrue();
     });
   });

--- a/entry/src/test/search_scope_deletion_test.cjs
+++ b/entry/src/test/search_scope_deletion_test.cjs
@@ -1,5 +1,5 @@
-// Host-only regression: native database IO is stubbed by search_scope_test.cjs.
-// Both deletion methods, source state, persistence and scope resolution are real.
+// 主机回归：原生数据库 IO 由 search_scope_test.cjs 替换。
+// 执行真实删除方法、来源状态、偏好持久化逻辑和范围解析。
 const { describe, it, expect, beforeEach, afterEach } = require('@ohos/hypium');
 const { VideoServerModel } = require('../main/ets/stores/servers/VideoServerModel.ets');
 const { SourceSwitchModel } = require('../main/ets/stores/media/SourceSwitchModel.ets');
@@ -7,7 +7,7 @@ const { AppPreferences, PrefKey } = require('../main/ets/utils/AppPreferences.et
 const { getSearchCapabilities, resolveSearchRoute } = require('../main/ets/models/search/SearchScope.ets');
 
 module.exports = function deletionTests() {
-  describe('Search scope actual server deletion', () => {
+  describe('搜索范围真实服务器删除', () => {
     let source, model, values;
     beforeEach(async () => {
       values = new Map();
@@ -30,7 +30,7 @@ module.exports = function deletionTests() {
       AppPreferences.setStoreLoaderForTesting(null);
       AppPreferences.resetForTesting();
     });
-    it('deleting active server preserves unavailable identity and persisted selection', 0, async () => {
+    it('删除当前服务器保留不可用身份与持久化选择', 0, async () => {
       const persisted = values.get(PrefKey.ACTIVE_MEDIA_SOURCE);
       await model.deleteVideoServerWithFallback(1);
       expect(model.getVideoServerById(1)).assertEqual(null);
@@ -46,7 +46,7 @@ module.exports = function deletionTests() {
       await restored.load(model.videoServers);
       expect(restored.getSearchScope(model.videoServers).kind).assertEqual('unavailable');
     });
-    it('deleting another server leaves active identity and persistence unchanged', 0, async () => {
+    it('删除其他服务器不改变当前身份与持久化选择', 0, async () => {
       const persisted = values.get(PrefKey.ACTIVE_MEDIA_SOURCE);
       await model.deleteVideoServerWithFallback(2);
       expect(model.getVideoServerById(2)).assertEqual(null);
@@ -54,7 +54,7 @@ module.exports = function deletionTests() {
       expect(source.getSearchScope(model.videoServers).key).assertEqual('video-server:jellyfin:1');
       expect(values.get(PrefKey.ACTIVE_MEDIA_SOURCE)).assertEqual(persisted);
     });
-    it('only explicit local selection enables local search after deletion', 0, async () => {
+    it('删除后仅主动选择本地才启用本地搜索', 0, async () => {
       await model.deleteVideoServerWithFallback(1);
       expect(getSearchCapabilities(source.getSearchScope(model.videoServers)).localSearch).assertEqual(false);
       await source.setFileSource();

--- a/entry/src/test/search_scope_deletion_test.cjs
+++ b/entry/src/test/search_scope_deletion_test.cjs
@@ -1,0 +1,70 @@
+// Host-only regression: native database IO is stubbed by search_scope_test.cjs.
+// Both deletion methods, source state, persistence and scope resolution are real.
+const { describe, it, expect, beforeEach, afterEach } = require('@ohos/hypium');
+const { VideoServerModel } = require('../main/ets/stores/servers/VideoServerModel.ets');
+const { SourceSwitchModel } = require('../main/ets/stores/media/SourceSwitchModel.ets');
+const { AppPreferences, PrefKey } = require('../main/ets/utils/AppPreferences.ets');
+const { getSearchCapabilities, resolveSearchRoute } = require('../main/ets/models/search/SearchScope.ets');
+
+module.exports = function deletionTests() {
+  describe('Search scope actual server deletion', () => {
+    let source, model, values;
+    beforeEach(async () => {
+      values = new Map();
+      AppPreferences.resetForTesting();
+      AppPreferences.setStoreLoaderForTesting(async () => ({
+        get: async (key, fallback) => values.has(key) ? values.get(key) : fallback,
+        put: async (key, value) => { values.set(key, value); },
+        flush: async () => {}
+      }));
+      await AppPreferences.init({});
+      source = SourceSwitchModel.getState();
+      model = new VideoServerModel();
+      model.videoServers = [1, 2].map(id => ({
+        id, name: `Server ${id}`, type: 'jellyfin', configJson: '{}', createdAt: 1
+      }));
+      await source.setVideoServer(model.videoServers[0]);
+    });
+    afterEach(async () => {
+      await source.setFileSource();
+      AppPreferences.setStoreLoaderForTesting(null);
+      AppPreferences.resetForTesting();
+    });
+    it('deleting active server preserves unavailable identity and persisted selection', 0, async () => {
+      const persisted = values.get(PrefKey.ACTIVE_MEDIA_SOURCE);
+      await model.deleteVideoServerWithFallback(1);
+      expect(model.getVideoServerById(1)).assertEqual(null);
+      expect(source.getActiveServerId()).assertEqual(1);
+      expect(values.get(PrefKey.ACTIVE_MEDIA_SOURCE)).assertEqual(persisted);
+      const scope = source.getSearchScope(model.videoServers);
+      expect(scope.kind).assertEqual('unavailable');
+      expect(getSearchCapabilities(scope).localSearch).assertEqual(false);
+      expect(getSearchCapabilities(scope).localHistory).assertEqual(false);
+      expect(resolveSearchRoute(null, scope, model.videoServers).scope.kind).assertEqual('unavailable');
+      expect(resolveSearchRoute('movie', scope, model.videoServers).scope.kind).assertEqual('unavailable');
+      const restored = new SourceSwitchModel();
+      await restored.load(model.videoServers);
+      expect(restored.getSearchScope(model.videoServers).kind).assertEqual('unavailable');
+    });
+    it('deleting another server leaves active identity and persistence unchanged', 0, async () => {
+      const persisted = values.get(PrefKey.ACTIVE_MEDIA_SOURCE);
+      await model.deleteVideoServerWithFallback(2);
+      expect(model.getVideoServerById(2)).assertEqual(null);
+      expect(source.getActiveServerId()).assertEqual(1);
+      expect(source.getSearchScope(model.videoServers).key).assertEqual('video-server:jellyfin:1');
+      expect(values.get(PrefKey.ACTIVE_MEDIA_SOURCE)).assertEqual(persisted);
+    });
+    it('only explicit local selection enables local search after deletion', 0, async () => {
+      await model.deleteVideoServerWithFallback(1);
+      expect(getSearchCapabilities(source.getSearchScope(model.videoServers)).localSearch).assertEqual(false);
+      await source.setFileSource();
+      const scope = source.getSearchScope(model.videoServers);
+      expect(scope.key).assertEqual('local-files');
+      expect(getSearchCapabilities(scope).localSearch).assertTrue();
+      expect(getSearchCapabilities(scope).localHistory).assertTrue();
+      const restored = new SourceSwitchModel();
+      await restored.load(model.videoServers);
+      expect(restored.getSearchScope(model.videoServers).key).assertEqual('local-files');
+    });
+  });
+};

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -1,0 +1,73 @@
+// Host adapter for the repository Hypium runner; no device or database required.
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+const root = path.resolve(__dirname, '../../..');
+const ts = require(process.env.TYPESCRIPT_PATH ||
+  '/Applications/DevEco-Studio.app/Contents/tools/hvigor/hvigor/node_modules/typescript');
+const hypium = fs.realpathSync(path.join(root, 'oh_modules/@ohos/hypium/src/main'));
+const originalJs = require.extensions['.js'];
+function compile(module, filename) {
+  module._compile(ts.transpileModule(fs.readFileSync(filename, 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2021,
+      experimentalDecorators: true }
+  }).outputText, filename);
+}
+require.extensions['.ets'] = compile;
+require.extensions['.js'] = (module, filename) => {
+  if (filename.startsWith(hypium)) compile(module, filename);
+  else originalJs(module, filename);
+};
+global.ObservedV2 = (target) => target;
+global.Trace = () => {};
+const load = Module._load;
+Module._load = function (request, parent, main) {
+  if (request === '@ohos/hypium') return require(path.join(hypium, 'interface.js'));
+  if (request === '@ohos.app.ability.abilityDelegatorRegistry') {
+    return { default: { getAbilityDelegator: () => ({ getAppContext: () => ({}) }) } };
+  }
+  if (request === '@ohos.data.preferences') return {};
+  return load.call(this, request, parent, main);
+};
+if (process.argv.includes('--integration')) {
+  // Static integration checks complement pure-model cases; they do not execute ArkUI.
+  const assert = require('node:assert/strict');
+  function checkGuard(file, method, capability) {
+    const source = fs.readFileSync(path.join(root, file), 'utf8');
+    const start = source.indexOf(method);
+    assert.notEqual(start, -1, method);
+    const body = source.slice(source.indexOf('{', start) + 1).trimStart();
+    assert.ok(body.startsWith(`if (!getSearchCapabilities(this.scope).${capability}`), method);
+  }
+  const workspace = 'entry/src/main/ets/pages/search/SearchWorkspacePage.ets';
+  const results = 'entry/src/main/ets/pages/search/MediaResultPage.ets';
+  for (const method of ['private loadHistory()', 'private deleteHistory(', 'private clearAllHistory()',
+    'private executeSearchWithHistory()']) checkGuard(workspace, method, 'localHistory');
+  checkGuard(workspace, 'private async executeSearch()', 'localSearch');
+  checkGuard(workspace, 'private navigateToDetail(', 'localDetail');
+  checkGuard(results, 'private async doSearch()', 'localSearch');
+  checkGuard(results, 'private async loadGenreOptions()', 'localSearch');
+  checkGuard(results, 'private navigateToDetail()', 'localDetail');
+  for (const file of [workspace, results]) {
+    const source = fs.readFileSync(path.join(root, file), 'utf8');
+    assert.ok(source.includes('resolveSearchRoute(param, SourceSwitchModel.getState().getSearchScope(servers), servers)'));
+    assert.ok(source.includes('searchScope: this.scope'));
+  }
+  console.log('Static routing/side-effect guards: passed');
+}
+const Core = require(path.join(hypium, 'core.js')).default;
+const core = Core.getInstance();
+core.init();
+require(path.join(root, 'entry/src/test/SearchScope.test.ets')).default();
+if (process.argv.includes('--integration')) {
+  require(path.join(root, 'entry/src/test/SourceSwitchModel.test.ets')).default();
+}
+core.registerEvent('task', {
+  id: 'host-result', taskStart() {},
+  taskDone() {
+    const summary = core.getDefaultService('suite').getSummary();
+    console.log(JSON.stringify(summary));
+    process.exitCode = summary.failure || summary.error || summary.total === 0 ? 1 : 0;
+  }
+});
+core.execute();

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -1,4 +1,4 @@
-// Host adapter for the repository Hypium runner; no device or database required.
+// 仓库 Hypium 运行器的主机适配层，无需设备或数据库。
 const fs = require('node:fs');
 const path = require('node:path');
 const Module = require('node:module');
@@ -27,7 +27,7 @@ Module._load = function (request, parent, main) {
     return { default: { getAbilityDelegator: () => ({ getAppContext: () => ({}) }) } };
   }
   if (request === '@ohos.data.preferences') return {};
-  // Host-only database boundary; execute the real VideoServerModel deletion/cache logic.
+  // 仅替换主机数据库边界，执行真实 VideoServerModel 删除与缓存逻辑。
   if (request === '../../db/files/FileSourceDatabase' && parent &&
     parent.filename.endsWith('/stores/servers/VideoServerModel.ets')) {
     return { FileSourceDatabase: { getInstance: () => ({ deleteVideoServer: async () => {} }) } };
@@ -35,7 +35,7 @@ Module._load = function (request, parent, main) {
   return load.call(this, request, parent, main);
 };
 if (process.argv.includes('--integration')) {
-  // Static integration checks complement pure-model cases; they do not execute ArkUI.
+  // 静态接入检查补充纯模型用例，不执行 ArkUI。
   const assert = require('node:assert/strict');
   function checkGuard(file, method, capability) {
     const source = fs.readFileSync(path.join(root, file), 'utf8');
@@ -58,7 +58,33 @@ if (process.argv.includes('--integration')) {
     assert.ok(source.includes('resolveSearchRoute(param, SourceSwitchModel.getState().getSearchScope(servers), servers)'));
     assert.ok(source.includes('searchScope: this.scope'));
   }
-  console.log('Static routing/side-effect guards: passed');
+  const resultSource = fs.readFileSync(path.join(root, results), 'utf8');
+  const resetBody = resultSource.match(/private resetAll\(\): void \{([\s\S]*?)\n  \}/)[1];
+  const reset = new Function(ts.transpileModule(`function reset() {${resetBody}}`, {
+    compilerOptions: { target: ts.ScriptTarget.ES2021 }
+  }).outputText + '; return reset;')();
+  for (const [rating, year] of [[8, '1990'], [0, '']]) {
+    const state = {
+      initialMediaType: 'movie', initialGenre: '剧情', initialPageTitle: '入口',
+      initialRating: rating, initialYearLabel: year,
+      filterRating: 9, filterYearLabel: '2020',
+      doSearch() { this.searched = true; return Promise.resolve(); }
+    };
+    reset.call(state);
+    assert.equal(state.filterRating, rating);
+    assert.equal(state.filterYearLabel, year);
+    assert.equal(state.filterMediaType, 'movie');
+    assert.equal(state.filterGenre, '剧情');
+    assert.equal(state.pageTitle, '入口');
+    assert.equal(state.searched, true);
+  }
+  for (const field of ['Rating', 'YearLabel']) {
+    assert.ok(resultSource.includes(`this.initial${field} = this.filter${field};`));
+  }
+  const sourceModel = fs.readFileSync(path.join(root,
+    'entry/src/main/ets/stores/media/SourceSwitchModel.ets'), 'utf8');
+  assert.match(sourceModel, /@Trace\s+private sourceLoaded: boolean/);
+  console.log('静态路由与观察字段检查、2项真实重置方法回归：通过');
 }
 const Core = require(path.join(hypium, 'core.js')).default;
 const core = Core.getInstance();

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -3,8 +3,12 @@ const fs = require('node:fs');
 const path = require('node:path');
 const Module = require('node:module');
 const root = path.resolve(__dirname, '../../..');
-const ts = require(process.env.TYPESCRIPT_PATH ||
-  '/Applications/DevEco-Studio.app/Contents/tools/hvigor/hvigor/node_modules/typescript');
+// 默认解析项目 TypeScript；允许通过绝对路径使用已有 SDK 中的模块。
+const typescriptPath = process.env.TYPESCRIPT_PATH;
+if (typescriptPath !== undefined && !path.isAbsolute(typescriptPath)) {
+  throw new Error('TYPESCRIPT_PATH 必须为已安装的 TypeScript 模块绝对路径');
+}
+const ts = require(typescriptPath === undefined ? 'typescript' : typescriptPath);
 const hypium = fs.realpathSync(path.join(root, 'oh_modules/@ohos/hypium/src/main'));
 const originalJs = require.extensions['.js'];
 function compile(module, filename) {

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -27,6 +27,11 @@ Module._load = function (request, parent, main) {
     return { default: { getAbilityDelegator: () => ({ getAppContext: () => ({}) }) } };
   }
   if (request === '@ohos.data.preferences') return {};
+  // Host-only database boundary; execute the real VideoServerModel deletion/cache logic.
+  if (request === '../../db/files/FileSourceDatabase' && parent &&
+    parent.filename.endsWith('/stores/servers/VideoServerModel.ets')) {
+    return { FileSourceDatabase: { getInstance: () => ({ deleteVideoServer: async () => {} }) } };
+  }
   return load.call(this, request, parent, main);
 };
 if (process.argv.includes('--integration')) {
@@ -61,6 +66,7 @@ core.init();
 require(path.join(root, 'entry/src/test/SearchScope.test.ets')).default();
 if (process.argv.includes('--integration')) {
   require(path.join(root, 'entry/src/test/SourceSwitchModel.test.ets')).default();
+  require('./search_scope_deletion_test.cjs')();
 }
 core.registerEvent('task', {
   id: 'host-result', taskStart() {},


### PR DESCRIPTION
## 关联与范围
关联 #315，属于 Epic #314；本 PR 不自行合并或关闭 Issue。

- 搜索入口严格承接顶部当前来源；WebDAV/SMB 配置聚合为 `local-files`，每个影视服务器配置使用 `video-server:<type>:<id>`。
- `SearchScope.ets` 统一身份解析、路由恢复和能力契约，来源 key 根据真实配置重建，不信任路由传入 key。
- 旧 null/string 路由跟随当前来源；删除、无效、类型不匹配或尚未恢复的来源不得回退本地搜索。
- 搜索页/结果页按能力禁止服务器范围访问本地媒体、类型列表及历史；详情保持原平铺参数并附可选 searchScope。
- 不实现服务器搜索接口、网盘或 #316 等后续 Issue。

## 验证
工作树：`/Users/yaoshining/Workspaces/MyProjects/copilot-worktrees/VidAll_TV/yaoshining-issue-315-1a6f89`
分支：`yaoshining-fix/search-context-scope`

独立 QA 在当前工作树执行：
```bash
devecocli build --modules entry@default
pnpm --config.manage-package-manager-versions=false --config.verify-deps-before-run=false --dir proxy/opensubtitles-worker exec node ../../entry/src/test/search_scope_test.cjs --integration
git diff --check
devecocli device list
```
- HAP 编译退出 0：`BUILD SUCCESSFUL in 22 s 673 ms`、`Build completed successfully`；首轮三处 ArkTS 类型错误已消除。
- 主机测试退出 0：17/17（SearchScope 8 项 + SourceSwitchModel 9 项），`Static routing/side-effect guards: passed`。提交前父会话再次执行同命令通过。
- diff 检查退出 0；QA 前后 diff SHA256 一致：`26f7b54dbafffcff522e1597b628d0bd4b95cd423664b7d85066a82ee100819a`。
- 构建产物：`entry/build/default/outputs/default/entry-default-signed.hap`。
- QA 原始输出保留在本会话 QA 子代理 `0669d097-26eb-4d09-9e38-96619b98983a` 的工具记录中；未取得单独落盘的完整构建日志路径。
- 设备查询退出 0：`No active devices.`。未启动模拟器、未安装应用；编译通过不等于真机验收。

## lint / format 未通过（工具执行缺口）
根目录 `pnpm run lint`、`pnpm run format` 均退出 1：根目录没有 package.json。随后检查现有 DevEco 工具实现并修正参数，实际完整 lint 调用如下（在上述 worktree 根目录运行）：
```bash
/Users/yaoshining/Library/pnpm/bin/pnpm \
  --config.manage-package-manager-versions=false \
  --config.verify-deps-before-run=false \
  --dir proxy/opensubtitles-worker exec \
  /Applications/DevEco-Studio.app/Contents/tools/node/bin/node \
  /Applications/DevEco-Studio.app/Contents/plugins/codelinter/index.js \
  --project "$PWD" \
  --dir "[\"$PWD/entry/src/main/ets/db/models/MediaEntity.ets\", \"$PWD/entry/src/main/ets/models/search/SearchScope.ets\", \"$PWD/entry/src/main/ets/pages/home/index.ets\", \"$PWD/entry/src/main/ets/pages/home/tabs/VideoServerTab.ets\", \"$PWD/entry/src/main/ets/pages/home/topbar/index.ets\", \"$PWD/entry/src/main/ets/pages/search/MediaResultPage.ets\", \"$PWD/entry/src/main/ets/pages/search/SearchWorkspacePage.ets\", \"$PWD/entry/src/main/ets/stores/media/SourceSwitchModel.ets\"]" \
  --config "$PWD/code-linter.json5" --product default \
  --workdir /Applications/DevEco-Studio.app/Contents/plugins/codelinter \
  --sdkPath /Applications/DevEco-Studio.app/Contents/sdk \
  --logPath /var/folders/7s/y7kx47nj0l7gk98hbd3shvv40000gn/T/issue315-lint-o4xad42d/lint.log \
  --inIde false
```
Lint 子进程退出 **255**，外层 Python 包装退出 0 不能当作 lint 成功。原始日志位置为上述 `--logPath`。原文：
```text
targets: undefined
The configuration file .../code-linter.json5 is in use.
Some error occurred during linting. This may cause incomplete report results.
```
已修正 `--dir` 为工具要求的 JSON 数组，并补齐 workdir/sdkPath/logPath，仍无完整检查报告或异常堆栈，根因尚未确定；不能据此宣称源码无 lint 问题。首次调用产生的 `undefined` 经授权核验为本轮 lint 日志后清理，无其他文件删除。

```bash
/Applications/DevEco-Studio.app/Contents/bin/format.sh -h
```
退出 **1**：`Only one instance of DevEcoStudio can be run at a time`。该脚本实际启动 `/Applications/DevEco-Studio.app/Contents/MacOS/devecostudio format -h`，错误来自 IDE 启动器；占用实例 PID 未确认，没有杀任何共享进程。帮助入口已失败，未实际完成格式化，输出仅保留在工具记录中。

## 待验收与已知偏差
- 等待独立代码评审；真机遥控器焦点、来源切换往返、真实数据库与设备侧集成待验证。
- 主机测试使用平台适配，静态路由守卫不是实际 ArkUI 集成测试。
- 首里程碑提交 `35bed87f1a0384ca35397195e0fd0ad21aed91df` 的中文首行缺少类型后的冒号；保留既有历史，未 amend/rebase/强推。后续提交严格采用中文类型加冒号及 Co-authored-by。

Fixes: #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增搜索范围管理，支持本地文件、视频服务器及不可用范围。
  * 搜索页面会根据当前范围启用相应的搜索、筛选、历史记录和详情功能。
  * 从首页进入搜索时保留当前视频服务器范围和搜索关键词。
  * 视频服务器状态变化后可更准确地恢复搜索来源。

* **Bug 修复**
  * 删除当前视频服务器后不再自动切换为本地文件源，并正确显示不可用范围。

* **测试**
  * 新增并完善搜索范围及媒体来源切换相关测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->