### PR TITLE
优化: 搜索异步状态、遥控器焦点流与结果懒加载

### DIFF
--- a/docs/search-lifecycle.md
+++ b/docs/search-lifecycle.md
@@ -1,63 +1,56 @@
-# Search lifecycle and TV regression checks
+# 搜索生命周期与电视回归检查
 
-`SearchWorkspacePage` and `MediaResultPage` use `SearchSession<T>` for request
-ownership. The loader is a `() => Promise<T[]>` and contains all provider-specific
-work. 本地查询通过 FileSourceDatabase 显式传播失败；服务器搜索通过
+`SearchWorkspacePage` 和 `MediaResultPage` 使用 `SearchSession<T>` 管理请求归属。
+加载函数类型为 `() => Promise<T[]>`，封装所有数据源专属操作。
+本地查询通过 FileSourceDatabase 显式传播失败；服务器搜索通过
 SearchWorkspaceSession 校验来源、配置快照和请求代次。切换来源立即清空旧结果，
 不把旧关键词自动发送到新服务器；同来源刷新失败保留已接受的懒加载结果。
 本地请求有 15 秒生命周期超时，服务器错误由服务器搜索服务分类。
 
-## State transitions
+## 状态流转
 
-- Empty input / clear: `invalidate(true)` → `idle`, clearing results and timers.
-- Input intent: `prepare()` immediately increments the generation, then the
-  workspace debounces for 800 ms. History selection and retry cancel that timer
-  and execute immediately.
-- Request: `loading`, or `refreshing` while previous results remain visible.
-- Accepted success: `results` or `empty`; only accepted responses reload the grid.
-- Failure / 15-second timeout: `error`, with a generic visible message and a
-  focusable retry button. Provider exception text is never displayed. A timeout
-  invalidates the response; it does not cancel the underlying provider operation.
-- Navigation hide / disappearance / back: invalidate and cancel pending debounce.
-  Returning resumes a search interrupted by navigation, and restores the selected
-  result when returning from details.
+- 空输入或清空：`invalidate(true)` → `idle`，清空结果和定时器。
+- 输入意图变化：`prepare()` 立即递增代次，随后工作台执行 800 毫秒防抖。
+  选择历史或重试会取消防抖定时器并立即执行。
+- 请求开始：无旧结果时为 `loading`；保留旧结果时为 `refreshing`。
+- 接受成功响应：进入 `results` 或 `empty`；仅被接受的响应刷新网格。
+- 失败或 15 秒超时：进入 `error`，展示通用错误提示和可聚焦的重试按钮，
+  不展示数据源异常原文。超时使响应失效，并使 `run()` 返回 `false`，
+  但不会取消底层数据源操作；迟到成功被忽略，迟到异常被消费。
+- 输入变化、清空、来源切换或离页使请求失效时，也立即结束旧 `run()` 的等待，
+  返回 `false` 并清除其定时器；旧请求不能修改新代次的状态或定时器。
+- 导航隐藏、消失或返回：使请求失效并取消待执行防抖。
+  再次进入时恢复被导航中断的搜索，从详情返回时恢复选中结果。
 
-Results use fixed-height, six-column `Grid` + `LazyForEach`, with two cached rows,
-so offscreen posters are not all built at once. The existing 200-row query cap
-remains; this change does not add database pagination. The workspace exposes
-“浏览结果” and “返回输入”; Up from the first row returns to input. Back from a
-focused workspace result first returns to input; Back again leaves the page.
-工作台焦点 ID 使用结果索引，懒加载 key 包含来源身份。 The filtered result page restores the selected
-card and sends Up from the first row to the filter reset control.
+结果使用固定高度的六列 `Grid` + `LazyForEach`，缓存两行，避免一次创建所有屏外海报。
+保留现有 200 行查询上限，本次改动不引入数据库分页。工作台提供“浏览结果”和
+“返回输入”；首行按上返回输入区。结果聚焦时按返回先回到输入区，再按返回离页。
+工作台焦点 ID 使用结果索引，懒加载 key 包含来源身份。
+筛选结果页恢复选中卡片，首行按上转到重置筛选控件。
 
-## Automated validation
+## 自动化验证
 
-`entry/src/test/SearchSession.test.ets` is registered in `List.test.ets`. It covers
-intent-time invalidation, clear/source replacement/leave, late failures,
-refresh/error/empty/retry, and timeout followed by a late success.
+`entry/src/test/SearchSession.test.ets` 已在 `List.test.ets` 注册，覆盖输入意图即时失效、
+清空/来源替换/离页、迟到失败、刷新/错误/空结果/重试、超时后迟到成功，
+以及数据源始终未完成时释放等待、迟到拒绝被消费、旧超时不干扰重试。
 
-The same tests can run on the host:
+同一组测试可在主机执行：
 
 ```sh
 TYPESCRIPT_PATH=/path/to/typescript/lib/typescript.js node scripts/tests/search-session.cjs
 ```
 
-The host runner removes only ArkUI observation decorators and supplies Hypium
-assertions. It verifies the actual lifecycle logic, not ArkUI reactivity or focus.
-Run `devecocli build` for ArkTS compilation and `devecocli run --device <TV>` for
-runtime checks.
+主机执行器仅移除 ArkUI 观察装饰器并提供 Hypium 断言，验证真实生命周期逻辑，
+不验证 ArkUI 响应式行为或焦点。使用 `devecocli build` 检查 ArkTS 编译，
+使用 `devecocli run --device <TV>` 检查设备运行行为。
 
-## Device acceptance checklist
+## 真机验收清单
 
-- Rapidly type multiple queries, clear during a request, leave, and re-enter;
-  no old results may reappear.
-- Open a result, return, and verify the same card remains focused and visible.
-- Browse 200 results using D-pad; verify Up/Back escape routes and visible focus.
-- Inject provider rejection and a response delayed beyond 15 seconds; verify
-  generic error, retained previous results, and remote-control retry.
+- 快速连续输入多个关键词，请求中清空、离开后重新进入，旧结果不得重新出现。
+- 打开结果再返回，确认同一卡片保持聚焦且可见。
+- 使用方向键浏览 200 个结果，确认上键/返回键退出路径与焦点可见性。
+- 注入数据源拒绝与超过 15 秒的延迟响应，确认通用错误提示、旧结果保留及遥控器重试。
 - 执行 `entry/src/test/search_scope_test.cjs --integration`，覆盖服务器切换、配置变更、失败恢复与详情返回。
-- Measure first display and long-list scrolling on the target physical TV;
-  emulator startup and host tests do not establish device performance.
+- 在目标电视测量首次展示与长列表滚动；模拟器启动和主机测试不能证明真机性能。
 
-Physical-TV performance, device focus behavior, and human review remain release
-acceptance steps; no numerical performance claim is made by these tests.
+电视性能、设备焦点行为与人工评审仍属于发布验收步骤；本测试不声明数值性能结论。

