### PR TITLE
新增: 接入影视服务器搜索与详情路由并完善实例身份隔离

### DIFF
--- a/.plans/plan-serverSearchSupportMatrix.md
+++ b/.plans/plan-serverSearchSupportMatrix.md
@@ -1,0 +1,120 @@
+# #316 服务器搜索支持矩阵与验证限制
+
+## 范围与基线
+
+本文记录实现基线 `1f586f93e5436889a8d04d698c2fe66988a72af4` 的能力及证据边界，不代表 #316 已完成全部验收。身份隔离实现已通过独立 QA 与增量复审；本次仅补文档，不改业务、不重新构建。
+
+搜索针对当前选中的一个具体服务器实例，不聚合多个服务器，不搜索本地媒体库，不在来源失效时回退本地。既有 `.plans/reference/` 文档涉及其他主题，因此本文件作为该矩阵的单一入口。
+
+## 三协议支持矩阵
+
+“已接入”仅表示源码与自动化覆盖，不表示已完成真实服务器或 TV 验收。
+
+| 能力 | Jellyfin | Emby | Plex |
+| --- | --- | --- | --- |
+| 搜索适配 | `JellyfinClient.searchItems` | 复用 `JellyfinClient.searchItems` | `PlexClient.searchItems` |
+| 请求路径 | `/Users/{userId}/Items` | `/Users/{userId}/Items` | `/hubs/search` |
+| 关键词参数 | `SearchTerm`，URL 编码 | `SearchTerm`，URL 编码 | `query`，URL 编码 |
+| 请求范围 | `Recursive=true`，`IncludeItemTypes=Movie,Series,Episode`，`Limit=100` | 同 Jellyfin，仍需验证实际版本兼容 | `limit=100`，`includeExternalMedia=0`；仅接收 movie/show/episode hub |
+| 电影 | Movie 归一为 `movie` | Movie 归一为 `movie` | movie 归一为 `movie` |
+| 剧集整体 | Series 归一为 `series` | Series 归一为 `series` | show 归一为 `series` |
+| 单集 | Episode 归一为 `episode` | Episode 归一为 `episode` | episode 归一为 `episode` |
+| 季独立搜索 | 未请求 Season，归一层不接收 season | 同 Jellyfin | season hub 不接收，归一层不接收 season |
+| 剧集详情中的季/集 | 既有详情链调用季列表、下一集及季详情入口 | 同 Jellyfin | 使用 Plex 季列表、下一集及既有详情入口 |
+| 真实 HTTP 搜索→详情→返回→再搜 | 尚未验证 | 尚未验证 | 尚未验证 |
+| TV 遥控器与系统键盘闭环 | 尚未验证 | 尚未验证 | 尚未验证 |
+
+电影与剧集整体使用各自媒体 ID 打开服务器详情。单集结果保留原始 `mediaId`；若存在 `seriesId`，详情目标 `detailItemId` 使用该剧集 ID，否则使用单集自身 ID。进入剧集详情不承诺自动定位或播放搜索命中的那一集：既有主播放目标为 `nextUp`，需按季/集入口选择目标。缺少父级元数据时的实际展示需用真实样本验收。
+
+剧集详情获取季列表/下一集失败时，当前实现保留已获取的基本详情，相关内容可能为空；这不是“详情完全加载成功”的保证，也没有独立的季列表重试承诺。
+
+## 结果、输入与容量限制
+
+- 搜索服务只保留 `movie`、`series`、`episode`，使用来源 scope 与编码后的媒体 ID 生成 key 并去重，不把季、人物、音乐等扩展为搜索结果类型。
+- 最终归一结果最多 100 项，界面明确显示“首批结果（最多 100 项，可能更少）”。Plex 请求限制不等于聚合 hub 后的统一总数；归一层仍截断至 100。
+- DTO 没有 `total`、`hasMore` 或分页游标，没有加载下一页能力。少于 100 项可能来自服务端返回、类型过滤或去重；恰好 100 项也不能证明仍有下一页。不得显示为完整命中总数。
+- 使用真实 `TextInput` 文本，输入变更防抖 800ms，提交可直接搜索；空白关键词不发搜索请求。服务器输入不依赖本地拼音索引，不承诺拼音、首字母、分词、模糊搜索或跨语言匹配，匹配能力以服务器为准。
+- 服务器搜索不读写本地搜索历史。系统键盘的实际弹出、中文输入和遥控器焦点行为仍需设备验证，组件接线或 host 测试不替代该证据。
+
+## 身份路由与异步隔离
+
+路由携带 `serverId`、`serverType`、`mediaId`、`mediaType`、详情目标 `itemId` 和标题，进入既有 `ServerMediaDetailPage`，不跳转本地电影/剧集详情。点击结果前校验来源快照，来源或同 ID 配置变化时拒绝旧结果并提示重新选择或搜索。
+
+搜索快照对外只有 scope/实例 ID/类型；原始配置比较保存在模块私有状态。详情首次 await 前固定配置修订校验依据；正常冷缓存初始化自动且恰好请求一次详情，不能将真实修改当作初始化认领。模型在 update/delete 的 DB 写入 pending 前同步发布修订，阻止迟到 load 用旧 DB 快照覆盖修改或删除。
+
+详情成功后仍在整个可见期监听修订；隐藏/离页解除监听并使请求、播放失效，显示时恢复监听与合法加载。播放开始捕获身份和修订，各 await 后及导航前复核 active、generation、身份、revision。旧成功、失败和 finally 不得回填详情、发起播放器或解除新请求的防重入锁。
+
+写失败也保守失效，旧详情/播放不会自动复活；待写入结束后通过新加载/重试重新校验，已删除或不可用来源需返回选择。模型修订是保守失效依据，不承诺其他实例修改完全不影响当前操作。
+
+不得将配置或凭据加入 DTO、路由、key、验证截图或日志。注意既有图片 URL 沿用客户端鉴权，可能包含认证参数；不能据此宣称整个结果对象无敏感信息，禁止记录完整结果或认证 URL。
+
+## 状态与恢复
+
+| 场景 | 当前行为与恢复方式 |
+| --- | --- |
+| 请求中 | 显示 loading；新关键词或失效使旧响应不能覆盖新状态 |
+| 无匹配 | 显示当前服务器未找到匹配内容；不是网络失败 |
+| 认证失败 | 归类 `auth`，提示检查来源配置后重试；重试本身不会修复凭据 |
+| 超时、网络、无效响应 | 分别归类 `timeout`、`network`、`invalidResponse`，显示可重试反馈 |
+| 来源不可用 | `unavailable`，返回重新选择来源；不回退本地 |
+| 搜索重试 | 按当前文本与来源重新请求，不复用失效结果 |
+| 详情失败/配置失效 | 显示错误及重试入口；成功和失败后均释放当前请求锁，失效旧 finally 不释放新锁 |
+| 返回再次搜索 | 重新校验当前来源再搜索；自动测试覆盖迟到响应隔离，真实设备返回顺序待验收 |
+
+错误分类是客户端归一结果，不是完整 HTTP 故障诊断；真实 401/403、超时、下线与异常响应尚需各协议实例验证。
+
+## 分层验证与原始证据
+
+最终 QA 在 `420c8856f53feb94b8af8a8d36bc11eea304142c` 上验证冻结 diff，随后原样提交为本文基线 `1f586f93e`。完整 diff SHA256：`da380c1a4e58248a5a5f428407f539cf2af6845f75ce5f8e7ca52085f7d39768`。903 个受跟踪及非忽略新增文件前后 hash 一致；最终三文件 hash 与冻结一致。
+
+| 层级 | 已有结果 | 能证明 / 不能证明 |
+| --- | --- | --- |
+| Hypium 用例 | 59 项通过，host runner 执行 | 断言与协议替身覆盖；不是 59 项真机测试 |
+| host 方法回归 | 冷入口 12 组、pending update/delete 8 组、loaded revision 8 组、stream/directory 隐藏与导航 12 组，另有首次 await、旧 catch/finally、重试等断言 | 转译真实模型、提取真实页面方法；DB、transport、navigation、context builder 为替身；上述组数不累加到 59 |
+| 原独立失败探针复验 | update/delete DB pending 均 `pushes=[]`、`hasDetail=false`，exit 0 | 原旧 stream 导航阻断已不再复现；非真实网络播放 |
+| 独立 QA 生产编译 | `devecocli build --modules entry@default --product default` exit 0；实际 CompileArkTS 3s934ms，BUILD SUCCESSFUL 7s162ms | 页面及模型进入非 ohosTest 生产图；HAP 中 ABC 与当前产物一致；有警告及其他缓存任务，不是 clean build |
+| 工程生产编译 | 实际 CompileArkTS 5s594ms | 工程中间证据，不替代独立 QA |
+| 工程后续缓存构建 | 634ms 缓存 build | 不计为重新实编译源码的证据 |
+| lint | SDK 22 / 6.0.2 找不到；工具虽 exit 0，结果不完整 | 未通过，不能用空 defects 声称合规 |
+| format | `format.sh -h` exit 1，IDE 单实例限制 | 未成功执行代码格式化，不声称通过 |
+| 真实 HTTP | 无本轮真实三协议闭环证据 | 服务器版本、数据/权限、故障码等仍待确认 |
+| TV | 未部署验收 | D-pad、OK、返回、键盘、保栈生命周期顺序、实际播放及性能均待验证 |
+
+原始日志由交付会话保留，不把不可移植的本机绝对路径作为项目链接：
+
+- 最终 QA 前缀 `issue316-loaded-revision-recovery-qa-`：`report.txt`、`verification.json`、`search.log`、`independent-probe.log`、`build.log`、`artifacts.json`、前后 manifest、lint/format 日志及退出码。
+- 工程实际编译：`issue316-loaded-revision-engineer-build-before-duplicate-check.log`；后续缓存构建：`issue316-loaded-revision-engineer-build.log`。
+- 原失败探针：`issue316-model-revision-final-qa-independent-probe.cjs`；历史失败日志同前缀 `.log`，修后原样运行的输出见最终 QA `independent-probe.log`。
+
+已有定向自动验证命令（需本地现有 TypeScript/依赖；仅供复验，本次文档修改不执行）：
+
+```bash
+TYPESCRIPT_PATH=/Applications/DevEco-Studio.app/Contents/tools/ohpm/node_modules/typescript/lib/typescript.js \
+pnpm --config.manage-package-manager-versions=false --config.verify-deps-before-run=false \
+  --dir proxy/opensubtitles-worker exec \
+  node ../../entry/src/test/search_scope_test.cjs --server-search --integration
+```
+
+## 待完成验收与可执行步骤
+
+本会话没有确认当前存在可用的真实三协议实例或 TV，亦没有确认它们一定不存在；连接、授权和设备可用性均待协调核实。不能将“尚无证据”改写为“已验证”或“设备缺失”。未输出或探测连接凭据。
+
+1. 准备获授权的 Jellyfin、Emby、Plex 测试实例，记录脱敏版本、媒体类型/父级关系、权限及是否可达；各含电影、剧集、季/集和空结果样本。未具备任一实例时，该协议 HTTP 验收阻塞。
+2. 每协议依次用中文/英文真实文本搜索，点击电影及单集结果、检查实例与剧集目标、进入季/集、返回再搜；检查首批提示，不以结果数量冒充总数。保存脱敏请求状态与界面记录，不保存 token、配置或完整认证 URL。
+3. 用获授权测试环境验证 401/403、超时、空结果、下线与恢复重试；在请求/播放 pending 时修改同 ID 配置或删除，验证旧响应无回填、无误导航，写失败后仅新重试恢复。
+4. 准备已配对、可安装签名 HAP 的 TV，按仓库局域网部署指令使用待验 worktree 构建安装；未具备设备/签名条件时，TV 验收阻塞。记录提交、产品、系统版本和包 hash。
+5. 在 TV 验证系统键盘中文输入、D-pad 聚焦结果/重试、OK 触发、返回再搜；播放 pending 时压入季/人物详情，确认隐藏旧页不能迟到 push，重新显示及正常播放器返回不破坏状态，正常播放只导航一次。
+6. 保存协议与设备分开的逐项结果，失败保持未通过；补齐 lint/format 环境验证。本轮不自动扩展修复范围。
+
+本文完成支持矩阵/限制说明最小项；真实协议与 TV 验收、代码规范工具缺口、全部 Issue 验收确认及 PR 合并仍未完成。独立复审接受实现不等于 #316 DONE；不在本任务创建 PR、合并、关闭或归档。
+
+## 源码与测试依据
+
+- [搜索归一、身份快照与容量](../entry/src/main/ets/services/search/VideoServerSearchService.ets)
+- [Jellyfin / Emby 请求](../entry/src/main/ets/lib/JellyfinClient.ets)
+- [Plex 请求及媒体映射](../entry/src/main/ets/lib/PlexClient.ets)
+- [输入、状态、重试与详情路由](../entry/src/main/ets/pages/search/SearchWorkspacePage.ets)
+- [详情、季入口与播放生命周期](../entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets)
+- [配置修订及真实写入链](../entry/src/main/ets/stores/servers/VideoServerModel.ets)
+- [服务器搜索用例](../entry/src/test/VideoServerSearch.test.ets)
+- [实际方法 host 回归入口](../entry/src/test/search_scope_test.cjs)

--- a/entry/src/main/ets/lib/JellyfinClient.ets
+++ b/entry/src/main/ets/lib/JellyfinClient.ets
@@ -786,6 +786,25 @@ export class JellyfinClient {
     return result;
   }
 
