### PR TITLE
优化: 为我的媒体库缺失缩略图添加分类占位图

### DIFF
--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -635,30 +635,28 @@ struct ServerLibraryCard {
   @Event onItemClick: () => void = () => {}
   @Local isHovered: boolean = false
 
+  private getPlaceholder(): Resource {
+    return this.library.type === 'tvshows'
+      ? $r('app.media.library_placeholder_tv')
+      : $r('app.media.library_placeholder_movie')
+  }
+
   build() {
-    Stack({ alignContent: Alignment.Center }) {
-      if (this.library.imageUrl.length > 0) {
-        Image(this.library.imageUrl)
-          .width(SERVER_WIDE_WIDTH)
-          .aspectRatio(LANDSCAPE_ASPECT_RATIO)
-          .objectFit(ImageFit.Cover)
-      } else {
-        Column() {
-          Text(this.library.name)
-            .fontSize(18).fontWeight(FontWeight.Bold)
-            .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
-            .width(SERVER_WIDE_WIDTH - 40)
-        }
+    Column({ space: 8 }) {
+      Image(this.library.imageUrl.length > 0 ? this.library.imageUrl : this.getPlaceholder())
+        .alt(this.getPlaceholder())
         .width(SERVER_WIDE_WIDTH)
         .aspectRatio(LANDSCAPE_ASPECT_RATIO)
-        .backgroundColor('#1C1C1C')
-        .justifyContent(FlexAlign.Center)
-        .alignItems(HorizontalAlign.Center)
-      }
+        .objectFit(ImageFit.Cover)
+        .borderRadius(6).clip(true)
+        .border({ width: 2, color: this.isHovered ? 'rgba(255,255,255,0.38)' : '#00FFFFFF' })
+
+      Text(this.library.name)
+        .fontSize(18).fontColor('#CCCCCC')
+        .maxLines(1).textOverflow({ overflow: TextOverflow.Ellipsis })
+        .width(SERVER_WIDE_WIDTH).textAlign(TextAlign.Center)
     }
-    .width(SERVER_WIDE_WIDTH).aspectRatio(LANDSCAPE_ASPECT_RATIO)
-    .borderRadius(6).clip(true)
-    .border({ width: 2, color: this.isHovered ? 'rgba(255,255,255,0.38)' : '#00FFFFFF' })
+    .width(SERVER_WIDE_WIDTH)
     .onHover((isHover: boolean) => { this.isHovered = isHover })
     .focusable(true)
     .onClick(() => { this.onItemClick() })

--- a/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
+++ b/entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets
@@ -634,6 +634,34 @@ struct ServerLibraryCard {
   @Require @Param library: VideoServerLibrary
   @Event onItemClick: () => void = () => {}
   @Local isHovered: boolean = false
+  @Local imageFailed: boolean = false
+
+  @Monitor('library')
+  private resetImageFailure(): void {
+    this.imageFailed = false
+  }
+
+  private onImageError(): void {
+    this.imageFailed = true
+  }
+
+  private shouldLoadThumbnail(): boolean {
+    return this.library.imageUrl.length > 0 && !this.imageFailed
+  }
+
+  @Builder
+  private LibraryImage() {
+    if (this.shouldLoadThumbnail()) {
+      Image(this.library.imageUrl)
+        .width('100%').height('100%').objectFit(ImageFit.Cover)
+        .alt(this.getPlaceholder())
+        .onError(() => { this.onImageError() })
+        .onComplete(() => { this.resetImageFailure() })
+    } else {
+      Image(this.getPlaceholder())
+        .width('100%').height('100%').objectFit(ImageFit.Cover)
+    }
+  }
 
   private getPlaceholder(): Resource {
     return this.library.type === 'tvshows'
@@ -643,11 +671,11 @@ struct ServerLibraryCard {
 
   build() {
     Column({ space: 8 }) {
-      Image(this.library.imageUrl.length > 0 ? this.library.imageUrl : this.getPlaceholder())
-        .alt(this.getPlaceholder())
+      Stack() {
+        this.LibraryImage()
+      }
         .width(SERVER_WIDE_WIDTH)
         .aspectRatio(LANDSCAPE_ASPECT_RATIO)
-        .objectFit(ImageFit.Cover)
         .borderRadius(6).clip(true)
         .border({ width: 2, color: this.isHovered ? 'rgba(255,255,255,0.38)' : '#00FFFFFF' })
 

--- a/entry/src/main/resources/base/media/library_placeholder_movie.svg
+++ b/entry/src/main/resources/base/media/library_placeholder_movie.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180">
+  <path fill="#66B4D6" d="M0 0h320v180H0z"/>
+  <path fill="#E1F2F8" d="M136 65h-1a5 5 0 0 0-5 5v38a5 5 0 0 0 5 5h50a5 5 0 0 0 5-5V65h-12l6 12h-9l-6-12h-9l6 12h-9l-6-12h-9l6 12h-9z"/>
+</svg>

--- a/entry/src/main/resources/base/media/library_placeholder_tv.svg
+++ b/entry/src/main/resources/base/media/library_placeholder_tv.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180">
+  <path fill="#1B4357" d="M0 0h320v180H0z"/>
+  <rect x="130" y="65" width="60" height="42" rx="3" fill="none" stroke="#D2DFE5" stroke-width="6"/>
+  <path fill="#D2DFE5" d="M149 109h22v7h-22z"/>
+</svg>

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -2019,7 +2019,43 @@ function registerAndExecuteCore() {
   core.execute();
 }
 
-if (process.argv.includes('--search-chains')) {
+function runLibraryImageChecks() {
+  const assert = require('node:assert/strict');
+  const page = fs.readFileSync(path.join(root,
+    'entry/src/main/ets/pages/home/tabs/MediaLibraryTab.ets'), 'utf8');
+  const source = page.slice(page.indexOf('struct ServerLibraryCard {'),
+    page.indexOf('struct SectionRow {'));
+  const card = { library: { imageUrl: '', type: 'movies' }, imageFailed: false };
+  for (const name of ['resetImageFailure', 'onImageError', 'shouldLoadThumbnail', 'getPlaceholder']) {
+    card[name] = loadMethod(source, `private ${name}(`, [], { $r: (value) => value });
+  }
+  assert.equal(card.shouldLoadThumbnail(), false);
+  assert.equal(card.getPlaceholder(), 'app.media.library_placeholder_movie');
+  card.library.imageUrl = 'https://invalid.example/missing.jpg';
+  assert.equal(card.shouldLoadThumbnail(), true);
+  card.onImageError();
+  assert.equal(card.shouldLoadThumbnail(), false);
+  assert.equal(card.getPlaceholder(), 'app.media.library_placeholder_movie');
+  card.library = { imageUrl: 'https://example.test/new.jpg', type: 'tvshows' };
+  card.resetImageFailure();
+  assert.equal(card.shouldLoadThumbnail(), true);
+  card.onImageError();
+  assert.equal(card.getPlaceholder(), 'app.media.library_placeholder_tv');
+  assert.equal(card.shouldLoadThumbnail(), false);
+  card.resetImageFailure();
+  assert.equal(card.imageFailed, false);
+  assert.match(source, /@Monitor\('library'\)/);
+  assert.match(source, /\.onError\(\(\) => \{ this.onImageError\(\) \}\)/);
+  assert.match(source, /\.onComplete\(\(\) => \{ this.resetImageFailure\(\) \}\)/);
+  const fallback = source.slice(source.indexOf('} else {'), source.indexOf('private getPlaceholder'));
+  assert.match(fallback, /Image\(this.getPlaceholder\(\)\)/);
+  assert.doesNotMatch(fallback, /onComplete|onError/);
+  console.log('媒体库图片回退: 空地址、非空失效地址错误回调、分类占位、复用恢复及占位图无重试循环检查通过');
+}
+
+if (process.argv.includes('--library-images')) {
+  runLibraryImageChecks();
+} else if (process.argv.includes('--search-chains')) {
   runSearchChainChecks().catch((error) => {
     console.error(error);
     process.exitCode = 1;


### PR DESCRIPTION
## 背景
“我的媒体”列表在没有缩略图时仅显示文字，缺少直观的媒体类型标识。本次参考用户提供的 Jellyfin 默认显示样式，为缺图卡片补充本地占位资源。

## 实现
- 剧集库使用深蓝背景与电视图标，电影及其他库使用浅蓝背景与场记板图标。
- 图片地址为空或图片加载失败时显示本地 SVG 占位图。
- 库名称统一显示在图片下方，保留现有点击、焦点和悬停交互。

## 验证
- `git diff --check` 和两张 SVG 的 XML 解析通过。
- `devecocli run --module entry --product default --device 127.0.0.1:5557` 构建成功，并已安装、启动至 HarmonyOS API24 TV 模拟器供用户查看。
- 同步 main 后源码树及本地改动哈希不变，搜索回归 runner 成功退出。
- lint/format 沿用此前已核实的环境阻塞结论，未重复已穷尽的诊断，也不声明通过。

## 范围与限制
仅包含1个组件和2张 SVG 的增量修改。此前搜索及详情实现已通过 #322 合并，不重复纳入。构建仍有警告；未完成 API22、实体电视或自动视觉验收，未访问真实服务器。

Fixes: #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **界面优化**
  - 媒体库卡片统一显示默认图片，提升无封面时的视觉一致性。
  - 优化卡片圆角裁剪、边框及间距布局。
  - 媒体库名称独立展示，悬停、聚焦和点击交互保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->