--- a/docs/search-lifecycle.md
+++ b/docs/search-lifecycle.md
@@ -1,0 +1,63 @@
+# Search lifecycle and TV regression checks
+
+`SearchWorkspacePage` and `MediaResultPage` use `SearchSession<T>` for request
+ownership. The loader is a `() => Promise<T[]>` and contains all provider-specific
+work. The current pages query `FileSourceDatabase`; there is no server-search or
+source-picker integration in these pages yet. A future provider switch must call
+`prepare(true)` immediately, before starting or debouncing the new loader, to
+remove results belonging to the previous source.
+
+## State transitions
+
+- Empty input / clear: `invalidate(true)` → `idle`, clearing results and timers.
+- Input intent: `prepare()` immediately increments the generation, then the
+  workspace debounces for 800 ms. History selection and retry cancel that timer
+  and execute immediately.
+- Request: `loading`, or `refreshing` while previous results remain visible.
+- Accepted success: `results` or `empty`; only accepted responses reload the grid.
+- Failure / 15-second timeout: `error`, with a generic visible message and a
+  focusable retry button. Provider exception text is never displayed. A timeout
+  invalidates the response; it does not cancel the underlying provider operation.
+- Navigation hide / disappearance / back: invalidate and cancel pending debounce.
+  Returning resumes a search interrupted by navigation, and restores the selected
+  result when returning from details.
+
+Results use fixed-height, six-column `Grid` + `LazyForEach`, with two cached rows,
+so offscreen posters are not all built at once. The existing 200-row query cap
+remains; this change does not add database pagination. The workspace exposes
+“浏览结果” and “返回输入”; Up from the first row returns to input. Back from a
+focused workspace result first returns to input; Back again leaves the page.
+Result IDs are based on media IDs. The filtered result page restores the selected
+card and sends Up from the first row to the filter reset control.
+
+## Automated validation
+
+`entry/src/test/SearchSession.test.ets` is registered in `List.test.ets`. It covers
+intent-time invalidation, clear/source replacement/leave, late failures,
+refresh/error/empty/retry, and timeout followed by a late success.
+
+The same tests can run on the host:
+
+```sh
+TYPESCRIPT_PATH=/path/to/typescript/lib/typescript.js node scripts/tests/search-session.cjs
+```
+
+The host runner removes only ArkUI observation decorators and supplies Hypium
+assertions. It verifies the actual lifecycle logic, not ArkUI reactivity or focus.
+Run `devecocli build` for ArkTS compilation and `devecocli run --device <TV>` for
+runtime checks.
+
+## Device acceptance checklist
+
+- Rapidly type multiple queries, clear during a request, leave, and re-enter;
+  no old results may reappear.
+- Open a result, return, and verify the same card remains focused and visible.
+- Browse 200 results using D-pad; verify Up/Back escape routes and visible focus.
+- Inject provider rejection and a response delayed beyond 15 seconds; verify
+  generic error, retained previous results, and remote-control retry.
+- Repeat the lifecycle suite with a server loader when server search is wired in.
+- Measure first display and long-list scrolling on the target physical TV;
+  emulator startup and host tests do not establish device performance.
+
+Physical-TV performance, server integration, and human review remain release
+acceptance steps; no numerical performance claim is made by these tests.

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -491,8 +491,8 @@ export class FileSourceDatabase {
     return this.mediaQueryDao.getRecentlyAddedList(limit);
   }
 