+  /** Search only this authenticated server; no local or cross-server fallback. */
+  async searchItems(keyword: string): Promise<VideoServerMediaItem[]> {
+    await this.authenticate();
+    const userId = await this.ensureUserId();
+    const resp = await JsonHttpClient.get(
+      `${this.buildBaseUrl()}/Users/${encodeURIComponent(userId)}/Items` +
+        `?SearchTerm=${encodeURIComponent(keyword)}&Recursive=true&IncludeItemTypes=Movie,Series,Episode&Limit=100`,
+      this.authHeaders()
+    );
+    if (resp.statusCode < 200 || resp.statusCode >= 300) {
+      throw new Error(JsonHttpClient.classifyError(resp.statusCode, '搜索失败'));
+    }
+    const parsed = JSON.parse(resp.body) as Record<string, Object>;
+    if (parsed === null || !Array.isArray(parsed['Items'])) {
+      throw new Error('Invalid search response');
+    }
+    return this.parseItems(resp.body);
+  }
+
   private parseItems(body: string): VideoServerMediaItem[] {
     const parsed = JSON.parse(body) as Object;
     const result: VideoServerMediaItem[] = [];

--- a/entry/src/main/ets/lib/JsonHttpClient.ets
+++ b/entry/src/main/ets/lib/JsonHttpClient.ets
@@ -9,6 +9,16 @@ export interface JsonHttpResponse {
   body: string;
 }
 
+/** Keep the native code so callers can classify timeouts without parsing localized messages. */
+export class JsonHttpTransportError extends Error {
+  code: number;
+
+  constructor(error: BusinessError) {
+    super(error.message || 'HTTP request failed');
+    this.code = error.code;
+  }
+}
+
 /**
  * 影视服务器客户端共用的 JSON HTTP 传输层。
  * 基于 @ohos.net.http，承载 GET/POST JSON 请求（Jellyfin / Emby / Plex 均为标准 REST）。
@@ -38,7 +48,7 @@ export class JsonHttpClient {
           if (err) {
             const bizErr = err as BusinessError;
             req.destroy();
-            reject(new Error(bizErr.message || 'HTTP request failed'));
+            reject(new JsonHttpTransportError(bizErr));
             return;
           }
           const response: JsonHttpResponse = {
@@ -53,7 +63,7 @@ export class JsonHttpClient {
         // req.request 同步抛出（如 URL 非法）时释放请求对象，避免 Promise 悬挂与资源泄漏。
         const bizErr = e as BusinessError;
         req.destroy();
-        reject(new Error(bizErr.message || 'HTTP request failed'));
+        reject(new JsonHttpTransportError(bizErr));
       }
     });
   }

--- a/entry/src/main/ets/lib/JsonHttpClient.ets
+++ b/entry/src/main/ets/lib/JsonHttpClient.ets
@@ -9,7 +9,7 @@ export interface JsonHttpResponse {
   body: string;
 }
 
-/** Keep the native code so callers can classify timeouts without parsing localized messages. */
+/** 保留原生错误码，调用方无需解析本地化消息即可识别超时。 */
 export class JsonHttpTransportError extends Error {
   code: number;
 

--- a/entry/src/main/ets/lib/PlexClient.ets
+++ b/entry/src/main/ets/lib/PlexClient.ets
@@ -298,6 +298,40 @@ export class PlexClient {
     return null;
   }
 
+  /** Local PMS hubs only: never use plex.tv discovery or remote providers. */
+  async searchItems(keyword: string): Promise<VideoServerMediaItem[]> {
+    this.ensureToken();
+    const resp = await JsonHttpClient.get(
+      `${this.buildBaseUrl()}/hubs/search?query=${encodeURIComponent(keyword)}&limit=100&includeExternalMedia=0`,
+      this.headers()
+    );
+    if (resp.statusCode < 200 || resp.statusCode >= 300) {
+      throw new Error(JsonHttpClient.classifyError(resp.statusCode, '搜索失败'));
+    }
+    const parsed = JSON.parse(resp.body) as Record<string, Object>;
+    const container = parsed?.['MediaContainer'] as Record<string, Object> | undefined;
+    if (container === undefined || container === null) {
+      throw new Error('Invalid search response');
+    }
+    const hubs = container['Hub'] as Array<Record<string, Object>> | undefined;
+    if (hubs === undefined && container['size'] === 0) { return []; }
+    if (!Array.isArray(hubs)) { throw new Error('Invalid search response'); }
+    const result: VideoServerMediaItem[] = [];
+    for (const hub of hubs) {
+      const type = String(hub['type'] ?? '');
+      if (type !== 'movie' && type !== 'show' && type !== 'episode') { continue; }
+      const items = hub['Metadata'] as Array<Record<string, Object>> | undefined;
+      if (items === undefined && hub['size'] === 0) { continue; }
+      if (!Array.isArray(items)) { throw new Error('Invalid search response'); }
+      for (const item of items) {
+        const media = this.mapMetadataItem(item);
+        if (media.type === 'show') { media.type = 'series'; }
+        result.push(media);
+      }
+    }
+    return result;
+  }
+
   private parseMetadata(body: string): VideoServerMediaItem[] {
     const parsed = JSON.parse(body) as Record<string, Object>;
     const mediaContainer = parsed['MediaContainer'] as Record<string, Object> | undefined;

--- a/entry/src/main/ets/models/search/SearchScope.ets
+++ b/entry/src/main/ets/models/search/SearchScope.ets
@@ -91,15 +91,15 @@ export function resolveSearchRoute(param: SearchRouteParam | string | null | und
   return route;
 }
 
-/** Only implemented capabilities are exposed. Server search is deliberately unavailable. */
+/** Only implemented capabilities are exposed. Server search accepts literal text only. */
 export function getSearchCapabilities(scope: SearchScope): SearchCapabilities {
   const local = scope.kind === 'localFiles';
   const capabilities: SearchCapabilities = {
-    localSearch: local, serverSearch: false, localHistory: local,
+    localSearch: local, serverSearch: scope.kind === 'videoServer', localHistory: local,
     localSuggestions: local, localDetail: local,
-    inputModes: local ? ['initials', 'pinyin', 'chinese'] : [],
+    inputModes: local ? ['initials', 'pinyin', 'chinese'] : scope.kind === 'videoServer' ? ['text'] : [],
     hint: local ? '支持首字母、全拼、中文片名搜索' :
-      scope.kind === 'videoServer' ? '当前影视服务器暂不支持搜索' : '来源不可用，请返回重新选择来源'
+      scope.kind === 'videoServer' ? '搜索当前服务器片名（首批最多 100 项，可能更少）' : '来源不可用，请返回重新选择来源'
   };
   return capabilities;
 }

--- a/entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets
@@ -42,6 +42,7 @@ interface ServerMediaDetailServerIdentity {
   serverId: number
   serverType: VideoServerType
   configuration: string
+  revision: number
 }
 
 @ComponentV2
@@ -68,13 +69,17 @@ export struct ServerMediaDetailPage {
   @Local initialLoadDone: boolean = false
   private expectedServerType: string = ''
   private detailLoadGeneration: number = 0
+  private detailRequestRevision: number = 0
   private detailRequestActive: boolean = false
   private playOperationGeneration: number = 0
   private playOperationActive: boolean = false
+  private detailTargetIdentity: ServerMediaDetailServerIdentity | null = null
   private pendingDetailIdentity: ServerMediaDetailServerIdentity | null = null
   private loadedDetailIdentity: ServerMediaDetailServerIdentity | null = null
+  private unsubscribeRequestConfiguration: () => void = () => {}
   private unsubscribeSource: () => void = () => {}
   private unsubscribeConfiguration: () => void = () => {}
+  private unsubscribeLifecycleRevision: () => void = () => {}
 
   private showToastSafe(message: string): void {
     try {
@@ -92,7 +97,8 @@ export struct ServerMediaDetailPage {
     return {
       serverId: server.id as number,
       serverType: server.type,
-      configuration: server.configJson
+      configuration: server.configJson,
+      revision: this.videoServerModel.searchConfigurationRevision
     }
   }
 
@@ -136,7 +142,9 @@ export struct ServerMediaDetailPage {
   }
 
   private beginDetailRequest(silent: boolean): number {
+    this.unsubscribeRequestConfiguration()
     const generation = ++this.detailLoadGeneration
+    this.detailRequestRevision = this.videoServerModel.searchConfigurationRevision
     this.detailRequestActive = true
     this.pendingDetailIdentity = null
     if (!silent) {
@@ -149,6 +157,7 @@ export struct ServerMediaDetailPage {
   private isActiveDetailRequest(generation: number, identity: ServerMediaDetailServerIdentity | null = null): boolean {
     return this.detailRequestActive &&
       generation === this.detailLoadGeneration &&
+      this.detailRequestRevision === this.videoServerModel.searchConfigurationRevision &&
       (identity === null || this.detailInvalidationMessage(identity).length === 0)
   }
 
@@ -193,6 +202,8 @@ export struct ServerMediaDetailPage {
   }
 
   private invalidateDetailState(message: string, clearState: boolean = true): void {
+    this.unsubscribeRequestConfiguration()
+    this.unsubscribeRequestConfiguration = () => {}
     this.detailLoadGeneration++
     this.detailRequestActive = false
     this.playOperationGeneration++
@@ -219,7 +230,8 @@ export struct ServerMediaDetailPage {
     if (identity === null) {
       return
     }
-    const message = this.detailInvalidationMessage(identity)
+    const message = identity.revision !== this.videoServerModel.searchConfigurationRevision ?
+      '服务器配置已变更，请返回重试' : this.detailInvalidationMessage(identity)
     if (message.length > 0) {
       this.invalidateDetailState(message)
     }
@@ -227,6 +239,9 @@ export struct ServerMediaDetailPage {
 
   private subscribeDetailGuards(): void {
     this.unsubscribeDetailGuards()
+    // This subscription outlives loadDetail.finally and observes pre-DB write intent.
+    this.unsubscribeLifecycleRevision = this.videoServerModel
+      .subscribeSearchConfigurationRevision(() => this.handleDetailConfigurationChange())
     this.unsubscribeConfiguration = this.videoServerModel
       .subscribeSearchConfiguration(() => this.handleDetailConfigurationChange())
     if (this.shouldTrackSearchSource()) {
@@ -237,8 +252,10 @@ export struct ServerMediaDetailPage {
 
   private unsubscribeDetailGuards(): void {
     this.unsubscribeConfiguration()
+    this.unsubscribeLifecycleRevision()
     this.unsubscribeSource()
     this.unsubscribeConfiguration = () => {}
+    this.unsubscribeLifecycleRevision = () => {}
     this.unsubscribeSource = () => {}
   }
 
@@ -249,7 +266,8 @@ export struct ServerMediaDetailPage {
 
   private resolvePlayableServer(): VideoServer | null {
     const identity = this.loadedDetailIdentity
-    const message = this.detailInvalidationMessage(identity)
+    const message = identity !== null && identity.revision !== this.videoServerModel.searchConfigurationRevision ?
+      '服务器配置已变更，请返回重试' : this.detailInvalidationMessage(identity)
     if (message.length > 0) {
       this.invalidateDetailState(message)
       this.showToastSafe(message)
@@ -271,6 +289,7 @@ export struct ServerMediaDetailPage {
   private isActivePlayOperation(generation: number, identity: ServerMediaDetailServerIdentity): boolean {
     return this.playOperationActive &&
       generation === this.playOperationGeneration &&
+      identity.revision === this.videoServerModel.searchConfigurationRevision &&
       this.detailInvalidationMessage(identity).length === 0
   }
 
@@ -291,20 +310,79 @@ export struct ServerMediaDetailPage {
 
   private async loadDetail(silent: boolean = false): Promise<void> {
     const generation = this.beginDetailRequest(silent)
+    const configurationRevision = this.videoServerModel.searchConfigurationRevision
     let identity: ServerMediaDetailServerIdentity | null = null
+    let unsubscribeColdConfiguration: () => void = () => {}
+    const unsubscribeRevision = this.videoServerModel.subscribeSearchConfigurationRevision(() => {
+      if (this.detailRequestActive && generation === this.detailLoadGeneration &&
+        configurationRevision !== this.videoServerModel.searchConfigurationRevision) {
+        this.invalidateDetailState('服务器配置已变更，请返回重试')
+      }
+    })
+    this.unsubscribeRequestConfiguration = () => {
+      unsubscribeColdConfiguration()
+      unsubscribeRevision()
+    }
     try {
-      await this.videoServerModel.loadVideoServers(true)
-      const server = this.videoServerModel.getVideoServerById(this.serverId)
+      // Pin the target before registry refresh; retries must not adopt a replacement configuration.
+      let server = this.videoServerModel.getVideoServerById(this.serverId)
+      const message = this.detailInvalidationMessage(this.detailTargetIdentity)
       if (!server) {
-        this.applyDetailFailure(generation, '服务器不存在')
+        if (this.detailTargetIdentity !== null || !this.matchesCurrentSearchSource()) {
+          this.applyDetailFailure(generation, message)
+          return
+        }
+        // The registry publishes synchronously before load resolves. Pin its first
+        // target publication, never the potentially replaced value after the await.
+        unsubscribeColdConfiguration = this.videoServerModel.subscribeSearchConfiguration(() => {
+          if (!this.isActiveDetailRequest(generation)) {
+            return
+          }
+          if (identity !== null) {
+            const changedMessage = this.detailInvalidationMessage(identity)
+            if (changedMessage.length > 0) {
+              this.invalidateDetailState(changedMessage)
+            }
+            return
+          }
+          const publishedServer = this.videoServerModel.getVideoServerById(this.serverId)
+          if (publishedServer) {
+            const publishedMessage = this.detailInvalidationMessage()
+            if (publishedMessage.length > 0) {
+              this.invalidateDetailState(publishedMessage)
+              return
+            }
+            identity = this.bindPendingDetailIdentity(generation, publishedServer)
+            this.detailTargetIdentity = identity
+          }
+        })
+      } else {
+        if (message.length > 0) {
+          this.applyDetailFailure(generation, message)
+          return
+        }
+        identity = this.bindPendingDetailIdentity(generation, server)
+        if (identity === null) {
+          return
+        }
+        this.detailTargetIdentity = identity
+      }
+      await this.videoServerModel.loadVideoServers(true)
+      if (!this.isActiveDetailRequest(generation)) {
         return
       }
-      if (this.expectedServerType.length > 0 && server.type !== this.expectedServerType) {
+      if (configurationRevision !== this.videoServerModel.searchConfigurationRevision) {
+        this.invalidateDetailState('服务器配置已变更，请返回重试')
+        return
+      }
+      const refreshedMessage = this.detailInvalidationMessage(identity)
+      if (refreshedMessage.length > 0) {
+        this.invalidateDetailState(refreshedMessage)
+        return
+      }
+      server = this.videoServerModel.getVideoServerById(this.serverId)
+      if (identity === null || server === null) {
         this.applyDetailFailure(generation, '服务器配置已变更，请返回重试')
-        return
-      }
-      identity = this.bindPendingDetailIdentity(generation, server)
-      if (identity === null) {
         return
       }
       let detail: VideoServerItemDetail
@@ -335,6 +413,8 @@ export struct ServerMediaDetailPage {
     } catch (e) {
       this.applyDetailFailure(generation, (e as BusinessError).message ?? '加载详情失败', identity)
     } finally {
+      unsubscribeColdConfiguration()
+      unsubscribeRevision()
       this.finishDetailRequest(generation, identity)
     }
   }
@@ -537,8 +617,24 @@ export struct ServerMediaDetailPage {
   }
 
   aboutToDisappear(): void {
+    this.handleDetailHidden()
+  }
+
+  private handleDetailHidden(): void {
+    this.initialLoadDone = true
     this.unsubscribeDetailGuards()
     this.invalidateDetailState('', false)
+  }
+
+  private handleDetailShown(): void {
+    this.subscribeDetailGuards()
+    if (!this.initialLoadDone) {
+      this.initialLoadDone = true
+      return
+    }
+    if (this.itemId.length > 0) {
+      this.loadDetail(true)
+    }
   }
 
   private openSeason(s: VideoServerSeason): void {
@@ -551,6 +647,7 @@ export struct ServerMediaDetailPage {
       seriesTitle: this.getTitle(),
       seasonPosterUrl: s.posterUrl
     }
+    this.handleDetailHidden()
     this.pageStack.pushPathByName(ServerSeasonDetailPage.PAGE_NAME, param)
   }
 
@@ -573,6 +670,7 @@ export struct ServerMediaDetailPage {
       role: c.role,
       imageUrl: c.imageUrl
     }
+    this.handleDetailHidden()
     this.pageStack.pushPathByName(ServerPersonDetailPage.PAGE_NAME, param)
   }
 
@@ -834,16 +932,8 @@ export struct ServerMediaDetailPage {
         this.loadDetail()
       }
     })
-    .onShown(() => {
-      // 首次显示由 onReady 发起加载，跳过静默刷新；之后（如从播放器返回）才刷新续播位置 / 进度
-      if (!this.initialLoadDone) {
-        this.initialLoadDone = true
-        return
-      }
-      if (this.itemId.length > 0) {
-        this.loadDetail(true)
-      }
-    })
+    .onHidden(() => { this.handleDetailHidden() })
+    .onShown(() => { this.handleDetailShown() })
     .onBackPressed(() => {
       if (this.showOverviewDialog) {
         this.showOverviewDialog = false

--- a/entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets
+++ b/entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets
@@ -10,6 +10,7 @@ import { buildServerEpisodePlaybackContext } from "../../utils/ServerEpisodePlay
 import { PlaybackContext } from "../../components/core/player/PlaybackContext"
 import { ServerSeasonDetailPage, ServerSeasonDetailPageParam } from "./ServerSeasonDetailPage"
 import { ServerPersonDetailPage, ServerPersonDetailPageParam } from "./ServerPersonDetailPage"
+import { SourceSwitchModel } from "../../stores/media/SourceSwitchModel"
 import { BusinessError } from "@kit.BasicServicesKit"
 import {
   DetailCastSection,
@@ -20,10 +21,27 @@ import {
   formatDetailDurationMs
 } from "../../components/detail/DetailSections"
 
+export type ServerMediaRouteMediaType = 'movie' | 'series' | 'episode'
+
 export interface ServerMediaDetailPageParam {
   serverId: number
   itemId: string
   title: string
+  serverType?: VideoServerType
+  mediaId?: string
+  mediaType?: ServerMediaRouteMediaType
+}
+
+interface ServerMediaDetailLoadPayload {
+  detail: VideoServerItemDetail
+  seasons: VideoServerSeason[]
+  nextUp: VideoServerMediaItem | null
+}
+
+interface ServerMediaDetailServerIdentity {
+  serverId: number
+  serverType: VideoServerType
+  configuration: string
 }
 
 @ComponentV2
@@ -34,6 +52,8 @@ export struct ServerMediaDetailPage {
   @Local serverId: number = 0
   @Local itemId: string = ''
   @Local fallbackTitle: string = ''
+  @Local sourceMediaId: string = ''
+  @Local sourceMediaType: string = ''
   @Local detail: VideoServerItemDetail | null = null
   @Local seasons: VideoServerSeason[] = []
   @Local isLoading: boolean = true
@@ -46,6 +66,15 @@ export struct ServerMediaDetailPage {
   @Local nextUp: VideoServerMediaItem | null = null
   /** 首次 onShown 跳过静默刷新（onReady 已发起首次加载），避免首帧重复请求 */
   @Local initialLoadDone: boolean = false
+  private expectedServerType: string = ''
+  private detailLoadGeneration: number = 0
+  private detailRequestActive: boolean = false
+  private playOperationGeneration: number = 0
+  private playOperationActive: boolean = false
+  private pendingDetailIdentity: ServerMediaDetailServerIdentity | null = null
+  private loadedDetailIdentity: ServerMediaDetailServerIdentity | null = null
+  private unsubscribeSource: () => void = () => {}
+  private unsubscribeConfiguration: () => void = () => {}
 
   private showToastSafe(message: string): void {
     try {
@@ -53,50 +82,260 @@ export struct ServerMediaDetailPage {
     } catch (_e) {}
   }
 
-  private async loadDetail(silent: boolean = false): Promise<void> {
+  private clearLoadedDetail(): void {
+    this.detail = null
+    this.seasons = []
+    this.nextUp = null
+  }
+
+  private captureServerIdentity(server: VideoServer): ServerMediaDetailServerIdentity {
+    return {
+      serverId: server.id as number,
+      serverType: server.type,
+      configuration: server.configJson
+    }
+  }
+
+  private matchesServerIdentity(identity: ServerMediaDetailServerIdentity): boolean {
+    const server = this.videoServerModel.getVideoServerById(identity.serverId)
+    return server !== null && server !== undefined &&
+      server.id === identity.serverId &&
+      server.type === identity.serverType &&
+      server.configJson === identity.configuration
+  }
+
+  private shouldTrackSearchSource(): boolean {
+    return this.sourceMediaId.length > 0 || this.sourceMediaType.length > 0
+  }
+
+  private matchesCurrentSearchSource(): boolean {
+    if (!this.shouldTrackSearchSource()) {
+      return true
+    }
+    const source = SourceSwitchModel.getState().activeSource
+    return source.kind === 'videoServer' &&
+      source.serverId === this.serverId &&
+      source.serverType === this.expectedServerType
+  }
+
+  private detailInvalidationMessage(identity: ServerMediaDetailServerIdentity | null = null): string {
+    if (!this.matchesCurrentSearchSource()) {
+      return '当前来源已变化，请返回重新选择来源'
+    }
+    const server = this.videoServerModel.getVideoServerById(this.serverId)
+    if (!server) {
+      return '服务器不存在'
+    }
+    if (this.expectedServerType.length > 0 && server.type !== this.expectedServerType) {
+      return '服务器配置已变更，请返回重试'
+    }
+    if (identity !== null && !this.matchesServerIdentity(identity)) {
+      return '服务器配置已变更，请返回重试'
+    }
+    return ''
+  }
+
+  private beginDetailRequest(silent: boolean): number {
+    const generation = ++this.detailLoadGeneration
+    this.detailRequestActive = true
+    this.pendingDetailIdentity = null
     if (!silent) {
       this.isLoading = true
     }
     this.error = ''
+    return generation
+  }
+
+  private isActiveDetailRequest(generation: number, identity: ServerMediaDetailServerIdentity | null = null): boolean {
+    return this.detailRequestActive &&
+      generation === this.detailLoadGeneration &&
+      (identity === null || this.detailInvalidationMessage(identity).length === 0)
+  }
+
+  private bindPendingDetailIdentity(generation: number, server: VideoServer): ServerMediaDetailServerIdentity | null {
+    const identity = this.captureServerIdentity(server)
+    if (!this.isActiveDetailRequest(generation, identity)) {
+      return null
+    }
+    this.pendingDetailIdentity = identity
+    return identity
+  }
+
+  private applyLoadedDetail(generation: number, identity: ServerMediaDetailServerIdentity,
+    payload: ServerMediaDetailLoadPayload): void {
+    if (!this.isActiveDetailRequest(generation, identity)) {
+      return
+    }
+    this.detail = payload.detail
+    this.seasons = payload.seasons
+    this.nextUp = payload.nextUp
+    this.loadedDetailIdentity = identity
+    this.error = ''
+  }
+
+  private applyDetailFailure(generation: number, message: string,
+    identity: ServerMediaDetailServerIdentity | null = null): void {
+    if (!this.isActiveDetailRequest(generation, identity)) {
+      return
+    }
+    this.clearLoadedDetail()
+    this.loadedDetailIdentity = null
+    this.error = message
+  }
+
+  private finishDetailRequest(generation: number, identity: ServerMediaDetailServerIdentity | null = null): void {
+    if (!this.isActiveDetailRequest(generation, identity)) {
+      return
+    }
+    this.detailRequestActive = false
+    this.pendingDetailIdentity = null
+    this.isLoading = false
+  }
+
+  private invalidateDetailState(message: string, clearState: boolean = true): void {
+    this.detailLoadGeneration++
+    this.detailRequestActive = false
+    this.playOperationGeneration++
+    this.playOperationActive = false
+    this.isPlaying = false
+    this.pendingDetailIdentity = null
+    this.loadedDetailIdentity = null
+    this.isLoading = false
+    if (clearState) {
+      this.clearLoadedDetail()
+    }
+    this.error = message
+  }
+
+  private handleDetailSourceChange(): void {
+    const message = this.detailInvalidationMessage()
+    if (message.length > 0) {
+      this.invalidateDetailState(message)
+    }
+  }
+
+  private handleDetailConfigurationChange(): void {
+    const identity = this.pendingDetailIdentity ?? this.loadedDetailIdentity
+    if (identity === null) {
+      return
+    }
+    const message = this.detailInvalidationMessage(identity)
+    if (message.length > 0) {
+      this.invalidateDetailState(message)
+    }
+  }
+
+  private subscribeDetailGuards(): void {
+    this.unsubscribeDetailGuards()
+    this.unsubscribeConfiguration = this.videoServerModel
+      .subscribeSearchConfiguration(() => this.handleDetailConfigurationChange())
+    if (this.shouldTrackSearchSource()) {
+      this.unsubscribeSource = SourceSwitchModel.getState()
+        .subscribeSearchSource(() => this.handleDetailSourceChange())
+    }
+  }
+
+  private unsubscribeDetailGuards(): void {
+    this.unsubscribeConfiguration()
+    this.unsubscribeSource()
+    this.unsubscribeConfiguration = () => {}
+    this.unsubscribeSource = () => {}
+  }
+
+  private leaveDetailPage(): void {
+    this.unsubscribeDetailGuards()
+    this.invalidateDetailState('', true)
+  }
+
+  private resolvePlayableServer(): VideoServer | null {
+    const identity = this.loadedDetailIdentity
+    const message = this.detailInvalidationMessage(identity)
+    if (message.length > 0) {
+      this.invalidateDetailState(message)
+      this.showToastSafe(message)
+      return null
+    }
+    if (identity === null) {
+      return null
+    }
+    return this.videoServerModel.getVideoServerById(identity.serverId)
+  }
+
+  private beginPlayOperation(): number {
+    const generation = ++this.playOperationGeneration
+    this.playOperationActive = true
+    this.isPlaying = true
+    return generation
+  }
+
+  private isActivePlayOperation(generation: number, identity: ServerMediaDetailServerIdentity): boolean {
+    return this.playOperationActive &&
+      generation === this.playOperationGeneration &&
+      this.detailInvalidationMessage(identity).length === 0
+  }
+
+  private finishPlayOperation(generation: number, identity: ServerMediaDetailServerIdentity): void {
+    if (!this.isActivePlayOperation(generation, identity)) {
+      return
+    }
+    this.playOperationActive = false
+    this.isPlaying = false
+  }
+
+  private retryDetail(): void {
+    if (this.isLoading) {
+      return
+    }
+    this.loadDetail()
+  }
+
+  private async loadDetail(silent: boolean = false): Promise<void> {
+    const generation = this.beginDetailRequest(silent)
+    let identity: ServerMediaDetailServerIdentity | null = null
     try {
       await this.videoServerModel.loadVideoServers(true)
       const server = this.videoServerModel.getVideoServerById(this.serverId)
       if (!server) {
-        if (!silent) {
-          this.error = '服务器不存在'
-        }
+        this.applyDetailFailure(generation, '服务器不存在')
         return
       }
-      if (server.type === VideoServerType.PLEX) {
-        this.detail = await PlexClient.fromConfigJson(server.configJson).getItemDetail(this.itemId)
-      } else {
-        this.detail = await JellyfinClient.fromConfigJson(server.configJson).getItemDetail(this.itemId)
+      if (this.expectedServerType.length > 0 && server.type !== this.expectedServerType) {
+        this.applyDetailFailure(generation, '服务器配置已变更，请返回重试')
+        return
       }
-      if (this.detail.media.type === 'series') {
+      identity = this.bindPendingDetailIdentity(generation, server)
+      if (identity === null) {
+        return
+      }
+      let detail: VideoServerItemDetail
+      if (server.type === VideoServerType.PLEX) {
+        detail = await PlexClient.fromConfigJson(server.configJson).getItemDetail(this.itemId)
+      } else {
+        detail = await JellyfinClient.fromConfigJson(server.configJson).getItemDetail(this.itemId)
+      }
+      let seasons: VideoServerSeason[] = []
+      let nextUp: VideoServerMediaItem | null = null
+      if (detail.media.type === 'series') {
         try {
           if (server.type === VideoServerType.PLEX) {
             const client = PlexClient.fromConfigJson(server.configJson)
-            this.seasons = await client.getSeasons(this.itemId)
-            this.nextUp = await client.getNextUp(this.itemId)
+            seasons = await client.getSeasons(this.itemId)
+            nextUp = await client.getNextUp(this.itemId)
           } else {
             const client = JellyfinClient.fromConfigJson(server.configJson)
-            this.seasons = await client.getSeasons(this.itemId)
-            this.nextUp = await client.getNextUp(this.itemId)
+            seasons = await client.getSeasons(this.itemId)
+            nextUp = await client.getNextUp(this.itemId)
           }
         } catch (e) {
           console.warn('[ServerMediaDetailPage] 获取季列表/下一集失败', (e as BusinessError).message)
         }
-      } else {
-        this.nextUp = null
       }
+      const payload: ServerMediaDetailLoadPayload = { detail, seasons, nextUp }
+      this.applyLoadedDetail(generation, identity, payload)
     } catch (e) {
-      if (!silent) {
-        this.error = (e as BusinessError).message ?? '加载详情失败'
-      }
+      this.applyDetailFailure(generation, (e as BusinessError).message ?? '加载详情失败', identity)
     } finally {
-      if (!silent) {
-        this.isLoading = false
-      }
+      this.finishDetailRequest(generation, identity)
     }
   }
 
@@ -128,6 +367,14 @@ export struct ServerMediaDetailPage {
     if (this.isPlaying) {
       return
     }
+    const server = this.resolvePlayableServer()
+    if (!server) {
+      return
+    }
+    const identity = this.loadedDetailIdentity
+    if (identity === null) {
+      return
+    }
     const target = this.playTarget()
     if (!target) {
       if (this.isSeries() && this.nextUp === null) {
@@ -135,12 +382,7 @@ export struct ServerMediaDetailPage {
       }
       return
     }
-    const server: VideoServer | null = this.videoServerModel.getVideoServerById(this.serverId)
-    if (!server) {
-      this.showToastSafe('服务器不存在')
-      return
-    }
-    this.isPlaying = true
+    const playGeneration = this.beginPlayOperation()
     try {
       let url = ''
       let header: Record<string, string> = {}
@@ -153,6 +395,9 @@ export struct ServerMediaDetailPage {
         url = await client.getStreamUrl(target.id)
         header = client.getStreamHeader()
       }
+      if (!this.isActivePlayOperation(playGeneration, identity)) {
+        return
+      }
       const playSessionId = 'vidall-' + Date.now().toString(36) + Math.random().toString(36).substring(2, 10)
       const playerTitle = this.isSeries() ? `${this.getTitle()} ${target.subtitle}` : target.title
       let playbackContext: PlaybackContext | undefined = undefined
@@ -160,7 +405,12 @@ export struct ServerMediaDetailPage {
         try {
           playbackContext = (await buildServerEpisodePlaybackContext(server, this.itemId, target.id)) ?? undefined
         } catch (e) {
-          console.warn('[ServerMediaDetailPage] 构建连续播放上下文失败', (e as BusinessError).message)
+          if (this.isActivePlayOperation(playGeneration, identity)) {
+            console.warn('[ServerMediaDetailPage] 构建连续播放上下文失败', (e as BusinessError).message)
+          }
+        }
+        if (!this.isActivePlayOperation(playGeneration, identity)) {
+          return
         }
       }
       const param: PlayerPageParam = {
@@ -182,12 +432,17 @@ export struct ServerMediaDetailPage {
       }
       reportServerPlaybackStarted(server.type, server.id ?? 0, target.id, playSessionId, target.positionMs, target.durationMs)
         .catch(() => {})
+      if (!this.isActivePlayOperation(playGeneration, identity)) {
+        return
+      }
       this.pageStack.pushPathByName(PlayerPage.PAGE_NAME, param)
     } catch (e) {
-      console.warn('[ServerMediaDetailPage] 播放失败', (e as BusinessError).message)
-      this.showToastSafe('播放失败，请重试')
+      if (this.isActivePlayOperation(playGeneration, identity)) {
+        console.warn('[ServerMediaDetailPage] 播放失败', (e as BusinessError).message)
+        this.showToastSafe('播放失败，请重试')
+      }
     } finally {
-      this.isPlaying = false
+      this.finishPlayOperation(playGeneration, identity)
     }
   }
 
@@ -273,6 +528,17 @@ export struct ServerMediaDetailPage {
       return `第${s.seasonNumber}季`
     }
     return s.name.length > 0 ? s.name : '特别篇'
+  }
+
+  aboutToAppear(): void {
+    if (this.itemId.length > 0) {
+      this.subscribeDetailGuards()
+    }
+  }
+
+  aboutToDisappear(): void {
+    this.unsubscribeDetailGuards()
+    this.invalidateDetailState('', false)
   }
 
   private openSeason(s: VideoServerSeason): void {
@@ -504,8 +770,16 @@ export struct ServerMediaDetailPage {
               }
               .width('100%').height(400).justifyContent(FlexAlign.Center).alignItems(HorizontalAlign.Center)
             } else if (this.error.length > 0) {
-              Column() {
+              Column({ space: 16 }) {
                 Text(this.error).fontSize(16).fontColor('#FF6B6B')
+                Text('重试')
+                  .fontSize(15).fontColor('#1B78F2')
+                  .defaultFocus(true)
+                  .focusable(true)
+                  .padding({ left: 20, right: 20, top: 8, bottom: 8 })
+                  .border({ width: 1, color: '#1B78F2' })
+                  .borderRadius(6)
+                  .onClick(() => { this.retryDetail() })
               }
               .width('100%').height(400).justifyContent(FlexAlign.Center).alignItems(HorizontalAlign.Center)
             } else {
@@ -553,6 +827,10 @@ export struct ServerMediaDetailPage {
         this.serverId = param.serverId
         this.itemId = param.itemId
         this.fallbackTitle = param.title
+        this.expectedServerType = param.serverType ?? ''
+        this.sourceMediaId = param.mediaId ?? ''
+        this.sourceMediaType = param.mediaType ?? ''
+        this.subscribeDetailGuards()
         this.loadDetail()
       }
     })
@@ -571,6 +849,7 @@ export struct ServerMediaDetailPage {
         this.showOverviewDialog = false
         return true
       }
+      this.leaveDetailPage()
       this.pageStack.pop()
       return true
     })

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -5,6 +5,7 @@ import { SourceSwitchModel } from '../../stores/media/SourceSwitchModel';
 import { VideoServerStore } from '../../stores/servers/VideoServerStore';
 import { MediaItem, SearchHistoryEntry, SeriesGroup } from '../../db/models/MediaEntity';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
+import { ServerMediaDetailPage, ServerMediaDetailPageParam } from '../detail/ServerMediaDetailPage';
 
 import { SeriesDetailPage } from '../detail/SeriesDetailPage';
 import { MovieDetailPage } from '../detail/MovieDetailPage';
@@ -319,6 +320,56 @@ struct WorkspacePosterCard {
   }
 }
 
+@ComponentV2
+struct ServerSearchResultCard {
+  @Require @Param item: VideoServerSearchItem;
+  @Event onPress: () => void = () => {};
+  @Local isFocused: boolean = false;
+
+  private getMediaTypeLabel(): string {
+    switch (this.item.selection.mediaType) {
+      case 'movie': return '电影';
+      case 'series': return '剧集';
+      default: return '单集';
+    }
+  }
+
+  build() {
+    Column({ space: 8 }) {
+      if (this.item.media.posterUrl.length > 0) {
+        Image(this.item.media.posterUrl)
+          .width(180)
+          .height(270)
+          .objectFit(ImageFit.Cover)
+          .borderRadius(8)
+      } else {
+        Text('暂无海报')
+          .width(180)
+          .height(270)
+          .textAlign(TextAlign.Center)
+          .backgroundColor(C_COMPONENT_BG)
+          .fontColor(C_SECONDARY)
+      }
+      Text(this.item.media.title)
+        .fontSize(22)
+        .fontColor(C_TEXT_BODY)
+        .maxLines(2)
+      Text(this.getMediaTypeLabel())
+        .fontSize(18)
+        .fontColor(C_SECONDARY)
+    }
+    .width(180)
+    .padding(8)
+    .borderRadius(12)
+    .border({ width: this.isFocused ? 2 : 1, color: this.isFocused ? '#4A9FFF' : TRANSPARENT })
+    .backgroundColor(this.isFocused ? '#1AFFFFFF' : TRANSPARENT)
+    .focusable(true)
+    .onFocus(() => { this.isFocused = true; })
+    .onBlur(() => { this.isFocused = false; })
+    .onClick(() => { this.onPress(); })
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // SearchWorkspacePage — main search entry page (TV vertical layout)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -347,6 +398,12 @@ struct SearchWorkspacePage {
   private searchGeneration: number = 0;
   private historyLoadGeneration: number = 0;
   private historySourceGeneration: number = 0;
+
+  private showToastSafe(message: string): void {
+    try {
+      this.getUIContext().getPromptAction().showToast({ message, duration: 2000 });
+    } catch (_e) {}
+  }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -602,6 +659,29 @@ struct SearchWorkspacePage {
     } else {
       this.pageStack.pushPathByName(MovieDetailPage.PAGE_NAME, item);
     }
+  }
+
+  private openServerResultDetail(item: VideoServerSearchItem): void {
+    const context = this.currentContext();
+    if (!item.sourceSnapshot.matches(context.scope, context.server)) {
+      if (context.scope.kind !== 'videoServer' || context.server === undefined ||
+        context.scope.serverId !== item.selection.serverId || context.scope.serverType !== item.selection.serverType) {
+        this.showToastSafe('当前来源已变化，请返回重新选择来源');
+      } else {
+        this.showToastSafe('当前服务器配置已变更，请重新搜索');
+      }
+      this.refreshSource();
+      return;
+    }
+    const param: ServerMediaDetailPageParam = {
+      serverId: item.selection.serverId,
+      serverType: item.selection.serverType,
+      mediaId: item.selection.mediaId,
+      mediaType: item.selection.mediaType,
+      itemId: item.selection.detailItemId,
+      title: item.media.title
+    };
+    this.pageStack.pushPathByName(ServerMediaDetailPage.PAGE_NAME, param);
   }
 
   // ── @Builder sections ─────────────────────────────────────────────────────
@@ -865,21 +945,14 @@ struct SearchWorkspacePage {
     } else if (this.serverResult?.status === 'empty') {
       Text('当前服务器未找到匹配内容').fontSize(22).fontColor(C_TEXT_BODY)
     } else if (this.serverResult?.status === 'success') {
-      Text('首批结果（最多 100 项，可能更少）；仅展示，暂不支持打开详情')
+      Text('首批结果（最多 100 项，可能更少）')
         .fontSize(18).fontColor(C_SECONDARY)
       Flex({ wrap: FlexWrap.Wrap }) {
         ForEach(this.serverResult.items, (item: VideoServerSearchItem) => {
-          Column({ space: 8 }) {
-            if (item.media.posterUrl.length > 0) {
-              Image(item.media.posterUrl).width(180).height(270).objectFit(ImageFit.Cover).borderRadius(8)
-            } else {
-              Text('暂无海报').width(180).height(270).textAlign(TextAlign.Center)
-                .backgroundColor(C_COMPONENT_BG).fontColor(C_SECONDARY)
-            }
-            Text(item.media.title).fontSize(22).fontColor(C_TEXT_BODY).maxLines(2)
-            Text(item.media.type === 'movie' ? '电影' : item.media.type === 'series' ? '剧集' : '单集')
-              .fontSize(18).fontColor(C_SECONDARY)
-          }.width(180).margin({ right: 20, bottom: 20 }).focusable(false)
+          ServerSearchResultCard({
+            item: item,
+            onPress: () => { this.openServerResultDetail(item); }
+          }).margin({ right: 20, bottom: 20 })
         }, (item: VideoServerSearchItem) => item.key)
       }.width('100%')
     } else {
@@ -932,4 +1005,3 @@ struct SearchWorkspacePage {
 }
 
 export { SearchWorkspacePage };
-

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -1,3 +1,5 @@
+import { SearchWorkspaceSession, SearchWorkspaceContext } from '../../services/search/SearchWorkspaceSession';
+import { VideoServerSearchResult, VideoServerSearchItem } from '../../services/search/VideoServerSearchService';
 import { SearchScope, SearchRouteParam, createUnavailableSearchScope, resolveSearchRoute, getSearchCapabilities } from '../../models/search/SearchScope';
 import { SourceSwitchModel } from '../../stores/media/SourceSwitchModel';
 import { VideoServerStore } from '../../stores/servers/VideoServerStore';
@@ -334,6 +336,11 @@ struct SearchWorkspacePage {
   @Local isSearching: boolean = false;
   @Local isSearchBarFocused: boolean = false;
 
+  @Local serverResult: VideoServerSearchResult | null = null;
+  private serverSession: SearchWorkspaceSession = new SearchWorkspaceSession();
+  private unsubscribeSource: () => void = () => {};
+  private unsubscribeConfiguration: () => void = () => {};
+  private pageActive: boolean = false;
   private db: FileSourceDatabase | null = null;
   @Local private searchDebounceTimer: number = -1;
   // 竞态保护：快速连续输入时，丢弃旧请求的返回结果
@@ -344,52 +351,112 @@ struct SearchWorkspacePage {
   private initializeRoute(param: SearchRouteParam | string | null | undefined): void {
     const servers = VideoServerStore.getState().videoServers;
     const route = resolveSearchRoute(param, SourceSwitchModel.getState().getSearchScope(servers), servers);
-    this.scope = route.scope;
+    // Route text is reusable, but the top-bar instance is the only source authority.
     this.searchText = route.keyword;
-    this.searchGeneration++;
-    this.searchResults = [];
-    this.historyList = [];
-    if (!getSearchCapabilities(this.scope).localSearch) { return; }
-    this.db = FileSourceDatabase.getInstance();
-    this.loadHistory();
-    this.scheduleSearch();
+    this.resumeSearch();
   }
 
-  aboutToDisappear(): void {
+  private currentContext(): SearchWorkspaceContext {
+    const servers = VideoServerStore.getState().videoServers;
+    const scope = SourceSwitchModel.getState().getSearchScope(servers);
+    const context: SearchWorkspaceContext = {
+      scope, server: servers.find((server) => server.id === scope.serverId)
+    };
+    return context;
+  }
+
+  private resumeSearch(): void {
+    if (this.pageActive) { return; }
+    this.pageActive = true;
+    this.serverSession.activate();
+    this.unsubscribeSource = SourceSwitchModel.getState().subscribeSearchSource(() => this.refreshSource());
+    this.unsubscribeConfiguration = VideoServerStore.getState()
+      .subscribeSearchConfiguration(() => this.refreshSource());
+    this.refreshSource();
+  }
+
+  private refreshSource(): void {
+    this.invalidateSearch();
+    this.scope = this.currentContext().scope;
+    this.searchResults = [];
+    this.historyList = [];
+    this.db = null;
+    if (getSearchCapabilities(this.scope).localSearch) {
+      this.db = FileSourceDatabase.getInstance();
+    }
+    this.scheduleSearch();
+    this.loadHistory();
+  }
+
+  private invalidateSearch(): void {
     this.searchGeneration++;
+    this.serverSession.invalidate();
+    this.serverResult = null;
+    this.isSearching = false;
     if (this.searchDebounceTimer !== -1) {
       clearTimeout(this.searchDebounceTimer);
+      this.searchDebounceTimer = -1;
     }
   }
+
+  private leaveSearch(): void {
+    this.pageActive = false;
+    this.invalidateSearch();
+    this.serverSession.dispose();
+    this.unsubscribeSource();
+    this.unsubscribeConfiguration();
+  }
+
+  aboutToDisappear(): void { this.leaveSearch(); }
 
   // ── Data helpers ──────────────────────────────────────────────────────────
 
   private loadHistory(): void {
     if (!getSearchCapabilities(this.scope).localHistory || this.db === null) { return; }
+    const generation = this.searchGeneration;
     this.db.getSearchHistory(20)
       .then((list: SearchHistoryEntry[]) => {
-        this.historyList = list;
+        if (this.pageActive && generation === this.searchGeneration &&
+          getSearchCapabilities(this.scope).localHistory) { this.historyList = list; }
       })
       .catch(() => {});
   }
 
 
   private scheduleSearch(): void {
-    this.searchGeneration++;
-    this.isSearching = false;
-    if (!getSearchCapabilities(this.scope).localSearch) { return; }
-    if (this.searchDebounceTimer !== -1) {
-      clearTimeout(this.searchDebounceTimer);
-      this.searchDebounceTimer = -1;
-    }
-    if (this.searchText.trim().length === 0) {
-      this.searchResults = [];
-      return;
-    }
+    this.invalidateSearch();
+    this.searchResults = [];
+    if (!this.pageActive || this.searchText.trim().length === 0) { return; }
+    const capabilities = getSearchCapabilities(this.scope);
+    if (!capabilities.localSearch && !capabilities.serverSearch) { return; }
+    this.isSearching = true;
     this.searchDebounceTimer = setTimeout(() => {
       this.searchDebounceTimer = -1;
-      this.executeSearch();
+      if (getSearchCapabilities(this.scope).serverSearch) {
+        this.executeServerSearch();
+      } else {
+        this.executeSearch();
+      }
     }, 800);
+  }
+
+  private executeServerSearch(): void {
+    this.invalidateSearch();
+    this.serverSession.search(this.searchText, () => this.currentContext(),
+      (result: VideoServerSearchResult) => {
+        this.serverResult = result;
+        this.isSearching = result.status === 'loading';
+      });
+  }
+
+  private serverErrorText(): string {
+    switch (this.serverResult?.errorCode) {
+      case 'auth': return '服务器认证失败，请检查来源配置后重试';
+      case 'timeout': return '搜索超时，请重试';
+      case 'invalidResponse': return '服务器响应无效，请重试';
+      case 'unavailable': return '来源不可用，请返回重新选择来源';
+      default: return '无法连接服务器，请检查网络后重试';
+    }
   }
 
   /** 本地预览搜索（仅实时展示结果，不保存历史、不跳转） */
@@ -515,7 +582,7 @@ struct SearchWorkspacePage {
       .justifyContent(FlexAlign.Center)
       .alignItems(VerticalAlign.Center)
       .focusable(true)
-      .onClick(() => { this.pageStack.pop(); })
+      .onClick(() => { this.leaveSearch(); this.pageStack.pop(); })
     }
     .width('100%')
     .height(48)
@@ -546,21 +613,24 @@ struct SearchWorkspacePage {
         .fontColor(C_ICON)
         .width(22)
         .height(22)
-      if (this.searchText.length > 0) {
-        Text(this.searchText)
-          .fontSize(22)
-          .fontWeight(500)
-          .fontColor(C_TEXT_TITLE)
-          .layoutWeight(1)
-          .maxLines(1)
-          .textOverflow({ overflow: TextOverflow.Ellipsis })
-      } else {
-        Text('\u652f\u6301\u9996\u5b57\u6bcd\u3001\u5168\u62fc\u3001\u4e2d\u6587\u7247\u540d\u641c\u7d22')
-          .fontSize(22)
-          .fontWeight(500)
-          .fontColor(C_PLACEHOLDER)
-          .layoutWeight(1)
-      }
+      TextInput({ text: this.searchText, placeholder: '输入片名' })
+        .fontSize(22)
+        .fontColor(C_TEXT_TITLE)
+        .placeholderColor(C_PLACEHOLDER)
+        .backgroundColor(Color.Transparent)
+        .layoutWeight(1)
+        .defaultFocus(true)
+        .onChange((value: string) => {
+          this.searchText = value;
+          this.scheduleSearch();
+        })
+        .onSubmit(() => {
+          if (getSearchCapabilities(this.scope).serverSearch) {
+            this.executeServerSearch();
+          } else {
+            this.executeSearchWithHistory();
+          }
+        })
     }
     .width('70%')
     .height(56)
@@ -574,8 +644,6 @@ struct SearchWorkspacePage {
     })
     .animation({ duration: 150, curve: Curve.EaseOut })
     .alignItems(VerticalAlign.Center)
-    .defaultFocus(true)
-    .focusable(true)
     .onFocus(() => { this.isSearchBarFocused = true; })
     .onBlur(() => { this.isSearchBarFocused = false; })
   }
@@ -745,6 +813,40 @@ struct SearchWorkspacePage {
     }
   }
 
+  @Builder
+  buildServerResults() {
+    if (this.isSearching) {
+      Text('正在搜索…').fontSize(22).fontColor(C_TEXT_BODY)
+    } else if (this.serverResult?.status === 'error') {
+      Text(this.serverErrorText()).fontSize(22).fontColor(C_TEXT_BODY)
+      Row() {
+        ActionKey({ label: '重试', keyAspect: 3, onPress: () => this.executeServerSearch() })
+      }.width(180)
+    } else if (this.serverResult?.status === 'empty') {
+      Text('当前服务器未找到匹配内容').fontSize(22).fontColor(C_TEXT_BODY)
+    } else if (this.serverResult?.status === 'success') {
+      Text('首批结果（最多 100 项，可能更少）；仅展示，暂不支持打开详情')
+        .fontSize(18).fontColor(C_SECONDARY)
+      Flex({ wrap: FlexWrap.Wrap }) {
+        ForEach(this.serverResult.items, (item: VideoServerSearchItem) => {
+          Column({ space: 8 }) {
+            if (item.media.posterUrl.length > 0) {
+              Image(item.media.posterUrl).width(180).height(270).objectFit(ImageFit.Cover).borderRadius(8)
+            } else {
+              Text('暂无海报').width(180).height(270).textAlign(TextAlign.Center)
+                .backgroundColor(C_COMPONENT_BG).fontColor(C_SECONDARY)
+            }
+            Text(item.media.title).fontSize(22).fontColor(C_TEXT_BODY).maxLines(2)
+            Text(item.media.type === 'movie' ? '电影' : item.media.type === 'series' ? '剧集' : '单集')
+              .fontSize(18).fontColor(C_SECONDARY)
+          }.width(180).margin({ right: 20, bottom: 20 }).focusable(false)
+        }, (item: VideoServerSearchItem) => item.key)
+      }.width('100%')
+    } else {
+      Text('输入片名搜索当前服务器').fontSize(22).fontColor(C_SECONDARY)
+    }
+  }
+
   build() {
     NavDestination() {
       Scroll() {
@@ -752,11 +854,15 @@ struct SearchWorkspacePage {
           this.buildBackRow()
           Text(this.scope.label).fontSize(24).fontColor(C_TEXT_TITLE)
           Text(getSearchCapabilities(this.scope).hint).fontSize(18).fontColor(C_SECONDARY)
-          if (getSearchCapabilities(this.scope).localSearch) {
+          if (getSearchCapabilities(this.scope).localSearch || getSearchCapabilities(this.scope).serverSearch) {
             this.buildSearchBar()
             this.buildKeyboard()
-            this.buildHistory()
-            this.buildResultsPreview()
+            if (getSearchCapabilities(this.scope).localSearch) {
+              this.buildHistory()
+              this.buildResultsPreview()
+            } else {
+              this.buildServerResults()
+            }
           }
         }
         .width('100%')
@@ -774,8 +880,11 @@ struct SearchWorkspacePage {
     .onReady((context: NavDestinationContext) => {
       this.initializeRoute(context.pathInfo.param as SearchRouteParam | string | null | undefined);
     })
+    .onShown(() => { this.resumeSearch(); })
+    .onWillHide(() => { this.leaveSearch(); })
     .hideTitleBar(true)
     .onBackPressed(() => {
+      this.leaveSearch();
       this.pageStack.pop();
       return true;
     })

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -410,7 +410,7 @@ struct SearchWorkspacePage {
   private initializeRoute(param: SearchRouteParam | string | null | undefined): void {
     const servers = VideoServerStore.getState().videoServers;
     const route = resolveSearchRoute(param, SourceSwitchModel.getState().getSearchScope(servers), servers);
-    // Route text is reusable, but the top-bar instance is the only source authority.
+    // 路由关键词可复用，但来源以顶部实时选择为准，旧路由快照不得覆盖当前实例。
     this.searchText = route.keyword;
     this.resumeSearch();
   }

--- a/entry/src/main/ets/services/search/SearchWorkspaceSession.ets
+++ b/entry/src/main/ets/services/search/SearchWorkspaceSession.ets
@@ -1,0 +1,66 @@
+import { VideoServer } from '../../db/models/VideoServerEntity';
+import { SearchScope } from '../../models/search/SearchScope';
+import { VideoServerSearchResult, VideoServerSearchService } from './VideoServerSearchService';
+
+export interface SearchWorkspaceContext {
+  scope: SearchScope;
+  server?: VideoServer;
+}
+
+/** Private value snapshots are never used as display keys or logged. */
+class SearchRequestIdentity {
+  readonly scopeKey: string;
+  readonly serverId: number | undefined;
+  readonly serverType: string;
+  private readonly configuration: string;
+
+  constructor(context: SearchWorkspaceContext) {
+    this.scopeKey = context.scope.key;
+    this.serverId = context.server?.id;
+    this.serverType = context.server?.type ?? '';
+    this.configuration = context.server?.configJson ?? '';
+  }
+
+  matches(context: SearchWorkspaceContext): boolean {
+    return this.scopeKey === context.scope.key && this.serverId === context.server?.id &&
+      this.serverType === (context.server?.type ?? '') &&
+      this.configuration === (context.server?.configJson ?? '');
+  }
+}
+
+export class SearchWorkspaceSession {
+  private generation: number = 0;
+  private active: boolean = true;
+
+  invalidate(): void { this.generation++; }
+  activate(): void { this.invalidate(); this.active = true; }
+  dispose(): void { this.invalidate(); this.active = false; }
+
+  async search(keyword: string, current: () => SearchWorkspaceContext,
+    publish: (result: VideoServerSearchResult) => void,
+    service: VideoServerSearchService = new VideoServerSearchService()): Promise<void> {
+    const generation = ++this.generation;
+    const context = current();
+    if (!this.active || keyword.trim().length === 0 || context.scope.kind !== 'videoServer' ||
+      context.server === undefined) { return; }
+    const identity = new SearchRequestIdentity(context);
+    const server: VideoServer = {
+      id: context.server.id, type: context.server.type, name: context.server.name,
+      configJson: context.server.configJson, createdAt: context.server.createdAt
+    };
+    const scope: SearchScope = {
+      kind: context.scope.kind, key: context.scope.key, label: context.scope.label,
+      serverId: context.scope.serverId, serverType: context.scope.serverType
+    };
+    publish(service.createLoadingState(scope, server, keyword));
+    let result: VideoServerSearchResult;
+    try {
+      result = await service.search(scope, server, keyword);
+    } catch {
+      result = { status: 'error', scopeKey: scope.key, keyword: keyword.trim(), items: [], errorCode: 'network' };
+    }
+    if (this.active && generation === this.generation && identity.matches(current())) {
+      publish(result);
+    }
+  }
+}

--- a/entry/src/main/ets/services/search/VideoServerSearchService.ets
+++ b/entry/src/main/ets/services/search/VideoServerSearchService.ets
@@ -7,12 +7,48 @@ import { SearchScope, resolveSearchScope, toSearchScopeIdentity } from '../../mo
 export type VideoServerSearchErrorCode =
   'none' | 'unavailable' | 'invalidQuery' | 'auth' | 'timeout' | 'network' | 'invalidResponse';
 
+export type NormalizedVideoServerMediaType = 'movie' | 'series' | 'episode';
+
+export interface VideoServerSearchSelection {
+  serverId: number;
+  serverType: VideoServerType;
+  mediaId: string;
+  mediaType: NormalizedVideoServerMediaType;
+  detailItemId: string;
+}
+
+const videoServerSearchSourceConfigurations = new WeakMap<VideoServerSearchSourceSnapshot, string>();
+
+/** 配置快照只保留在内存对象中用于失效校验，不进 key / 日志 / 持久化。 */
+export class VideoServerSearchSourceSnapshot {
+  readonly scopeKey: string;
+  readonly serverId: number;
+  readonly serverType: VideoServerType;
+
+  constructor(scopeKey: string, server: VideoServer) {
+    this.scopeKey = scopeKey;
+    this.serverId = server.id as number;
+    this.serverType = server.type;
+    videoServerSearchSourceConfigurations.set(this, server.configJson);
+  }
+
+  matches(scope: SearchScope, server: VideoServer | undefined): boolean {
+    const configuration = videoServerSearchSourceConfigurations.get(this) ?? '';
+    return scope.kind === 'videoServer' && scope.key === this.scopeKey &&
+      scope.serverId === this.serverId && scope.serverType === this.serverType &&
+      server !== undefined && server.id === this.serverId && server.type === this.serverType &&
+      server.configJson === configuration;
+  }
+}
+
 export interface VideoServerSearchItem {
   key: string;
   scopeKey: string;
   serverId: number;
   serverType: VideoServerType;
   media: VideoServerMediaItem;
+  selection: VideoServerSearchSelection;
+  sourceSnapshot: VideoServerSearchSourceSnapshot;
 }
 
 /** Terminal results contain no raw errors/configuration. Image URLs inherit client authentication: do not log them. */
@@ -49,6 +85,7 @@ export class VideoServerSearchService {
     // Snapshot identity before awaiting; callers may mutate their selected server while IO is pending.
     const serverId = server.id as number;
     const serverType = server.type;
+    const sourceSnapshot = new VideoServerSearchSourceSnapshot(result.scopeKey, server);
     try {
       let mediaItems: VideoServerMediaItem[];
       if (serverType === VideoServerType.PLEX) {
@@ -58,12 +95,15 @@ export class VideoServerSearchService {
       }
       const seen = new Set<string>();
       for (const media of mediaItems) {
-        if (media.id.length === 0 ||
-          (media.type !== 'movie' && media.type !== 'series' && media.type !== 'episode')) { continue; }
+        const mediaType = this.normalizeMediaType(media.type);
+        if (media.id.length === 0 || mediaType === null) { continue; }
         const key = `${result.scopeKey}:${encodeURIComponent(media.id)}`;
         if (seen.has(key)) { continue; }
         seen.add(key);
-        const item: VideoServerSearchItem = { key, scopeKey: result.scopeKey, serverId, serverType, media };
+        const selection = this.createSelection(serverId, serverType, media, mediaType);
+        const item: VideoServerSearchItem = {
+          key, scopeKey: result.scopeKey, serverId, serverType, media, selection, sourceSnapshot
+        };
         result.items.push(item);
         if (result.items.length === 100) { break; }
       }
@@ -89,5 +129,21 @@ export class VideoServerSearchService {
     result.items = [];
     result.errorCode = code;
     return result;
+  }
+
+  private normalizeMediaType(type: string): NormalizedVideoServerMediaType | null {
+    if (type === 'movie' || type === 'series' || type === 'episode') {
+      return type;
+    }
+    return null;
+  }
+
+  private createSelection(serverId: number, serverType: VideoServerType, media: VideoServerMediaItem,
+    mediaType: NormalizedVideoServerMediaType): VideoServerSearchSelection {
+    const detailItemId = mediaType === 'episode' && media.seriesId.length > 0 ? media.seriesId : media.id;
+    const selection: VideoServerSearchSelection = {
+      serverId, serverType, mediaId: media.id, mediaType, detailItemId
+    };
+    return selection;
   }
 }

--- a/entry/src/main/ets/services/search/VideoServerSearchService.ets
+++ b/entry/src/main/ets/services/search/VideoServerSearchService.ets
@@ -51,7 +51,7 @@ export interface VideoServerSearchItem {
   sourceSnapshot: VideoServerSearchSourceSnapshot;
 }
 
-/** Terminal results contain no raw errors/configuration. Image URLs inherit client authentication: do not log them. */
+/** 终态结果不包含原始错误或配置；图片 URL 沿用客户端鉴权，禁止写入日志。 */
 export interface VideoServerSearchResult {
   status: 'loading' | 'success' | 'empty' | 'error';
   scopeKey: string;
@@ -60,9 +60,9 @@ export interface VideoServerSearchResult {
   errorCode: VideoServerSearchErrorCode;
 }
 
-/** Stateless, bounded first-page search (100 items); not a total count or pagination contract.
- * Each invocation captures its identity before IO and never publishes shared state.
- * Consumers must guard completion with their request generation, invalidating on source/config changes or disposal.
+/** 无状态搜索仅返回首屏最多 100 条，不代表总数或分页契约。
+ * 每次调用在 IO 前捕获身份，不发布共享状态。
+ * 调用方须用请求代次校验完成回调，并在来源、配置变化或销毁时使请求失效。
  */
 export class VideoServerSearchService {
   createLoadingState(scope: SearchScope, server: VideoServer, keyword: string): VideoServerSearchResult {
@@ -82,7 +82,7 @@ export class VideoServerSearchService {
   async search(scope: SearchScope, server: VideoServer, keyword: string): Promise<VideoServerSearchResult> {
     const result = this.createLoadingState(scope, server, keyword);
     if (result.status === 'error') { return result; }
-    // Snapshot identity before awaiting; callers may mutate their selected server while IO is pending.
+    // 在等待前捕获身份快照，避免 IO 期间调用方修改所选服务器。
     const serverId = server.id as number;
     const serverType = server.type;
     const sourceSnapshot = new VideoServerSearchSourceSnapshot(result.scopeKey, server);

--- a/entry/src/main/ets/services/search/VideoServerSearchService.ets
+++ b/entry/src/main/ets/services/search/VideoServerSearchService.ets
@@ -1,0 +1,93 @@
+import { BusinessError } from '@kit.BasicServicesKit';
+import { VideoServer, VideoServerType } from '../../db/models/VideoServerEntity';
+import { JellyfinClient, VideoServerMediaItem } from '../../lib/JellyfinClient';
+import { PlexClient } from '../../lib/PlexClient';
+import { SearchScope, resolveSearchScope, toSearchScopeIdentity } from '../../models/search/SearchScope';
+
+export type VideoServerSearchErrorCode =
+  'none' | 'unavailable' | 'invalidQuery' | 'auth' | 'timeout' | 'network' | 'invalidResponse';
+
+export interface VideoServerSearchItem {
+  key: string;
+  scopeKey: string;
+  serverId: number;
+  serverType: VideoServerType;
+  media: VideoServerMediaItem;
+}
+
+/** Terminal results contain no raw errors/configuration. Image URLs inherit client authentication: do not log them. */
+export interface VideoServerSearchResult {
+  status: 'loading' | 'success' | 'empty' | 'error';
+  scopeKey: string;
+  keyword: string;
+  items: VideoServerSearchItem[];
+  errorCode: VideoServerSearchErrorCode;
+}
+
+/** Stateless, bounded first-page search (100 items); not a total count or pagination contract.
+ * Each invocation captures its identity before IO and never publishes shared state.
+ * Consumers must guard completion with their request generation, invalidating on source/config changes or disposal.
+ */
+export class VideoServerSearchService {
+  createLoadingState(scope: SearchScope, server: VideoServer, keyword: string): VideoServerSearchResult {
+    const resolved = resolveSearchScope(toSearchScopeIdentity(scope), [server]);
+    const result: VideoServerSearchResult = {
+      status: 'loading', scopeKey: resolved.key, keyword: keyword.trim(), items: [], errorCode: 'none'
+    };
+    if (scope.kind !== 'videoServer' || resolved.kind !== 'videoServer' ||
+      scope.serverType !== server.type || resolved.serverId === undefined) {
+      result.scopeKey = 'unavailable';
+      return this.fail(result, 'unavailable');
+    }
+    if (result.keyword.length === 0) { return this.fail(result, 'invalidQuery'); }
+    return result;
+  }
+
+  async search(scope: SearchScope, server: VideoServer, keyword: string): Promise<VideoServerSearchResult> {
+    const result = this.createLoadingState(scope, server, keyword);
+    if (result.status === 'error') { return result; }
+    // Snapshot identity before awaiting; callers may mutate their selected server while IO is pending.
+    const serverId = server.id as number;
+    const serverType = server.type;
+    try {
+      let mediaItems: VideoServerMediaItem[];
+      if (serverType === VideoServerType.PLEX) {
+        mediaItems = await PlexClient.fromConfigJson(server.configJson).searchItems(result.keyword);
+      } else {
+        mediaItems = await JellyfinClient.fromConfigJson(server.configJson).searchItems(result.keyword);
+      }
+      const seen = new Set<string>();
+      for (const media of mediaItems) {
+        if (media.id.length === 0 ||
+          (media.type !== 'movie' && media.type !== 'series' && media.type !== 'episode')) { continue; }
+        const key = `${result.scopeKey}:${encodeURIComponent(media.id)}`;
+        if (seen.has(key)) { continue; }
+        seen.add(key);
+        const item: VideoServerSearchItem = { key, scopeKey: result.scopeKey, serverId, serverType, media };
+        result.items.push(item);
+        if (result.items.length === 100) { break; }
+      }
+      result.status = result.items.length > 0 ? 'success' : 'empty';
+      return result;
+    } catch (e) {
+      const error = e as BusinessError;
+      const message = (error.message ?? '').toLowerCase();
+      if (message.includes('鉴权失败') || message.includes('缺少') || message.includes('accesstoken')) {
+        return this.fail(result, 'auth');
+      }
+      if (error.code === 2300028 || message.includes('timeout') || message.includes('timed out') ||
+        message.includes('超时')) { return this.fail(result, 'timeout'); }
+      if (e instanceof SyntaxError || e instanceof TypeError || message === 'invalid search response') {
+        return this.fail(result, 'invalidResponse');
+      }
+      return this.fail(result, 'network');
+    }
+  }
+
+  private fail(result: VideoServerSearchResult, code: VideoServerSearchErrorCode): VideoServerSearchResult {
+    result.status = 'error';
+    result.items = [];
+    result.errorCode = code;
+    return result;
+  }
+}

--- a/entry/src/main/ets/stores/media/SourceSwitchModel.ets
+++ b/entry/src/main/ets/stores/media/SourceSwitchModel.ets
@@ -31,7 +31,19 @@ export class SourceSwitchModel {
 
   private sourceLoaded: boolean = false;
 
-  @Trace activeSource: ActiveMediaSource = { kind: 'fileSource' };
+  @Trace private selectedSource: ActiveMediaSource = { kind: 'fileSource' };
+  private searchListeners: Set<() => void> = new Set<() => void>();
+
+  get activeSource(): ActiveMediaSource { return this.selectedSource; }
+  set activeSource(value: ActiveMediaSource) {
+    this.selectedSource = value;
+    this.searchListeners.forEach((listener: () => void) => listener());
+  }
+
+  subscribeSearchSource(listener: () => void): () => void {
+    this.searchListeners.add(listener);
+    return () => { this.searchListeners.delete(listener); };
+  }
 
   /** 数据源切换弹窗是否可见（供返回键拦截） */
   @Trace sourceSwitchDialogVisible: boolean = false;
@@ -107,6 +119,7 @@ export class SourceSwitchModel {
       this.activeSource = { kind: 'videoServer', name: '来源不可用' };
     } finally {
       this.sourceLoaded = true;
+      this.searchListeners.forEach((listener: () => void) => listener());
     }
   }
 

--- a/entry/src/main/ets/stores/servers/VideoServerModel.ets
+++ b/entry/src/main/ets/stores/servers/VideoServerModel.ets
@@ -13,7 +13,23 @@ export class VideoServerModel {
   private static readonly CACHE_DURATION = 5 * 60 * 1000;
 
   // 影视服务器列表
-  @Trace videoServers: VideoServer[] = [];
+  @Trace private servers: VideoServer[] = [];
+  private searchListeners: Set<() => void> = new Set<() => void>();
+
+  get videoServers(): VideoServer[] { return this.servers; }
+  set videoServers(value: VideoServer[]) {
+    this.servers = value;
+    this.notifySearchConfiguration();
+  }
+
+  subscribeSearchConfiguration(listener: () => void): () => void {
+    this.searchListeners.add(listener);
+    return () => { this.searchListeners.delete(listener); };
+  }
+
+  private notifySearchConfiguration(): void {
+    this.searchListeners.forEach((listener: () => void) => listener());
+  }
 
   // 是否已加载
   @Trace isLoaded: boolean = false;
@@ -73,7 +89,7 @@ export class VideoServerModel {
       const rowId = await database.insertVideoServer(server);
 
       server.id = rowId;
-      this.videoServers.push(server);
+      this.videoServers = this.videoServers.concat([server]);
       this.lastUpdateTime = Date.now();
 
       console.info(`VideoServerModel: Added video server with id ${rowId}`);
@@ -117,7 +133,7 @@ export class VideoServerModel {
 
       const index = this.videoServers.findIndex(item => item.id === id);
       if (index !== -1) {
-        this.videoServers.splice(index, 1);
+        this.videoServers = this.videoServers.filter((server: VideoServer) => server.id !== id);
       }
       this.lastUpdateTime = Date.now();
     } catch (error) {

--- a/entry/src/main/ets/stores/servers/VideoServerModel.ets
+++ b/entry/src/main/ets/stores/servers/VideoServerModel.ets
@@ -16,9 +16,41 @@ export class VideoServerModel {
   @Trace private servers: VideoServer[] = [];
   private searchListeners: Set<() => void> = new Set<() => void>();
 
+  // Separate intent notifications preserve the existing publication-only listener contract.
+  private revisionListeners: Set<() => void> = new Set<() => void>();
+  private configurationRevision: number = 0;
+  private pendingConfigurationWrites: number = 0;
+
+  get searchConfigurationRevision(): number { return this.configurationRevision; }
+
+  subscribeSearchConfigurationRevision(listener: () => void): () => void {
+    this.revisionListeners.add(listener);
+    return () => { this.revisionListeners.delete(listener); };
+  }
+
+  private notifyConfigurationRevision(): void {
+    this.revisionListeners.forEach((listener: () => void) => listener());
+  }
+
+  private beginConfigurationWrite(): void {
+    this.pendingConfigurationWrites++;
+    this.configurationRevision++;
+    this.invalidateCache();
+    this.notifyConfigurationRevision();
+  }
+
+  private finishConfigurationWrite(): void {
+    this.pendingConfigurationWrites--;
+    this.configurationRevision++;
+    this.invalidateCache();
+    this.notifyConfigurationRevision();
+  }
+
   get videoServers(): VideoServer[] { return this.servers; }
   set videoServers(value: VideoServer[]) {
+    this.configurationRevision++;
     this.servers = value;
+    this.notifyConfigurationRevision();
     this.notifySearchConfiguration();
   }
 
@@ -45,6 +77,9 @@ export class VideoServerModel {
    * @param forceReload 是否强制重新加载
    */
   async loadVideoServers(forceReload: boolean = false): Promise<void> {
+    if (this.pendingConfigurationWrites > 0) {
+      throw new Error('Server configuration write in progress');
+    }
     const now = Date.now();
 
     if (!forceReload && this.isLoaded && (now - this.lastUpdateTime) < VideoServerModel.CACHE_DURATION) {
@@ -64,12 +99,19 @@ export class VideoServerModel {
   }
 
   private async doLoad(now: number): Promise<void> {
+    const revision = this.configurationRevision;
     try {
       console.info('VideoServerModel: Loading video servers from database');
       const database = FileSourceDatabase.getInstance();
       // 等待数据库就绪，避免冷启动时 getStore 抛「Database not initialized」导致列表为空
       await FileSourceDatabase.whenDatabaseReady();
-      this.videoServers = await database.getAllVideoServers();
+      const servers = await database.getAllVideoServers();
+      // Never publish a read that overlaps a write, including a failed write.
+      if (revision !== this.configurationRevision || this.pendingConfigurationWrites > 0) {
+        throw new Error('Server configuration changed during load');
+      }
+      this.servers = servers;
+      this.notifySearchConfiguration();
       this.isLoaded = true;
       this.lastUpdateTime = now;
       console.info(`VideoServerModel: Loaded ${this.videoServers.length} video server(s)`);
@@ -84,6 +126,7 @@ export class VideoServerModel {
    * 添加影视服务器
    */
   async addVideoServer(server: VideoServer): Promise<number> {
+    this.beginConfigurationWrite();
     try {
       const database = FileSourceDatabase.getInstance();
       const rowId = await database.insertVideoServer(server);
@@ -98,6 +141,8 @@ export class VideoServerModel {
       const msg = (error as BusinessError).message ?? String(error);
       console.error('VideoServerModel: Failed to add video server', msg);
       throw new Error('Failed to add video server: ' + msg);
+    } finally {
+      this.finishConfigurationWrite();
     }
   }
 
@@ -109,6 +154,7 @@ export class VideoServerModel {
       throw new Error('Video server id is required for update');
     }
 
+    this.beginConfigurationWrite();
     try {
       const database = FileSourceDatabase.getInstance();
       await database.updateVideoServer(server);
@@ -120,6 +166,8 @@ export class VideoServerModel {
       const msg = (error as BusinessError).message ?? String(error);
       console.error('VideoServerModel: Failed to update video server', msg);
       throw new Error('Failed to update video server: ' + msg);
+    } finally {
+      this.finishConfigurationWrite();
     }
   }
 
@@ -127,6 +175,7 @@ export class VideoServerModel {
    * 删除影视服务器
    */
   async deleteVideoServer(id: number): Promise<void> {
+    this.beginConfigurationWrite();
     try {
       const database = FileSourceDatabase.getInstance();
       await database.deleteVideoServer(id);
@@ -140,6 +189,8 @@ export class VideoServerModel {
       const msg = (error as BusinessError).message ?? String(error);
       console.error('VideoServerModel: Failed to delete video server', msg);
       throw new Error('Failed to delete video server: ' + msg);
+    } finally {
+      this.finishConfigurationWrite();
     }
   }
 

--- a/entry/src/main/ets/stores/servers/VideoServerModel.ets
+++ b/entry/src/main/ets/stores/servers/VideoServerModel.ets
@@ -16,7 +16,7 @@ export class VideoServerModel {
   @Trace private servers: VideoServer[] = [];
   private searchListeners: Set<() => void> = new Set<() => void>();
 
-  // Separate intent notifications preserve the existing publication-only listener contract.
+  // 独立的变更意图通知保留现有监听器仅在数据发布时触发的契约。
   private revisionListeners: Set<() => void> = new Set<() => void>();
   private configurationRevision: number = 0;
   private pendingConfigurationWrites: number = 0;

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -1,3 +1,4 @@
+import searchWorkspaceSessionTest from './SearchWorkspaceSession.test';
 import videoServerSearchTest from './VideoServerSearch.test';
 import searchScopeTest from './SearchScope.test';
 import timeUtilTest from './TimeUtil.test';
@@ -125,6 +126,7 @@ export default function testsuite() {
   subtitleRelevanceFilterTest();
   sourceSwitchModelTest();
   videoServerSearchTest();
+  searchWorkspaceSessionTest();
   searchScopeTest();
   videoServerLabelsTest();
   videoServerDaoTest();

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -1,3 +1,4 @@
+import videoServerSearchTest from './VideoServerSearch.test';
 import searchScopeTest from './SearchScope.test';
 import timeUtilTest from './TimeUtil.test';
 import playbackContextTest from './ets/PlaybackContextTest';
@@ -123,6 +124,7 @@ export default function testsuite() {
   subtitleLanguageFilterTest();
   subtitleRelevanceFilterTest();
   sourceSwitchModelTest();
+  videoServerSearchTest();
   searchScopeTest();
   videoServerLabelsTest();
   videoServerDaoTest();

--- a/entry/src/test/SearchScope.test.ets
+++ b/entry/src/test/SearchScope.test.ets
@@ -18,8 +18,8 @@ export default function searchScopeTest() {
       expect(scope.key).assertEqual('video-server:jellyfin:1');
       expect(scope.label).assertEqual('A');
       expect(getSearchCapabilities(scope).localHistory).assertEqual(false);
-      expect(getSearchCapabilities(scope).serverSearch).assertEqual(false);
-      expect(getSearchCapabilities(scope).inputModes.length).assertEqual(0);
+      expect(getSearchCapabilities(scope).serverSearch).assertEqual(true);
+      expect(getSearchCapabilities(scope).inputModes.join(',')).assertEqual('text');
     });
     it('separates server instances and types', 0, () => {
       expect(resolveSearchScope({ kind: 'videoServer', serverId: 2 } as SearchScopeIdentity, servers).key)

--- a/entry/src/test/SearchWorkspaceSession.test.ets
+++ b/entry/src/test/SearchWorkspaceSession.test.ets
@@ -1,0 +1,146 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { VideoServer, VideoServerType } from '../main/ets/db/models/VideoServerEntity';
+import { SearchScope, SearchScopeIdentity, resolveSearchScope, createLocalSearchScope } from '../main/ets/models/search/SearchScope';
+import { SearchWorkspaceContext, SearchWorkspaceSession } from '../main/ets/services/search/SearchWorkspaceSession';
+import { VideoServerSearchService, VideoServerSearchResult } from '../main/ets/services/search/VideoServerSearchService';
+
+class PendingResult {
+  private resolveResult: (result: VideoServerSearchResult) => void = () => {};
+  promise: Promise<VideoServerSearchResult> = new Promise<VideoServerSearchResult>((resolve) => {
+    this.resolveResult = resolve;
+  });
+  complete(scope: SearchScope, status: 'success' | 'empty' | 'error'): void {
+    const result: VideoServerSearchResult = {
+      status, scopeKey: scope.key, keyword: 'film', items: [], errorCode: status === 'error' ? 'network' : 'none'
+    };
+    this.resolveResult(result);
+  }
+}
+
+class ControlledSearch extends VideoServerSearchService {
+  pending: PendingResult[] = [];
+  configurations: string[] = [];
+  search(_scope: SearchScope, server: VideoServer, _keyword: string): Promise<VideoServerSearchResult> {
+    const pending = new PendingResult();
+    this.pending.push(pending);
+    this.configurations.push(server.configJson);
+    return pending.promise;
+  }
+}
+
+function context(id: number): SearchWorkspaceContext {
+  const server: VideoServer = {
+    id, name: `Server ${id}`, type: VideoServerType.JELLYFIN, configJson: '{}', createdAt: 1
+  };
+  const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: id };
+  const result: SearchWorkspaceContext = { scope: resolveSearchScope(identity, [server]), server };
+  return result;
+}
+
+export default function searchWorkspaceSessionTest() {
+  describe('SearchWorkspaceSession', () => {
+    for (const terminal of ['success', 'empty', 'error']) {
+      it(`publishes loading then ${terminal}`, 0, async () => {
+        const session = new SearchWorkspaceSession();
+        const service = new ControlledSearch();
+        const current = context(1);
+        const states: string[] = [];
+        const task = session.search('film', () => current, (result) => { states.push(result.status); }, service);
+        expect(states.join(',')).assertEqual('loading');
+        service.pending[0].complete(current.scope, terminal as 'success' | 'empty' | 'error');
+        await task;
+        expect(states.join(',')).assertEqual(`loading,${terminal}`);
+      });
+    }
+    for (const action of ['input', 'clear', 'leave', 'source', 'configuration']) {
+      it(`immediately rejects old completion after ${action}`, 0, async () => {
+        const session = new SearchWorkspaceSession();
+        const service = new ControlledSearch();
+        const current = context(1);
+        const states: string[] = [];
+        const task = session.search('film', () => current, (result) => { states.push(result.status); }, service);
+        if (action === 'leave') { session.dispose(); } else { session.invalidate(); }
+        service.pending[0].complete(current.scope, 'error');
+        await task;
+        expect(states.join(',')).assertEqual('loading');
+      });
+    }
+    it('same-protocol A B A rejects both earlier requests and old errors', 0, async () => {
+      const session = new SearchWorkspaceSession();
+      const service = new ControlledSearch();
+      let current = context(1);
+      const states: string[] = [];
+      const publish = (result: VideoServerSearchResult): void => { states.push(`${result.scopeKey}:${result.status}`); };
+      const a = session.search('film', () => current, publish, service);
+      session.invalidate(); current = context(2);
+      const b = session.search('film', () => current, publish, service);
+      session.invalidate(); current = context(1);
+      const latest = session.search('film', () => current, publish, service);
+      service.pending[2].complete(current.scope, 'success'); await latest;
+      service.pending[0].complete(context(1).scope, 'error'); await a;
+      service.pending[1].complete(context(2).scope, 'success'); await b;
+      expect(states.length).assertEqual(4);
+      expect(states[3]).assertEqual('video-server:jellyfin:1:success');
+    });
+    it('same keyword retry rejects an older error', 0, async () => {
+      const session = new SearchWorkspaceSession();
+      const service = new ControlledSearch();
+      const current = context(1);
+      const states: string[] = [];
+      const publish = (result: VideoServerSearchResult): void => { states.push(result.status); };
+      const first = session.search('film', () => current, publish, service);
+      const retry = session.search('film', () => current, publish, service);
+      service.pending[1].complete(current.scope, 'empty'); await retry;
+      service.pending[0].complete(current.scope, 'error'); await first;
+      expect(states.join(',')).assertEqual('loading,loading,empty');
+    });
+    it('captures config by value and rejects same-id in-place edits without notification', 0, async () => {
+      const session = new SearchWorkspaceSession();
+      const service = new ControlledSearch();
+      const current = context(1);
+      const states: string[] = [];
+      const task = session.search('film', () => current, (result) => { states.push(result.status); }, service);
+      if (current.server !== undefined) { current.server.configJson = '{"url":"changed"}'; }
+      expect(service.configurations[0]).assertEqual('{}');
+      service.pending[0].complete(current.scope, 'success'); await task;
+      expect(states.join(',')).assertEqual('loading');
+    });
+    it('captured source identity rejects unannounced same-protocol switch', 0, async () => {
+      const session = new SearchWorkspaceSession();
+      const service = new ControlledSearch();
+      let current = context(1);
+      const states: string[] = [];
+      const task = session.search('film', () => current, (result) => { states.push(result.status); }, service);
+      current = context(2);
+      service.pending[0].complete(context(1).scope, 'success'); await task;
+      expect(states.join(',')).assertEqual('loading');
+    });
+    it('blank local missing and disposed contexts never start transport', 0, async () => {
+      const session = new SearchWorkspaceSession();
+      const service = new ControlledSearch();
+      let current = context(1);
+      const publish = (_result: VideoServerSearchResult): void => {};
+      await session.search('  ', () => current, publish, service);
+      current = { scope: createLocalSearchScope() };
+      await session.search('film', () => current, publish, service);
+      current = { scope: context(1).scope };
+      await session.search('film', () => current, publish, service);
+      current = context(1); session.dispose();
+      await session.search('film', () => current, publish, service);
+      expect(service.pending.length).assertEqual(0);
+    });
+    it('reactivation does not revive request from previous page lifetime', 0, async () => {
+      const session = new SearchWorkspaceSession();
+      const service = new ControlledSearch();
+      const current = context(1);
+      const states: string[] = [];
+      const publish = (result: VideoServerSearchResult): void => { states.push(result.status); };
+      const first = session.search('film', () => current, publish, service);
+      session.dispose(); session.activate();
+      const next = session.search('film', () => current, publish, service);
+      service.pending[1].complete(current.scope, 'empty'); await next;
+      service.pending[0].complete(current.scope, 'success'); await first;
+      expect(states.join(',')).assertEqual('loading,loading,empty');
+    });
+  });
+}

--- a/entry/src/test/SearchWorkspaceSession.test.ets
+++ b/entry/src/test/SearchWorkspaceSession.test.ets
@@ -40,7 +40,7 @@ function context(id: number): SearchWorkspaceContext {
 export default function searchWorkspaceSessionTest() {
   describe('SearchWorkspaceSession', () => {
     for (const terminal of ['success', 'empty', 'error']) {
-      it(`publishes loading then ${terminal}`, 0, async () => {
+      it(`先发布加载态，再发布 ${terminal} 终态`, 0, async () => {
         const session = new SearchWorkspaceSession();
         const service = new ControlledSearch();
         const current = context(1);
@@ -53,7 +53,7 @@ export default function searchWorkspaceSessionTest() {
       });
     }
     for (const action of ['input', 'clear', 'leave', 'source', 'configuration']) {
-      it(`immediately rejects old completion after ${action}`, 0, async () => {
+      it(`在 ${action} 后立即拒绝旧请求完成回调`, 0, async () => {
         const session = new SearchWorkspaceSession();
         const service = new ControlledSearch();
         const current = context(1);
@@ -65,7 +65,7 @@ export default function searchWorkspaceSessionTest() {
         expect(states.join(',')).assertEqual('loading');
       });
     }
-    it('same-protocol A B A rejects both earlier requests and old errors', 0, async () => {
+    it('同协议 A B A 切换拒绝此前请求与旧错误', 0, async () => {
       const session = new SearchWorkspaceSession();
       const service = new ControlledSearch();
       let current = context(1);
@@ -82,7 +82,7 @@ export default function searchWorkspaceSessionTest() {
       expect(states.length).assertEqual(4);
       expect(states[3]).assertEqual('video-server:jellyfin:1:success');
     });
-    it('same keyword retry rejects an older error', 0, async () => {
+    it('相同关键词重试拒绝更早请求的错误', 0, async () => {
       const session = new SearchWorkspaceSession();
       const service = new ControlledSearch();
       const current = context(1);
@@ -94,7 +94,7 @@ export default function searchWorkspaceSessionTest() {
       service.pending[0].complete(current.scope, 'error'); await first;
       expect(states.join(',')).assertEqual('loading,loading,empty');
     });
-    it('captures config by value and rejects same-id in-place edits without notification', 0, async () => {
+    it('按值捕获配置并拒绝未通知的同身份原地修改', 0, async () => {
       const session = new SearchWorkspaceSession();
       const service = new ControlledSearch();
       const current = context(1);
@@ -105,7 +105,7 @@ export default function searchWorkspaceSessionTest() {
       service.pending[0].complete(current.scope, 'success'); await task;
       expect(states.join(',')).assertEqual('loading');
     });
-    it('captured source identity rejects unannounced same-protocol switch', 0, async () => {
+    it('捕获的来源身份拒绝未通知的同协议切源', 0, async () => {
       const session = new SearchWorkspaceSession();
       const service = new ControlledSearch();
       let current = context(1);
@@ -115,7 +115,7 @@ export default function searchWorkspaceSessionTest() {
       service.pending[0].complete(context(1).scope, 'success'); await task;
       expect(states.join(',')).assertEqual('loading');
     });
-    it('blank local missing and disposed contexts never start transport', 0, async () => {
+    it('空关键词、本地、缺失及已销毁上下文不发起传输', 0, async () => {
       const session = new SearchWorkspaceSession();
       const service = new ControlledSearch();
       let current = context(1);
@@ -129,7 +129,7 @@ export default function searchWorkspaceSessionTest() {
       await session.search('film', () => current, publish, service);
       expect(service.pending.length).assertEqual(0);
     });
-    it('reactivation does not revive request from previous page lifetime', 0, async () => {
+    it('重新激活不恢复上一页面生命周期的请求', 0, async () => {
       const session = new SearchWorkspaceSession();
       const service = new ControlledSearch();
       const current = context(1);

--- a/entry/src/test/VideoServerSearch.test.ets
+++ b/entry/src/test/VideoServerSearch.test.ets
@@ -73,6 +73,12 @@ export default function videoServerSearchTest() {
         expect(result.items[0].serverId).assertEqual(2);
         expect(result.items[0].serverType).assertEqual(type);
         expect(result.items[0].media.type).assertEqual(type === VideoServerType.PLEX ? 'series' : 'movie');
+        expect(result.items[0].selection.serverId).assertEqual(2);
+        expect(result.items[0].selection.serverType).assertEqual(type);
+        expect(result.items[0].selection.mediaId).assertEqual('same');
+        expect(result.items[0].selection.mediaType).assertEqual(type === VideoServerType.PLEX ? 'series' : 'movie');
+        expect(result.items[0].selection.detailItemId).assertEqual('same');
+        expect(result.items[0].sourceSnapshot.matches(scope, target)).assertTrue();
         expect(urls.every((url: string) => url.startsWith('https://server-2.test:8096/'))).assertTrue();
         expect(urls[urls.length - 1].includes(encodeURIComponent('中文 &/?'))).assertTrue();
         expect(tokens.every((token: string) => token === 'fake-2')).assertTrue();
@@ -163,6 +169,8 @@ export default function videoServerSearchTest() {
       expect(result.items.length).assertEqual(2);
       expect(result.items[0].key).assertEqual('video-server:jellyfin:1:a%3Ab%2Fc');
       expect(result.items[1].key).assertEqual('video-server:jellyfin:1:a%253Ab%252Fc');
+      expect(result.items[0].selection.mediaId).assertEqual('a:b/c');
+      expect(result.items[1].selection.mediaId).assertEqual('a%3Ab%2Fc');
     });
     it('Plex handles empty hubs, filters non-video and deduplicates local metadata', 0, async () => {
       const a = server(1, VideoServerType.PLEX);
@@ -180,6 +188,17 @@ export default function videoServerSearchTest() {
         body = invalid;
         expect((await service.search(scope, a, 'film')).errorCode).assertEqual('invalidResponse');
       }
+    });
+    it('source snapshot serialization never exposes raw config', 0, async () => {
+      const a = server(1);
+      const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      const result = await service.search(resolveSearchScope(identity, [a]), a, 'film');
+      expect(result.items.length).assertEqual(1);
+      const serialized = JSON.stringify(result.items[0].sourceSnapshot);
+      expect(serialized).assertEqual('{"scopeKey":"video-server:jellyfin:1","serverId":1,"serverType":"jellyfin"}');
+      expect(serialized.includes('fake-1')).assertEqual(false);
+      expect(serialized.includes('server-1.test')).assertEqual(false);
+      expect(serialized.includes('config')).assertEqual(false);
     });
     it('late request completion keeps captured identity and cannot mutate newer result', 0, async () => {
       const a = server(1, VideoServerType.PLEX);
@@ -209,6 +228,23 @@ export default function videoServerSearchTest() {
       expect(current.status).assertEqual('empty');
       expect(current.items.length).assertEqual(0);
     });
+    for (const type of [VideoServerType.JELLYFIN, VideoServerType.EMBY, VideoServerType.PLEX]) {
+      it(`episodes retain original media identity and route ${type} detail to series entry`, 0, async () => {
+        const a = server(1, type);
+        const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1, serverType: type };
+        if (type === VideoServerType.PLEX) {
+          body = '{"MediaContainer":{"Hub":[{"type":"episode","Metadata":[{"ratingKey":"episode-1",' +
+            '"grandparentRatingKey":"series-1","title":"Episode","type":"episode"}]}]}}';
+        } else {
+          body = '{"Items":[{"Id":"episode-1","SeriesId":"series-1","Name":"Episode","Type":"Episode"}]}';
+        }
+        const result = await service.search(resolveSearchScope(identity, [a]), a, 'film');
+        expect(result.items.length).assertEqual(1);
+        expect(result.items[0].selection.mediaId).assertEqual('episode-1');
+        expect(result.items[0].selection.mediaType).assertEqual('episode');
+        expect(result.items[0].selection.detailItemId).assertEqual('series-1');
+      });
+    }
     it('reuses password authentication and its returned user', 0, async () => {
       const a = server(1);
       a.configJson = '{"url":"server-1.test","authMethod":"password","username":"test","password":"fake"}';

--- a/entry/src/test/VideoServerSearch.test.ets
+++ b/entry/src/test/VideoServerSearch.test.ets
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
+import { describe, it, expect, beforeEach, afterEach, MockKit, when, ArgumentMatchers } from '@ohos/hypium';
 import { VideoServer, VideoServerType } from '../main/ets/db/models/VideoServerEntity';
 import { SearchScopeIdentity, resolveSearchScope, createLocalSearchScope } from '../main/ets/models/search/SearchScope';
 import { JsonHttpClient, JsonHttpResponse, JsonHttpTransportError } from '../main/ets/lib/JsonHttpClient';
@@ -28,20 +28,22 @@ class DeferredSearchResponse {
 export default function videoServerSearchTest() {
   describe('VideoServerSearch', () => {
     const service = new VideoServerSearchService();
-    const originalGet = JsonHttpClient.get;
-    const originalPost = JsonHttpClient.post;
+    let mocker = new MockKit();
     let urls: string[] = [];
     let tokens: string[] = [];
     let status = 200;
     let body = '';
     let failure = '';
     beforeEach(() => {
+      mocker = new MockKit();
       urls = [];
       tokens = [];
       status = 200;
       failure = '';
       body = '{"Items":[{"Id":"same","Name":"Film","Type":"Movie"}]}';
-      JsonHttpClient.get = async (url: string, headers: Record<string, string>): Promise<JsonHttpResponse> => {
+      // 仅替换 HTTP 边界，协议解析、鉴权与搜索归一化仍执行真实客户端。
+      const mockGet: Function = mocker.mockFunc(JsonHttpClient, JsonHttpClient.get);
+      when(mockGet)(ArgumentMatchers.anyString, ArgumentMatchers.anyObj).afterAction(async (url: string, headers: Record<string, string>): Promise<JsonHttpResponse> => {
         urls.push(url);
         tokens.push(headers['X-Emby-Token'] ?? headers['X-Plex-Token'] ?? '');
         if (failure === 'native') {
@@ -54,11 +56,14 @@ export default function videoServerSearchTest() {
           statusCode: status, body: url.endsWith('/Users') ? '[{"Id":"user"}]' : body
         };
         return response;
-      };
+      });
+      const mockPost: Function = mocker.mockFunc(JsonHttpClient, JsonHttpClient.post);
+      when(mockPost)(ArgumentMatchers.anyString, ArgumentMatchers.anyObj, ArgumentMatchers.anyString).afterAction((): Promise<JsonHttpResponse> => {
+        return Promise.reject(new Error('非预期的 HTTP POST 请求'));
+      });
     });
     afterEach(() => {
-      JsonHttpClient.get = originalGet;
-      JsonHttpClient.post = originalPost;
+      mocker.clear(JsonHttpClient);
     });
     for (const type of [VideoServerType.JELLYFIN, VideoServerType.EMBY, VideoServerType.PLEX]) {
       it(`routes ${type} only to selected instance and normalizes media`, 0, async () => {
@@ -207,11 +212,13 @@ export default function videoServerSearchTest() {
       const identityB: SearchScopeIdentity = { kind: 'videoServer', serverId: 2 };
       const scopeA = resolveSearchScope(identityA, [a]);
       const pending = new DeferredSearchResponse();
-      JsonHttpClient.get = (url: string): Promise<JsonHttpResponse> => {
+      const deferredMocker = new MockKit();
+      const mockGet: Function = deferredMocker.mockFunc(JsonHttpClient, JsonHttpClient.get);
+      when(mockGet)(ArgumentMatchers.anyString, ArgumentMatchers.anyObj).afterAction((url: string): Promise<JsonHttpResponse> => {
         if (url.includes('server-1.test')) { return pending.promise; }
         const response: JsonHttpResponse = { statusCode: 200, body: '{"MediaContainer":{"size":0}}' };
         return Promise.resolve(response);
-      };
+      });
       const oldRequest = service.search(scopeA, a, 'old');
       a.id = 99;
       scopeA.serverId = 99;
@@ -248,10 +255,12 @@ export default function videoServerSearchTest() {
     it('reuses password authentication and its returned user', 0, async () => {
       const a = server(1);
       a.configJson = '{"url":"server-1.test","authMethod":"password","username":"test","password":"fake"}';
-      JsonHttpClient.post = async (): Promise<JsonHttpResponse> => {
+      const authenticationMocker = new MockKit();
+      const mockPost: Function = authenticationMocker.mockFunc(JsonHttpClient, JsonHttpClient.post);
+      when(mockPost)(ArgumentMatchers.anyString, ArgumentMatchers.anyObj, ArgumentMatchers.anyString).afterAction(async (): Promise<JsonHttpResponse> => {
         const response: JsonHttpResponse = { statusCode: 200, body: '{"AccessToken":"fake-1","User":{"Id":"signed-in"}}' };
         return response;
-      };
+      });
       const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
       expect((await service.search(resolveSearchScope(identity, [a]), a, 'film')).status).assertEqual('success');
       expect(urls.length).assertEqual(1);

--- a/entry/src/test/VideoServerSearch.test.ets
+++ b/entry/src/test/VideoServerSearch.test.ets
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach } from '@ohos/hypium';
+import { VideoServer, VideoServerType } from '../main/ets/db/models/VideoServerEntity';
+import { SearchScopeIdentity, resolveSearchScope, createLocalSearchScope } from '../main/ets/models/search/SearchScope';
+import { JsonHttpClient, JsonHttpResponse, JsonHttpTransportError } from '../main/ets/lib/JsonHttpClient';
+import { BusinessError } from '@kit.BasicServicesKit';
+import { VideoServerSearchService } from '../main/ets/services/search/VideoServerSearchService';
+
+function server(id: number, type: VideoServerType = VideoServerType.JELLYFIN): VideoServer {
+  const value: VideoServer = {
+    id, type, name: `Server ${id}`, createdAt: 1,
+    configJson: JSON.stringify({ url: `server-${id}.test`, port: 8096, protocol: 'https',
+      basePath: '/media', authMethod: 'apikey', apiKey: `fake-${id}`, token: `fake-${id}` })
+  };
+  return value;
+}
+
+class DeferredSearchResponse {
+  private resolveResponse: (response: JsonHttpResponse) => void = () => {};
+  promise: Promise<JsonHttpResponse> = new Promise<JsonHttpResponse>((resolve) => {
+    this.resolveResponse = resolve;
+  });
+
+  complete(response: JsonHttpResponse): void {
+    this.resolveResponse(response);
+  }
+}
+
+export default function videoServerSearchTest() {
+  describe('VideoServerSearch', () => {
+    const service = new VideoServerSearchService();
+    const originalGet = JsonHttpClient.get;
+    const originalPost = JsonHttpClient.post;
+    let urls: string[] = [];
+    let tokens: string[] = [];
+    let status = 200;
+    let body = '';
+    let failure = '';
+    beforeEach(() => {
+      urls = [];
+      tokens = [];
+      status = 200;
+      failure = '';
+      body = '{"Items":[{"Id":"same","Name":"Film","Type":"Movie"}]}';
+      JsonHttpClient.get = async (url: string, headers: Record<string, string>): Promise<JsonHttpResponse> => {
+        urls.push(url);
+        tokens.push(headers['X-Emby-Token'] ?? headers['X-Plex-Token'] ?? '');
+        if (failure === 'native') {
+          const error = new Error('localized transport failure') as BusinessError;
+          error.code = 2300028;
+          throw new JsonHttpTransportError(error);
+        }
+        if (failure.length > 0) { throw new Error(failure); }
+        const response: JsonHttpResponse = {
+          statusCode: status, body: url.endsWith('/Users') ? '[{"Id":"user"}]' : body
+        };
+        return response;
+      };
+    });
+    afterEach(() => {
+      JsonHttpClient.get = originalGet;
+      JsonHttpClient.post = originalPost;
+    });
+    for (const type of [VideoServerType.JELLYFIN, VideoServerType.EMBY, VideoServerType.PLEX]) {
+      it(`routes ${type} only to selected instance and normalizes media`, 0, async () => {
+        const target = server(2, type);
+        if (type === VideoServerType.PLEX) {
+          body = '{"MediaContainer":{"Hub":[{"type":"show","Metadata":[{"ratingKey":"same","title":"TV","type":"show"}]}]}}';
+        }
+        const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 2, serverType: type };
+        const scope = resolveSearchScope(identity, [server(1, type), target]);
+        const result = await service.search(scope, target, ' 中文 &/? ');
+        expect(result.status).assertEqual('success');
+        expect(result.items[0].serverId).assertEqual(2);
+        expect(result.items[0].serverType).assertEqual(type);
+        expect(result.items[0].media.type).assertEqual(type === VideoServerType.PLEX ? 'series' : 'movie');
+        expect(urls.every((url: string) => url.startsWith('https://server-2.test:8096/'))).assertTrue();
+        expect(urls[urls.length - 1].includes(encodeURIComponent('中文 &/?'))).assertTrue();
+        expect(tokens.every((token: string) => token === 'fake-2')).assertTrue();
+        expect(urls[urls.length - 1].includes(type === VideoServerType.PLEX ? '/hubs/search?' : '/media/Users/user/Items?')).assertTrue();
+      });
+    }
+    it('separates identical media IDs across same-protocol A/B and ignores forged key', 0, async () => {
+      const a = server(1);
+      const b = server(2);
+      const identityA: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      const identityB: SearchScopeIdentity = { kind: 'videoServer', serverId: 2 };
+      const scopeA = resolveSearchScope(identityA, [a, b]);
+      scopeA.key = 'local-files';
+      const first = await service.search(scopeA, a, 'film');
+      const second = await service.search(resolveSearchScope(identityB, [a, b]), b, 'film');
+      expect(first.items[0].key).assertEqual('video-server:jellyfin:1:same');
+      expect(second.items[0].key).assertEqual('video-server:jellyfin:2:same');
+    });
+    it('rejects local, missing and mismatched identity without IO or fallback', 0, async () => {
+      const a = server(1);
+      const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      const scope = resolveSearchScope(identity, [a]);
+      expect((await service.search(createLocalSearchScope(), a, 'film')).errorCode).assertEqual('unavailable');
+      expect((await service.search(scope, server(2), 'film')).errorCode).assertEqual('unavailable');
+      expect((await service.search(scope, server(1, VideoServerType.PLEX), 'film')).errorCode).assertEqual('unavailable');
+      expect((await service.search(resolveSearchScope(identity, []), a, 'film')).errorCode).assertEqual('unavailable');
+      expect((await service.search(scope, a, '  ')).errorCode).assertEqual('invalidQuery');
+      expect(urls.length).assertEqual(0);
+    });
+    it('exposes independent loading, empty and malformed-response states', 0, async () => {
+      const a = server(1);
+      const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      const scope = resolveSearchScope(identity, [a]);
+      const loading = service.createLoadingState(scope, a, ' film ');
+      body = '{"Items":[]}';
+      expect((await service.search(scope, a, 'film')).status).assertEqual('empty');
+      expect(loading.status).assertEqual('loading');
+      expect(loading.keyword).assertEqual('film');
+      for (const invalid of ['{}', 'not json', 'null']) {
+        body = invalid;
+        expect((await service.search(scope, a, 'film')).errorCode).assertEqual('invalidResponse');
+      }
+    });
+    for (const type of [VideoServerType.JELLYFIN, VideoServerType.EMBY, VideoServerType.PLEX]) {
+      for (const code of [401, 403]) {
+        it(`normalizes ${type} ${code} without exposing response`, 0, async () => {
+          const a = server(1, type);
+          const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+          status = code;
+          body = 'sensitive response';
+          const result = await service.search(resolveSearchScope(identity, [a]), a, 'film');
+          expect(result.errorCode).assertEqual('auth');
+          expect(result.items.length).assertEqual(0);
+          expect(JSON.stringify(result).includes('sensitive')).assertEqual(false);
+        });
+      }
+    }
+    it('normalizes native and textual timeouts and generic network failures', 0, async () => {
+      const a = server(1);
+      const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      const scope = resolveSearchScope(identity, [a]);
+      for (const message of ['native', 'timeout', 'timed out']) {
+        failure = message;
+        expect((await service.search(scope, a, 'film')).errorCode).assertEqual('timeout');
+      }
+      failure = 'private host refused';
+      const result = await service.search(scope, a, 'film');
+      expect(result.errorCode).assertEqual('network');
+      expect(JSON.stringify(result).includes('private host')).assertEqual(false);
+    });
+    it('loading factory validates real identity and blank input without IO', 0, () => {
+      const a = server(1);
+      const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      const scope = resolveSearchScope(identity, [a]);
+      scope.key = 'forged';
+      expect(service.createLoadingState(scope, a, 'film').scopeKey).assertEqual('video-server:jellyfin:1');
+      expect(service.createLoadingState(scope, server(2), 'film').errorCode).assertEqual('unavailable');
+      expect(service.createLoadingState(scope, server(1, VideoServerType.PLEX), 'film').status).assertEqual('error');
+      expect(service.createLoadingState(createLocalSearchScope(), a, 'film').scopeKey).assertEqual('unavailable');
+      expect(service.createLoadingState(scope, a, '  ').errorCode).assertEqual('invalidQuery');
+      expect(urls.length).assertEqual(0);
+    });
+    it('encodes media identity segments without delimiter or percent collisions', 0, async () => {
+      const a = server(1);
+      const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      body = '{"Items":[{"Id":"a:b/c","Type":"Movie"},{"Id":"a%3Ab%2Fc","Type":"Movie"}]}';
+      const result = await service.search(resolveSearchScope(identity, [a]), a, 'film');
+      expect(result.items.length).assertEqual(2);
+      expect(result.items[0].key).assertEqual('video-server:jellyfin:1:a%3Ab%2Fc');
+      expect(result.items[1].key).assertEqual('video-server:jellyfin:1:a%253Ab%252Fc');
+    });
+    it('Plex handles empty hubs, filters non-video and deduplicates local metadata', 0, async () => {
+      const a = server(1, VideoServerType.PLEX);
+      const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      const scope = resolveSearchScope(identity, [a]);
+      for (const empty of ['{"MediaContainer":{"size":0}}', '{"MediaContainer":{"Hub":[]}}']) {
+        body = empty;
+        expect((await service.search(scope, a, 'film')).status).assertEqual('empty');
+      }
+      body = '{"MediaContainer":{"Hub":[{"type":"actor"},{"type":"movie","Metadata":[' +
+        '{"ratingKey":"same","type":"movie"},{"ratingKey":"same","type":"movie"},' +
+        '{"type":"movie"}]}]}}';
+      expect((await service.search(scope, a, 'film')).items.length).assertEqual(1);
+      for (const invalid of ['{}', '{"MediaContainer":{"Hub":{}}}', '{"MediaContainer":null}']) {
+        body = invalid;
+        expect((await service.search(scope, a, 'film')).errorCode).assertEqual('invalidResponse');
+      }
+    });
+    it('late request completion keeps captured identity and cannot mutate newer result', 0, async () => {
+      const a = server(1, VideoServerType.PLEX);
+      const b = server(2, VideoServerType.PLEX);
+      const identityA: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      const identityB: SearchScopeIdentity = { kind: 'videoServer', serverId: 2 };
+      const scopeA = resolveSearchScope(identityA, [a]);
+      const pending = new DeferredSearchResponse();
+      JsonHttpClient.get = (url: string): Promise<JsonHttpResponse> => {
+        if (url.includes('server-1.test')) { return pending.promise; }
+        const response: JsonHttpResponse = { statusCode: 200, body: '{"MediaContainer":{"size":0}}' };
+        return Promise.resolve(response);
+      };
+      const oldRequest = service.search(scopeA, a, 'old');
+      a.id = 99;
+      scopeA.serverId = 99;
+      const current = await service.search(resolveSearchScope(identityB, [b]), b, 'new');
+      const response: JsonHttpResponse = { statusCode: 200,
+        body: '{"MediaContainer":{"Hub":[{"type":"movie","Metadata":[{"ratingKey":"same","type":"movie"}]}]}}' };
+      pending.complete(response);
+      const old = await oldRequest;
+      expect(old.items[0].serverId).assertEqual(1);
+      expect(old.scopeKey).assertEqual('video-server:plex:1');
+      expect(old.keyword).assertEqual('old');
+      expect(current.scopeKey).assertEqual('video-server:plex:2');
+      expect(current.keyword).assertEqual('new');
+      expect(current.status).assertEqual('empty');
+      expect(current.items.length).assertEqual(0);
+    });
+    it('reuses password authentication and its returned user', 0, async () => {
+      const a = server(1);
+      a.configJson = '{"url":"server-1.test","authMethod":"password","username":"test","password":"fake"}';
+      JsonHttpClient.post = async (): Promise<JsonHttpResponse> => {
+        const response: JsonHttpResponse = { statusCode: 200, body: '{"AccessToken":"fake-1","User":{"Id":"signed-in"}}' };
+        return response;
+      };
+      const identity: SearchScopeIdentity = { kind: 'videoServer', serverId: 1 };
+      expect((await service.search(resolveSearchScope(identity, [a]), a, 'film')).status).assertEqual('success');
+      expect(urls.length).assertEqual(1);
+      expect(urls[0].includes('/Users/signed-in/Items?')).assertTrue();
+      expect(tokens[0]).assertEqual('fake-1');
+    });
+  });
+}

--- a/entry/src/test/search_scope_deletion_test.cjs
+++ b/entry/src/test/search_scope_deletion_test.cjs
@@ -30,7 +30,7 @@ module.exports = function deletionTests() {
       AppPreferences.setStoreLoaderForTesting(null);
       AppPreferences.resetForTesting();
     });
-    it('source notifications invalidate A B A synchronously before persistence', 0, async () => {
+    it('来源通知在持久化前同步使 A B A 旧请求失效', 0, async () => {
       const { SearchWorkspaceSession } = require('../main/ets/services/search/SearchWorkspaceSession.ets');
       const { VideoServerSearchService } = require('../main/ets/services/search/VideoServerSearchService.ets');
       const session = new SearchWorkspaceSession();
@@ -56,7 +56,7 @@ module.exports = function deletionTests() {
       await source.setVideoServer(model.videoServers[0]);
       expect(notifications).assertEqual(2);
     });
-    it('real same-id configuration update invalidates even after config returns to original', 0, async () => {
+    it('真实同身份配置更新即使恢复原值也使旧请求失效', 0, async () => {
       const { SearchWorkspaceSession } = require('../main/ets/services/search/SearchWorkspaceSession.ets');
       const { VideoServerSearchService } = require('../main/ets/services/search/VideoServerSearchService.ets');
       const session = new SearchWorkspaceSession();
@@ -82,7 +82,7 @@ module.exports = function deletionTests() {
       await model.updateVideoServer(original);
       expect(notifications).assertEqual(2);
     });
-    it('deletion notifies configuration consumers with unavailable active source', 0, async () => {
+    it('删除后向配置订阅方通知活动来源不可用', 0, async () => {
       let observed = '';
       const unsubscribe = model.subscribeSearchConfiguration(() => {
         observed = source.getSearchScope(model.videoServers).kind;
@@ -91,7 +91,7 @@ module.exports = function deletionTests() {
       expect(observed).assertEqual('unavailable');
       unsubscribe();
     });
-    it('deleting active server preserves unavailable identity and persisted selection', 0, async () => {
+    it('删除活动服务器保留不可用身份与持久化选择', 0, async () => {
       const persisted = values.get(PrefKey.ACTIVE_MEDIA_SOURCE);
       await model.deleteVideoServerWithFallback(1);
       expect(model.getVideoServerById(1)).assertEqual(null);

--- a/entry/src/test/search_scope_deletion_test.cjs
+++ b/entry/src/test/search_scope_deletion_test.cjs
@@ -30,6 +30,67 @@ module.exports = function deletionTests() {
       AppPreferences.setStoreLoaderForTesting(null);
       AppPreferences.resetForTesting();
     });
+    it('source notifications invalidate A B A synchronously before persistence', 0, async () => {
+      const { SearchWorkspaceSession } = require('../main/ets/services/search/SearchWorkspaceSession.ets');
+      const { VideoServerSearchService } = require('../main/ets/services/search/VideoServerSearchService.ets');
+      const session = new SearchWorkspaceSession();
+      const service = new VideoServerSearchService();
+      let complete;
+      service.search = () => new Promise(resolve => { complete = resolve; });
+      const states = [];
+      const current = () => {
+        const scope = source.getSearchScope(model.videoServers);
+        return { scope, server: model.getVideoServerById(scope.serverId) };
+      };
+      let notifications = 0;
+      const unsubscribe = source.subscribeSearchSource(() => { notifications++; session.invalidate(); });
+      const request = session.search('film', current, result => states.push(result.status), service);
+      const b = source.setVideoServer(model.videoServers[1]);
+      expect(notifications).assertEqual(1);
+      const a = source.setVideoServer(model.videoServers[0]);
+      expect(notifications).assertEqual(2);
+      complete({ status: 'error', scopeKey: current().scope.key, keyword: 'film', items: [], errorCode: 'network' });
+      await request; await a; await b;
+      expect(states.join(',')).assertEqual('loading');
+      unsubscribe();
+      await source.setVideoServer(model.videoServers[0]);
+      expect(notifications).assertEqual(2);
+    });
+    it('real same-id configuration update invalidates even after config returns to original', 0, async () => {
+      const { SearchWorkspaceSession } = require('../main/ets/services/search/SearchWorkspaceSession.ets');
+      const { VideoServerSearchService } = require('../main/ets/services/search/VideoServerSearchService.ets');
+      const session = new SearchWorkspaceSession();
+      const service = new VideoServerSearchService();
+      let complete;
+      service.search = () => new Promise(resolve => { complete = resolve; });
+      const current = () => {
+        const scope = source.getSearchScope(model.videoServers);
+        return { scope, server: model.getVideoServerById(scope.serverId) };
+      };
+      let notifications = 0;
+      const unsubscribe = model.subscribeSearchConfiguration(() => { notifications++; session.invalidate(); });
+      const states = [];
+      const request = session.search('film', current, result => states.push(result.status), service);
+      const original = model.videoServers[0];
+      await model.updateVideoServer({ ...original, configJson: '{"url":"changed"}' });
+      await model.updateVideoServer(original);
+      expect(notifications).assertEqual(2);
+      complete({ status: 'success', scopeKey: current().scope.key, keyword: 'film', items: [], errorCode: 'none' });
+      await request;
+      expect(states.join(',')).assertEqual('loading');
+      unsubscribe();
+      await model.updateVideoServer(original);
+      expect(notifications).assertEqual(2);
+    });
+    it('deletion notifies configuration consumers with unavailable active source', 0, async () => {
+      let observed = '';
+      const unsubscribe = model.subscribeSearchConfiguration(() => {
+        observed = source.getSearchScope(model.videoServers).kind;
+      });
+      await model.deleteVideoServerWithFallback(1);
+      expect(observed).assertEqual('unavailable');
+      unsubscribe();
+    });
     it('deleting active server preserves unavailable identity and persisted selection', 0, async () => {
       const persisted = values.get(PrefKey.ACTIVE_MEDIA_SOURCE);
       await model.deleteVideoServerWithFallback(1);

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -1713,6 +1713,258 @@ async function runHostIntegrationChecks() {
   console.log('静态路由/副作用/输入/生命周期守卫、真实页面方法与详情页身份/错误态回归、reject/resetAll 回归：通过');
 }
 
+async function runSearchChainChecks() {
+  const assert = require('node:assert/strict');
+  const { VideoServerModel } = require('../main/ets/stores/servers/VideoServerModel.ets');
+  const { SourceSwitchModel } = require('../main/ets/stores/media/SourceSwitchModel.ets');
+  const { AppPreferences } = require('../main/ets/utils/AppPreferences.ets');
+  const { SearchWorkspaceSession } = require('../main/ets/services/search/SearchWorkspaceSession.ets');
+  const { JsonHttpClient } = require('../main/ets/lib/JsonHttpClient.ets');
+  const scopes = require('../main/ets/models/search/SearchScope.ets');
+  const sourceText = fs.readFileSync(path.join(root,
+    'entry/src/main/ets/pages/search/SearchWorkspacePage.ets'), 'utf8');
+  const failures = [];
+
+  async function runCase(name, scenario) {
+    console.log(`[search-chain] ${name}: START`);
+    let assertions = 0;
+    const check = (label, actual, expected) => {
+      assert.deepEqual(actual, expected, `${name}: ${label}`);
+      assertions++;
+      console.log(`[search-chain] ${name}: PASS ${label}`);
+    };
+    const timers = installFakeTimers();
+    const originalGet = JsonHttpClient.get;
+    const originalPost = JsonHttpClient.post;
+    const originalDelete = detailRegistryDatabase.delete;
+    const source = SourceSwitchModel.getState();
+    const model = new VideoServerModel();
+    const requests = [], searches = [], responses = [], pushes = [], toasts = [], localCalls = [];
+    let deletes = 0;
+    let page;
+    try {
+      const preferences = new Map();
+      AppPreferences.resetForTesting();
+      AppPreferences.setStoreLoaderForTesting(async () => ({
+        get: async (key, fallback) => preferences.has(key) ? preferences.get(key) : fallback,
+        put: async (key, value) => { preferences.set(key, value); },
+        flush: async () => {}
+      }));
+      await AppPreferences.init({});
+      const servers = [1, 2].map(id => ({
+        id, name: `Chain ${id}`, type: 'jellyfin', createdAt: 1,
+        configJson: JSON.stringify({ protocol: 'https', url: `chain-${id}.invalid`, port: 443,
+          authMethod: 'apikey', apiKey: 'host-test-only' })
+      }));
+      model.videoServers = servers;
+      await source.setVideoServer(servers[0]);
+      detailRegistryDatabase.delete = async () => { deletes++; };
+      // Keep real client protocol adaptation; replace only JSON HTTP IO.
+      JsonHttpClient.get = async (url) => {
+        const parsed = new URL(url);
+        requests.push({ host: parsed.hostname, path: parsed.pathname });
+        assert.ok(['chain-1.invalid', 'chain-2.invalid'].includes(parsed.hostname), 'unexpected host');
+        if (parsed.pathname === '/Users') {
+          return { statusCode: 200, body: JSON.stringify([{ Id: 'host-user' }]) };
+        }
+        assert.equal(parsed.pathname, '/Users/host-user/Items', 'unexpected HTTP path');
+        assert.equal(parsed.searchParams.get('Limit'), '100');
+        searches.push({ host: parsed.hostname, keyword: parsed.searchParams.get('SearchTerm') });
+        assert.ok(responses.length > 0, 'unexpected extra search request');
+        return await responses.shift()();
+      };
+      JsonHttpClient.post = async () => { throw new Error('unexpected HTTP POST'); };
+      const localDb = {
+        searchMediaItems: async () => { localCalls.push('search'); return []; },
+        getSearchHistory: async () => { localCalls.push('history'); return []; }
+      };
+      const dependencies = {
+        ...scopes, SourceSwitchModel,
+        // Host accessor exposes the real model without the ArkUI StateStore runtime.
+        VideoServerStore: { getState: () => model },
+        FileSourceDatabase: { getInstance: () => { localCalls.push('database'); return localDb; } },
+        ServerMediaDetailPage: { PAGE_NAME: 'serverMediaDetail' }
+      };
+      page = {
+        scope: scopes.createUnavailableSearchScope(), searchText: 'film', searchResults: [],
+        historyList: [], isSearching: false, serverResult: null,
+        serverSession: new SearchWorkspaceSession(), pageActive: false, db: null,
+        searchDebounceTimer: -1, searchGeneration: 0, historyLoadGeneration: 0,
+        historySourceGeneration: 0, unsubscribeSource: () => {}, unsubscribeConfiguration: () => {},
+        pageStack: { pushPathByName: (route, param) => pushes.push({ route, param }) },
+        getUIContext: () => ({ getPromptAction: () => ({ showToast: value => toasts.push(value.message) }) })
+      };
+      for (const method of ['currentContext', 'resumeSearch', 'refreshSource', 'invalidateSearch',
+        'leaveSearch', 'invalidateHistoryRequests', 'invalidateHistorySource', 'loadHistory',
+        'scheduleSearch', 'executeServerSearch', 'serverErrorText']) {
+        page[method] = loadMethod(sourceText, `private ${method}(`, [], dependencies);
+      }
+      page.executeSearch = loadMethod(sourceText, 'private async executeSearch(', [], dependencies, true);
+      page.showToastSafe = loadMethod(sourceText, 'private showToastSafe(', ['message'], dependencies);
+      page.openServerResultDetail = loadMethod(sourceText, 'private openServerResultDetail(', ['item'], dependencies);
+      const response = title => ({ statusCode: 200, body: JSON.stringify({
+        Items: [{ Id: 'shared-media', Name: title, Type: 'Movie' }]
+      }) });
+      const enqueue = title => responses.push(async () => response(title));
+      const tick = async () => {
+        check('exactly one scheduled search', timers.pendingCount(), 1);
+        timers.runNext();
+        await flushMicrotasks();
+        check('timer callback executed and drained', timers.pendingCount(), 0);
+      };
+      const success = (title, id = 1) => {
+        check('page publishes nonempty success', page.serverResult?.status, 'success');
+        check('one result from expected instance', page.serverResult.items.map(item => ({
+          id: item.serverId, title: item.media.title, mediaId: item.selection.mediaId
+        })), [{ id, title, mediaId: 'shared-media' }]);
+        check('page loading released', page.isSearching, false);
+        return page.serverResult.items[0];
+      };
+      await scenario({ check, timers, source, model, servers, requests, searches, responses,
+        pushes, toasts, page, response, enqueue, tick, success, deleteCount: () => deletes });
+      check('no local DB, search or history access', localCalls, []);
+      check('all queued transport responses consumed', responses.length, 0);
+      page.leaveSearch();
+      await source.setVideoServer(servers[1]);
+      model.videoServers = [];
+      check('leave unsubscribes source/configuration listeners', timers.pendingCount(), 0);
+      console.log(`[search-chain] ${name}: PASS (${assertions} assertions)`);
+    } catch (error) {
+      failures.push(error);
+      console.error(`[search-chain] ${name}: FAIL after ${assertions} assertions`, error);
+    } finally {
+      if (page) page.leaveSearch();
+      JsonHttpClient.get = originalGet;
+      JsonHttpClient.post = originalPost;
+      detailRegistryDatabase.delete = originalDelete;
+      await source.setFileSource();
+      AppPreferences.setStoreLoaderForTesting(null);
+      AppPreferences.resetForTesting();
+      timers.restore();
+    }
+  }
+
+  await runCase('delete-success-return-same-word', async h => {
+    h.enqueue('before deletion');
+    h.page.resumeSearch();
+    await h.tick();
+    const oldCard = h.success('before deletion');
+    await h.model.deleteVideoServerWithFallback(1);
+    h.check('real deletion reaches DB once', h.deleteCount(), 1);
+    h.check('deleted instance absent; other retained', h.model.videoServers.map(s => s.id), [2]);
+    h.check('active deleted identity preserved', h.source.getActiveServerId(), 1);
+    h.check('real configuration notification refreshes to unavailable', h.page.scope.kind, 'unavailable');
+    h.check('deletion clears cards', h.page.serverResult, null);
+    h.page.openServerResultDetail(oldCard);
+    h.check('old card cannot push after deletion', h.pushes, []);
+    h.check('identity gate reports changed source', h.toasts.length, 1);
+    const before = h.requests.length;
+    h.page.leaveSearch();
+    h.page.resumeSearch();
+    h.page.resumeSearch();
+    h.page.scheduleSearch();
+    await flushMicrotasks();
+    h.check('return preserves keyword', h.page.searchText, 'film');
+    h.check('unavailable return schedules no timer', h.timers.pendingCount(), 0);
+    h.check('no deleted or alternative instance HTTP after return', h.requests.length, before);
+    h.check('only original instance searched', h.searches, [{ host: 'chain-1.invalid', keyword: 'film' }]);
+    h.check('return has no cards or local results', [h.page.serverResult, h.page.searchResults], [null, []]);
+  });
+
+  await runCase('same-instance-reject-recover-stale-response', async h => {
+    h.enqueue('initial');
+    h.page.resumeSearch();
+    await h.tick();
+    h.success('initial');
+    const stale = createDeferred();
+    h.responses.push(() => stale.promise);
+    h.page.scheduleSearch();
+    await h.tick();
+    h.check('pending request removes initial cards', [h.page.serverResult.status, h.page.serverResult.items], ['loading', []]);
+    h.responses.push(async () => { throw new Error('host transport disconnected'); });
+    h.page.scheduleSearch();
+    await h.tick();
+    h.check('transport reject becomes page network error', [h.page.serverResult.status, h.page.serverResult.errorCode], ['error', 'network']);
+    h.check('error has no old cards', [h.page.serverResult.items, h.page.searchResults], [[], []]);
+    h.check('error releases loading', h.page.isSearching, false);
+    h.check('page exposes connection error text', h.page.serverErrorText(), '无法连接服务器，请检查网络后重试');
+    const recovery = createDeferred();
+    h.responses.push(() => recovery.promise);
+    h.page.scheduleSearch();
+    await h.tick();
+    stale.resolve(h.response('must not return'));
+    await flushMicrotasks();
+    h.check('deferred old response cannot refill recovering page',
+      [h.page.serverResult.status, h.page.serverResult.items, h.page.isSearching], ['loading', [], true]);
+    recovery.resolve(h.response('recovered'));
+    await flushMicrotasks();
+    h.success('recovered');
+    h.check('same-word recovery searches only original instance', h.searches,
+      Array.from({ length: 4 }, () => ({ host: 'chain-1.invalid', keyword: 'film' })));
+    h.check('all HTTP remains on original instance', h.requests.every(r => r.host === 'chain-1.invalid'), true);
+    h.check('error/recovery does not navigate', h.pushes, []);
+  });
+
+  await runCase('detail-return-once-same-protocol-media-isolation', async h => {
+    h.enqueue('A initial');
+    h.page.resumeSearch();
+    await h.tick();
+    const cardA = h.success('A initial');
+    h.page.openServerResultDetail(cardA);
+    h.check('successful card pushes exact detail identity', h.pushes, [{ route: 'serverMediaDetail', param: {
+      serverId: 1, serverType: 'jellyfin', mediaId: 'shared-media', mediaType: 'movie',
+      itemId: 'shared-media', title: 'A initial'
+    } }]);
+    h.page.leaveSearch();
+    h.check('leave clears cards and timer', [h.page.serverResult, h.timers.pendingCount()], [null, 0]);
+    h.enqueue('A returned');
+    h.page.resumeSearch();
+    h.page.resumeSearch();
+    await h.tick();
+    h.success('A returned');
+    h.check('detail return triggers exactly one same-word re-search', h.searches,
+      Array.from({ length: 2 }, () => ({ host: 'chain-1.invalid', keyword: 'film' })));
+    const staleA = createDeferred();
+    h.responses.push(() => staleA.promise);
+    h.page.scheduleSearch();
+    await h.tick();
+    await h.source.setVideoServer(h.servers[1]);
+    h.check('real source notification switches page to B', h.page.scope.serverId, 2);
+    h.page.openServerResultDetail(cardA);
+    h.check('A card cannot push while B active', h.pushes.length, 1);
+    h.enqueue('B same media');
+    await h.tick();
+    const cardB = h.success('B same media', 2);
+    h.check('same protocol and mediaId fixture', [cardA.serverType, cardA.selection.mediaId],
+      [cardB.serverType, cardB.selection.mediaId]);
+    h.check('A/B result keys isolated', cardA.key === cardB.key, false);
+    const publishedB = h.page.serverResult;
+    staleA.resolve(h.response('late A same media'));
+    await flushMicrotasks();
+    h.check('deferred A cannot replace B result object', h.page.serverResult === publishedB, true);
+    h.success('B same media', 2);
+    h.page.openServerResultDetail(cardB);
+    h.check('B card pushes B identity despite same mediaId', h.pushes[1], { route: 'serverMediaDetail', param: {
+      serverId: 2, serverType: 'jellyfin', mediaId: 'shared-media', mediaType: 'movie',
+      itemId: 'shared-media', title: 'B same media'
+    } });
+    h.page.leaveSearch();
+    h.enqueue('B returned');
+    h.page.resumeSearch();
+    h.page.resumeSearch();
+    await h.tick();
+    h.success('B returned', 2);
+    h.check('A/B requests preserve keyword and exact counts', h.searches, [
+      ...Array.from({ length: 3 }, () => ({ host: 'chain-1.invalid', keyword: 'film' })),
+      ...Array.from({ length: 2 }, () => ({ host: 'chain-2.invalid', keyword: 'film' }))
+    ]);
+    h.page.openServerResultDetail(cardA);
+    h.check('old A remains blocked after B detail return', h.pushes.length, 2);
+    h.page.leaveSearch();
+  });
+  if (failures.length > 0) throw new AggregateError(failures, 'Search chain regressions');
+}
+
 function registerAndExecuteCore() {
   const Core = require(path.join(hypium, 'core.js')).default;
   const core = Core.getInstance();
@@ -1737,8 +1989,14 @@ function registerAndExecuteCore() {
   core.execute();
 }
 
-if (process.argv.includes('--integration')) {
+if (process.argv.includes('--search-chains')) {
+  runSearchChainChecks().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+} else if (process.argv.includes('--integration')) {
   runHostIntegrationChecks()
+    .then(() => runSearchChainChecks())
     .then(() => { registerAndExecuteCore(); })
     .catch((error) => {
       console.error(error);

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -24,6 +24,12 @@ require.extensions['.js'] = (module, filename) => {
 };
 global.ObservedV2 = (target) => target;
 global.Trace = () => {};
+const detailRegistryDatabase = {
+  whenReady: async () => {},
+  update: async () => {},
+  delete: async () => {},
+  getAll: async () => []
+};
 const load = Module._load;
 Module._load = function (request, parent, main) {
   if (request === '@ohos/hypium') return require(path.join(hypium, 'interface.js'));
@@ -35,7 +41,14 @@ Module._load = function (request, parent, main) {
   // 仅替换网络与主机数据库边界，执行真实 VideoServerModel 删除、通知与缓存逻辑。
   if (request === '../../db/files/FileSourceDatabase' && parent &&
     parent.filename.endsWith('/stores/servers/VideoServerModel.ets')) {
-    return { FileSourceDatabase: { getInstance: () => ({ deleteVideoServer: async () => {}, updateVideoServer: async () => {} }) } };
+    return { FileSourceDatabase: {
+      whenDatabaseReady: () => detailRegistryDatabase.whenReady(),
+      getInstance: () => ({
+        deleteVideoServer: () => detailRegistryDatabase.delete(),
+        updateVideoServer: () => detailRegistryDatabase.update(),
+        getAllVideoServers: () => detailRegistryDatabase.getAll()
+      })
+    } };
   }
   return load.call(this, request, parent, main);
 };
@@ -191,6 +204,8 @@ async function runHostIntegrationChecks() {
   assert.ok(detailPageSource.includes('aboutToAppear(): void'));
   assert.ok(detailPageSource.includes('aboutToDisappear(): void'));
   assert.ok(detailPageSource.includes("this.invalidateDetailState('', false)"));
+  assert.ok(detailPageSource.includes('.onHidden(() => { this.handleDetailHidden() })'));
+  assert.ok(detailPageSource.includes('.onShown(() => { this.handleDetailShown() })'));
   const playBody = extractMethodBody(detailPageSource, 'private async play(): Promise<void>');
   assert.ok(playBody.indexOf('const server = this.resolvePlayableServer()') <
     playBody.indexOf('const target = this.playTarget()'));
@@ -242,6 +257,7 @@ async function runHostIntegrationChecks() {
     refreshSource: loadMethod(workspaceSource, 'private refreshSource(): void', [], methodDeps)
   };
   const detailClientState = {
+    buildContext: async () => null,
     jellyfinClient: null,
     plexClient: null
   };
@@ -313,6 +329,15 @@ async function runHostIntegrationChecks() {
     playTarget: loadMethod(detailPageSource, 'private playTarget(): VideoServerMediaItem | null', [], {}),
     getTitle: loadMethod(detailPageSource, 'private getTitle(): string', [], {}),
     aboutToAppear: loadMethod(detailPageSource, 'aboutToAppear(): void', [], {}),
+    handleDetailHidden: loadMethod(detailPageSource, 'private handleDetailHidden(): void', [], {}),
+    handleDetailShown: loadMethod(detailPageSource, 'private handleDetailShown(): void', [], {}),
+    getSeasonLabel: loadMethod(detailPageSource, 'private getSeasonLabel(s: VideoServerSeason): string', ['s'], {}),
+    openSeason: loadMethod(detailPageSource, 'private openSeason(s: VideoServerSeason): void', ['s'], {
+      ServerSeasonDetailPage: { PAGE_NAME: 'season' }
+    }),
+    openPerson: loadMethod(detailPageSource, 'private openPerson(c: DetailCastMember): void', ['c'], {
+      ServerPersonDetailPage: { PAGE_NAME: 'person' }
+    }),
     aboutToDisappear: loadMethod(detailPageSource, 'aboutToDisappear(): void', [], {}),
     loadDetail: loadMethod(detailPageSource, 'private async loadDetail(silent: boolean = false): Promise<void>',
       ['silent'], {
@@ -324,7 +349,7 @@ async function runHostIntegrationChecks() {
       VideoServerType,
       PlayerPage: { PAGE_NAME: 'player' },
       reportServerPlaybackStarted: () => Promise.resolve(),
-      buildServerEpisodePlaybackContext: async () => null,
+      buildServerEpisodePlaybackContext: (...args) => detailClientState.buildContext(...args),
       JellyfinClient: { fromConfigJson: () => detailClientState.jellyfinClient },
       PlexClient: { fromConfigJson: () => detailClientState.plexClient }
     }, true)
@@ -400,6 +425,8 @@ async function runHostIntegrationChecks() {
         listeners: new Set(),
         loadCalls: 0,
         async loadVideoServers() { this.loadCalls++; },
+        searchConfigurationRevision: 0,
+        subscribeSearchConfigurationRevision() { return () => {}; },
         subscribeSearchConfiguration(listener) {
           this.listeners.add(listener);
           return () => { this.listeners.delete(listener); };
@@ -419,10 +446,15 @@ async function runHostIntegrationChecks() {
       nextUp: createDetailMedia('episode'),
       error: 'stale error',
       isLoading: false,
+      unsubscribeRequestConfiguration: () => {},
+      unsubscribeLifecycleRevision: () => {},
+      detailRequestRevision: 0,
       detailLoadGeneration: 0,
       detailRequestActive: false,
       playOperationGeneration: 0,
       playOperationActive: false,
+      initialLoadDone: false,
+      detailTargetIdentity: null,
       pendingDetailIdentity: null,
       loadedDetailIdentity: null,
       unsubscribeSource() {},
@@ -465,6 +497,11 @@ async function runHostIntegrationChecks() {
     page.getTitle = detailMethods.getTitle;
     page.aboutToAppear = detailMethods.aboutToAppear;
     page.aboutToDisappear = detailMethods.aboutToDisappear;
+    page.handleDetailHidden = detailMethods.handleDetailHidden;
+    page.handleDetailShown = detailMethods.handleDetailShown;
+    page.openSeason = detailMethods.openSeason;
+    page.openPerson = detailMethods.openPerson;
+    page.getSeasonLabel = detailMethods.getSeasonLabel;
     page.loadDetail = detailMethods.loadDetail;
     page.play = detailMethods.play;
     return page;
@@ -1256,6 +1293,421 @@ async function runHostIntegrationChecks() {
     page.aboutToAppear();
     detailSourceModel.emitChange();
     assert.equal(page.error, '当前来源已变化，请返回重新选择来源');
+  }
+
+  {
+    const server = { id: 59, type: 'jellyfin', name: 'Server', configJson: 'original', createdAt: 1 };
+    const page = createDetailPageHarness(server);
+    const pending = createDeferred();
+    let calls = 0;
+    installDetailClient('jellyfin', { getItemDetail: async () => {
+      calls++;
+      return createDetailPayload('movie');
+    } });
+    page.videoServerModel.loadVideoServers = () => pending.promise;
+    const initial = page.loadDetail(false);
+    // Hide before the first onShown: returning must restart the cancelled initial load.
+    page.handleDetailHidden();
+    pending.resolve();
+    await initial;
+    assert.equal(calls, 0);
+    page.handleDetailShown();
+    await flushMicrotasks();
+    assert.equal(calls, 1);
+    assert.equal(page.isLoading, false);
+    page.handleDetailHidden();
+    page.videoServerModel.server = { ...server, configJson: 'replacement' };
+    page.videoServerModel.emitChange();
+    page.handleDetailShown();
+    await flushMicrotasks();
+    assert.equal(calls, 1, 'show must not reclaim a hidden replacement configuration');
+    assert.equal(page.error, '服务器配置已变更，请返回重试');
+    page.aboutToDisappear();
+  }
+
+  // Exercise the production methods at the registry-refresh and retained-page boundaries.
+  for (const retry of [false, true]) {
+    for (const reject of [false, true]) {
+      const server = { id: 60, type: 'jellyfin', name: 'Server', configJson: 'original', createdAt: 1 };
+      const page = createDetailPageHarness(server);
+      page.clearLoadedDetail();
+      page.subscribeDetailGuards();
+      let mediaCalls = 0;
+      installDetailClient('jellyfin', {
+        getItemDetail: async () => { mediaCalls++; throw new Error('initial failure'); }
+      });
+      if (retry) {
+        await page.loadDetail(false);
+        assert.equal(page.error, 'initial failure');
+        assert.equal(page.loadedDetailIdentity, null);
+      }
+      const pending = createDeferred();
+      page.videoServerModel.loadVideoServers = () => pending.promise;
+      const request = retry ? (page.retryDetail(), null) : page.loadDetail(false);
+      assert.equal(page.pendingDetailIdentity.configuration, 'original');
+      page.videoServerModel.server = { ...server, configJson: 'replacement' };
+      page.videoServerModel.emitChange();
+      assert.equal(page.isLoading, false);
+      if (reject) pending.reject(new Error('late registry error'));
+      else pending.resolve();
+      if (request) await request;
+      await flushMicrotasks();
+      assert.equal(mediaCalls, retry ? 1 : 0);
+      assert.equal(page.error, '服务器配置已变更，请返回重试');
+      page.retryDetail();
+      await flushMicrotasks();
+      assert.equal(mediaCalls, retry ? 1 : 0, 'retry must not reclaim replacement config');
+      page.aboutToDisappear();
+    }
+  }
+
+  {
+    const page = createDetailPageHarness(null);
+    const pending = createDeferred();
+    page.videoServerModel.loadVideoServers = () => pending.promise;
+    let calls = 0;
+    installDetailClient('jellyfin', { getItemDetail: async () => {
+      calls++; return createDetailPayload('movie');
+    } });
+    const request = page.loadDetail(false);
+    page.videoServerModel.server = { id: 0, type: 'jellyfin', name: 'warm', configJson: 'warm', createdAt: 1 };
+    pending.resolve();
+    await request;
+    assert.equal(calls, 0);
+    assert.equal(page.error, '服务器配置已变更，请返回重试');
+    assert.equal(page.detailTargetIdentity, null, 'unpublished registry values cannot establish identity');
+    assert.equal(page.isLoading, false);
+  }
+
+  // Real registry loading/setter/notifications; only database and transport are stubbed.
+  const { VideoServerModel } = require(path.join(root,
+    'entry/src/main/ets/stores/servers/VideoServerModel.ets'));
+  for (const type of ['jellyfin', 'emby', 'plex']) {
+    for (const replacement of ['none', 'notified', 'unnotified', 'aba']) {
+      const server = { id: 81, type, name: 'cold', configJson: 'cold-original', createdAt: 1 };
+      const page = createDetailPageHarness(null, type);
+      page.serverId = server.id;
+      page.clearLoadedDetail();
+      const model = new VideoServerModel();
+      page.videoServerModel = model;
+      detailRegistryDatabase.getAll = async () => [server];
+      let calls = 0;
+      installDetailClient(type, { getItemDetail: async () => {
+        calls++; return createDetailPayload('movie');
+      } });
+      page.subscribeDetailGuards();
+      const request = page.loadDetail(false);
+      page.handleDetailShown();
+      // Register after the cold observer: mutate in the first publication before load resolves.
+      let published = false;
+      const unsubscribe = model.subscribeSearchConfiguration(() => {
+        if (published) return;
+        published = true;
+        assert.equal(page.detailTargetIdentity.configuration, 'cold-original');
+        if (replacement === 'unnotified') server.configJson = 'replacement';
+        else if (replacement !== 'none') {
+          model.videoServers = [{ ...server, configJson: 'replacement' }];
+          if (replacement === 'aba') model.videoServers = [server];
+        }
+      });
+      await request;
+      unsubscribe();
+      assert.equal(calls, replacement === 'none' ? 1 : 0);
+      assert.equal(page.isLoading, false);
+      if (replacement === 'none') {
+        assert.ok(page.detail);
+        assert.equal(page.error, '');
+        page.handleDetailHidden();
+        page.handleDetailShown();
+        await flushMicrotasks();
+        assert.equal(calls, 2, 'normal retained-page return reloads automatically');
+        assert.equal(page.error, '');
+      } else {
+        assert.equal(page.detail, null);
+        assert.equal(page.error, '服务器配置已变更，请返回重试');
+        if (replacement !== 'aba') {
+          page.retryDetail();
+          await flushMicrotasks();
+          assert.equal(calls, 0, 'retry cannot adopt the replacement');
+        }
+        const fresh = createDetailPageHarness(model.getVideoServerById(server.id), type);
+        fresh.videoServerModel = model;
+        detailRegistryDatabase.getAll = async () => model.videoServers;
+        await fresh.loadDetail(false);
+        assert.equal(calls, 1, 'a fresh legitimate entry can bind the current configuration');
+        assert.equal(fresh.error, '');
+        fresh.aboutToDisappear();
+      }
+      page.aboutToDisappear();
+      assert.equal(model.revisionListeners.size, 0);
+      assert.equal(model.searchListeners.size, 0, 'cold observer must also be released');
+      console.log(`冷入口真实模型/页面方法 ${type}/${replacement}：通过`);
+    }
+  }
+  for (const boundary of ['hidden', 'source']) {
+    const server = { id: 90, type: 'jellyfin', name: 'fixture', configJson: 'original', createdAt: 1 };
+    const page = createDetailPageHarness(server);
+    const model = new VideoServerModel(); page.videoServerModel = model;
+    page.sourceMediaId = 'movie'; page.clearLoadedDetail();
+    const read = createDeferred(); detailRegistryDatabase.getAll = () => read.promise;
+    let calls = 0;
+    installDetailClient('jellyfin', { getItemDetail: async () => {
+      calls++; return createDetailPayload('movie');
+    } });
+    page.subscribeDetailGuards();
+    const request = page.loadDetail(false);
+    await flushMicrotasks();
+    if (boundary === 'hidden') page.handleDetailHidden();
+    else {
+      detailSourceModel.activeSource = { kind: 'fileSource' };
+      detailSourceModel.emitChange();
+    }
+    read.resolve([server]); await request;
+    assert.equal(calls, 0); assert.equal(page.detail, null);
+    if (boundary === 'hidden') {
+      page.handleDetailShown(); await flushMicrotasks();
+      assert.equal(calls, 1); assert.equal(page.error, '');
+    }
+    page.aboutToDisappear();
+    assert.equal(model.searchListeners.size, 0);
+    assert.equal(model.revisionListeners.size, 0);
+    console.log(`真实冷加载 ${boundary} 与清理：通过`);
+  }
+  for (const settlement of ['read-first', 'write-first']) {
+  for (const operation of ['update', 'delete']) {
+    for (const fail of [false, true]) {
+      const server = { id: 91, type: 'jellyfin', name: 'fixture', configJson: 'original', createdAt: 1 };
+      const page = createDetailPageHarness(null, 'jellyfin');
+      page.serverId = 91; page.clearLoadedDetail();
+      const model = new VideoServerModel(); page.videoServerModel = model;
+      const read = createDeferred(), write = createDeferred();
+      detailRegistryDatabase.getAll = () => read.promise;
+      detailRegistryDatabase[operation] = () => write.promise;
+      let calls = 0;
+      installDetailClient('jellyfin', { getItemDetail: async () => {
+        calls++; return createDetailPayload('movie');
+      } });
+      page.subscribeDetailGuards();
+      const request = page.loadDetail(false);
+      await flushMicrotasks();
+      const before = model.searchConfigurationRevision;
+      const mutation = operation === 'update' ?
+        model.updateVideoServer({ ...server, configJson: 'replacement' }) : model.deleteVideoServer(91);
+      const settled = mutation.catch(() => {});
+      assert.ok(model.searchConfigurationRevision > before, 'write intent is visible before DB settlement');
+      assert.equal(page.isLoading, false);
+      if (settlement === 'write-first') {
+        if (fail) write.reject(new Error('fixture write failure')); else write.resolve();
+        await settled;
+      }
+      read.resolve([server]); await request;
+      assert.equal(calls, 0);
+      assert.equal(model.videoServers.length, 0, 'late initial snapshot cannot resurrect a target');
+      if (settlement === 'read-first') {
+        if (fail) write.reject(new Error('fixture write failure')); else write.resolve();
+        await settled;
+      }
+      assert.equal(model.isLoaded, false);
+      detailRegistryDatabase[operation] = async () => {};
+      detailRegistryDatabase.getAll = async () => fail ? [server] :
+        operation === 'update' ? [{ ...server, configJson: 'replacement' }] : [];
+      page.retryDetail(); await flushMicrotasks();
+      assert.equal(calls, fail || operation === 'update' ? 1 : 0);
+      if (fail) assert.equal(page.error, '', 'failed write permits explicit fresh retry');
+      page.aboutToDisappear();
+      assert.equal(model.revisionListeners.size, 0);
+      assert.equal(model.searchListeners.size, 0);
+      console.log(`真实 pending ${operation}/failure=${fail}/${settlement} 与恢复：通过`);
+    }
+  }
+  }
+  // Loaded-page writes use real model methods; DB and transport settlement are controlled.
+  for (const operation of ['update', 'delete']) {
+    for (const fail of [false, true]) {
+      for (const rejectOld of [false, true]) {
+        const server = { id: 992, type: 'jellyfin', name: 'fixture', configJson: 'original', createdAt: 1 };
+        const model = new VideoServerModel();
+        const page = createDetailPageHarness(server);
+        page.videoServerModel = model;
+        detailRegistryDatabase.getAll = async () => [server];
+        const oldStream = createDeferred(), write = createDeferred(), freshStream = createDeferred();
+        detailRegistryDatabase[operation] = () => write.promise;
+        let streamCalls = 0;
+        installDetailClient('jellyfin', {
+          getItemDetail: async () => createDetailPayload('movie'),
+          getStreamUrl: () => { streamCalls++; return oldStream.promise; }
+        });
+        page.subscribeDetailGuards();
+        await page.loadDetail(false);
+        assert.equal(model.revisionListeners.size, 1, 'visible guard survives load finally');
+        const oldPlay = page.play();
+        await flushMicrotasks();
+        await page.play();
+        assert.equal(streamCalls, 1, 'duplicate click cannot start a second pending stream');
+        const mutation = operation === 'update' ?
+          model.updateVideoServer({ ...server, configJson: 'replacement' }) : model.deleteVideoServer(server.id);
+        const settled = mutation.catch(() => {});
+        assert.equal(page.detail, null, 'write intent clears loaded media before DB settlement');
+        assert.equal(page.isPlaying, false);
+        assert.equal(page.error, '服务器配置已变更，请返回重试');
+        page.retryDetail(); await flushMicrotasks();
+        assert.equal(page.detail, null, 'retry cannot load while write is pending');
+        assert.equal(page.isLoading, false);
+        if (fail) write.reject(new Error('fixture write failure')); else write.resolve();
+        await settled;
+        const current = fail ? server : operation === 'update' ? { ...server, configJson: 'replacement' } : null;
+        detailRegistryDatabase.getAll = async () => current ? [current] : [];
+        // Failed writes permit the existing page to retry. Successful replacements require a fresh entry.
+        const recovery = fail ? page : createDetailPageHarness(current, 'jellyfin');
+        recovery.serverId = server.id;
+        recovery.videoServerModel = model;
+        recovery.subscribeDetailGuards();
+        installDetailClient('jellyfin', {
+          getItemDetail: async () => { throw new Error('new revision detail failure'); }
+        });
+        await recovery.loadDetail(false);
+        assert.equal(recovery.isLoading, false);
+        assert.equal(recovery.error, current ? 'new revision detail failure' : '服务器不存在');
+        if (!fail) {
+          await page.loadDetail(false);
+          assert.equal(page.detail, null, 'old entry cannot adopt replacement media');
+        }
+        const newDetail = createDeferred();
+        installDetailClient('jellyfin', {
+          getItemDetail: () => newDetail.promise,
+          getStreamUrl: () => { streamCalls++; return freshStream.promise; }
+        });
+        recovery.retryDetail(); await flushMicrotasks();
+        let newPlay = null;
+        if (current && rejectOld) {
+          newDetail.resolve(createDetailPayload('movie')); await flushMicrotasks();
+          newPlay = recovery.play(); await flushMicrotasks();
+          assert.equal(recovery.isPlaying, true);
+        }
+        if (rejectOld) oldStream.reject(new Error('old revision stream failure'));
+        else oldStream.resolve('https://fixture.invalid/old-stream');
+        await oldPlay;
+        assert.equal(page.pageStack.pushed.length, 0, 'old result never pushes player');
+        assert.deepEqual(page.toastMessages, [], 'old catch cannot report an error in the new revision');
+        if (current) {
+          if (rejectOld) {
+            assert.equal(recovery.isPlaying, true, 'old catch/finally cannot unlock new play');
+          } else {
+            assert.equal(recovery.isLoading, true, 'old completion cannot unlock new load');
+            newDetail.resolve(createDetailPayload('movie')); await flushMicrotasks();
+            newPlay = recovery.play(); await flushMicrotasks();
+          }
+          assert.equal(recovery.error, '');
+          assert.equal(recovery.isPlaying, true);
+          await recovery.play();
+          assert.equal(streamCalls, 2, 'recovered pending playback also rejects duplicate clicks');
+          freshStream.resolve('https://fixture.invalid/new-stream'); await newPlay;
+          assert.equal(recovery.pageStack.pushed.length, 1);
+          recovery.handleDetailHidden();
+          if (recovery !== page) page.handleDetailHidden();
+          assert.equal(model.revisionListeners.size, 0);
+          assert.equal(model.searchListeners.size, 0);
+          recovery.handleDetailShown(); await flushMicrotasks();
+          assert.equal(recovery.error, '', 'normal player return reloads');
+          assert.equal(model.revisionListeners.size, 1);
+        }
+        page.aboutToDisappear(); recovery.aboutToDisappear();
+        assert.equal(model.revisionListeners.size, 0);
+        assert.equal(model.searchListeners.size, 0);
+        console.log(`Loaded revision real ${operation}/failure=${fail}/oldReject=${rejectOld}: PASS`);
+      }
+    }
+  }
+  detailRegistryDatabase.getAll = async () => [];
+  detailRegistryDatabase.update = async () => {};
+  detailRegistryDatabase.delete = async () => {};
+
+  for (const boundary of ['stream', 'directory']) {
+    for (const navigation of ['hidden', 'season', 'person']) {
+      for (const reject of [false, true]) {
+        const server = { id: 61, type: 'jellyfin', name: 'Server', configJson: 'original', createdAt: 1 };
+        const page = createDetailPageHarness(server);
+        const series = boundary === 'directory';
+        const stale = createDeferred();
+        const fresh = createDeferred();
+        let calls = 0;
+        page.detail = createDetailPayload(series ? 'series' : 'movie');
+        page.loadedDetailIdentity = page.captureServerIdentity(server);
+        page.initialLoadDone = true;
+        page.subscribeDetailGuards();
+        detailClientState.buildContext = series ? () => (++calls === 1 ? stale.promise : fresh.promise) : async () => null;
+        installDetailClient('jellyfin', {
+          getItemDetail: async () => createDetailPayload(series ? 'series' : 'movie'),
+          getSeasons: async () => [],
+          getNextUp: async () => createDetailMedia('episode'),
+          getStreamUrl: async () => series ? 'https://stream/episode' : (++calls === 1 ? stale.promise : fresh.promise)
+        });
+        const oldPlay = page.play();
+        await flushMicrotasks();
+        assert.equal(calls, 1);
+        if (navigation === 'season') page.openSeason({ id: 's1', seasonNumber: 1, name: 'Season', posterUrl: '' });
+        else if (navigation === 'person') page.openPerson({ personId: 'p1', name: 'Person', role: '', imageUrl: '' });
+        else page.handleDetailHidden();
+        const pushed = page.pageStack.pushed.length;
+        assert.equal(pushed, navigation === 'hidden' ? 0 : 1);
+        assert.equal(page.isPlaying, false);
+        assert.equal(page.videoServerModel.listeners.size, 0);
+        // The actual onHidden may follow a push; repeated hiding is safe.
+        page.handleDetailHidden();
+        page.handleDetailShown();
+        await flushMicrotasks();
+        assert.equal(page.videoServerModel.listeners.size, 1);
+        assert.equal(page.error, '');
+        const newPlay = page.play();
+        await flushMicrotasks();
+        assert.equal(page.isPlaying, true);
+        if (reject) stale.reject(new Error('late playback failure'));
+        else stale.resolve(series ? null : 'https://stream/stale');
+        await oldPlay;
+        assert.equal(page.pageStack.pushed.length, pushed);
+        assert.equal(page.isPlaying, true, 'old finally must not release new play lock');
+        assert.deepEqual(page.toastMessages, []);
+        fresh.resolve(series ? null : 'https://stream/fresh');
+        await newPlay;
+        assert.equal(page.pageStack.pushed.length, pushed + 1);
+        assert.equal(page.pageStack.pushed[pushed].name, 'player');
+        assert.equal(page.isPlaying, false);
+        page.handleDetailHidden();
+        page.handleDetailShown();
+        await flushMicrotasks();
+        assert.equal(page.error, '');
+        assert.ok(page.loadedDetailIdentity);
+        page.aboutToDisappear();
+      }
+    }
+  }
+  detailClientState.buildContext = async () => null;
+
+  for (const reject of [false, true]) {
+    const server = { id: 62, type: 'jellyfin', name: 'Server', configJson: 'original', createdAt: 1 };
+    const page = createDetailPageHarness(server);
+    const stale = createDeferred();
+    const fresh = createDeferred();
+    let calls = 0;
+    installDetailClient('jellyfin', { getItemDetail: () => ++calls === 1 ? stale.promise : fresh.promise });
+    page.initialLoadDone = true;
+    const oldLoad = page.loadDetail(false);
+    await flushMicrotasks();
+    page.handleDetailHidden();
+    page.handleDetailShown();
+    page.retryDetail();
+    await flushMicrotasks();
+    assert.equal(page.isLoading, true);
+    if (reject) stale.reject(new Error('late detail failure'));
+    else stale.resolve(createDetailPayload('series'));
+    await oldLoad;
+    assert.equal(page.isLoading, true, 'old detail finally must not release new load lock');
+    assert.equal(page.error, '');
+    fresh.resolve(createDetailPayload('movie'));
+    await flushMicrotasks();
+    assert.equal(page.isLoading, false);
+    assert.equal(page.detail.media.type, 'movie');
+    page.aboutToDisappear();
   }
 
   console.log('静态路由/副作用/输入/生命周期守卫、真实页面方法与详情页身份/错误态回归、reject/resetAll 回归：通过');

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -126,15 +126,18 @@ async function runHostIntegrationChecks() {
   const assert = require('node:assert/strict');
   const workspace = 'entry/src/main/ets/pages/search/SearchWorkspacePage.ets';
   const results = 'entry/src/main/ets/pages/search/MediaResultPage.ets';
+  const detailPage = 'entry/src/main/ets/pages/detail/ServerMediaDetailPage.ets';
   const workspacePath = path.join(root, workspace);
   const resultPath = path.join(root, results);
   const workspaceSource = fs.readFileSync(workspacePath, 'utf8');
   const resultSource = fs.readFileSync(resultPath, 'utf8');
+  const detailPageSource = fs.readFileSync(path.join(root, detailPage), 'utf8');
   const { createLocalSearchScope, resolveSearchScope, getSearchCapabilities } =
     require(path.join(root, 'entry/src/main/ets/models/search/SearchScope.ets'));
+  const { VideoServerType } = require(path.join(root, 'entry/src/main/ets/db/models/VideoServerEntity.ets'));
   const { SearchWorkspaceSession } = require(path.join(root,
     'entry/src/main/ets/services/search/SearchWorkspaceSession.ets'));
-  const { VideoServerSearchService } = require(path.join(root,
+  const { VideoServerSearchService, VideoServerSearchSourceSnapshot } = require(path.join(root,
     'entry/src/main/ets/services/search/VideoServerSearchService.ets'));
 
   function checkGuard(file, method, capability) {
@@ -166,8 +169,34 @@ async function runHostIntegrationChecks() {
   assert.ok(workspaceSource.includes('.onWillHide(() => { this.leaveSearch(); })'));
   const preview = workspaceSource.slice(workspaceSource.indexOf('  buildServerResults()'),
     workspaceSource.indexOf('  build() \n    NavDestination()'));
-  assert.ok(!preview.includes('onClick') && !preview.includes('navigateToDetail'));
-  assert.ok(preview.includes('.focusable(false)'));
+  assert.ok(preview.includes('ServerSearchResultCard'));
+  assert.ok(preview.includes('this.openServerResultDetail(item);'));
+  assert.ok(!preview.includes('focusable(false)'));
+  assert.ok(!preview.includes('暂不支持打开详情'));
+  assert.ok(workspaceSource.includes('mediaId: item.selection.mediaId'));
+  assert.ok(workspaceSource.includes('mediaType: item.selection.mediaType'));
+  assert.ok(workspaceSource.includes('itemId: item.selection.detailItemId'));
+  assert.ok(workspaceSource.includes('item.sourceSnapshot.matches(context.scope, context.server)'));
+  assert.ok(detailPageSource.includes("Text('重试')"));
+  assert.ok(detailPageSource.includes('.defaultFocus(true)'));
+  assert.ok(detailPageSource.includes('.focusable(true)'));
+  assert.ok(detailPageSource.includes('.onClick(() => { this.retryDetail() })'));
+  assert.ok(detailPageSource.includes('private detailRequestActive: boolean = false'));
+  assert.ok(detailPageSource.includes('private playOperationGeneration: number = 0'));
+  assert.ok(detailPageSource.includes('private playOperationActive: boolean = false'));
+  assert.ok(detailPageSource.includes('subscribeSearchConfiguration(() => this.handleDetailConfigurationChange())'));
+  assert.ok(detailPageSource.includes('subscribeSearchSource(() => this.handleDetailSourceChange())'));
+  assert.ok(detailPageSource.includes('private unsubscribeDetailGuards(): void'));
+  assert.ok(detailPageSource.includes('this.leaveDetailPage()'));
+  assert.ok(detailPageSource.includes('aboutToAppear(): void'));
+  assert.ok(detailPageSource.includes('aboutToDisappear(): void'));
+  assert.ok(detailPageSource.includes("this.invalidateDetailState('', false)"));
+  const playBody = extractMethodBody(detailPageSource, 'private async play(): Promise<void>');
+  assert.ok(playBody.indexOf('const server = this.resolvePlayableServer()') <
+    playBody.indexOf('const target = this.playTarget()'));
+  assert.ok(playBody.includes('const playGeneration = this.beginPlayOperation()'));
+  assert.ok(playBody.includes('if (!this.isActivePlayOperation(playGeneration, identity)) {'));
+  assert.ok(playBody.includes('this.finishPlayOperation(playGeneration, identity)'));
   const resetBody = resultSource.match(/private resetAll\(\): void \{([\s\S]*?)\n  \}/)[1];
   const reset = new Function(ts.transpileModule(`function reset() {${resetBody}}`, {
     compilerOptions: { target: ts.ScriptTarget.ES2021 }
@@ -205,11 +234,253 @@ async function runHostIntegrationChecks() {
     loadHistory: loadMethod(workspaceSource, 'private loadHistory(): void', [], { getSearchCapabilities }),
     scheduleSearch: loadMethod(workspaceSource, 'private scheduleSearch(): void', [], { getSearchCapabilities }),
     executeServerSearch: loadMethod(workspaceSource, 'private executeServerSearch(): void', [], {}),
+    openServerResultDetail: loadMethod(workspaceSource, 'private openServerResultDetail(item: VideoServerSearchItem): void',
+      ['item'], { ServerMediaDetailPage: { PAGE_NAME: 'serverMediaDetail' } }),
     appendChar: loadMethod(workspaceSource, 'private appendChar(c: string): void', ['c'], {}),
     clearSearch: loadMethod(workspaceSource, 'private clearSearch(): void', [], {}),
     leaveSearch: loadMethod(workspaceSource, 'private leaveSearch(): void', [], {}),
     refreshSource: loadMethod(workspaceSource, 'private refreshSource(): void', [], methodDeps)
   };
+  const detailClientState = {
+    jellyfinClient: null,
+    plexClient: null
+  };
+  const detailSourceModel = {
+    activeSource: { kind: 'fileSource' },
+    listeners: new Set(),
+    subscribeSearchSource(listener) {
+      this.listeners.add(listener);
+      return () => { this.listeners.delete(listener); };
+    },
+    emitChange() {
+      this.listeners.forEach((listener) => listener());
+    }
+  };
+  const rawDetailMethods = {
+    clearLoadedDetail: loadMethod(detailPageSource, 'private clearLoadedDetail(): void', [], {}),
+    captureServerIdentity: loadMethod(detailPageSource,
+      'private captureServerIdentity(server: VideoServer): ServerMediaDetailServerIdentity',
+      ['server'], {}),
+    matchesServerIdentity: loadMethod(detailPageSource,
+      'private matchesServerIdentity(identity: ServerMediaDetailServerIdentity): boolean',
+      ['identity'], {}),
+    shouldTrackSearchSource: loadMethod(detailPageSource, 'private shouldTrackSearchSource(): boolean', [], {}),
+    matchesCurrentSearchSource: loadMethod(detailPageSource, 'private matchesCurrentSearchSource(): boolean', [], {
+      SourceSwitchModel: { getState: () => detailSourceModel }
+    }),
+    detailInvalidationMessage: loadMethod(detailPageSource,
+      'private detailInvalidationMessage(identity: ServerMediaDetailServerIdentity | null = null): string',
+      ['identity'], {
+        SourceSwitchModel: { getState: () => detailSourceModel }
+      }),
+    beginDetailRequest: loadMethod(detailPageSource, 'private beginDetailRequest(silent: boolean): number',
+      ['silent'], {}),
+    isActiveDetailRequest: loadMethod(detailPageSource,
+      'private isActiveDetailRequest(generation: number, identity: ServerMediaDetailServerIdentity | null = null): boolean',
+      ['generation', 'identity'], {}),
+    bindPendingDetailIdentity: loadMethod(detailPageSource,
+      'private bindPendingDetailIdentity(generation: number, server: VideoServer): ServerMediaDetailServerIdentity | null',
+      ['generation', 'server'], {}),
+    applyLoadedDetail: loadMethod(detailPageSource,
+      'private applyLoadedDetail(generation: number, identity: ServerMediaDetailServerIdentity,\n    payload: ServerMediaDetailLoadPayload): void',
+      ['generation', 'identity', 'payload'], {}),
+    applyDetailFailure: loadMethod(detailPageSource,
+      'private applyDetailFailure(generation: number, message: string,\n    identity: ServerMediaDetailServerIdentity | null = null): void',
+      ['generation', 'message', 'identity'], {}),
+    finishDetailRequest: loadMethod(detailPageSource,
+      'private finishDetailRequest(generation: number, identity: ServerMediaDetailServerIdentity | null = null): void',
+      ['generation', 'identity'], {}),
+    invalidateDetailState: loadMethod(detailPageSource,
+      'private invalidateDetailState(message: string, clearState: boolean = true): void',
+      ['message', 'clearState'], {}),
+    handleDetailSourceChange: loadMethod(detailPageSource, 'private handleDetailSourceChange(): void', [], {}),
+    handleDetailConfigurationChange: loadMethod(detailPageSource, 'private handleDetailConfigurationChange(): void', [], {}),
+    subscribeDetailGuards: loadMethod(detailPageSource, 'private subscribeDetailGuards(): void', [], {
+      SourceSwitchModel: { getState: () => detailSourceModel }
+    }),
+    unsubscribeDetailGuards: loadMethod(detailPageSource, 'private unsubscribeDetailGuards(): void', [], {}),
+    leaveDetailPage: loadMethod(detailPageSource, 'private leaveDetailPage(): void', [], {}),
+    resolvePlayableServer: loadMethod(detailPageSource, 'private resolvePlayableServer(): VideoServer | null', [], {}),
+    beginPlayOperation: loadMethod(detailPageSource, 'private beginPlayOperation(): number', [], {}),
+    isActivePlayOperation: loadMethod(detailPageSource,
+      'private isActivePlayOperation(generation: number, identity: ServerMediaDetailServerIdentity): boolean',
+      ['generation', 'identity'], {}),
+    finishPlayOperation: loadMethod(detailPageSource,
+      'private finishPlayOperation(generation: number, identity: ServerMediaDetailServerIdentity): void',
+      ['generation', 'identity'], {}),
+    retryDetail: loadMethod(detailPageSource, 'private retryDetail(): void', [], {}),
+    isSeries: loadMethod(detailPageSource, 'private isSeries(): boolean', [], {}),
+    playTarget: loadMethod(detailPageSource, 'private playTarget(): VideoServerMediaItem | null', [], {}),
+    getTitle: loadMethod(detailPageSource, 'private getTitle(): string', [], {}),
+    aboutToAppear: loadMethod(detailPageSource, 'aboutToAppear(): void', [], {}),
+    aboutToDisappear: loadMethod(detailPageSource, 'aboutToDisappear(): void', [], {}),
+    loadDetail: loadMethod(detailPageSource, 'private async loadDetail(silent: boolean = false): Promise<void>',
+      ['silent'], {
+        VideoServerType,
+        JellyfinClient: { fromConfigJson: () => detailClientState.jellyfinClient },
+        PlexClient: { fromConfigJson: () => detailClientState.plexClient }
+      }, true),
+    play: loadMethod(detailPageSource, 'private async play(): Promise<void>', [], {
+      VideoServerType,
+      PlayerPage: { PAGE_NAME: 'player' },
+      reportServerPlaybackStarted: () => Promise.resolve(),
+      buildServerEpisodePlaybackContext: async () => null,
+      JellyfinClient: { fromConfigJson: () => detailClientState.jellyfinClient },
+      PlexClient: { fromConfigJson: () => detailClientState.plexClient }
+    }, true)
+  };
+  const detailMethods = {
+    ...rawDetailMethods,
+    detailInvalidationMessage(identity) {
+      return rawDetailMethods.detailInvalidationMessage.call(this, identity ?? null);
+    },
+    isActiveDetailRequest(generation, identity) {
+      return rawDetailMethods.isActiveDetailRequest.call(this, generation, identity ?? null);
+    },
+    applyDetailFailure(generation, message, identity) {
+      return rawDetailMethods.applyDetailFailure.call(this, generation, message, identity ?? null);
+    },
+    finishDetailRequest(generation, identity) {
+      return rawDetailMethods.finishDetailRequest.call(this, generation, identity ?? null);
+    },
+    invalidateDetailState(message, clearState) {
+      return rawDetailMethods.invalidateDetailState.call(this, message, clearState ?? true);
+    }
+  };
+
+  function createDetailMedia(type) {
+    return {
+      id: `${type}-1`,
+      title: `${type} title`,
+      type,
+      backdropUrl: '',
+      posterUrl: '',
+      progress: 0,
+      positionMs: 0,
+      durationMs: 0,
+      subtitle: '',
+      seriesId: type === 'episode' ? 'series-1' : '',
+      seasonNumber: 0,
+      episodeNumber: 0,
+      lastPlayedDate: 0
+    };
+  }
+
+  function createDetailPayload(type) {
+    return {
+      media: createDetailMedia(type),
+      overview: `${type} overview`,
+      rating: 0,
+      year: 2024,
+      people: []
+    };
+  }
+
+  function createSeason(id) {
+    return { id, title: id, posterUrl: '', indexNumber: 1, episodeCount: 1 };
+  }
+
+  function createDetailPageHarness(server, expectedServerType = server?.type ?? '') {
+    detailSourceModel.activeSource = {
+      kind: 'videoServer',
+      serverId: server?.id,
+      serverType: server?.type,
+      name: server?.name
+    };
+    detailSourceModel.listeners = new Set();
+    const page = {
+      serverId: server?.id ?? 0,
+      itemId: 'series-1',
+      fallbackTitle: 'fallback',
+      sourceMediaId: '',
+      sourceMediaType: '',
+      expectedServerType,
+      videoServerModel: {
+        server,
+        listeners: new Set(),
+        loadCalls: 0,
+        async loadVideoServers() { this.loadCalls++; },
+        subscribeSearchConfiguration(listener) {
+          this.listeners.add(listener);
+          return () => { this.listeners.delete(listener); };
+        },
+        emitChange() {
+          this.listeners.forEach((listener) => listener());
+        },
+        getVideoServerById(id) {
+          if (this.server !== undefined && this.server !== null && this.server.id === id) {
+            return this.server;
+          }
+          return null;
+        }
+      },
+      detail: createDetailPayload('series'),
+      seasons: [createSeason('stale-season')],
+      nextUp: createDetailMedia('episode'),
+      error: 'stale error',
+      isLoading: false,
+      detailLoadGeneration: 0,
+      detailRequestActive: false,
+      playOperationGeneration: 0,
+      playOperationActive: false,
+      pendingDetailIdentity: null,
+      loadedDetailIdentity: null,
+      unsubscribeSource() {},
+      unsubscribeConfiguration() {},
+      pageStack: {
+        pushed: [],
+        pushPathByName(name, param) {
+          this.pushed.push({ name, param });
+        }
+      },
+      toastMessages: [],
+      showToastSafe(message) { this.toastMessages.push(message); },
+      isPlaying: false
+    };
+    page.clearLoadedDetail = detailMethods.clearLoadedDetail;
+    page.captureServerIdentity = detailMethods.captureServerIdentity;
+    page.matchesServerIdentity = detailMethods.matchesServerIdentity;
+    page.shouldTrackSearchSource = detailMethods.shouldTrackSearchSource;
+    page.matchesCurrentSearchSource = detailMethods.matchesCurrentSearchSource;
+    page.detailInvalidationMessage = detailMethods.detailInvalidationMessage;
+    page.beginDetailRequest = detailMethods.beginDetailRequest;
+    page.isActiveDetailRequest = detailMethods.isActiveDetailRequest;
+    page.bindPendingDetailIdentity = detailMethods.bindPendingDetailIdentity;
+    page.applyLoadedDetail = detailMethods.applyLoadedDetail;
+    page.applyDetailFailure = detailMethods.applyDetailFailure;
+    page.finishDetailRequest = detailMethods.finishDetailRequest;
+    page.invalidateDetailState = detailMethods.invalidateDetailState;
+    page.handleDetailSourceChange = detailMethods.handleDetailSourceChange;
+    page.handleDetailConfigurationChange = detailMethods.handleDetailConfigurationChange;
+    page.subscribeDetailGuards = detailMethods.subscribeDetailGuards;
+    page.unsubscribeDetailGuards = detailMethods.unsubscribeDetailGuards;
+    page.leaveDetailPage = detailMethods.leaveDetailPage;
+    page.resolvePlayableServer = detailMethods.resolvePlayableServer;
+    page.beginPlayOperation = detailMethods.beginPlayOperation;
+    page.isActivePlayOperation = detailMethods.isActivePlayOperation;
+    page.finishPlayOperation = detailMethods.finishPlayOperation;
+    page.retryDetail = detailMethods.retryDetail;
+    page.isSeries = detailMethods.isSeries;
+    page.playTarget = detailMethods.playTarget;
+    page.getTitle = detailMethods.getTitle;
+    page.aboutToAppear = detailMethods.aboutToAppear;
+    page.aboutToDisappear = detailMethods.aboutToDisappear;
+    page.loadDetail = detailMethods.loadDetail;
+    page.play = detailMethods.play;
+    return page;
+  }
+
+  function installDetailClient(type, behavior) {
+    const client = {
+      getItemDetail: behavior.getItemDetail,
+      getSeasons: behavior.getSeasons ?? (async () => []),
+      getNextUp: behavior.getNextUp ?? (async () => null),
+      getStreamUrl: behavior.getStreamUrl ?? (async (id) => `https://stream/${type}/${id}`),
+      getStreamHeader: behavior.getStreamHeader ?? (() => ({ Authorization: `Bearer ${type}` }))
+    };
+    detailClientState.jellyfinClient = client;
+    detailClientState.plexClient = client;
+  }
 
   function createServerContext(id) {
     const server = { id, name: `Server ${id}`, type: 'jellyfin', configJson: '{}', createdAt: 1 };
@@ -230,8 +501,15 @@ async function runHostIntegrationChecks() {
       searchGeneration: 0,
       historyLoadGeneration: 0,
       historySourceGeneration: 0,
+      refreshSourceCalls: 0,
+      toastMessages: [],
       unsubscribeSource() {},
       unsubscribeConfiguration() {},
+      showToastSafe(message) { this.toastMessages.push(message); },
+      pageStack: {
+        pushed: [],
+        pushPathByName(name, param) { this.pushed.push({ name, param }); }
+      },
       executeSearchCalls: 0,
       executeSearch() { this.executeSearchCalls++; },
       currentContext() { return { scope: this.scope }; },
@@ -253,6 +531,7 @@ async function runHostIntegrationChecks() {
     page.loadHistory = methods.loadHistory;
     page.scheduleSearch = methods.scheduleSearch;
     page.executeServerSearch = methods.executeServerSearch;
+    page.openServerResultDetail = methods.openServerResultDetail;
     page.appendChar = methods.appendChar;
     page.clearSearch = methods.clearSearch;
     page.leaveSearch = methods.leaveSearch;
@@ -338,6 +617,157 @@ async function runHostIntegrationChecks() {
   }
 
   {
+    const timers = installFakeTimers();
+    try {
+      const page = createPageHarness(createServerContext(3).scope, null);
+      page.currentContext = () => createServerContext(3);
+      page.searchText = 'return-search';
+      page.refreshSource();
+      assert.equal(page.scope.key, 'video-server:jellyfin:3');
+      assert.equal(page.searchResults.length, 0);
+      assert.equal(page.db, null);
+      assert.equal(timers.pendingCount(), 1);
+    } finally {
+      timers.restore();
+    }
+  }
+
+  {
+    const server = { id: 5, name: 'Server 5', type: 'jellyfin', configJson: '{}', createdAt: 1 };
+    const scope = resolveSearchScope({ kind: 'videoServer', serverId: 5 }, [server]);
+    const page = createPageHarness(scope, null);
+    page.currentContext = () => ({ scope, server });
+    const item = {
+      key: 'video-server:jellyfin:5:episode-5',
+      scopeKey: scope.key,
+      serverId: 5,
+      serverType: 'jellyfin',
+      media: {
+        id: 'episode-5',
+        title: 'Episode 5',
+        type: 'episode',
+        backdropUrl: '',
+        posterUrl: '',
+        progress: 0,
+        positionMs: 0,
+        durationMs: 0,
+        subtitle: '',
+        seriesId: 'series-5',
+        seasonNumber: 1,
+        episodeNumber: 5,
+        lastPlayedDate: 0
+      },
+      selection: {
+        serverId: 5,
+        serverType: 'jellyfin',
+        mediaId: 'episode-5',
+        mediaType: 'episode',
+        detailItemId: 'series-5'
+      },
+      sourceSnapshot: new VideoServerSearchSourceSnapshot(scope.key, server)
+    };
+    page.openServerResultDetail(item);
+    assert.equal(page.toastMessages.length, 0);
+    assert.equal(page.pageStack.pushed.length, 1);
+    assert.deepEqual(page.pageStack.pushed[0], {
+      name: 'serverMediaDetail',
+      param: {
+        serverId: 5,
+        serverType: 'jellyfin',
+        mediaId: 'episode-5',
+        mediaType: 'episode',
+        itemId: 'series-5',
+        title: 'Episode 5'
+      }
+    });
+  }
+
+  {
+    const originalServer = { id: 6, name: 'Server 6', type: 'jellyfin', configJson: '{}', createdAt: 1 };
+    const scope = resolveSearchScope({ kind: 'videoServer', serverId: 6 }, [originalServer]);
+    const page = createPageHarness(scope, null);
+    page.currentContext = () => ({
+      scope,
+      server: { id: 6, name: 'Server 6', type: 'jellyfin', configJson: '{"changed":true}', createdAt: 1 }
+    });
+    const item = {
+      key: 'video-server:jellyfin:6:movie-6',
+      scopeKey: scope.key,
+      serverId: 6,
+      serverType: 'jellyfin',
+      media: {
+        id: 'movie-6',
+        title: 'Movie 6',
+        type: 'movie',
+        backdropUrl: '',
+        posterUrl: '',
+        progress: 0,
+        positionMs: 0,
+        durationMs: 0,
+        subtitle: '',
+        seriesId: '',
+        seasonNumber: 0,
+        episodeNumber: 0,
+        lastPlayedDate: 0
+      },
+      selection: {
+        serverId: 6,
+        serverType: 'jellyfin',
+        mediaId: 'movie-6',
+        mediaType: 'movie',
+        detailItemId: 'movie-6'
+      },
+      sourceSnapshot: new VideoServerSearchSourceSnapshot(scope.key, originalServer)
+    };
+    page.refreshSource = function () { this.refreshSourceCalls++; };
+    page.openServerResultDetail(item);
+    assert.deepEqual(page.toastMessages, ['当前服务器配置已变更，请重新搜索']);
+    assert.equal(page.refreshSourceCalls, 1);
+    assert.equal(page.pageStack.pushed.length, 0);
+  }
+
+  {
+    const originalServer = { id: 7, name: 'Server 7', type: 'jellyfin', configJson: '{}', createdAt: 1 };
+    const scope = resolveSearchScope({ kind: 'videoServer', serverId: 7 }, [originalServer]);
+    const page = createPageHarness(scope, null);
+    page.currentContext = () => ({ scope: createLocalSearchScope(), server: undefined });
+    const item = {
+      key: 'video-server:jellyfin:7:movie-7',
+      scopeKey: scope.key,
+      serverId: 7,
+      serverType: 'jellyfin',
+      media: {
+        id: 'movie-7',
+        title: 'Movie 7',
+        type: 'movie',
+        backdropUrl: '',
+        posterUrl: '',
+        progress: 0,
+        positionMs: 0,
+        durationMs: 0,
+        subtitle: '',
+        seriesId: '',
+        seasonNumber: 0,
+        episodeNumber: 0,
+        lastPlayedDate: 0
+      },
+      selection: {
+        serverId: 7,
+        serverType: 'jellyfin',
+        mediaId: 'movie-7',
+        mediaType: 'movie',
+        detailItemId: 'movie-7'
+      },
+      sourceSnapshot: new VideoServerSearchSourceSnapshot(scope.key, originalServer)
+    };
+    page.refreshSource = function () { this.refreshSourceCalls++; };
+    page.openServerResultDetail(item);
+    assert.deepEqual(page.toastMessages, ['当前来源已变化，请返回重新选择来源']);
+    assert.equal(page.refreshSourceCalls, 1);
+    assert.equal(page.pageStack.pushed.length, 0);
+  }
+
+  {
     const session = new SearchWorkspaceSession();
     const service = new VideoServerSearchService();
     const current = createServerContext(7);
@@ -351,7 +781,484 @@ async function runHostIntegrationChecks() {
     assert.deepEqual(states, ['loading']);
   }
 
-  console.log('静态路由/副作用/输入/生命周期守卫、4 项真实页面回归、1 项真实 reject 隔离与 2 项真实重置方法回归：通过');
+  {
+    const page = createDetailPageHarness(null, 'jellyfin');
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => { throw new Error('不应访问客户端'); }
+    });
+    await page.loadDetail(false);
+    assert.equal(page.error, '服务器不存在');
+    assert.equal(page.detail, null);
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+    assert.equal(page.isLoading, false);
+  }
+
+  {
+    const page = createDetailPageHarness(null, 'jellyfin');
+    page.error = '';
+    await page.loadDetail(true);
+    assert.equal(page.error, '服务器不存在');
+    assert.equal(page.detail, null);
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+    assert.equal(page.isLoading, false);
+  }
+
+  {
+    const server = { id: 11, type: 'plex', name: 'Server 11', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    installDetailClient('plex', {
+      getItemDetail: async () => { throw new Error('不应访问客户端'); }
+    });
+    await page.loadDetail(false);
+    assert.equal(page.error, '服务器配置已变更，请返回重试');
+    assert.equal(page.detail, null);
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+  }
+
+  {
+    const server = { id: 12, type: 'plex', name: 'Server 12', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.error = '';
+    await page.loadDetail(true);
+    assert.equal(page.error, '服务器配置已变更，请返回重试');
+    assert.equal(page.detail, null);
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+  }
+
+  for (const mode of [
+    { silent: false, label: 'initial' },
+    { silent: true, label: 'silent' }
+  ]) {
+    for (const failure of [
+      { label: '401', message: '鉴权失败，请检查凭据' },
+      { label: '403', message: '鉴权失败，请检查凭据' },
+      { label: 'timeout', message: '获取详情失败 timeout' }
+    ]) {
+      const server = { id: 20, type: 'jellyfin', name: 'Server 20', configJson: '{"token":"a"}', createdAt: 1 };
+      const page = createDetailPageHarness(server, 'jellyfin');
+      page.error = '';
+      installDetailClient('jellyfin', {
+        getItemDetail: async () => { throw new Error(failure.message); }
+      });
+      await page.loadDetail(mode.silent);
+      assert.equal(page.error, failure.message, `${mode.label}-${failure.label}`);
+      assert.equal(page.detail, null, `${mode.label}-${failure.label}`);
+      assert.deepEqual(page.seasons, [], `${mode.label}-${failure.label}`);
+      assert.equal(page.nextUp, null, `${mode.label}-${failure.label}`);
+      assert.equal(page.isLoading, false, `${mode.label}-${failure.label}`);
+    }
+  }
+
+  {
+    const server = { id: 30, type: 'jellyfin', name: 'Server 30', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => createDetailPayload('movie')
+    });
+    await page.loadDetail(true);
+    assert.equal(page.error, '');
+    assert.equal(page.detail.media.type, 'movie');
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+  }
+
+  {
+    const first = createDeferred();
+    const server = { id: 31, type: 'jellyfin', name: 'Server 31', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    let callCount = 0;
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return first.promise;
+        }
+        throw new Error('鉴权失败，请检查凭据');
+      }
+    });
+    const staleRequest = page.loadDetail(false);
+    await flushMicrotasks();
+    await page.loadDetail(true);
+    first.resolve(createDetailPayload('movie'));
+    await staleRequest;
+    assert.equal(page.error, '鉴权失败，请检查凭据');
+    assert.equal(page.detail, null);
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+  }
+
+  {
+    const first = createDeferred();
+    const server = { id: 36, type: 'jellyfin', name: 'Server 36', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.sourceMediaId = 'episode-36';
+    page.sourceMediaType = 'episode';
+    page.aboutToAppear();
+    let callCount = 0;
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return first.promise;
+        }
+        return createDetailPayload('movie');
+      }
+    });
+    const staleRequest = page.loadDetail(false);
+    await flushMicrotasks();
+    detailSourceModel.activeSource = { kind: 'fileSource' };
+    detailSourceModel.emitChange();
+    detailSourceModel.activeSource = {
+      kind: 'videoServer',
+      serverId: server.id,
+      serverType: server.type,
+      name: server.name
+    };
+    detailSourceModel.emitChange();
+    await page.loadDetail(false);
+    first.resolve(createDetailPayload('series'));
+    await staleRequest;
+    assert.equal(page.error, '');
+    assert.equal(page.detail.media.type, 'movie');
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+    page.aboutToDisappear();
+  }
+
+  {
+    const first = createDeferred();
+    const server = { id: 37, type: 'jellyfin', name: 'Server 37', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    let callCount = 0;
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return first.promise;
+        }
+        return createDetailPayload('movie');
+      }
+    });
+    const staleRequest = page.loadDetail(false);
+    await flushMicrotasks();
+    await page.loadDetail(false);
+    first.resolve(createDetailPayload('series'));
+    await staleRequest;
+    assert.equal(page.error, '');
+    assert.equal(page.detail.media.type, 'movie');
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+    assert.equal(page.isLoading, false);
+  }
+
+  {
+    const first = createDeferred();
+    const server = { id: 38, type: 'jellyfin', name: 'Server 38', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    let callCount = 0;
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return first.promise;
+        }
+        return createDetailPayload('movie');
+      }
+    });
+    const staleRequest = page.loadDetail(false);
+    await flushMicrotasks();
+    await page.loadDetail(false);
+    first.reject(new Error('鉴权失败，请检查凭据'));
+    await staleRequest;
+    assert.equal(page.error, '');
+    assert.equal(page.detail.media.type, 'movie');
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+    assert.equal(page.isLoading, false);
+  }
+
+  for (const scenario of ['leave', 'source-switch', 'same-id-config-change', 'delete']) {
+    const first = createDeferred();
+    const server = { id: 34, type: 'jellyfin', name: 'Server 34', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.sourceMediaId = 'episode-34';
+    page.sourceMediaType = 'episode';
+    page.subscribeDetailGuards();
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => first.promise
+    });
+    const request = page.loadDetail(false);
+    await flushMicrotasks();
+    if (scenario === 'leave') {
+      page.leaveDetailPage();
+    } else if (scenario === 'source-switch') {
+      detailSourceModel.activeSource = { kind: 'fileSource' };
+      detailSourceModel.emitChange();
+    } else if (scenario === 'same-id-config-change') {
+      page.videoServerModel.server = { ...server, configJson: '{"changed":true}' };
+      page.videoServerModel.emitChange();
+    } else {
+      page.videoServerModel.server = null;
+      page.videoServerModel.emitChange();
+    }
+    first.resolve(createDetailPayload('movie'));
+    await request;
+    assert.equal(page.detail, null, scenario);
+    assert.deepEqual(page.seasons, [], scenario);
+    assert.equal(page.nextUp, null, scenario);
+    assert.equal(page.isLoading, false, scenario);
+    if (scenario === 'leave') {
+      assert.equal(page.error, '', scenario);
+    } else if (scenario === 'source-switch') {
+      assert.equal(page.error, '当前来源已变化，请返回重新选择来源', scenario);
+    } else if (scenario === 'delete') {
+      assert.equal(page.error, '服务器不存在', scenario);
+    } else {
+      assert.equal(page.error, '服务器配置已变更，请返回重试', scenario);
+    }
+  }
+
+  for (const scenario of ['leave', 'source-switch', 'same-id-config-change', 'delete']) {
+    const first = createDeferred();
+    const server = { id: 35, type: 'jellyfin', name: 'Server 35', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.sourceMediaId = 'episode-35';
+    page.sourceMediaType = 'episode';
+    page.subscribeDetailGuards();
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => first.promise
+    });
+    const request = page.loadDetail(false);
+    await flushMicrotasks();
+    if (scenario === 'leave') {
+      page.leaveDetailPage();
+    } else if (scenario === 'source-switch') {
+      detailSourceModel.activeSource = { kind: 'fileSource' };
+      detailSourceModel.emitChange();
+    } else if (scenario === 'same-id-config-change') {
+      page.videoServerModel.server = { ...server, configJson: '{"changed":true}' };
+      page.videoServerModel.emitChange();
+    } else {
+      page.videoServerModel.server = null;
+      page.videoServerModel.emitChange();
+    }
+    first.reject(new Error('鉴权失败，请检查凭据'));
+    await request;
+    assert.equal(page.detail, null, `${scenario}-reject`);
+    assert.deepEqual(page.seasons, [], `${scenario}-reject`);
+    assert.equal(page.nextUp, null, `${scenario}-reject`);
+    assert.equal(page.isLoading, false, `${scenario}-reject`);
+    if (scenario === 'leave') {
+      assert.equal(page.error, '', `${scenario}-reject`);
+    } else if (scenario === 'source-switch') {
+      assert.equal(page.error, '当前来源已变化，请返回重新选择来源', `${scenario}-reject`);
+    } else if (scenario === 'delete') {
+      assert.equal(page.error, '服务器不存在', `${scenario}-reject`);
+    } else {
+      assert.equal(page.error, '服务器配置已变更，请返回重试', `${scenario}-reject`);
+    }
+  }
+
+  {
+    const server = { id: 32, type: 'jellyfin', name: 'Server 32', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => { throw new Error('获取详情失败 timeout'); }
+    });
+    await page.loadDetail(false);
+    assert.equal(page.error, '获取详情失败 timeout');
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => createDetailPayload('movie')
+    });
+    page.retryDetail();
+    await flushMicrotasks();
+    assert.equal(page.error, '');
+    assert.equal(page.detail.media.type, 'movie');
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+    assert.equal(page.isLoading, false);
+  }
+
+  {
+    const first = createDeferred();
+    const server = { id: 33, type: 'jellyfin', name: 'Server 33', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    let callCount = 0;
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => {
+        callCount++;
+        return first.promise;
+      }
+    });
+    page.error = '鉴权失败，请检查凭据';
+    page.retryDetail();
+    page.retryDetail();
+    await flushMicrotasks();
+    assert.equal(callCount, 1);
+    assert.equal(page.isLoading, true);
+    first.resolve(createDetailPayload('movie'));
+    await flushMicrotasks();
+    assert.equal(page.error, '');
+    assert.equal(page.detail.media.type, 'movie');
+    assert.equal(page.isLoading, false);
+  }
+
+  {
+    const server = { id: 40, type: 'jellyfin', name: 'Server 40', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.detail = createDetailPayload('movie');
+    page.loadedDetailIdentity = page.captureServerIdentity(server);
+    page.videoServerModel.server = { ...server, configJson: '{"changed":true}' };
+    const playable = page.resolvePlayableServer();
+    assert.equal(playable, null);
+    assert.equal(page.error, '服务器配置已变更，请返回重试');
+    assert.equal(page.detail, null);
+    assert.deepEqual(page.seasons, []);
+    assert.equal(page.nextUp, null);
+    assert.deepEqual(page.toastMessages, ['服务器配置已变更，请返回重试']);
+  }
+
+  {
+    const server = { id: 41, type: 'jellyfin', name: 'Server 41', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.detail = createDetailPayload('movie');
+    page.loadedDetailIdentity = page.captureServerIdentity(server);
+    const playable = page.resolvePlayableServer();
+    assert.equal(playable.id, 41);
+    assert.equal(page.error, 'stale error');
+    assert.equal(page.detail.media.type, 'movie');
+  }
+
+  {
+    const server = { id: 42, type: 'jellyfin', name: 'Server 42', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.detail = createDetailPayload('movie');
+    page.loadedDetailIdentity = page.captureServerIdentity(server);
+    page.aboutToAppear();
+    let streamCalls = 0;
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => createDetailPayload('movie'),
+      getStreamUrl: async (id) => {
+        streamCalls++;
+        return `https://stream/jellyfin/${id}`;
+      }
+    });
+    page.videoServerModel.server = { ...server, configJson: '{"changed":true}' };
+    page.videoServerModel.emitChange();
+    await page.play();
+    assert.equal(streamCalls, 0);
+    assert.equal(page.pageStack.pushed.length, 0);
+    assert.equal(page.error, '服务器配置已变更，请返回重试');
+    assert.equal(page.detail, null);
+    assert.deepEqual(page.toastMessages, []);
+    page.aboutToDisappear();
+  }
+
+  {
+    const first = createDeferred();
+    const second = createDeferred();
+    const server = { id: 44, type: 'jellyfin', name: 'Server 44', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.detail = createDetailPayload('movie');
+    page.loadedDetailIdentity = page.captureServerIdentity(server);
+    page.aboutToAppear();
+    let streamCalls = 0;
+    installDetailClient('jellyfin', {
+      getStreamUrl: async (id) => {
+        streamCalls++;
+        if (streamCalls === 1) {
+          return first.promise;
+        }
+        return second.promise;
+      }
+    });
+    const stalePlaying = page.play();
+    await flushMicrotasks();
+    page.videoServerModel.server = { ...server, configJson: '{"changed":true}' };
+    page.videoServerModel.emitChange();
+    assert.equal(page.isPlaying, false);
+    page.videoServerModel.server = { ...server };
+    page.detail = createDetailPayload('movie');
+    page.loadedDetailIdentity = page.captureServerIdentity(page.videoServerModel.server);
+    page.error = '';
+    const activePlaying = page.play();
+    await flushMicrotasks();
+    assert.equal(page.isPlaying, true);
+    first.resolve('https://stream/jellyfin/stale');
+    await stalePlaying;
+    assert.equal(page.pageStack.pushed.length, 0);
+    assert.equal(page.isPlaying, true);
+    second.resolve('https://stream/jellyfin/fresh');
+    await activePlaying;
+    assert.equal(page.pageStack.pushed.length, 1);
+    assert.equal(page.pageStack.pushed[0].param.url, 'https://stream/jellyfin/fresh');
+    assert.equal(page.isPlaying, false);
+    page.aboutToDisappear();
+  }
+
+  {
+    const pending = createDeferred();
+    const server = { id: 45, type: 'jellyfin', name: 'Server 45', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.detail = createDetailPayload('movie');
+    page.loadedDetailIdentity = page.captureServerIdentity(server);
+    page.aboutToAppear();
+    installDetailClient('jellyfin', {
+      getStreamUrl: async () => pending.promise
+    });
+    const playing = page.play();
+    await flushMicrotasks();
+    page.aboutToDisappear();
+    assert.equal(page.isPlaying, false);
+    pending.resolve('https://stream/jellyfin/disappear');
+    await playing;
+    assert.equal(page.pageStack.pushed.length, 0);
+    assert.equal(page.detail.media.type, 'movie');
+    assert.equal(page.error, '');
+  }
+
+  {
+    const pending = createDeferred();
+    const server = { id: 46, type: 'jellyfin', name: 'Server 46', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.detail = createDetailPayload('movie');
+    page.loadedDetailIdentity = page.captureServerIdentity(server);
+    page.aboutToAppear();
+    installDetailClient('jellyfin', {
+      getItemDetail: async () => pending.promise
+    });
+    page.retryDetail();
+    await flushMicrotasks();
+    page.aboutToDisappear();
+    assert.equal(page.videoServerModel.listeners.size, 0);
+    assert.equal(page.isLoading, false);
+    pending.resolve(createDetailPayload('series'));
+    await flushMicrotasks();
+    assert.equal(page.detail.media.type, 'movie');
+    assert.equal(page.loadedDetailIdentity, null);
+    assert.equal(page.error, '');
+  }
+
+  {
+    const server = { id: 43, type: 'jellyfin', name: 'Server 43', configJson: '{"token":"a"}', createdAt: 1 };
+    const page = createDetailPageHarness(server, 'jellyfin');
+    page.sourceMediaId = 'episode-43';
+    page.sourceMediaType = 'episode';
+    page.aboutToAppear();
+    page.aboutToDisappear();
+    detailSourceModel.activeSource = { kind: 'fileSource' };
+    detailSourceModel.emitChange();
+    assert.equal(page.error, '');
+    page.aboutToAppear();
+    detailSourceModel.emitChange();
+    assert.equal(page.error, '当前来源已变化，请返回重新选择来源');
+  }
+
+  console.log('静态路由/副作用/输入/生命周期守卫、真实页面方法与详情页身份/错误态回归、reject/resetAll 回归：通过');
 }
 
 function registerAndExecuteCore() {

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -32,7 +32,12 @@ const detailRegistryDatabase = {
 };
 const load = Module._load;
 Module._load = function (request, parent, main) {
-  if (request === '@ohos/hypium') return require(path.join(hypium, 'interface.js'));
+  if (request === '@ohos/hypium') {
+    // 补齐真实 Hypium 的边界替身导出，避免加载依赖设备运行时的包入口。
+    return { ...require(path.join(hypium, 'interface.js')),
+      ...require(path.join(hypium, 'module/mock/MockKit.js')),
+      ArgumentMatchers: require(path.join(hypium, 'module/mock/ArgumentMatchers.js')).default };
+  }
   if (request === '@ohos.app.ability.abilityDelegatorRegistry') {
     return { default: { getAbilityDelegator: () => ({ getAppContext: () => ({}) }) } };
   }
@@ -1325,7 +1330,7 @@ async function runHostIntegrationChecks() {
     page.aboutToDisappear();
   }
 
-  // Exercise the production methods at the registry-refresh and retained-page boundaries.
+  // 在注册表刷新与保留页面边界执行真实生产方法。
   for (const retry of [false, true]) {
     for (const reject of [false, true]) {
       const server = { id: 60, type: 'jellyfin', name: 'Server', configJson: 'original', createdAt: 1 };
@@ -1356,7 +1361,7 @@ async function runHostIntegrationChecks() {
       assert.equal(page.error, '服务器配置已变更，请返回重试');
       page.retryDetail();
       await flushMicrotasks();
-      assert.equal(mediaCalls, retry ? 1 : 0, 'retry must not reclaim replacement config');
+      assert.equal(mediaCalls, retry ? 1 : 0, '重试不得重新绑定替换后的配置');
       page.aboutToDisappear();
     }
   }
@@ -1375,11 +1380,11 @@ async function runHostIntegrationChecks() {
     await request;
     assert.equal(calls, 0);
     assert.equal(page.error, '服务器配置已变更，请返回重试');
-    assert.equal(page.detailTargetIdentity, null, 'unpublished registry values cannot establish identity');
+    assert.equal(page.detailTargetIdentity, null, '未发布的注册表值不得建立身份');
     assert.equal(page.isLoading, false);
   }
 
-  // Real registry loading/setter/notifications; only database and transport are stubbed.
+  // 执行真实注册表加载、赋值与通知，仅替换数据库和传输边界。
   const { VideoServerModel } = require(path.join(root,
     'entry/src/main/ets/stores/servers/VideoServerModel.ets'));
   for (const type of ['jellyfin', 'emby', 'plex']) {
@@ -1398,7 +1403,7 @@ async function runHostIntegrationChecks() {
       page.subscribeDetailGuards();
       const request = page.loadDetail(false);
       page.handleDetailShown();
-      // Register after the cold observer: mutate in the first publication before load resolves.
+      // 在冷启动观察者之后注册，在加载完成前的首次发布中修改配置。
       let published = false;
       const unsubscribe = model.subscribeSearchConfiguration(() => {
         if (published) return;
@@ -1420,7 +1425,7 @@ async function runHostIntegrationChecks() {
         page.handleDetailHidden();
         page.handleDetailShown();
         await flushMicrotasks();
-        assert.equal(calls, 2, 'normal retained-page return reloads automatically');
+        assert.equal(calls, 2, '正常返回保留页面时自动重新加载');
         assert.equal(page.error, '');
       } else {
         assert.equal(page.detail, null);
@@ -1428,19 +1433,19 @@ async function runHostIntegrationChecks() {
         if (replacement !== 'aba') {
           page.retryDetail();
           await flushMicrotasks();
-          assert.equal(calls, 0, 'retry cannot adopt the replacement');
+          assert.equal(calls, 0, '重试不得采用替换后的配置');
         }
         const fresh = createDetailPageHarness(model.getVideoServerById(server.id), type);
         fresh.videoServerModel = model;
         detailRegistryDatabase.getAll = async () => model.videoServers;
         await fresh.loadDetail(false);
-        assert.equal(calls, 1, 'a fresh legitimate entry can bind the current configuration');
+        assert.equal(calls, 1, '新的合法入口可绑定当前配置');
         assert.equal(fresh.error, '');
         fresh.aboutToDisappear();
       }
       page.aboutToDisappear();
       assert.equal(model.revisionListeners.size, 0);
-      assert.equal(model.searchListeners.size, 0, 'cold observer must also be released');
+      assert.equal(model.searchListeners.size, 0, '冷启动观察者也必须释放');
       console.log(`冷入口真实模型/页面方法 ${type}/${replacement}：通过`);
     }
   }
@@ -1494,7 +1499,7 @@ async function runHostIntegrationChecks() {
       const mutation = operation === 'update' ?
         model.updateVideoServer({ ...server, configJson: 'replacement' }) : model.deleteVideoServer(91);
       const settled = mutation.catch(() => {});
-      assert.ok(model.searchConfigurationRevision > before, 'write intent is visible before DB settlement');
+      assert.ok(model.searchConfigurationRevision > before, '数据库完成前写入意图已可见');
       assert.equal(page.isLoading, false);
       if (settlement === 'write-first') {
         if (fail) write.reject(new Error('fixture write failure')); else write.resolve();
@@ -1502,7 +1507,7 @@ async function runHostIntegrationChecks() {
       }
       read.resolve([server]); await request;
       assert.equal(calls, 0);
-      assert.equal(model.videoServers.length, 0, 'late initial snapshot cannot resurrect a target');
+      assert.equal(model.videoServers.length, 0, '迟到的初始快照不得恢复目标');
       if (settlement === 'read-first') {
         if (fail) write.reject(new Error('fixture write failure')); else write.resolve();
         await settled;
@@ -1513,7 +1518,7 @@ async function runHostIntegrationChecks() {
         operation === 'update' ? [{ ...server, configJson: 'replacement' }] : [];
       page.retryDetail(); await flushMicrotasks();
       assert.equal(calls, fail || operation === 'update' ? 1 : 0);
-      if (fail) assert.equal(page.error, '', 'failed write permits explicit fresh retry');
+      if (fail) assert.equal(page.error, '', '写入失败允许显式重新重试');
       page.aboutToDisappear();
       assert.equal(model.revisionListeners.size, 0);
       assert.equal(model.searchListeners.size, 0);
@@ -1521,7 +1526,7 @@ async function runHostIntegrationChecks() {
     }
   }
   }
-  // Loaded-page writes use real model methods; DB and transport settlement are controlled.
+  // 已加载页面的写操作使用真实模型方法，数据库和传输的完成时机由测试控制。
   for (const operation of ['update', 'delete']) {
     for (const fail of [false, true]) {
       for (const rejectOld of [false, true]) {
@@ -1539,25 +1544,25 @@ async function runHostIntegrationChecks() {
         });
         page.subscribeDetailGuards();
         await page.loadDetail(false);
-        assert.equal(model.revisionListeners.size, 1, 'visible guard survives load finally');
+        assert.equal(model.revisionListeners.size, 1, '加载完成清理后可见性守卫仍有效');
         const oldPlay = page.play();
         await flushMicrotasks();
         await page.play();
-        assert.equal(streamCalls, 1, 'duplicate click cannot start a second pending stream');
+        assert.equal(streamCalls, 1, '重复点击不得启动第二个待完成流请求');
         const mutation = operation === 'update' ?
           model.updateVideoServer({ ...server, configJson: 'replacement' }) : model.deleteVideoServer(server.id);
         const settled = mutation.catch(() => {});
-        assert.equal(page.detail, null, 'write intent clears loaded media before DB settlement');
+        assert.equal(page.detail, null, '写入意图在数据库完成前清除已加载媒体');
         assert.equal(page.isPlaying, false);
         assert.equal(page.error, '服务器配置已变更，请返回重试');
         page.retryDetail(); await flushMicrotasks();
-        assert.equal(page.detail, null, 'retry cannot load while write is pending');
+        assert.equal(page.detail, null, '写入未完成时重试不得加载');
         assert.equal(page.isLoading, false);
         if (fail) write.reject(new Error('fixture write failure')); else write.resolve();
         await settled;
         const current = fail ? server : operation === 'update' ? { ...server, configJson: 'replacement' } : null;
         detailRegistryDatabase.getAll = async () => current ? [current] : [];
-        // Failed writes permit the existing page to retry. Successful replacements require a fresh entry.
+        // 写入失败允许当前页面重试；成功替换配置则要求重新进入页面。
         const recovery = fail ? page : createDetailPageHarness(current, 'jellyfin');
         recovery.serverId = server.id;
         recovery.videoServerModel = model;
@@ -1570,7 +1575,7 @@ async function runHostIntegrationChecks() {
         assert.equal(recovery.error, current ? 'new revision detail failure' : '服务器不存在');
         if (!fail) {
           await page.loadDetail(false);
-          assert.equal(page.detail, null, 'old entry cannot adopt replacement media');
+          assert.equal(page.detail, null, '旧入口不得采用替换后的媒体');
         }
         const newDetail = createDeferred();
         installDetailClient('jellyfin', {
@@ -1587,20 +1592,20 @@ async function runHostIntegrationChecks() {
         if (rejectOld) oldStream.reject(new Error('old revision stream failure'));
         else oldStream.resolve('https://fixture.invalid/old-stream');
         await oldPlay;
-        assert.equal(page.pageStack.pushed.length, 0, 'old result never pushes player');
-        assert.deepEqual(page.toastMessages, [], 'old catch cannot report an error in the new revision');
+        assert.equal(page.pageStack.pushed.length, 0, '旧结果不得打开播放器');
+        assert.deepEqual(page.toastMessages, [], '旧异常处理不得向新版本报告错误');
         if (current) {
           if (rejectOld) {
-            assert.equal(recovery.isPlaying, true, 'old catch/finally cannot unlock new play');
+            assert.equal(recovery.isPlaying, true, '旧异常处理与清理不得解除新播放锁');
           } else {
-            assert.equal(recovery.isLoading, true, 'old completion cannot unlock new load');
+            assert.equal(recovery.isLoading, true, '旧完成回调不得解除新加载锁');
             newDetail.resolve(createDetailPayload('movie')); await flushMicrotasks();
             newPlay = recovery.play(); await flushMicrotasks();
           }
           assert.equal(recovery.error, '');
           assert.equal(recovery.isPlaying, true);
           await recovery.play();
-          assert.equal(streamCalls, 2, 'recovered pending playback also rejects duplicate clicks');
+          assert.equal(streamCalls, 2, '恢复后的待完成播放仍拒绝重复点击');
           freshStream.resolve('https://fixture.invalid/new-stream'); await newPlay;
           assert.equal(recovery.pageStack.pushed.length, 1);
           recovery.handleDetailHidden();
@@ -1608,13 +1613,13 @@ async function runHostIntegrationChecks() {
           assert.equal(model.revisionListeners.size, 0);
           assert.equal(model.searchListeners.size, 0);
           recovery.handleDetailShown(); await flushMicrotasks();
-          assert.equal(recovery.error, '', 'normal player return reloads');
+          assert.equal(recovery.error, '', '正常从播放器返回时重新加载');
           assert.equal(model.revisionListeners.size, 1);
         }
         page.aboutToDisappear(); recovery.aboutToDisappear();
         assert.equal(model.revisionListeners.size, 0);
         assert.equal(model.searchListeners.size, 0);
-        console.log(`Loaded revision real ${operation}/failure=${fail}/oldReject=${rejectOld}: PASS`);
+        console.log(`已加载版本真实操作 ${operation}/失败=${fail}/旧请求拒绝=${rejectOld}：通过`);
       }
     }
   }
@@ -1652,7 +1657,7 @@ async function runHostIntegrationChecks() {
         assert.equal(pushed, navigation === 'hidden' ? 0 : 1);
         assert.equal(page.isPlaying, false);
         assert.equal(page.videoServerModel.listeners.size, 0);
-        // The actual onHidden may follow a push; repeated hiding is safe.
+        // 实际 onHidden 可能在路由跳转后触发，重复隐藏仍应安全。
         page.handleDetailHidden();
         page.handleDetailShown();
         await flushMicrotasks();
@@ -1665,7 +1670,7 @@ async function runHostIntegrationChecks() {
         else stale.resolve(series ? null : 'https://stream/stale');
         await oldPlay;
         assert.equal(page.pageStack.pushed.length, pushed);
-        assert.equal(page.isPlaying, true, 'old finally must not release new play lock');
+        assert.equal(page.isPlaying, true, '旧清理回调不得释放新播放锁');
         assert.deepEqual(page.toastMessages, []);
         fresh.resolve(series ? null : 'https://stream/fresh');
         await newPlay;
@@ -1701,7 +1706,7 @@ async function runHostIntegrationChecks() {
     if (reject) stale.reject(new Error('late detail failure'));
     else stale.resolve(createDetailPayload('series'));
     await oldLoad;
-    assert.equal(page.isLoading, true, 'old detail finally must not release new load lock');
+    assert.equal(page.isLoading, true, '旧详情清理回调不得释放新加载锁');
     assert.equal(page.error, '');
     fresh.resolve(createDetailPayload('movie'));
     await flushMicrotasks();
@@ -1799,6 +1804,7 @@ async function runSearchChainChecks() {
         'scheduleSearch', 'executeServerSearch', 'serverErrorText']) {
         page[method] = loadMethod(sourceText, `private ${method}(`, [], dependencies);
       }
+      page.initializeRoute = loadMethod(sourceText, 'private initializeRoute(', ['param'], dependencies);
       page.executeSearch = loadMethod(sourceText, 'private async executeSearch(', [], dependencies, true);
       page.showToastSafe = loadMethod(sourceText, 'private showToastSafe(', ['message'], dependencies);
       page.openServerResultDetail = loadMethod(sourceText, 'private openServerResultDetail(', ['item'], dependencies);
@@ -1843,6 +1849,30 @@ async function runSearchChainChecks() {
       timers.restore();
     }
   }
+
+  await runCase('旧显式路由不得覆盖顶部实时来源', async h => {
+    await h.source.setVideoServer(h.servers[1]);
+    h.enqueue('当前来源 B');
+    h.page.initializeRoute({ scope: { kind: 'videoServer', serverId: 1, serverType: 'jellyfin' }, keyword: '路由词' });
+    h.check('初始化保留路由关键词', h.page.searchText, '路由词');
+    h.check('初始化采用当前 B 而非路由 A', h.page.scope.serverId, 2);
+    await h.tick();
+    const oldCard = h.success('当前来源 B', 2);
+    h.check('仅向当前来源发送路由关键词', h.searches, [{ host: 'chain-2.invalid', keyword: '路由词' }]);
+    h.page.leaveSearch();
+    await h.source.setVideoServer(h.servers[0]);
+    h.enqueue('返回后的来源 A');
+    h.page.resumeSearch();
+    h.check('返回后跟随实时 A', h.page.scope.serverId, 1);
+    h.page.openServerResultDetail(oldCard);
+    h.check('旧 B 卡片不得打开详情', h.pushes, []);
+    h.check('旧卡片触发身份变化提示', h.toasts.length, 1);
+    await h.tick();
+    h.success('返回后的来源 A');
+    h.check('返回后只新增 A 请求且保留关键词', h.searches, [
+      { host: 'chain-2.invalid', keyword: '路由词' }, { host: 'chain-1.invalid', keyword: '路由词' }
+    ]);
+  });
 
   await runCase('delete-success-return-same-word', async h => {
     h.enqueue('before deletion');

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -27,6 +27,7 @@ Module._load = function (request, parent, main) {
     return { default: { getAbilityDelegator: () => ({ getAppContext: () => ({}) }) } };
   }
   if (request === '@ohos.data.preferences') return {};
+  if (request === '@ohos.net.http') return {}; // Search tests stub only the native transport boundary.
   // Host-only database boundary; execute the real VideoServerModel deletion/cache logic.
   if (request === '../../db/files/FileSourceDatabase' && parent &&
     parent.filename.endsWith('/stores/servers/VideoServerModel.ets')) {
@@ -64,6 +65,9 @@ const Core = require(path.join(hypium, 'core.js')).default;
 const core = Core.getInstance();
 core.init();
 require(path.join(root, 'entry/src/test/SearchScope.test.ets')).default();
+if (process.argv.includes('--server-search')) {
+  require(path.join(root, 'entry/src/test/VideoServerSearch.test.ets')).default();
+}
 if (process.argv.includes('--integration')) {
   require(path.join(root, 'entry/src/test/SourceSwitchModel.test.ets')).default();
   require('./search_scope_deletion_test.cjs')();

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -31,7 +31,7 @@ Module._load = function (request, parent, main) {
   // Host-only database boundary; execute the real VideoServerModel deletion/cache logic.
   if (request === '../../db/files/FileSourceDatabase' && parent &&
     parent.filename.endsWith('/stores/servers/VideoServerModel.ets')) {
-    return { FileSourceDatabase: { getInstance: () => ({ deleteVideoServer: async () => {} }) } };
+    return { FileSourceDatabase: { getInstance: () => ({ deleteVideoServer: async () => {}, updateVideoServer: async () => {} }) } };
   }
   return load.call(this, request, parent, main);
 };
@@ -59,7 +59,15 @@ if (process.argv.includes('--integration')) {
     assert.ok(source.includes('resolveSearchRoute(param, SourceSwitchModel.getState().getSearchScope(servers), servers)'));
     assert.ok(source.includes('searchScope: this.scope'));
   }
-  console.log('Static routing/side-effect guards: passed');
+  const page = fs.readFileSync(path.join(root, workspace), 'utf8');
+  assert.ok(page.includes('TextInput({ text: this.searchText'));
+  assert.ok(page.includes('subscribeSearchSource(() => this.refreshSource())'));
+  assert.ok(page.includes('subscribeSearchConfiguration(() => this.refreshSource())'));
+  assert.ok(page.includes('.onWillHide(() => { this.leaveSearch(); })'));
+  const preview = page.slice(page.indexOf('  buildServerResults()'), page.indexOf('  build() {\n    NavDestination()'));
+  assert.ok(!preview.includes('onClick') && !preview.includes('navigateToDetail'));
+  assert.ok(preview.includes('.focusable(false)'));
+  console.log('Static routing/side-effect/input/lifecycle guards: passed');
 }
 const Core = require(path.join(hypium, 'core.js')).default;
 const core = Core.getInstance();
@@ -67,6 +75,7 @@ core.init();
 require(path.join(root, 'entry/src/test/SearchScope.test.ets')).default();
 if (process.argv.includes('--server-search')) {
   require(path.join(root, 'entry/src/test/VideoServerSearch.test.ets')).default();
+  require(path.join(root, 'entry/src/test/SearchWorkspaceSession.test.ets')).default();
 }
 if (process.argv.includes('--integration')) {
   require(path.join(root, 'entry/src/test/SourceSwitchModel.test.ets')).default();


### PR DESCRIPTION
## 背景
服务器来源下的搜索需要遵循当前具体实例的能力与身份，避免回退本地搜索，或在切源、删除配置、页面隐藏后把旧结果及播放地址带入新上下文。本 PR 接入 Jellyfin、Emby、Plex 搜索和服务器详情路由，并补充异步隔离与自动回归。

Fixes: #316

## 实现方案
- 按当前来源选择本地或单服务器搜索，通过统一搜索服务适配三协议，保留具体实例、媒体类型与媒体 ID。
- 使用独立搜索会话、请求代次和来源快照隔离旧响应，处理搜索防抖、错误、重试及页面离开/返回。
- 搜索卡片进入对应服务器详情；详情请求与播放跨 await 检查生命周期、实例身份和配置修订。真实更新/删除进入 DB pending 即使旧请求失效，写失败不恢复旧播放。
- 冷缓存正常初始化自动且仅请求一次详情；保持配置变更、删除、隐藏及迟到请求的隔离。
- 复用已合并 #315 的来源契约。最后的 main 同步仅补合并拓扑，源码树完全不变。

## 支持范围与限制
- 三协议电影、剧集及季集支持差异详见 `.plans/plan-serverSearchSupportMatrix.md`；episode 搜索结果进入所属 series 详情，不承诺直接定位或播放该集。
- 搜索仅返回最多 100 项首批结果，不提供 total/hasMore 或完整分页承诺；不承诺服务器拼音搜索能力。
- 自动测试使用真实生产方法与 DB、HTTP、导航、时钟等边界替身，不等同真实 HTTP、ArkUI 渲染或电视遥控器验收。

## 验证
- 独立 QA: `search_scope_test.cjs --server-search --integration` 59/59；`--integration` 23/23。两组存在重叠，不累计为独立案例总数。
- 页面串联三组共 85 项断言通过: 非空搜索后真实删除与返回同词搜索；transport 失败/恢复及旧响应隔离；详情返回恰好一次重搜及同协议 A/B 相同 mediaId 隔离。假时钟实际执行 debounce 回调。
- 前序独立 QA 还验证默认 runner 8/8、`--server-search` 44/44，以及 `node --check`、`git diff --check`。
- 执行 `devecocli build clean` 后实际编译，日志包含 `CompileArkTS` 和 `BUILD SUCCESSFUL`，不是仅缓存构建。实际安装 ETS SDK 为 API24 / 6.1.1.115 Beta1，此证据不代表 API22 验证通过。
- 零源码同步前后 904 个 tracked 文件 hash 一致；最终 tree 为 `d8d5c221ad160d8770648e4be894b9f9c06fd3f1`。

## 未关闭的验收缺口
- API22 基线验证及整体 lint/format 仍未通过验收。CodeLinter 的既有 SDK/分析器问题与 formatter 共享 IDE 单实例限制已记录，未通过更改 SDK 或关闭 IDE 绕过。
- #316 三协议授权真实实例、样本、真实 HTTP 与 TV 操作窗口尚未确认，未进行实例探测或 TV 部署。#315 的模拟器/真机验收不能推广为 #316 通过。
- 离页后无 timer 的断言不能单独证明监听器已退订；此局限已披露，不据此判定业务缺陷。
- 本 PR 创建用于代码审查，不表示 #316 完整 DoD 或 OpenSpec 2.5 已验收。正文按请求包含关闭引用，合并前需由维护者确认剩余验收及 Issue 关闭时机。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持在当前 Jellyfin、Plex 服务器中搜索电影、剧集和单集。
  - 搜索结果最多显示 100 项，并支持从结果进入详情页。
  - 搜索页面新增加载中、无结果、错误和重试状态。
  - 支持本地来源与服务器来源切换。

- **问题修复**
  - 优化服务器切换、配置变更及重复请求时的结果隔离，避免显示过期内容。
  - 改善认证失败、网络异常和无效响应时的错误提示与恢复体验。

- **文档**
  - 新增服务器搜索支持范围及验收边界说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->