-  async searchMediaItems(keyword: string, options?: SearchMediaOptions): Promise<MediaItem[]> {
-    return this.mediaQueryDao.searchMediaItems(keyword, options);
+  async searchMediaItems(keyword: string, options?: SearchMediaOptions, propagateErrors: boolean = false): Promise<MediaItem[]> {
+    return this.mediaQueryDao.searchMediaItems(keyword, options, propagateErrors);
   }
 
   async getDistinctGenres(): Promise<string[]> {

--- a/entry/src/main/ets/db/files/MediaQueryDao.ets
+++ b/entry/src/main/ets/db/files/MediaQueryDao.ets
@@ -11,6 +11,22 @@ import {
 import { FileSourceDbCore } from './FileSourceDbCore';
 import { countSeriesEpisodeRows } from './SeriesGroupCountUtil';
 
+/** 搜索模块自定义兜底码，不属于 HarmonyOS 平台错误码。 */
+export enum MediaSearchErrorCode {
+  DatabaseNotReady = -1,
+  QueryFailed = -2
+}
+
+export class MediaSearchError extends Error implements BusinessError {
+  code: number;
+
+  constructor(code: number, message: string) {
+    super(message);
+    this.name = 'MediaSearchError';
+    this.code = code;
+  }
+}
+
 /**
  * 媒体库聚合查询、搜索与流派查询。
  * 拆分自 FileSourceDatabase，保持原方法签名与行为不变。
@@ -918,7 +934,9 @@ export class MediaQueryDao {
    */
   async searchMediaItems(keyword: string, options?: SearchMediaOptions, propagateErrors: boolean = false): Promise<MediaItem[]> {
     if (!this.core.isReady()) {
-      if (propagateErrors) { throw new Error('搜索数据库尚未就绪'); }
+      if (propagateErrors) {
+        throw new MediaSearchError(MediaSearchErrorCode.DatabaseNotReady, '搜索数据库尚未就绪');
+      }
       return [];
     }
     const store = this.core.getStore();
@@ -1121,7 +1139,9 @@ export class MediaQueryDao {
     } catch (e) {
       const err = e as BusinessError;
       console.error(`[DB][searchMediaItems] 异常 code=${err.code} msg=${err.message}`);
-      if (propagateErrors) { throw new Error('搜索数据库查询失败'); }
+      if (propagateErrors) {
+        throw new MediaSearchError(err.code ?? MediaSearchErrorCode.QueryFailed, '搜索数据库查询失败');
+      }
       return [];
     } finally {
       try { rs?.close(); } catch { }

--- a/entry/src/main/ets/db/files/MediaQueryDao.ets
+++ b/entry/src/main/ets/db/files/MediaQueryDao.ets
@@ -916,8 +916,9 @@ export class MediaQueryDao {
    * @param keyword  搜索关键词（标题 / 原始标题模糊匹配）
    * @param options  可选筛选与排序参数，缺省值见各字段注释
    */
-  async searchMediaItems(keyword: string, options?: SearchMediaOptions): Promise<MediaItem[]> {
+  async searchMediaItems(keyword: string, options?: SearchMediaOptions, propagateErrors: boolean = false): Promise<MediaItem[]> {
     if (!this.core.isReady()) {
+      if (propagateErrors) { throw new Error('搜索数据库尚未就绪'); }
       return [];
     }
     const store = this.core.getStore();
@@ -1120,6 +1121,7 @@ export class MediaQueryDao {
     } catch (e) {
       const err = e as BusinessError;
       console.error(`[DB][searchMediaItems] 异常 code=${err.code} msg=${err.message}`);
+      if (propagateErrors) { throw new Error('搜索数据库查询失败'); }
       return [];
     } finally {
       try { rs?.close(); } catch { }

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -359,7 +359,7 @@ export struct MediaResultPage {
         originCountry: this.filterRegion.length > 0 ? this.filterRegion : undefined,
       };
 
-      return this.db.searchMediaItems(this.keyword, options);
+      return this.db.searchMediaItems(this.keyword, options, true);
     });
     if (!accepted) { return; }
     this.resultSource.replace(this.session.results);

--- a/entry/src/main/ets/pages/search/MediaResultPage.ets
+++ b/entry/src/main/ets/pages/search/MediaResultPage.ets
@@ -1,3 +1,6 @@
+import { KeyCode } from '@kit.InputKit';
+import { SearchSession } from '../../services/search/SearchSession';
+import { SearchResultSource } from './SearchResultSource';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 import { MediaItem, SeriesGroup, SearchMediaOptions } from '../../db/models/MediaEntity';
 import { MovieDetailPage } from '../detail/MovieDetailPage';
@@ -156,10 +159,13 @@ function scoreText(r: number | undefined): string {
 @ComponentV2
 struct ResultPosterCard {
   @Require @Param item: MediaItem;
+  @Event onFocused: () => void = () => {};
+  @Event onOpen: () => void = () => {};
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
   @Local isFocused: boolean = false;
 
   private navigateToDetail(): void {
+    this.onOpen();
     if (this.item.tvSeriesId !== undefined) {
       const group: SeriesGroup = {
         title: itemTitle(this.item),
@@ -233,7 +239,8 @@ struct ResultPosterCard {
     .width(180)
     .alignItems(HorizontalAlign.Start)
     .focusable(true)
-    .onFocus(() => { this.isFocused = true; })
+    .id('media_result_' + this.item.id)
+    .onFocus(() => { this.isFocused = true; this.onFocused(); })
     .onBlur(() => { this.isFocused = false; })
     .onClick(() => { this.navigateToDetail(); })
   }
@@ -293,13 +300,17 @@ export struct MediaResultPage {
   @Local genreOptions: string[] = [];      // 从库中动态加载
 
   // ── Data state ────────────────────────────────────────────────────────────
-  @Local results: MediaItem[] = [];
-  @Local isLoading: boolean = false;
+  @Local session: SearchSession<MediaItem> = new SearchSession<MediaItem>();
+  private resultSource: SearchResultSource = new SearchResultSource();
+  private resultScroller: Scroller = new Scroller();
+  private focusedResult: number = 0;
+  private restoreResult: boolean = false;
+  private needsRefresh: boolean = false;
   @Local totalCount: number = 0;
 
   private db: FileSourceDatabase = FileSourceDatabase.getInstance();
   // 竞态保护：每次发起新请求时递增，回调中比对版本号，过期则丢弃
-  private searchGeneration: number = 0;
+  private genreGeneration: number = 0;
   // 路由初始参数，用于 resetAll() 恢复入口语义
   private initialMediaType: string = '';
   private initialGenre: string = '';
@@ -312,22 +323,11 @@ export struct MediaResultPage {
     return undefined;
   }
 
-  /** 计算 Grid 高度，用于 Scroll 内 Grid 无法使用 layoutWeight 时的替代方案 */
-  private calcGridHeight(): number {
-    if (this.results.length === 0) { return 300; }
-    const cols = 6;
-    const rows = Math.ceil(this.results.length / cols);
-    // ResultPosterCard: poster(270) + space(8) + title(~26) + score(~26) ≈ 330
-    // rowsGap: 30
-    return rows * (330 + 30) + 60;
-  }
-
   // ── Data operations ───────────────────────────────────────────────────────
 
   private async doSearch(): Promise<void> {
-    const generation = ++this.searchGeneration;
-    this.isLoading = true;
-    try {
+    this.needsRefresh = false;
+    const accepted = await this.session.run(async (): Promise<MediaItem[]> => {
       let mt: 'movie' | 'tv' | 'all' | undefined = undefined;
       if (this.filterMediaType === 'movie') { mt = 'movie'; }
       else if (this.filterMediaType === 'tv') { mt = 'tv'; }
@@ -359,29 +359,28 @@ export struct MediaResultPage {
         originCountry: this.filterRegion.length > 0 ? this.filterRegion : undefined,
       };
 
-      const items: MediaItem[] = await this.db.searchMediaItems(this.keyword, options);
-      if (generation !== this.searchGeneration) { return; } // 丢弃过期结果
-      this.results = items;
-      this.totalCount = items.length;
-    } catch {
-      if (generation !== this.searchGeneration) { return; }
-      this.results = [];
-      this.totalCount = 0;
-    } finally {
-      if (generation === this.searchGeneration) {
-        this.isLoading = false;
-      }
-    }
+      return this.db.searchMediaItems(this.keyword, options);
+    });
+    if (!accepted) { return; }
+    this.resultSource.replace(this.session.results);
+    this.totalCount = this.session.results.length;
+  }
+
+  aboutToDisappear(): void {
+    this.needsRefresh = this.needsRefresh || this.session.status === 'loading' || this.session.status === 'refreshing';
+    this.session.invalidate();
+    this.genreGeneration++;
   }
 
   // ── Filter option getters ─────────────────────────────────────────────────
 
   private async loadGenreOptions(): Promise<void> {
+    const generation = ++this.genreGeneration;
     let mt: 'movie' | 'tv' | undefined = undefined;
     if (this.filterMediaType === 'movie') { mt = 'movie'; }
     else if (this.filterMediaType === 'tv') { mt = 'tv'; }
     const names = await this.db.getDistinctGenreNames(mt);
-    this.genreOptions = names;
+    if (generation === this.genreGeneration) { this.genreOptions = names; }
   }
 
   private getGenreList(): string[] {
@@ -473,6 +472,7 @@ export struct MediaResultPage {
         .backgroundColor(C_ORANGE)
         .borderRadius(8)
         .focusable(true)
+        .id('media_filters')
         .onClick(() => { this.resetAll(); })
     }
     .width('100%')
@@ -718,39 +718,56 @@ export struct MediaResultPage {
 
   @Builder
   buildResultGrid() {
-    if (this.isLoading) {
+    if (this.session.status === 'loading' || this.session.status === 'refreshing') {
       Column() {
-        Text('\u52A0\u8F7D\u4E2D\u2026')
+        Text(this.session.status === 'refreshing' ? '正在更新，以下为上次结果…' : '正在搜索…')
           .fontSize(18)
           .fontColor(C_SECONDARY)
       }
       .width('100%')
-      .height(300)
+      .height(60)
       .justifyContent(FlexAlign.Center)
       .alignItems(HorizontalAlign.Center)
-    } else if (this.results.length === 0) {
+    } else if (this.session.status === 'error') {
+      Column({ space: 12 }) {
+        Text('搜索失败，请检查连接后重试。').fontSize(18).fontColor(C_TEXT_BODY)
+        Button('重试').onClick(() => { this.doSearch(); })
+      }
+    } else if (this.session.status === 'empty') {
       Column() {
         Text('\u6682\u65E0\u7ED3\u679C')
           .fontSize(18)
           .fontColor(C_SECONDARY)
       }
       .width('100%')
-      .height(300)
+      .height(60)
       .justifyContent(FlexAlign.Center)
       .alignItems(HorizontalAlign.Center)
-    } else {
-      Grid() {
-        ForEach(this.results, (item: MediaItem) => {
+    }
+    if (this.session.results.length > 0) {
+      Grid(this.resultScroller) {
+        LazyForEach(this.resultSource, (item: MediaItem, index: number) => {
           GridItem() {
-            ResultPosterCard({ item: item })
+            ResultPosterCard({
+              item: item,
+              onFocused: () => { this.focusedResult = index; },
+              onOpen: () => { this.restoreResult = true; this.aboutToDisappear(); }
+            })
           }
+          .onKeyEvent((event: KeyEvent) => {
+            if (event.type === KeyType.Down && event.keyCode === KeyCode.KEYCODE_DPAD_UP && index < 6) {
+              this.getUIContext().getFocusController().requestFocus('media_filters');
+              event.stopPropagation();
+            }
+          })
         }, (item: MediaItem) => String(item.id))
       }
       .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr')
       .columnsGap(30)
       .rowsGap(30)
       .width('100%')
-      .height(this.calcGridHeight())
+      .height(400)
+      .cachedCount(2)
       .nestedScroll({ scrollForward: NestedScrollMode.PARENT_FIRST, scrollBackward: NestedScrollMode.SELF_FIRST })
     }
   }
@@ -795,8 +812,19 @@ export struct MediaResultPage {
       this.loadGenreOptions().catch((): void => {});
       this.doSearch().catch((): void => {});
     })
+    .onHidden(() => { this.aboutToDisappear(); })
+    .onShown(() => {
+      if (this.restoreResult && this.session.results.length > 0) {
+        this.restoreResult = false;
+        this.focusedResult = Math.min(this.focusedResult, this.session.results.length - 1);
+        this.resultScroller.scrollToIndex(this.focusedResult);
+        this.getUIContext().getFocusController().requestFocus('media_result_' + this.session.results[this.focusedResult].id);
+      }
+      if (this.needsRefresh || this.session.status === 'idle') { this.doSearch(); }
+    })
     .hideTitleBar(true)
     .onBackPressed(() => {
+      this.aboutToDisappear();
       this.pageStack.pop();
       return true;
     })

--- a/entry/src/main/ets/pages/search/SearchResultSource.ets
+++ b/entry/src/main/ets/pages/search/SearchResultSource.ets
@@ -1,11 +1,15 @@
 /** 懒加载网格适配器；仅在搜索响应被接受后原子替换结果。 */
+@ObservedV2
 export class SearchResultSource<T> implements IDataSource {
   private items: T[] = [];
+  // 父级条件渲染必须在 LazyForEach 尚未注册监听器时也能收到数量变化。
+  @Trace private count: number = 0;
   private listeners: DataChangeListener[] = [];
-  totalCount(): number { return this.items.length; }
+  totalCount(): number { return this.count; }
   getData(index: number): T { return this.items[index]; }
   replace(items: T[]): void {
     this.items = items;
+    this.count = items.length;
     this.listeners.forEach((listener: DataChangeListener) => listener.onDataReloaded());
   }
   registerDataChangeListener(listener: DataChangeListener): void {

--- a/entry/src/main/ets/pages/search/SearchResultSource.ets
+++ b/entry/src/main/ets/pages/search/SearchResultSource.ets
@@ -1,0 +1,20 @@
+import { MediaItem } from '../../db/models/MediaEntity';
+
+/** Lazy grid adapter. Replace atomically after an accepted search response. */
+export class SearchResultSource implements IDataSource {
+  private items: MediaItem[] = [];
+  private listeners: DataChangeListener[] = [];
+  totalCount(): number { return this.items.length; }
+  getData(index: number): MediaItem { return this.items[index]; }
+  replace(items: MediaItem[]): void {
+    this.items = items;
+    this.listeners.forEach((listener: DataChangeListener) => listener.onDataReloaded());
+  }
+  registerDataChangeListener(listener: DataChangeListener): void {
+    if (this.listeners.indexOf(listener) < 0) { this.listeners.push(listener); }
+  }
+  unregisterDataChangeListener(listener: DataChangeListener): void {
+    const index = this.listeners.indexOf(listener);
+    if (index >= 0) { this.listeners.splice(index, 1); }
+  }
+}

--- a/entry/src/main/ets/pages/search/SearchResultSource.ets
+++ b/entry/src/main/ets/pages/search/SearchResultSource.ets
@@ -1,4 +1,4 @@
-/** Lazy grid adapter. Replace atomically after an accepted search response. */
+/** 懒加载网格适配器；仅在搜索响应被接受后原子替换结果。 */
 export class SearchResultSource<T> implements IDataSource {
   private items: T[] = [];
   private listeners: DataChangeListener[] = [];

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -365,6 +365,7 @@ struct SearchWorkspacePage {
   private pageActive: boolean = false;
   private sourceBound: boolean = false;
   private inputController: TextInputController = new TextInputController();
+  // 返回层级只记录用户主动编辑；程序获焦也可能异步上报 onEditChange(true)。
   private isEditing: boolean = false;
   private resultsFocused: boolean = false;
   private db: FileSourceDatabase | null = null;
@@ -443,25 +444,33 @@ struct SearchWorkspacePage {
   }
 
   private focusInput(): void {
-    this.inputController.stopEditing();
     this.isEditing = false;
+    this.inputController.stopEditing();
     this.resultsFocused = false;
     this.getUIContext().getFocusController().requestFocus('search-workspace-input');
   }
 
   private handleBack(): boolean {
-    if (this.isEditing || this.resultsFocused) {
+    if (this.resultsFocused) {
+      console.info('[SearchWorkspace] back: results -> input');
       this.focusInput();
       return true;
     }
+    if (this.isEditing) {
+      console.info('[SearchWorkspace] back: editing -> input');
+      this.isEditing = false;
+      this.inputController.stopEditing();
+      return true;
+    }
+    console.info('[SearchWorkspace] back: leave');
     this.leaveSearch();
     this.pageStack.pop();
     return true;
   }
 
   private leaveSearch(): void {
-    this.inputController.stopEditing();
     this.isEditing = false;
+    this.inputController.stopEditing();
     this.resultsFocused = false;
     this.pageActive = false;
     this.invalidateSearch(true);
@@ -763,9 +772,22 @@ struct SearchWorkspacePage {
         .backgroundColor(Color.Transparent)
         .layoutWeight(1)
         .defaultFocus(true)
-        .onEditChange((editing: boolean) => { this.isEditing = editing; })
+        .onEditChange((editing: boolean) => {
+          console.info(`[SearchWorkspace] edit callback=${editing}, userEditing=${this.isEditing}`);
+          // true 也可能来自 requestFocus / IME 延迟绑定，不能据此新增返回层级。
+          if (!editing) { this.isEditing = false; }
+        })
+        .onClick(() => { this.isEditing = true; })
+        .onKeyEvent((event: KeyEvent) => {
+          if (event.type === KeyType.Down &&
+            (event.keyCode === KeyCode.KEYCODE_DPAD_CENTER || event.keyCode === KeyCode.KEYCODE_ENTER)) {
+            this.isEditing = true;
+          }
+        })
+        .onBlur(() => { this.isEditing = false; })
         .onFocus(() => { this.resultsFocused = false; })
         .onChange((value: string) => {
+          this.isEditing = true;
           this.searchText = value;
           this.scheduleSearch();
         })
@@ -1005,8 +1027,8 @@ struct SearchWorkspacePage {
 
   private focusResults(): void {
     if (this.resultSource.totalCount() === 0) { return; }
-    this.inputController.stopEditing();
     this.isEditing = false;
+    this.inputController.stopEditing();
     this.resultsFocused = true;
     this.focusedResult = Math.min(this.focusedResult, this.resultSource.totalCount() - 1);
     this.resultScroller.scrollToIndex(this.focusedResult);

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -1,3 +1,5 @@
+import { SearchSession } from '../../services/search/SearchSession';
+import { SearchResultSource } from './SearchResultSource';
 import { MediaItem, SearchHistoryEntry, SeriesGroup } from '../../db/models/MediaEntity';
 import { FileSourceDatabase } from '../../db/files/FileSourceDatabase';
 
@@ -253,6 +255,9 @@ struct ActionKey {
 @ComponentV2
 struct WorkspacePosterCard {
   @Require @Param item: MediaItem;
+  @Param focusId: string = '';
+  @Event onFocused: () => void = () => {};
+  @Event onBlurred: () => void = () => {};
   @Event onPress: () => void = () => {};
   @Local isFocused: boolean = false;
 
@@ -307,9 +312,10 @@ struct WorkspacePosterCard {
     }
     .width(180)
     .alignItems(HorizontalAlign.Start)
+    .id(this.focusId)
     .focusable(true)
-    .onFocus(() => { this.isFocused = true; })
-    .onBlur(() => { this.isFocused = false; })
+    .onFocus(() => { this.isFocused = true; this.onFocused(); })
+    .onBlur(() => { this.isFocused = false; this.onBlurred(); })
     .onClick(() => { this.onPress(); })
   }
 }
@@ -325,15 +331,20 @@ struct SearchWorkspacePage {
   @Consumer('pageStack') pageStack: NavPathStack = new NavPathStack();
 
   @Local searchText: string = '';
-  @Local searchResults: MediaItem[] = [];
+  @Local session: SearchSession<MediaItem> = new SearchSession<MediaItem>();
+  private resultSource: SearchResultSource = new SearchResultSource();
+  private resultScroller: Scroller = new Scroller();
+  private focusedResult: number = 0;
+  private restoreResult: boolean = false;
+  private needsRefresh: boolean = false;
+  private resultsFocused: boolean = false;
   @Local historyList: SearchHistoryEntry[] = [];
-  @Local isSearching: boolean = false;
   @Local isSearchBarFocused: boolean = false;
 
   private db: FileSourceDatabase | null = null;
   @Local private searchDebounceTimer: number = -1;
   // 竞态保护：快速连续输入时，丢弃旧请求的返回结果
-  private searchGeneration: number = 0;
+
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -346,10 +357,31 @@ struct SearchWorkspacePage {
     }
   }
 
-  aboutToDisappear(): void {
+  aboutToDisappear(): void { this.suspendSearch(); }
+
+  private cancelDebounce(): void {
     if (this.searchDebounceTimer !== -1) {
       clearTimeout(this.searchDebounceTimer);
+      this.searchDebounceTimer = -1;
     }
+  }
+
+  private suspendSearch(): void {
+    this.needsRefresh = this.needsRefresh || this.session.status === 'loading' || this.session.status === 'refreshing';
+    this.cancelDebounce();
+    this.session.invalidate();
+  }
+
+  private focusInput(): void {
+    this.resultsFocused = false;
+    this.getUIContext().getFocusController().requestFocus('search_input');
+  }
+
+  private focusResults(): void {
+    if (this.session.results.length === 0) { return; }
+    this.focusedResult = Math.min(this.focusedResult, this.session.results.length - 1);
+    this.resultScroller.scrollToIndex(this.focusedResult);
+    this.getUIContext().getFocusController().requestFocus('search_result_' + this.session.results[this.focusedResult].id);
   }
 
   // ── Data helpers ──────────────────────────────────────────────────────────
@@ -365,55 +397,39 @@ struct SearchWorkspacePage {
 
 
   private scheduleSearch(): void {
-    if (this.searchDebounceTimer !== -1) {
-      clearTimeout(this.searchDebounceTimer);
-      this.searchDebounceTimer = -1;
-    }
+    this.cancelDebounce();
     if (this.searchText.trim().length === 0) {
-      this.searchResults = [];
+      this.session.invalidate(true);
+      this.resultSource.replace([]);
+      this.focusedResult = 0;
       return;
     }
+    this.session.prepare();
     this.searchDebounceTimer = setTimeout(() => {
       this.searchDebounceTimer = -1;
       this.executeSearch();
     }, 800);
   }
 
-  /** 本地预览搜索（仅实时展示结果，不保存历史、不跳转） */
   private async executeSearch(): Promise<void> {
-    const kw: string = this.searchText.trim();
-    if (kw.length === 0) {
-      this.searchResults = [];
-      return;
-    }
-    const generation = ++this.searchGeneration;
-    this.isSearching = true;
-    try {
-      const items: MediaItem[] = await this.db!.searchMediaItems(kw, { limit: 200 });
-      if (generation !== this.searchGeneration) { return; }
-      // 按 (tvSeriesId, movieId) 去重：同一部剧/电影只保留第一条
+    this.cancelDebounce();
+    this.needsRefresh = false;
+    const kw = this.searchText.trim();
+    if (kw.length === 0) { this.session.invalidate(true); return; }
+    const accepted = await this.session.run(async (): Promise<MediaItem[]> => {
+      if (this.db === null) { throw new Error('Search unavailable'); }
+      const items = await this.db.searchMediaItems(kw, { limit: 200 });
       const seen: Set<string> = new Set<string>();
-      const deduped: MediaItem[] = [];
-      for (const item of items) {
-        const key: string = item.tvSeriesId !== undefined
-          ? `tv-${item.tvSeriesId}`
-          : item.movieId !== undefined
-            ? `mv-${item.movieId}`
-            : `v-${item.id}`;
-        if (!seen.has(key)) {
-          seen.add(key);
-          deduped.push(item);
-        }
-      }
-      this.searchResults = deduped;
-    } catch {
-      if (generation !== this.searchGeneration) { return; }
-      this.searchResults = [];
-    } finally {
-      if (generation === this.searchGeneration) {
-        this.isSearching = false;
-      }
-    }
+      return items.filter((item: MediaItem) => {
+        const key = item.tvSeriesId !== undefined ? `tv-${item.tvSeriesId}` :
+          item.movieId !== undefined ? `mv-${item.movieId}` : `v-${item.id}`;
+        if (seen.has(key)) { return false; }
+        seen.add(key);
+        return true;
+      });
+    });
+    if (!accepted) { return; }
+    this.resultSource.replace(this.session.results);
   }
 
   /** 执行搜索并保存历史 */
@@ -442,7 +458,6 @@ struct SearchWorkspacePage {
 
   private clearSearch(): void {
     this.searchText = '';
-    this.searchResults = [];
     this.scheduleSearch();
   }
 
@@ -461,6 +476,8 @@ struct SearchWorkspacePage {
   }
 
   private navigateToDetail(item: MediaItem): void {
+    this.restoreResult = true;
+    this.suspendSearch();
     if (item.tvSeriesId !== undefined) {
       const group: SeriesGroup = {
         title: item.title ?? '',
@@ -556,6 +573,7 @@ struct SearchWorkspacePage {
     })
     .animation({ duration: 150, curve: Curve.EaseOut })
     .alignItems(VerticalAlign.Center)
+    .id('search_input')
     .defaultFocus(true)
     .focusable(true)
     .onFocus(() => { this.isSearchBarFocused = true; })
@@ -713,18 +731,47 @@ struct SearchWorkspacePage {
 
   @Builder
   buildResultsPreview() {
-    if (this.searchResults.length > 0) {
-      Flex({ wrap: FlexWrap.Wrap, justifyContent: FlexAlign.Start }) {
-        ForEach(this.searchResults, (item: MediaItem) => {
-          WorkspacePosterCard({
-            item: item,
-            onPress: () => { this.navigateToDetail(item); }
-          })
-          .margin({ right: 20, bottom: 20 })
-        }, (item: MediaItem) => String(item.id))
+    Column({ space: 12 }) {
+      if (this.session.status === 'loading' || this.session.status === 'refreshing') {
+        Text(this.session.status === 'refreshing' ? '正在更新，以下为上次结果…' : '正在搜索…')
+          .fontSize(18).fontColor(C_TEXT_BODY)
+      } else if (this.session.status === 'error') {
+        Text('搜索失败，请检查连接后重试。').fontSize(18).fontColor(C_TEXT_BODY)
+        Button('重试').onClick(() => { this.executeSearch(); })
+      } else if (this.session.status === 'empty') {
+        Text('未找到相关内容，请尝试其他关键词。').fontSize(18).fontColor(C_TEXT_BODY)
       }
-      .width('100%')
+      if (this.session.results.length > 0) {
+        Row({ space: 16 }) {
+          Button('浏览结果').onClick(() => { this.focusResults(); })
+          Button('返回输入').onClick(() => { this.focusInput(); })
+          Text('最多显示 200 项，可继续输入缩小范围').fontColor(C_SECONDARY)
+        }
+        Grid(this.resultScroller) {
+          LazyForEach(this.resultSource, (item: MediaItem, index: number) => {
+            GridItem() {
+              WorkspacePosterCard({
+                item: item,
+                focusId: 'search_result_' + item.id,
+                onFocused: () => { this.focusedResult = index; this.resultsFocused = true; },
+                onBlurred: () => { this.resultsFocused = false; },
+                onPress: () => { this.navigateToDetail(item); }
+              })
+            }
+            .onKeyEvent((event: KeyEvent) => {
+              if (event.type === KeyType.Down && event.keyCode === KeyCode.KEYCODE_DPAD_UP && index < 6) {
+                this.focusInput();
+                event.stopPropagation();
+              }
+            })
+          }, (item: MediaItem) => String(item.id))
+        }
+        .columnsTemplate('1fr 1fr 1fr 1fr 1fr 1fr')
+        .columnsGap(20).rowsGap(20).cachedCount(2)
+        .width('100%').height(380)
+      }
     }
+    .width('100%')
   }
 
   build() {
@@ -749,8 +796,20 @@ struct SearchWorkspacePage {
       .align(Alignment.TopStart)
       .backgroundColor(C_PAGE_BG)
     }
+    .onHidden(() => { this.suspendSearch(); })
+    .onShown(() => {
+      if (this.restoreResult) {
+        this.restoreResult = false;
+        this.focusResults();
+      }
+      if (this.searchText.trim().length > 0 && (this.needsRefresh || this.session.status === 'idle')) {
+        this.executeSearch();
+      }
+    })
     .hideTitleBar(true)
     .onBackPressed(() => {
+      if (this.resultsFocused) { this.focusInput(); return true; }
+      this.suspendSearch();
       this.pageStack.pop();
       return true;
     })

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -1015,12 +1015,8 @@ struct SearchWorkspacePage {
 
   @Builder
   buildResultList() {
-    Row({ space: 16 }) {
-      Button('浏览结果').onClick(() => { this.focusResults(); })
-      Button('返回输入').onClick(() => { this.focusInput(); })
-      Text(getSearchCapabilities(this.scope).serverSearch ? '首批结果（最多 100 项，可能更少）' : '最多显示 200 项')
-        .fontSize(18).fontColor(C_SECONDARY)
-    }
+    Text(getSearchCapabilities(this.scope).serverSearch ? '首批结果（最多 100 项，可能更少）' : '最多显示 200 项')
+      .fontSize(18).fontColor(C_SECONDARY)
     Grid(this.resultScroller) {
       LazyForEach(this.resultSource, (item: WorkspaceSearchItem, index: number) => {
         GridItem() {

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -376,7 +376,7 @@ struct SearchWorkspacePage {
   private showToastSafe(message: string): void {
     try {
       this.getUIContext().getPromptAction().showToast({ message, duration: 2000 });
-    } catch (_e) {}
+    } catch (e) {}
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -418,7 +418,7 @@ struct SearchWorkspacePage {
     if (kw.length === 0) { this.session.invalidate(true); return; }
     const accepted = await this.session.run(async (): Promise<MediaItem[]> => {
       if (this.db === null) { throw new Error('Search unavailable'); }
-      const items = await this.db.searchMediaItems(kw, { limit: 200 });
+      const items = await this.db.searchMediaItems(kw, { limit: 200 }, true);
       const seen: Set<string> = new Set<string>();
       return items.filter((item: MediaItem) => {
         const key = item.tvSeriesId !== undefined ? `tv-${item.tvSeriesId}` :

--- a/entry/src/main/ets/services/search/SearchSession.ets
+++ b/entry/src/main/ets/services/search/SearchSession.ets
@@ -1,14 +1,15 @@
-/** Source-independent request lifecycle. Invalidate at intent time, before debounce. */
+/** 与数据源无关的请求生命周期；输入意图变化时立即失效，不等待防抖。 */
 @ObservedV2
 export class SearchSession<T> {
   @Trace results: T[] = [];
   @Trace status: string = 'idle';
   private generation: number = 0;
   private timeout: number = -1;
+  private pendingResolve: ((accepted: boolean) => void) | undefined = undefined;
 
   invalidate(clear: boolean = false): void {
     this.generation++;
-    if (this.timeout !== -1) { clearTimeout(this.timeout); this.timeout = -1; }
+    this.finish(false);
     if (clear) { this.results = []; }
     this.status = this.results.length > 0 ? 'results' : 'idle';
   }
@@ -21,28 +22,37 @@ export class SearchSession<T> {
   async run(loader: () => Promise<T[]>, timeoutMs: number = 15000): Promise<boolean> {
     this.prepare();
     const generation = this.generation;
-    this.timeout = setTimeout(() => {
-      if (generation !== this.generation) { return; }
-      this.generation++;
-      this.timeout = -1;
-      this.status = 'error';
-    }, timeoutMs);
+    return new Promise<boolean>((resolve) => {
+      this.pendingResolve = resolve;
+      this.timeout = setTimeout(() => {
+        if (generation !== this.generation) { return; }
+        this.generation++;
+        this.status = 'error';
+        this.finish(false);
+      }, timeoutMs);
+      this.load(loader, generation);
+    });
+  }
+
+  private finish(accepted: boolean): void {
+    if (this.timeout !== -1) { clearTimeout(this.timeout); this.timeout = -1; }
+    const resolve = this.pendingResolve;
+    this.pendingResolve = undefined;
+    if (resolve) { resolve(accepted); }
+  }
+
+  private async load(loader: () => Promise<T[]>, generation: number): Promise<void> {
     try {
       const items = await loader();
-      if (generation !== this.generation) { return false; }
+      if (generation !== this.generation) { return; }
       this.results = items;
       this.status = items.length > 0 ? 'results' : 'empty';
-      return true;
+      this.finish(true);
     } catch {
-      if (generation !== this.generation) { return false; }
-      // Never render provider errors: they may contain credentials or private URLs.
+      if (generation !== this.generation) { return; }
+      // 不展示数据源异常原文，避免泄露凭据或私有地址；迟到异常也在此消费。
       this.status = 'error';
-      return false;
-    } finally {
-      if (generation === this.generation && this.timeout !== -1) {
-        clearTimeout(this.timeout);
-        this.timeout = -1;
-      }
+      this.finish(false);
     }
   }
 }

--- a/entry/src/main/ets/services/search/SearchSession.ets
+++ b/entry/src/main/ets/services/search/SearchSession.ets
@@ -1,0 +1,48 @@
+/** Source-independent request lifecycle. Invalidate at intent time, before debounce. */
+@ObservedV2
+export class SearchSession<T> {
+  @Trace results: T[] = [];
+  @Trace status: string = 'idle';
+  private generation: number = 0;
+  private timeout: number = -1;
+
+  invalidate(clear: boolean = false): void {
+    this.generation++;
+    if (this.timeout !== -1) { clearTimeout(this.timeout); this.timeout = -1; }
+    if (clear) { this.results = []; }
+    this.status = this.results.length > 0 ? 'results' : 'idle';
+  }
+
+  prepare(clear: boolean = false): void {
+    this.invalidate(clear);
+    this.status = this.results.length > 0 ? 'refreshing' : 'loading';
+  }
+
+  async run(loader: () => Promise<T[]>, timeoutMs: number = 15000): Promise<boolean> {
+    this.prepare();
+    const generation = this.generation;
+    this.timeout = setTimeout(() => {
+      if (generation !== this.generation) { return; }
+      this.generation++;
+      this.timeout = -1;
+      this.status = 'error';
+    }, timeoutMs);
+    try {
+      const items = await loader();
+      if (generation !== this.generation) { return false; }
+      this.results = items;
+      this.status = items.length > 0 ? 'results' : 'empty';
+      return true;
+    } catch {
+      if (generation !== this.generation) { return false; }
+      // Never render provider errors: they may contain credentials or private URLs.
+      this.status = 'error';
+      return false;
+    } finally {
+      if (generation === this.generation && this.timeout !== -1) {
+        clearTimeout(this.timeout);
+        this.timeout = -1;
+      }
+    }
+  }
+}

--- a/entry/src/test/List.test.ets
+++ b/entry/src/test/List.test.ets
@@ -1,3 +1,4 @@
+import searchSessionTest from './SearchSession.test';
 import timeUtilTest from './TimeUtil.test';
 import playbackContextTest from './ets/PlaybackContextTest';
 import settingsControllerTest from './SettingsController.test';
@@ -68,6 +69,7 @@ import directedScanStrategyTest from './DirectedScanStrategy.test';
 import serverEpisodePlaybackContextUtilTest from './ets/ServerEpisodePlaybackContextUtilTest';
 
 export default function testsuite() {
+  searchSessionTest();
   timeUtilTest();
   playbackContextTest();
   serverEpisodePlaybackContextUtilTest();

--- a/entry/src/test/SearchSession.test.ets
+++ b/entry/src/test/SearchSession.test.ets
@@ -1,0 +1,75 @@
+import { describe, it, expect } from '@ohos/hypium';
+import { SearchSession } from '../main/ets/services/search/SearchSession';
+
+class DeferredSearch {
+  resolve: (items: string[]) => void = () => {};
+  reject: (reason: Error) => void = () => {};
+  promise: Promise<string[]> = new Promise<string[]>((resolve, reject) => {
+    this.resolve = resolve;
+    this.reject = reject;
+  });
+}
+
+export default function searchSessionTest() {
+  describe('SearchSession', () => {
+    it('invalidates immediately before the next debounced request', 0, async () => {
+      const session = new SearchSession<string>();
+      const old = new DeferredSearch();
+      const pending = session.run(() => old.promise);
+      session.prepare();
+      old.resolve(['old']);
+      expect(await pending).assertFalse();
+      expect(session.results.length).assertEqual(0);
+      expect(session.status).assertEqual('loading');
+      session.invalidate();
+    });
+    it('clear, source replacement and page leave discard late responses', 0, async () => {
+      const session = new SearchSession<string>();
+      for (let i = 0; i < 3; i++) {
+        const old = new DeferredSearch();
+        const pending = session.run(() => old.promise);
+        session.invalidate(true);
+        old.resolve(['old source']);
+        expect(await pending).assertFalse();
+        expect(session.status).assertEqual('idle');
+        expect(session.results.length).assertEqual(0);
+      }
+    });
+    it('late failure cannot replace newer success', 0, async () => {
+      const session = new SearchSession<string>();
+      const old = new DeferredSearch();
+      const pending = session.run(() => old.promise);
+      await session.run(() => Promise.resolve(['new']));
+      old.reject(new Error('private-url'));
+      await pending;
+      expect(session.results[0]).assertEqual('new');
+      expect(session.status).assertEqual('results');
+    });
+    it('refresh preserves results, failure is distinct from empty, retry succeeds', 0, async () => {
+      const session = new SearchSession<string>();
+      await session.run(() => Promise.resolve(['previous']));
+      const refresh = new DeferredSearch();
+      const pending = session.run(() => refresh.promise);
+      expect(session.status).assertEqual('refreshing');
+      expect(session.results[0]).assertEqual('previous');
+      refresh.reject(new Error('password=secret'));
+      await pending;
+      expect(session.status).assertEqual('error');
+      expect(session.results[0]).assertEqual('previous');
+      await session.run(() => Promise.resolve([]));
+      expect(session.status).assertEqual('empty');
+    });
+    it('timeout stays an error when provider eventually responds', 0, async () => {
+      const session = new SearchSession<string>();
+      const slow = new DeferredSearch();
+      const pending = session.run(() => slow.promise, 1);
+      await new Promise<void>((resolve) => { setTimeout(resolve, 10); });
+      expect(session.status).assertEqual('error');
+      slow.resolve(['late']);
+      expect(await pending).assertFalse();
+      expect(session.status).assertEqual('error');
+      await session.run(() => Promise.resolve(['retry']));
+      expect(session.results[0]).assertEqual('retry');
+    });
+  });
+}

--- a/entry/src/test/SearchSession.test.ets
+++ b/entry/src/test/SearchSession.test.ets
@@ -10,6 +10,18 @@ class DeferredSearch {
   });
 }
 
+async function awaitSettled(pending: Promise<boolean>): Promise<boolean> {
+  let timer: number = -1;
+  const deadline = new Promise<boolean>((resolve, reject) => {
+    timer = setTimeout(() => reject(new Error('搜索等待未及时结束')), 200);
+  });
+  try {
+    return await Promise.race([pending, deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export default function searchSessionTest() {
   describe('SearchSession', () => {
     it('invalidates immediately before the next debounced request', 0, async () => {
@@ -65,11 +77,52 @@ export default function searchSessionTest() {
       const pending = session.run(() => slow.promise, 1);
       await new Promise<void>((resolve) => { setTimeout(resolve, 10); });
       expect(session.status).assertEqual('error');
+      expect(await awaitSettled(pending)).assertFalse();
       slow.resolve(['late']);
-      expect(await pending).assertFalse();
+      await Promise.resolve();
       expect(session.status).assertEqual('error');
       await session.run(() => Promise.resolve(['retry']));
       expect(session.results[0]).assertEqual('retry');
+    });
+    it('失效立即释放未完成调用，旧超时不影响重试', 0, async () => {
+      const session = new SearchSession<string>();
+      const old = new DeferredSearch();
+      const pending = session.run(() => old.promise, 10);
+      session.prepare();
+      expect(await awaitSettled(pending)).assertFalse();
+      const retry = new DeferredSearch();
+      const current = session.run(() => retry.promise, 1000);
+      await new Promise<void>((resolve) => { setTimeout(resolve, 30); });
+      expect(session.status).assertEqual('loading');
+      old.resolve(['旧结果']);
+      await Promise.resolve();
+      expect(session.results.length).assertEqual(0);
+      retry.resolve(['重试结果']);
+      expect(await awaitSettled(current)).assertTrue();
+      expect(session.results[0]).assertEqual('重试结果');
+    });
+    it('超时后迟到拒绝被消费且不影响新代次', 0, async () => {
+      const session = new SearchSession<string>();
+      const old = new DeferredSearch();
+      const pending = session.run(() => old.promise, 1);
+      expect(await awaitSettled(pending)).assertFalse();
+      expect(session.status).assertEqual('error');
+      const retry = new DeferredSearch();
+      const current = session.run(() => retry.promise, 1000);
+      old.reject(new Error('私有地址'));
+      await new Promise<void>((resolve) => { setTimeout(resolve, 10); });
+      expect(session.status).assertEqual('loading');
+      retry.resolve(['新结果']);
+      expect(await awaitSettled(current)).assertTrue();
+      expect(session.results[0]).assertEqual('新结果');
+    });
+    it('清空与离页不等待数据源完成', 0, async () => {
+      const session = new SearchSession<string>();
+      const old = new DeferredSearch();
+      const pending = session.run(() => old.promise);
+      session.invalidate(true);
+      expect(await awaitSettled(pending)).assertFalse();
+      expect(session.status).assertEqual('idle');
     });
   });
 }

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -1944,7 +1944,8 @@ async function runSearchChainChecks() {
         ActionKey: options => node('action', options),
         Color: { Transparent: '' }, ItemAlign: {}, HorizontalAlign: {}, VerticalAlign: {},
         FlexAlign: {}, ScrollDirection: {}, Alignment: {}, BorderStyle: {}, Curve: {},
-        EnterKeyType: { Search: 'Search' } };
+        EnterKeyType: { Search: 'Search' },
+        KeyType: { Down: 0, Up: 1 }, KeyCode: { KEYCODE_DPAD_CENTER: 23, KEYCODE_ENTER: 66 } };
       for (const match of sourceText.matchAll(/const (C_\w+|TRANSPARENT): string = '([^']*)';/g)) {
         inputDependencies[match[1]] = match[2];
       }
@@ -1998,6 +1999,92 @@ async function runSearchChainChecks() {
       AppPreferences.resetForTesting();
       timers.restore();
     }
+  }
+
+  for (const delayed of [false, true]) {
+    await runCase(`返回焦点编辑回调-${delayed ? '异步' : '同步'}`, async h => {
+      h.page.searchText = '';
+      h.page.resumeSearch();
+      const input = h.renderInput().nodes.find(n => n.type === 'input');
+      const events = input.attributes;
+      const pending = [];
+      const emit = editing => {
+        const callback = () => events.onEditChange[0](editing);
+        if (delayed) pending.push(callback); else callback();
+      };
+      const drain = () => { while (pending.length) pending.shift()(); };
+      h.page.inputController.stopEditing = () => {
+        h.page.stoppedEditing++;
+        events.onBlur[0]();
+        emit(false);
+      };
+      h.page.getUIContext = () => ({ getFocusController: () => ({ requestFocus: id => {
+        h.page.focusRequests.push(id);
+        if (id === 'search-workspace-input') {
+          events.onFocus[0]();
+          // enableKeyboardOnFocus(false) still permits caret editing / IME attachment.
+          emit(true);
+        }
+        return true;
+      } }) });
+      h.check('被动获焦不主动弹键盘', events.enableKeyboardOnFocus, [false]);
+      h.page.focusInput();
+      drain();
+      h.check('首次程序聚焦不新增编辑返回层', h.page.isEditing, false);
+      h.page.backPressed();
+      h.check('首次输入焦点返回直接退出', h.page.popCount, 1);
+      drain();
+      h.page.shown();
+      drain();
+      h.page.resultsFocused = true;
+      h.page.backPressed();
+      drain();
+      h.check('结果返回输入且不退出', [h.page.resultsFocused, h.page.isEditing, h.page.popCount],
+        [false, false, 1]);
+      h.page.backPressed();
+      h.check('结果回输入后再次返回退出', h.page.popCount, 2);
+      drain();
+      for (const activate of [
+        () => events.onClick[0](),
+        () => events.onKeyEvent[0]({ type: 0, keyCode: 23 }),
+        () => events.onKeyEvent[0]({ type: 0, keyCode: 66 }),
+        () => events.onChange[0]('typed')
+      ]) {
+        h.page.shown();
+        drain();
+        activate();
+        emit(true);
+        drain();
+        const pops = h.page.popCount;
+        const requests = h.page.focusRequests.length;
+        const stops = h.page.stoppedEditing;
+        h.page.backPressed();
+        // A late positive callback after stopEditing must not re-arm Back consumption.
+        emit(true);
+        drain();
+        h.check('主动编辑返回仅停止编辑、不重复聚焦',
+          [h.page.isEditing, h.page.popCount, h.page.focusRequests.length, h.page.stoppedEditing],
+          [false, pops, requests, stops + 1]);
+        h.page.backPressed();
+        h.check('编辑退出后再次返回离页', h.page.popCount, pops + 1);
+        drain();
+        h.page.searchText = '';
+      }
+      h.page.shown();
+      drain();
+      events.onClick[0]();
+      emit(false);
+      drain();
+      h.page.backPressed();
+      h.check('系统已结束编辑时不额外消费返回', h.page.pageActive, false);
+      h.page.shown();
+      // Back before queued focus callbacks arrive must also leave immediately.
+      const pops = h.page.popCount;
+      h.page.backPressed();
+      drain();
+      h.check('快速返回及离页后迟到回调不恢复编辑',
+        [h.page.popCount, h.page.pageActive, h.page.isEditing], [pops + 1, false, false]);
+    });
   }
 
   await runCase('输入能力真实切换与按钮IME连续链', async h => {

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -163,6 +163,9 @@ async function runHostIntegrationChecks() {
   const resultPath = path.join(root, results);
   const workspaceSource = fs.readFileSync(workspacePath, 'utf8');
   const resultSource = fs.readFileSync(resultPath, 'utf8');
+  // 结果区不再添加多余的焦点跳转按钮，保留首行向上返回输入的路径。
+  assert.doesNotMatch(workspaceSource, /Button\('(浏览结果|返回输入)'\)/);
+  assert.match(workspaceSource, /KEYCODE_DPAD_UP && index < 6\) \{\s*this\.focusInput\(\)/);
   const detailPageSource = fs.readFileSync(path.join(root, detailPage), 'utf8');
   const adapterSource = fs.readFileSync(path.join(root,
     'entry/src/main/ets/pages/search/SearchResultSource.ets'), 'utf8');

--- a/entry/src/test/search_scope_test.cjs
+++ b/entry/src/test/search_scope_test.cjs
@@ -164,6 +164,34 @@ async function runHostIntegrationChecks() {
   const workspaceSource = fs.readFileSync(workspacePath, 'utf8');
   const resultSource = fs.readFileSync(resultPath, 'utf8');
   const detailPageSource = fs.readFileSync(path.join(root, detailPage), 'utf8');
+  const adapterSource = fs.readFileSync(path.join(root,
+    'entry/src/main/ets/pages/search/SearchResultSource.ets'), 'utf8');
+  // 主机不运行 ArkUI，静态护栏确保首次挂载条件具有可观察的数量依赖。
+  assert.match(adapterSource, /@ObservedV2\s+export class SearchResultSource/);
+  assert.match(adapterSource, /@Trace private count: number/);
+  assert.match(adapterSource, /totalCount\(\): number \{ return this\.count; \}/);
+  const adapter = new SearchResultSource();
+  assert.equal(adapter.totalCount(), 0);
+  adapter.replace([{ id: 'local' }]);
+  assert.equal(adapter.totalCount(), 1);
+  let reloads = 0;
+  const listener = { onDataReloaded() {
+    reloads += 1;
+    assert.equal(adapter.totalCount(), expectedCount);
+  } };
+  let expectedCount = 1;
+  adapter.registerDataChangeListener(listener);
+  adapter.replace([{ id: 'server' }]);
+  assert.equal(adapter.getData(0).id, 'server');
+  expectedCount = 0;
+  adapter.replace([]);
+  assert.equal(adapter.totalCount(), 0);
+  assert.equal(reloads, 2);
+  adapter.unregisterDataChangeListener(listener);
+  adapter.replace([{ id: 'retry' }]);
+  assert.equal(adapter.totalCount(), 1);
+  assert.equal(reloads, 2);
+
   const { createLocalSearchScope, resolveSearchScope, getSearchCapabilities } =
     require(path.join(root, 'entry/src/main/ets/models/search/SearchScope.ets'));
   const { VideoServerType } = require(path.join(root, 'entry/src/main/ets/db/models/VideoServerEntity.ets'));

--- a/scripts/tests/search-session.cjs
+++ b/scripts/tests/search-session.cjs
@@ -17,7 +17,40 @@ const suite = compile('entry/src/test/SearchSession.test.ets', name => name.incl
   expect: value => ({ assertTrue: () => assert.equal(value, true), assertFalse: () => assert.equal(value, false), assertEqual: expected => assert.equal(value, expected) })
 });
 suite.default();
-const { MediaQueryDao } = compile('entry/src/main/ets/db/files/MediaQueryDao.ets', () => ({}));
+const { MediaQueryDao, MediaSearchError, MediaSearchErrorCode } = compile('entry/src/main/ets/db/files/MediaQueryDao.ets', () => ({}));
+tests.push({ name: '数据库传播 Error 子类、稳定兜底码和底层 code，消息不含私密信息', fn: async () => {
+  const cases = [
+    { ready: false, expectedCode: MediaSearchErrorCode.DatabaseNotReady, message: '搜索数据库尚未就绪' },
+    { ready: true, expectedCode: MediaSearchErrorCode.QueryFailed, message: '搜索数据库查询失败' },
+    { ready: true, code: 14800014, expectedCode: 14800014, message: '搜索数据库查询失败' }
+  ];
+  assert.notEqual(MediaSearchErrorCode.DatabaseNotReady, MediaSearchErrorCode.QueryFailed);
+  for (const scenario of cases) {
+    let storeAccesses = 0;
+    const dao = new MediaQueryDao({
+      isReady: () => scenario.ready,
+      getStore: () => {
+        storeAccesses++;
+        return { querySql: async () => {
+          const error = new Error('private-url');
+          if (scenario.code !== undefined) { error.code = scenario.code; }
+          throw error;
+        } };
+      }
+    });
+    assert.equal((await dao.searchMediaItems('test')).length, 0);
+    assert.equal((await dao.searchMediaItems('test', undefined, false)).length, 0);
+    await assert.rejects(() => dao.searchMediaItems('test', undefined, true), error => {
+      assert.ok(error instanceof Error);
+      assert.ok(error instanceof MediaSearchError);
+      assert.equal(error.code, scenario.expectedCode);
+      assert.equal(error.message, scenario.message);
+      assert.equal(error.message.includes('private-url'), false);
+      return true;
+    });
+    if (!scenario.ready) { assert.equal(storeAccesses, 0); }
+  }
+} });
 tests.push({ name: '数据库未就绪和查询失败可进入错误状态，默认调用保持兼容', fn: async () => {
   for (const ready of [false, true]) {
     const dao = new MediaQueryDao({

--- a/scripts/tests/search-session.cjs
+++ b/scripts/tests/search-session.cjs
@@ -17,4 +17,19 @@ const suite = compile('entry/src/test/SearchSession.test.ets', name => name.incl
   expect: value => ({ assertTrue: () => assert.equal(value, true), assertFalse: () => assert.equal(value, false), assertEqual: expected => assert.equal(value, expected) })
 });
 suite.default();
+const { MediaQueryDao } = compile('entry/src/main/ets/db/files/MediaQueryDao.ets', () => ({}));
+tests.push({ name: '数据库未就绪和查询失败可进入错误状态，默认调用保持兼容', fn: async () => {
+  for (const ready of [false, true]) {
+    const dao = new MediaQueryDao({
+      isReady: () => ready,
+      getStore: () => ({ querySql: async () => { throw new Error('private-url'); } })
+    });
+    assert.equal((await dao.searchMediaItems('test')).length, 0);
+    const state = new session.SearchSession();
+    await state.run(() => Promise.resolve(['previous']));
+    assert.equal(await state.run(() => dao.searchMediaItems('test', undefined, true)), false);
+    assert.equal(state.status, 'error');
+    assert.equal(state.results[0], 'previous');
+  }
+} });
 (async () => { for (const t of tests) { await t.fn(); console.log('PASS ' + t.name); } })().catch(e => { console.error(e); process.exitCode = 1; });

--- a/scripts/tests/search-session.cjs
+++ b/scripts/tests/search-session.cjs
@@ -1,0 +1,20 @@
+const fs = require('node:fs');
+const vm = require('node:vm');
+const assert = require('node:assert/strict');
+// Pass TYPESCRIPT_PATH when TypeScript is not installed in the local Node resolution path.
+const ts = require(process.env.TYPESCRIPT_PATH || 'typescript');
+const tests = [];
+function compile(path, req) {
+  const source = fs.readFileSync(path, 'utf8').replace(/@ObservedV2\s*/g, '').replace(/@Trace\s*/g, '');
+  const js = ts.transpileModule(source, { compilerOptions: { target: ts.ScriptTarget.ES2021, module: ts.ModuleKind.CommonJS } }).outputText;
+  const exports = {};
+  vm.runInNewContext(js, { exports, require: req, setTimeout, clearTimeout, Promise, Error });
+  return exports;
+}
+const session = compile('entry/src/main/ets/services/search/SearchSession.ets');
+const suite = compile('entry/src/test/SearchSession.test.ets', name => name.includes('SearchSession') ? session : {
+  describe: (_, fn) => fn(), it: (name, _, fn) => tests.push({name, fn}),
+  expect: value => ({ assertTrue: () => assert.equal(value, true), assertFalse: () => assert.equal(value, false), assertEqual: expected => assert.equal(value, expected) })
+});
+suite.default();
+(async () => { for (const t of tests) { await t.fn(); console.log('PASS ' + t.name); } })().catch(e => { console.error(e); process.exitCode = 1; });


### PR DESCRIPTION
## 背景
快速输入、清空或离开搜索页时，旧请求可能覆盖新意图；搜索失败与无结果缺少明确区分，大量海报同时构建也影响 TV 浏览体验。

## 实现
- 引入共享 SearchSession，在输入意图发生时立即使旧请求失效，区分加载、刷新、空结果和可重试错误状态，刷新期间保留上次结果。
- 搜索页隐藏时清理防抖并使请求失效，返回后恢复被中断的搜索；增加结果浏览、返回输入、首行向上与详情返回焦点恢复。
- 使用固定高度 Grid + LazyForEach 按需构建海报，保留现有 200 项查询上限，不增加数据库分页。
- 两个搜索页显式启用数据库错误传播，避免异常被空数组吞掉；其他调用方保持原有行为。

## 验证
- 6 项主机定向测试通过，覆盖请求失效、迟到失败、刷新与重试、超时、数据库未就绪及查询失败。
- `devecocli build --modules entry` 成功，日志包含 `BUILD SUCCESSFUL`，退出码为 0。
- `node --check scripts/tests/search-session.cjs` 和 `git diff --check` 通过。
- 未找到可直接运行的 lint/format 脚本，未宣称完整 lint 或自动格式化通过。

## 限制与审查重点
- 超时仅使响应失效，不取消底层数据库操作。
- 当前接入本地数据库搜索，尚未接入服务端搜索与来源切换。
- 主机测试不覆盖 ArkUI 焦点和响应式渲染；遥控器焦点恢复、200 项滚动性能仍需真机验证，不作性能数值承诺。

Fixes: #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持服务器端搜索，并展示加载、空结果、失败及重试状态。
  - 搜索结果采用懒加载网格，提升大量结果下的浏览体验。
  - 返回搜索页面时可恢复结果、焦点和滚动位置。
  - 支持方向键在筛选区域与结果区域间导航。
  - 刷新时保留已有结果，避免界面突然清空。
  - 搜索框支持直接输入、搜索及清空操作。

- **文档**
  - 新增搜索生命周期及电视端回归检查说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->