### PR TITLE
修复: 改进本地文件源拼音搜索准确率与相关度

### DIFF
--- a/entry/src/main/ets/db/files/DbConstants.ets
+++ b/entry/src/main/ets/db/files/DbConstants.ets
@@ -2,7 +2,7 @@
  * 数据库共享常量：表名、版本号、事件名。
  * 拆分自 FileSourceDatabase.ets 的私有静态常量，供 DbCore 与各 DAO 共用。
  */
-export const DB_VERSION: number = 13;
+export const DB_VERSION: number = 14;
 export const DEFAULT_DB_NAME: string = 'FILE_SOURCES_DB';
 export const DATABASE_READY: string = 'FILE_SOURCES_DB_READY';
 

--- a/entry/src/main/ets/db/files/DbConstants.ets
+++ b/entry/src/main/ets/db/files/DbConstants.ets
@@ -2,7 +2,7 @@
  * 数据库共享常量：表名、版本号、事件名。
  * 拆分自 FileSourceDatabase.ets 的私有静态常量，供 DbCore 与各 DAO 共用。
  */
-export const DB_VERSION: number = 12;
+export const DB_VERSION: number = 13;
 export const DEFAULT_DB_NAME: string = 'FILE_SOURCES_DB';
 export const DATABASE_READY: string = 'FILE_SOURCES_DB_READY';
 

--- a/entry/src/main/ets/db/files/FileSourceDbCore.ets
+++ b/entry/src/main/ets/db/files/FileSourceDbCore.ets
@@ -1,6 +1,6 @@
 import relationalStore from '@ohos.data.relationalStore';
 import { Context } from '@ohos.abilityAccessCtrl';
-import { toPinyinFull, toPinyinInitials, toPinyinSegments } from '../../utils/PinyinUtil';
+import { normalizeSearchText, toPinyinFull, toPinyinInitials, toPinyinSegments } from '../../utils/PinyinUtil';
 import { BusinessError, emitter } from "@kit.BasicServicesKit";
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import {
@@ -156,7 +156,7 @@ export class FileSourceDbCore {
 
       // 回填历史数据 origin_country_json（await 确保 DATABASE_READY 前数据可用）
       await this.backfillOriginCountryFromRawJson();
-      // Missing v13 indexes are rebuilt before search becomes available; subsequent starts skip them.
+      // 在搜索可用前回填 v13 拼音及 v14 规范化标题；后续启动跳过已完成记录。
       await this.backfillPinyinFields(this.rdbStore);
       this.fullyReady = true;
       emitter.emit(DATABASE_READY);
@@ -345,6 +345,7 @@ export class FileSourceDbCore {
         origin_country_json TEXT,
         raw_json TEXT,
         scraped_at INTEGER NOT NULL,
+        title_normalized TEXT,
         title_pinyin TEXT,
         title_pinyin_segments TEXT,
         title_initials TEXT,
@@ -376,6 +377,7 @@ export class FileSourceDbCore {
         origin_country_json TEXT,
         raw_json TEXT,
         scraped_at INTEGER NOT NULL,
+        title_normalized TEXT,
         title_pinyin TEXT,
         title_pinyin_segments TEXT,
         title_initials TEXT,
@@ -624,6 +626,23 @@ export class FileSourceDbCore {
           if (!tableExists) {
             await this.createMediaTablesV3(rdbStore);
           } else if (!exists) { await rdbStore.executeSql(`ALTER TABLE ${table} ADD COLUMN title_pinyin_segments TEXT`); }
+        }
+      }
+      // v14 独立迁移，确保已完成 v13 拼音回填的用户也能补齐规范化标题。
+      if (currentVersion < 14) {
+        for (const table of [TABLE_MOVIES, TABLE_TV_SERIES]) {
+          const columns = await rdbStore.querySql(`PRAGMA table_info(${table})`);
+          let exists = false;
+          let tableExists = false;
+          try {
+            while (columns.goToNextRow()) {
+              tableExists = true;
+              if (columns.getString(columns.getColumnIndex('name')) === 'title_normalized') { exists = true; }
+            }
+          } finally { columns.close(); }
+          if (!tableExists) {
+            await this.createMediaTablesV3(rdbStore);
+          } else if (!exists) { await rdbStore.executeSql(`ALTER TABLE ${table} ADD COLUMN title_normalized TEXT`); }
         }
       }
       console.info('FileSourceDatabase: Upgrade complete');
@@ -897,7 +916,7 @@ export class FileSourceDbCore {
         const rows: PinyinRow[] = [];
         const rs = await rdbStore.querySql(
           `SELECT id, title FROM ${table} WHERE id > ? AND title IS NOT NULL ` +
-          `AND title_pinyin_segments IS NULL ORDER BY id LIMIT 100`, [lastId]);
+          `AND (title_pinyin_segments IS NULL OR title_normalized IS NULL) ORDER BY id LIMIT 100`, [lastId]);
         try {
           while (rs.goToNextRow()) {
             const row: PinyinRow = { id: rs.getLong(rs.getColumnIndex('id')), title: rs.getString(rs.getColumnIndex('title')) };
@@ -908,9 +927,9 @@ export class FileSourceDbCore {
         // Close the cursor before writes; a failed/interrupted batch remains resumable via NULL.
         for (const row of rows) {
           await rdbStore.executeSql(
-            `UPDATE ${table} SET title_pinyin = ?, title_initials = ?, title_pinyin_segments = ? ` +
+            `UPDATE ${table} SET title_pinyin = ?, title_initials = ?, title_pinyin_segments = ?, title_normalized = ? ` +
             `WHERE id = ? AND title = ?`,
-            [toPinyinFull(row.title), toPinyinInitials(row.title), toPinyinSegments(row.title), row.id, row.title]);
+            [toPinyinFull(row.title), toPinyinInitials(row.title), toPinyinSegments(row.title), normalizeSearchText(row.title), row.id, row.title]);
           lastId = row.id;
         }
       }

--- a/entry/src/main/ets/db/files/FileSourceDbCore.ets
+++ b/entry/src/main/ets/db/files/FileSourceDbCore.ets
@@ -1,6 +1,6 @@
 import relationalStore from '@ohos.data.relationalStore';
 import { Context } from '@ohos.abilityAccessCtrl';
-import { toPinyinFull, toPinyinInitials } from '../../utils/PinyinUtil';
+import { toPinyinFull, toPinyinInitials, toPinyinSegments } from '../../utils/PinyinUtil';
 import { BusinessError, emitter } from "@kit.BasicServicesKit";
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import {
@@ -69,7 +69,7 @@ export class FileSourceDbCore {
     return this.rdbStore !== null;
   }
 
-  /** 数据库是否已完成 schema 迁移与记录级回填（origin_country）。不含异步拼音回填。 */
+  /** 数据库是否已完成 schema 迁移与记录级回填（origin_country、拼音）。 */
   isFullyReady(): boolean {
     return this.fullyReady;
   }
@@ -156,9 +156,8 @@ export class FileSourceDbCore {
 
       // 回填历史数据 origin_country_json（await 确保 DATABASE_READY 前数据可用）
       await this.backfillOriginCountryFromRawJson();
-      // 回填拼音字段（数据库就绪后异步执行，不阻塞 DATABASE_READY 事件）。
-      // 注意：fullyReady 仅表示 schema 迁移/回填(origin_country)完成，不包含此异步拼音回填。
-      this.backfillPinyinFields(this.rdbStore!).catch(() => {});
+      // Missing v13 indexes are rebuilt before search becomes available; subsequent starts skip them.
+      await this.backfillPinyinFields(this.rdbStore);
       this.fullyReady = true;
       emitter.emit(DATABASE_READY);
       console.info('FileSourceDatabase: Database initialized successfully');
@@ -347,6 +346,7 @@ export class FileSourceDbCore {
         raw_json TEXT,
         scraped_at INTEGER NOT NULL,
         title_pinyin TEXT,
+        title_pinyin_segments TEXT,
         title_initials TEXT,
         UNIQUE(provider, provider_id)
       )
@@ -377,6 +377,7 @@ export class FileSourceDbCore {
         raw_json TEXT,
         scraped_at INTEGER NOT NULL,
         title_pinyin TEXT,
+        title_pinyin_segments TEXT,
         title_initials TEXT,
         UNIQUE(provider, provider_id)
       )
@@ -608,6 +609,22 @@ export class FileSourceDbCore {
         await this.createVideoServersTable(rdbStore);
         currentVersion = 12;
         console.info('[DB] 已迁移到 v12：新增 video_servers 表');
+      }
+      if (currentVersion < 13) {
+        for (const table of [TABLE_MOVIES, TABLE_TV_SERIES]) {
+          const columns = await rdbStore.querySql(`PRAGMA table_info(${table})`);
+          let exists = false;
+          let tableExists = false;
+          try {
+            while (columns.goToNextRow()) {
+              tableExists = true;
+              if (columns.getString(columns.getColumnIndex('name')) === 'title_pinyin_segments') { exists = true; }
+            }
+          } finally { columns.close(); }
+          if (!tableExists) {
+            await this.createMediaTablesV3(rdbStore);
+          } else if (!exists) { await rdbStore.executeSql(`ALTER TABLE ${table} ADD COLUMN title_pinyin_segments TEXT`); }
+        }
       }
       console.info('FileSourceDatabase: Upgrade complete');
     } catch (error) {
@@ -873,43 +890,29 @@ export class FileSourceDbCore {
   }
 
   private async backfillPinyinFields(rdbStore: relationalStore.RdbStore): Promise<void> {
-    const tables: string[] = ['movies', 'tv_series'];
-    for (const tbl of tables) {
-      // ── 第一步：先将全量行读入内存，关闭 ResultSet ──
-      // 避免在游标未关闭时对同一表执行 UPDATE，防止游标失效/锁冲突
-      interface PinyinRow { id: number; title: string }
-      const rows: PinyinRow[] = [];
-      let rs: relationalStore.ResultSet | null = null;
-      try {
-        rs = await rdbStore.querySql(`SELECT id, title FROM ${tbl} WHERE title IS NOT NULL`);
-        while (rs.goToNextRow()) {
-          const row: PinyinRow = {
-            id: rs.getLong(rs.getColumnIndex('id')),
-            title: rs.getString(rs.getColumnIndex('title'))
-          };
-          rows.push(row);
-        }
-      } catch (e) {
-        const msg: string = (e instanceof Error) ? e.message : String(e);
-        console.warn(`[DB] v11 读取 ${tbl} 拼音回填数据失败: ${msg}`);
-      } finally {
-        try { rs?.close(); } catch { }
-      }
-
-      // ── 第二步：ResultSet 已关闭，再批量 UPDATE ──
-      try {
+    interface PinyinRow { id: number; title: string }
+    for (const table of [TABLE_MOVIES, TABLE_TV_SERIES]) {
+      let lastId = -1;
+      while (true) {
+        const rows: PinyinRow[] = [];
+        const rs = await rdbStore.querySql(
+          `SELECT id, title FROM ${table} WHERE id > ? AND title IS NOT NULL ` +
+          `AND title_pinyin_segments IS NULL ORDER BY id LIMIT 100`, [lastId]);
+        try {
+          while (rs.goToNextRow()) {
+            const row: PinyinRow = { id: rs.getLong(rs.getColumnIndex('id')), title: rs.getString(rs.getColumnIndex('title')) };
+            rows.push(row);
+          }
+        } finally { rs.close(); }
+        if (rows.length === 0) { break; }
+        // Close the cursor before writes; a failed/interrupted batch remains resumable via NULL.
         for (const row of rows) {
-          const full = toPinyinFull(row.title);
-          const initials = toPinyinInitials(row.title);
           await rdbStore.executeSql(
-            `UPDATE ${tbl} SET title_pinyin = ?, title_initials = ? WHERE id = ?`,
-            [full, initials, row.id]
-          );
+            `UPDATE ${table} SET title_pinyin = ?, title_initials = ?, title_pinyin_segments = ? ` +
+            `WHERE id = ? AND title = ?`,
+            [toPinyinFull(row.title), toPinyinInitials(row.title), toPinyinSegments(row.title), row.id, row.title]);
+          lastId = row.id;
         }
-        console.info(`[DB] v11 回填 ${tbl} 拼音字段完成，共 ${rows.length} 条`);
-      } catch (e) {
-        const msg: string = (e instanceof Error) ? e.message : String(e);
-        console.warn(`[DB] v11 回填 ${tbl} 失败: ${msg}`);
       }
     }
   }

--- a/entry/src/main/ets/db/files/MediaContentDao.ets
+++ b/entry/src/main/ets/db/files/MediaContentDao.ets
@@ -1,6 +1,6 @@
 import relationalStore from '@ohos.data.relationalStore';
 import { MovieEntity, TvSeriesEntity, TvSeasonEntity, TvEpisodeEntity } from '../models/MediaEntity';
-import { toPinyinFull, toPinyinInitials, toPinyinSegments } from '../../utils/PinyinUtil';
+import { normalizeSearchText, toPinyinFull, toPinyinInitials, toPinyinSegments } from '../../utils/PinyinUtil';
 import { BusinessError } from "@kit.BasicServicesKit";
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { TABLE_MOVIES, TABLE_TV_SERIES, TABLE_TV_SEASONS, TABLE_TV_EPISODES } from './DbConstants';
@@ -177,6 +177,7 @@ export class MediaContentDao {
         runtime: e.runtime ?? null, original_language: e.originalLanguage ?? null,
         origin_country_json: e.originCountryJson ?? null,
         raw_json: e.rawJson ?? null, scraped_at: e.scrapedAt,
+        title_normalized: normalizeSearchText(e.title),
         title_pinyin: toPinyinFull(e.title),
         title_pinyin_segments: toPinyinSegments(e.title),
         title_initials: toPinyinInitials(e.title)
@@ -261,6 +262,8 @@ export class MediaContentDao {
       columns.push('raw_json');
       args.push(e.rawJson);
     }
+    columns.push('title_normalized');
+    args.push(normalizeSearchText(e.title));
     columns.push('title_pinyin');
     args.push(toPinyinFull(e.title));
     columns.push('title_pinyin_segments');
@@ -351,6 +354,7 @@ export class MediaContentDao {
         original_language: e.originalLanguage ?? null, origin_country_json: e.originCountryJson ?? null,
         raw_json: e.rawJson ?? null,
         scraped_at: e.scrapedAt,
+        title_normalized: normalizeSearchText(e.title),
         title_pinyin: toPinyinFull(e.title),
         title_pinyin_segments: toPinyinSegments(e.title),
         title_initials: toPinyinInitials(e.title)
@@ -382,6 +386,7 @@ export class MediaContentDao {
       origin_country_json: e.originCountryJson ?? null,
       raw_json: e.rawJson ?? null,
       scraped_at: e.scrapedAt,
+      title_normalized: normalizeSearchText(e.title),
       title_pinyin: toPinyinFull(e.title),
       title_pinyin_segments: toPinyinSegments(e.title),
       title_initials: toPinyinInitials(e.title)

--- a/entry/src/main/ets/db/files/MediaContentDao.ets
+++ b/entry/src/main/ets/db/files/MediaContentDao.ets
@@ -1,6 +1,6 @@
 import relationalStore from '@ohos.data.relationalStore';
 import { MovieEntity, TvSeriesEntity, TvSeasonEntity, TvEpisodeEntity } from '../models/MediaEntity';
-import { toPinyinFull, toPinyinInitials } from '../../utils/PinyinUtil';
+import { toPinyinFull, toPinyinInitials, toPinyinSegments } from '../../utils/PinyinUtil';
 import { BusinessError } from "@kit.BasicServicesKit";
 import { hilog } from '@kit.PerformanceAnalysisKit';
 import { TABLE_MOVIES, TABLE_TV_SERIES, TABLE_TV_SEASONS, TABLE_TV_EPISODES } from './DbConstants';
@@ -178,6 +178,7 @@ export class MediaContentDao {
         origin_country_json: e.originCountryJson ?? null,
         raw_json: e.rawJson ?? null, scraped_at: e.scrapedAt,
         title_pinyin: toPinyinFull(e.title),
+        title_pinyin_segments: toPinyinSegments(e.title),
         title_initials: toPinyinInitials(e.title)
       };
       const pred = new relationalStore.RdbPredicates(TABLE_MOVIES);
@@ -262,6 +263,8 @@ export class MediaContentDao {
     }
     columns.push('title_pinyin');
     args.push(toPinyinFull(e.title));
+    columns.push('title_pinyin_segments');
+    args.push(toPinyinSegments(e.title));
     columns.push('title_initials');
     args.push(toPinyinInitials(e.title));
     const placeholders = columns.map(() => '?').join(', ');
@@ -349,6 +352,7 @@ export class MediaContentDao {
         raw_json: e.rawJson ?? null,
         scraped_at: e.scrapedAt,
         title_pinyin: toPinyinFull(e.title),
+        title_pinyin_segments: toPinyinSegments(e.title),
         title_initials: toPinyinInitials(e.title)
       };
       const pred = new relationalStore.RdbPredicates(TABLE_TV_SERIES);
@@ -379,6 +383,7 @@ export class MediaContentDao {
       raw_json: e.rawJson ?? null,
       scraped_at: e.scrapedAt,
       title_pinyin: toPinyinFull(e.title),
+      title_pinyin_segments: toPinyinSegments(e.title),
       title_initials: toPinyinInitials(e.title)
     };
     let insertedRowId = -1;

--- a/entry/src/main/ets/db/files/MediaQueryDao.ets
+++ b/entry/src/main/ets/db/files/MediaQueryDao.ets
@@ -10,6 +10,7 @@ import {
 } from './DbConstants';
 import { FileSourceDbCore } from './FileSourceDbCore';
 import { countSeriesEpisodeRows } from './SeriesGroupCountUtil';
+import { buildLocalSearchQuery } from '../../services/search/LocalSearchQuery';
 
 /** 搜索模块自定义兜底码，不属于 HarmonyOS 平台错误码。 */
 export enum MediaSearchErrorCode {
@@ -948,20 +949,10 @@ export class MediaQueryDao {
       // ── 统一 trim keyword，避免含前后空格时无法正确匹配 ──
       const kw: string = keyword.trim();
 
-      // ── keyword 非空时：title / original_title + 拼音字段模糊匹配 ──
-      if (kw.length > 0) {
-        const kwLike: string = `%${kw}%`;
-        const kwLower: string = kw.toLowerCase();
-        // 拼音前缀匹配：转义 LIKE 通配符，避免 %/_ 被误当通配符；使用 ESCAPE '\'
-        const kwLowerEscape: string = kwLower.replace(/%/g, '\\%').replace(/_/g, '\\_');
-        const kwLowerEscapePrefix: string = `${kwLowerEscape}%`;
-        conditions.push(
-          '(m.title LIKE ? OR m.original_title LIKE ? OR ts.title LIKE ? OR ts.original_title LIKE ?' +
-          " OR m.title_pinyin LIKE ? ESCAPE '\\' OR m.title_initials LIKE ? ESCAPE '\\'" +
-          " OR ts.title_pinyin LIKE ? ESCAPE '\\' OR ts.title_initials LIKE ? ESCAPE '\\')"
-        );
-        params.push(kwLike, kwLike, kwLike, kwLike);
-        params.push(kwLowerEscapePrefix, kwLowerEscapePrefix, kwLowerEscapePrefix, kwLowerEscapePrefix);
+      const searchQuery = buildLocalSearchQuery(kw);
+      if (searchQuery.whereClause.length > 0) {
+        conditions.push(searchQuery.whereClause);
+        params.push(...searchQuery.whereParams);
       }
 
       // ── mediaType 过滤（'all' 时不加条件） ──
@@ -1060,24 +1051,16 @@ export class MediaQueryDao {
       } else if (sortBy === 'title') {
         orderClause = ' ORDER BY COALESCE(m.title, ts.title) ASC';
       } else if (kw.length > 0) {
-        // keyword 搜索时：相关度分层排序，次级按评分降序
-        // SQLite ORDER BY CASE WHEN 不支持 ? 参数化绑定（relationalStore API 限制）；
-        // 已通过三重转义保证安全：单引号转义（''）+ LIKE 通配符转义（\%/\_）+ ESCAPE '\\'
-        const kwEscape: string = kw.replace(/'/g, "''").replace(/%/g, '\\%').replace(/_/g, '\\_');
-        const kwLowerEscape: string = kw.toLowerCase().replace(/'/g, "''").replace(/%/g, '\\%').replace(/_/g, '\\_');
-        orderClause =
-          ` ORDER BY CASE` +
-          ` WHEN COALESCE(m.title, ts.title) = '${kwEscape}' THEN 0` +
-          ` WHEN COALESCE(m.title, ts.title) LIKE '${kwEscape}%' ESCAPE '\\' THEN 1` +
-          ` WHEN COALESCE(m.title, ts.title) LIKE '%${kwEscape}%' ESCAPE '\\' THEN 2` +
-          ` WHEN COALESCE(m.title_pinyin, ts.title_pinyin) LIKE '${kwLowerEscape}%' ESCAPE '\\' THEN 3` +
-          ` WHEN COALESCE(m.title_initials, ts.title_initials) LIKE '${kwLowerEscape}%' ESCAPE '\\' THEN 4` +
-          ` ELSE 5 END ASC,` +
-          ` COALESCE(m.rating, ts.rating) DESC`;
+        orderClause = ` ORDER BY ${searchQuery.rankExpression} ASC, COALESCE(m.rating, ts.rating) DESC`;
+        params.push(...searchQuery.rankParams);
       } else {
         // 无 keyword：默认按评分
         orderClause = ' ORDER BY COALESCE(m.rating, ts.rating) DESC';
       }
+
+      // Stable final tie-breakers prevent equal-score results from shuffling between requests.
+      orderClause += ', COALESCE(m.title, ts.title, s.title) COLLATE NOCASE ASC, ' +
+        'COALESCE(m.id, ts.id) ASC, v.id ASC';
 
       // ── LIMIT 范围校验，防止 NaN/负数/超大值 ──
       const rawLimit: number = options?.limit ?? 50;

--- a/entry/src/main/ets/db/files/MediaQueryDao.ets
+++ b/entry/src/main/ets/db/files/MediaQueryDao.ets
@@ -1058,7 +1058,7 @@ export class MediaQueryDao {
         orderClause = ' ORDER BY COALESCE(m.rating, ts.rating) DESC';
       }
 
-      // Stable final tie-breakers prevent equal-score results from shuffling between requests.
+      // 追加稳定的排序兜底，避免同分结果在多次请求之间顺序变化。
       orderClause += ', COALESCE(m.title, ts.title, s.title) COLLATE NOCASE ASC, ' +
         'COALESCE(m.id, ts.id) ASC, v.id ASC';
 

--- a/entry/src/main/ets/services/search/LocalSearchQuery.ets
+++ b/entry/src/main/ets/services/search/LocalSearchQuery.ets
@@ -1,0 +1,114 @@
+import { normalizeSearchText, toPinyinFull, toPinyinInitials } from '../../utils/PinyinUtil';
+
+export interface LocalSearchQuery {
+  whereClause: string;
+  whereParams: string[];
+  rankExpression: string;
+  rankParams: string[];
+}
+
+interface SearchMatch {
+  sql: string;
+  params: string[];
+}
+
+/** Escape LIKE metacharacters before adding intentional prefix/contains wildcards. */
+export function escapeSearchLike(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+}
+
+function titleMatch(columns: string[], values: string[], exact: boolean): SearchMatch {
+  const sql: string[] = [];
+  const params: string[] = [];
+  for (const column of columns) {
+    for (const value of values) {
+      sql.push(exact ? `${column} = ? COLLATE NOCASE` : `${column} LIKE ? ESCAPE '\\'`);
+      params.push(value);
+    }
+  }
+  return { sql: '(' + sql.join(' OR ') + ')', params: params };
+}
+
+function pinyinMatch(column: string, value: string, exact: boolean, hanParts: string[]): SearchMatch {
+  const alternatives: string[] = [];
+  const params: string[] = [];
+  for (const alias of ['m', 'ts']) {
+    const constraints: string[] = [exact ? `${alias}.${column} = ?` : `${alias}.${column} LIKE ? ESCAPE '\\'`];
+    params.push(value);
+    // Keep actual Chinese text on the same row; mixed queries must not expand to homophones.
+    for (const part of hanParts) {
+      constraints.push(`${alias}.title LIKE ? ESCAPE '\\'`);
+      params.push('%' + escapeSearchLike(part) + '%');
+    }
+    alternatives.push('(' + constraints.join(' AND ') + ')');
+  }
+  return { sql: '(' + alternatives.join(' OR ') + ')', params: params };
+}
+
+/** Shared WHERE/rank predicates keep recall and relevance identical; no SQL contains user text. */
+export function buildLocalSearchQuery(keyword: string): LocalSearchQuery {
+  const raw = keyword.trim();
+  if (raw.length === 0) {
+    return { whereClause: '', whereParams: [], rankExpression: '0', rankParams: [] };
+  }
+  const normalized = normalizeSearchText(raw);
+  const titleValues: string[] = [raw];
+  const compatibilityText = raw.normalize('NFKC').trim();
+  if (compatibilityText.length > 0 && compatibilityText !== raw) {
+    titleValues.push(compatibilityText);
+  }
+  // Preserve Latin word spacing in original titles. Han input also gets a compact literal candidate.
+  if (normalized.length > 0 && /[\u3400-\u9fff]/.test(normalized) && !titleValues.includes(normalized)) {
+    titleValues.push(normalized);
+  }
+  const prefixes: string[] = [];
+  const contains: string[] = [];
+  for (const value of titleValues) {
+    const escaped = escapeSearchLike(value);
+    prefixes.push(escaped + '%');
+    contains.push('%' + escaped + '%');
+  }
+  const columns: string[] = ['m.title', 'ts.title', 's.title', 'm.original_title', 'ts.original_title'];
+  const matches: SearchMatch[] = [
+    titleMatch(columns, titleValues, true),
+    titleMatch(columns, prefixes, false),
+    titleMatch(columns, contains, false)
+  ];
+  const hanParts: string[] = normalized.match(/[\u3400-\u9fff]+/g) ?? [];
+  const hasLatin = /[a-z]/.test(normalized);
+  // Pure Chinese queries use literal titles only. Punctuation-only input cannot become LIKE '%'.
+  if (hasLatin) {
+    const full = hanParts.length > 0 ? toPinyinFull(raw) : normalized;
+    const initials = hanParts.length > 0 ? toPinyinInitials(raw) : normalized;
+    if (/^[a-z0-9]+$/.test(full)) {
+      matches.push(pinyinMatch('title_pinyin', full, true, hanParts));
+      if (full.length > 1) {
+        matches.push(pinyinMatch('title_pinyin', escapeSearchLike(full) + '%', false, hanParts));
+        matches.push(pinyinMatch('title_pinyin_segments', '%|' + escapeSearchLike(full) + '%', false, hanParts));
+      }
+    }
+    if (/^[a-z0-9]+$/.test(initials)) {
+      matches.push(pinyinMatch('title_initials', initials, true, hanParts));
+      if (initials.length > 1) {
+        matches.push(pinyinMatch('title_initials', escapeSearchLike(initials) + '%', false, hanParts));
+      }
+    }
+  }
+  const where: string[] = [];
+  const whereParams: string[] = [];
+  const ranks: string[] = [];
+  const rankParams: string[] = [];
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    where.push(match.sql);
+    whereParams.push(...match.params);
+    ranks.push(`WHEN ${match.sql} THEN ${i}`);
+    rankParams.push(...match.params);
+  }
+  return {
+    whereClause: '(' + where.join(' OR ') + ')',
+    whereParams: whereParams,
+    rankExpression: 'CASE ' + ranks.join(' ') + ` ELSE ${matches.length} END`,
+    rankParams: rankParams
+  };
+}

--- a/entry/src/main/ets/services/search/LocalSearchQuery.ets
+++ b/entry/src/main/ets/services/search/LocalSearchQuery.ets
@@ -37,7 +37,7 @@ function pinyinMatch(column: string, value: string, exact: boolean, hanParts: st
     params.push(value);
     // Keep actual Chinese text on the same row; mixed queries must not expand to homophones.
     for (const part of hanParts) {
-      constraints.push(`${alias}.title LIKE ? ESCAPE '\\'`);
+      constraints.push(`${alias}.title_normalized LIKE ? ESCAPE '\\'`);
       params.push('%' + escapeSearchLike(part) + '%');
     }
     alternatives.push('(' + constraints.join(' AND ') + ')');
@@ -74,6 +74,20 @@ export function buildLocalSearchQuery(keyword: string): LocalSearchQuery {
     titleMatch(columns, prefixes, false),
     titleMatch(columns, contains, false)
   ];
+  // 标题与查询采用相同规范化；只为含汉字的查询扩展，保留拉丁字面量及通配符语义。
+  if (normalized.length > 0 && /[\u3400-\u9fff]/.test(normalized)) {
+    const normalizedColumns: string[] = ['m.title_normalized', 'ts.title_normalized'];
+    const escaped = escapeSearchLike(normalized);
+    const normalizedMatches: SearchMatch[] = [
+      titleMatch(normalizedColumns, [normalized], true),
+      titleMatch(normalizedColumns, [escaped + '%'], false),
+      titleMatch(normalizedColumns, ['%' + escaped + '%'], false)
+    ];
+    for (let i = 0; i < normalizedMatches.length; i++) {
+      matches[i].sql = '(' + matches[i].sql + ' OR ' + normalizedMatches[i].sql + ')';
+      matches[i].params.push(...normalizedMatches[i].params);
+    }
+  }
   const hanParts: string[] = normalized.match(/[\u3400-\u9fff]+/g) ?? [];
   const hasLatin = /[a-z]/.test(normalized);
   // Pure Chinese queries use literal titles only. Punctuation-only input cannot become LIKE '%'.

--- a/entry/src/main/ets/utils/PinyinUtil.ets
+++ b/entry/src/main/ets/utils/PinyinUtil.ets
@@ -1,27 +1,43 @@
 import { pinyin } from 'pinyin-pro';
 
-/**
- * 汉字转全拼（无声调，小写，连续字符串）
- * 非汉字字符原样保留（ASCII 字母/数字）。
- * 示例："斗罗大陆" → "douluodalu"
- */
-export function toPinyinFull(text: string): string {
-  if (text.length === 0) {
-    return '';
-  }
-  // pattern: 'pinyin' 不带声调；type: 'array' 返回逐字数组
-  const parts: string[] = pinyin(text, { toneType: 'none', type: 'array' }) as string[];
-  return parts.join('').toLowerCase();
+/** Shared normalization for local title indexes and queries; ü / u: / v are equivalent. */
+export function normalizeSearchText(text: string): string {
+  return text.normalize('NFKC').toLowerCase().replace(/u:/g, 'v')
+    .replace(/[üǖǘǚǜ]/g, 'v').normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .replace(/[\s\-_'’·.,，。:：!?！？、()（）\[\]【】]/g, '');
 }
 
-/**
- * 汉字转首字母（小写）
- * 示例："斗罗大陆" → "dldl"
- */
-export function toPinyinInitials(text: string): string {
-  if (text.length === 0) {
-    return '';
+function titleParts(text: string): string[] {
+  // Phrase-level conversion preserves contextual readings (重庆、长安、音乐).
+  const parts = pinyin(text.normalize('NFKC').replace(/u:/gi, 'v'), { toneType: 'none', type: 'array', nonZh: 'consecutive' }) as string[];
+  const result: string[] = [];
+  for (const part of parts) {
+    for (const word of part.split(/[\s\-_'’·.,，。:：!?！？、()（）\[\]【】]+/)) {
+      const normalized = normalizeSearchText(word);
+      if (normalized.length > 0) { result.push(normalized); }
+    }
   }
-  const parts: string[] = pinyin(text, { pattern: 'initial', type: 'array', toneType: 'none' }) as string[];
-  return parts.join('').toLowerCase();
+  return result;
+}
+
+export function toPinyinFull(text: string): string {
+  return titleParts(text).join('');
+}
+
+export function toPinyinInitials(text: string): string {
+  // `initial` means 声母 (zh/ch/sh), whereas `first` means one initial per Han character.
+  const parts = pinyin(text.normalize('NFKC').replace(/u:/gi, 'v'), { pattern: 'first', type: 'array', toneType: 'none' }) as string[];
+  return normalizeSearchText(parts.join(''));
+}
+
+/** Suffixes start only at syllable/Latin-word boundaries, never inside a syllable.
+ * Bound auxiliary storage to 64 starts × 256 characters for pathological metadata.
+ */
+export function toPinyinSegments(text: string): string {
+  const parts = titleParts(text);
+  const suffixes: string[] = [];
+  for (let i = 1; i < Math.min(parts.length, 65); i++) {
+    suffixes.push(parts.slice(i).join('').slice(0, 256));
+  }
+  return '|' + suffixes.join('|') + '|';
 }

--- a/entry/src/test/README.md
+++ b/entry/src/test/README.md
@@ -158,3 +158,27 @@
 - `/entry/src/main/ets/lib/models/FileSourceModel.ets` - 数据模型定义
 - `/entry/src/main/ets/lib/stores/FileSourceStore.ets` - 缓存管理类
 
+
+## 本地拼音搜索回归（Issue #319）
+
+使用 Node.js 22.13+ 的内置 SQLite 执行实际 ArkTS 查询、写入和迁移代码：
+
+```sh
+TYPESCRIPT_PATH=/Applications/DevEco-Studio.app/Contents/tools/hvigor/hvigor/node_modules/typescript \
+  node entry/src/test/local_pinyin_search_test.cjs
+```
+
+可将 `TYPESCRIPT_PATH` 改为已安装的 TypeScript 模块绝对路径；依赖由 `devecocli build` 安装。
+加 `--benchmark` 可在 10,000 条合成电影记录上输出主机查询耗时，不代表 TV 设备性能。
+
+匹配规则：
+
+- 原文（标题、原始标题、刮削标题）按精确、前缀、包含优先；之后为全拼精确、前缀、音节中段，再到首字母精确、前缀。同层按评分、标题和视频 ID 稳定排序；显式年份/标题排序仍可覆盖相关度。
+- 拼音使用词组上下文，例如重庆 `chongqing`、长安 `changan`、音乐 `yinyue`；首字母每个汉字只取一个字母，重庆森林为 `cqsl`，不再误用声母 `chqsl`。
+- 支持大小写、全角、声调、空格和常见分隔符规范化；`ü`、`u:` 和 `v` 等价。纯中文不扩展为同音字；混合输入要求原片名保留输入的中文片段。
+- 中段全拼从音节或英文词起点匹配，例如 `senlin` 命中重庆森林；不允许从 `chong` 内部的 `ong` 起点召回。单字母拼音和首字母只做精确匹配；两字母及以上首字母只匹配片名开头，不做任意中段、跳字或编辑距离模糊匹配。
+- v13 增加 `title_pinyin_segments`，电影/电视剧插入和改名同步更新。旧库按 100 行一批，在数据库完全就绪前回填缺失字段；中断后下次启动续做，正常启动不重写已有字段。
+- 辅助后缀字段最多保留 64 个音节/词起点，每个后缀最多 256 字符；超长片名仍支持完整标题及全拼前缀，但不保证超出上限的中段召回。该字段用于匹配，未建立无效的前导通配符 B-tree 索引。
+- 仅本地文件库使用这些规则。服务器搜索、外部建议词与多音字所有读音的组合扩展不在范围内；未收录词组的读音仍受 `pinyin-pro` 词典限制。
+
+回归覆盖中文、全拼、首字母、混合输入、多音词、原始英文标题、通配符/引号/反斜杠、排序、过滤、写入与改名、v12 升级及重启。测试只替换鸿蒙数据库桥接，不替换拼音库或查询算法；设备焦点和实际设备性能仍需设备验收。

--- a/entry/src/test/local_pinyin_search_test.cjs
+++ b/entry/src/test/local_pinyin_search_test.cjs
@@ -1,0 +1,186 @@
+// Executes production ArkTS query/write/migration code against real SQLite (Node >= 22.13).
+// TYPESCRIPT_PATH may point to DevEco's installed TypeScript module.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+const { DatabaseSync } = require('node:sqlite');
+const root = path.resolve(__dirname, '../../..');
+const ts = require(process.env.TYPESCRIPT_PATH || 'typescript');
+require.extensions['.ets'] = (module, filename) => module._compile(ts.transpileModule(
+  fs.readFileSync(filename, 'utf8'), { compilerOptions: { module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2021 } }).outputText, filename);
+class Predicates {
+  constructor(table) { this.table = table; }
+  equalTo(column, value) { this.column = column; this.value = value; return this; }
+}
+const originalLoad = Module._load;
+Module._load = function(request, parent, main) {
+  if (request === 'pinyin-pro') return originalLoad.call(this, path.join(root, 'oh_modules/pinyin-pro/dist/index.js'), parent, main);
+  if (request === '@ohos.data.relationalStore') return { default: { RdbPredicates: Predicates } };
+  if (request === '@kit.BasicServicesKit') return { emitter: { emit() {} } };
+  if (request === '@kit.PerformanceAnalysisKit') return { hilog: { error() {} } };
+  return originalLoad.call(this, request, parent, main);
+};
+const source = name => require(path.join(root, 'entry/src/main/ets', name));
+const { toPinyinFull, toPinyinInitials, toPinyinSegments, normalizeSearchText } = source('utils/PinyinUtil.ets');
+const { FileSourceDbCore } = source('db/files/FileSourceDbCore.ets');
+const { MediaContentDao } = source('db/files/MediaContentDao.ets');
+const { MediaQueryDao } = source('db/files/MediaQueryDao.ets');
+
+class Store {
+  constructor() { this.db = new DatabaseSync(':memory:'); this.calls = []; this.openCursors = 0; }
+  async executeSql(sql, params = []) { this.calls.push(sql); this.db.prepare(sql).run(...params); }
+  async querySql(sql, params = []) {
+    this.calls.push(sql);
+    const stmt = this.db.prepare(sql);
+    const columns = stmt.columns().map(c => c.name);
+    const rows = stmt.all(...params);
+    let index = -1;
+    this.openCursors++;
+    const value = col => rows[index][columns[col]];
+    return { rowCount: rows.length, goToNextRow: () => ++index < rows.length,
+      goToFirstRow: () => { index = 0; return rows.length > 0; },
+      getColumnIndex: name => columns.indexOf(name), isColumnNull: col => value(col) == null,
+      getString: col => value(col), getLong: col => value(col), getDouble: col => value(col),
+      close: () => { this.openCursors--; } };
+  }
+  async insert(table, bucket) {
+    const columns = Object.keys(bucket);
+    return Number(this.db.prepare(`INSERT INTO ${table} (${columns}) VALUES (${columns.map(() => '?')})`)
+      .run(...Object.values(bucket)).lastInsertRowid);
+  }
+  async update(bucket, pred) {
+    return Number(this.db.prepare(`UPDATE ${pred.table} SET ${Object.keys(bucket).map(c => `${c} = ?`)} WHERE ${pred.column} = ?`)
+      .run(...Object.values(bucket), pred.value).changes);
+  }
+}
+
+async function main() {
+  assert.equal(toPinyinInitials('重庆森林'), 'cqsl');
+  assert.equal(toPinyinInitials('长安三万里'), 'caswl');
+  assert.equal(toPinyinInitials('音乐之声'), 'yyzs');
+  assert.equal(toPinyinInitials('阿Q正传'), 'aqzz');
+  assert.equal(toPinyinFull('重庆森林'), 'chongqingsenlin');
+  assert.equal(toPinyinFull('长津湖'), 'changjinhu');
+  assert.equal(toPinyinFull('音乐之声'), 'yinyuezhisheng');
+  assert.equal(normalizeSearchText(' ＣＨÓＮＧ-QING '), 'chongqing');
+  for (const input of ['lǜ', 'lü', 'lu:', 'ｌｖ']) assert.equal(normalizeSearchText(input), 'lv');
+  assert.equal(toPinyinFull('绿皮书'), 'lvpishu');
+  assert.equal(toPinyinFull('lu:皮书'), 'lvpishu');
+  assert.ok(toPinyinSegments('重庆森林').includes('|senlin|'));
+  assert.ok(!toPinyinSegments('重庆森林').includes('|ong'));
+  assert.ok(toPinyinSegments('人'.repeat(1000)).length <= 64 * 257 + 1);
+  const store = new Store();
+  const core = new FileSourceDbCore();
+  core.rdbStore = store;
+  await core.onCreate(store);
+  await store.executeSql("INSERT INTO file_sources (id, name, type, config_json, created_at) VALUES (1, 'Local', 'webdav', '{}', 1)");
+  const content = new MediaContentDao(core);
+  const query = new MediaQueryDao(core);
+  let nextId = 0;
+  async function add(title, type = 'movie', rating = 5, originalTitle) {
+    const id = ++nextId;
+    const entity = { provider: 'tmdb', providerId: String(id), title, rating, originalTitle,
+      scrapedAt: 1, genresJson: '["剧情"]', releaseDate: '2020-01-01', firstAirDate: '2020-01-01' };
+    const mediaId = type === 'movie' ? await content.upsertMovie(entity) : await content.upsertTvSeries(entity);
+    await store.executeSql('INSERT INTO videos (id, source_id, directory_path, file_path, file_name, scanned_at) VALUES (?, 1, ?, ?, ?, 1)',
+      [id, '/', `/${id}.mkv`, `${title}.mkv`]);
+    await store.executeSql(`INSERT INTO scrape_info (video_id, provider, provider_id, title, scraped_at, media_type, ${type === 'movie' ? 'movie_id' : 'tv_series_id'}) VALUES (?, 'tmdb', ?, ?, 1, ?, ?)`,
+      [id, String(id), title, type, mediaId]);
+    return { mediaId, entity };
+  }
+  const fixtures = ['重庆森林', '长安三万里', '长津湖', '音乐之声', '绿皮书', '少年派的奇幻漂流',
+    '阿Q正传', '重启之极海听雷', '楚乔传', '重庆', '森林', '挪威的森林', '虫情森林',
+    '爱', '爱在黎明破晓前', '100% Love', '1000 Love', 'A_B', 'AXB', 'Back\\Slash', "O'Connor"];
+  for (const title of fixtures) await add(title);
+  await add('庆余年', 'tv');
+  await add('庆余年第二季', 'tv');
+  await add('千与千寻', 'movie', 9, 'Spirited Away');
+  const titles = async (kw, options) => (await query.searchMediaItems(kw, options, true)).map(i => i.title);
+  const includes = async (kw, wanted) => assert.ok((await titles(kw)).includes(wanted), `${kw} should match ${wanted}`);
+  const excludes = async (kw, unwanted) => assert.ok(!(await titles(kw)).includes(unwanted), `${kw} must not match ${unwanted}`);
+  for (const [kw, title] of [
+    ['重 庆', '重庆森林'], ['长安·三万里', '长安三万里'], ['重庆', '重庆森林'], ['chongqing', '重庆森林'], ['ＣＨÓＮＧ ＱＩＮＧ', '重庆森林'],
+    ['cqsl', '重庆森林'], ['cq', '重庆森林'], ['senlin', '重庆森林'],
+    ['changjinhu', '长津湖'], ['cjh', '长津湖'], ['caswl', '长安三万里'],
+    ['yinyue', '音乐之声'], ['yyzs', '音乐之声'], ['lǜ pi shu', '绿皮书'], ['lu: pi shu', '绿皮书'],
+    ['奇幻piaoliu', '少年派的奇幻漂流'], ['重庆senlin', '重庆森林'], ['chongqing森林', '重庆森林'],
+    ['重庆sl', '重庆森林'], ['aqzz', '阿Q正传'], ['qyn', '庆余年'], ['Spirited', '千与千寻'],
+    ['Ｓｐｉｒｉｔｅｄ', '千与千寻'], ['100%', '100% Love'], ['A_B', 'A_B'], ['Back\\', 'Back\\Slash'], ["O'Connor", "O'Connor"]
+  ]) await includes(kw, title);
+  for (const [kw, title] of [['c', '重庆森林'], ['qsl', '重庆森林'], ['ongqing', '重庆森林'],
+    ['重庆', '虫情森林'], ['重庆senlin', '虫情森林'], ['100%', '1000 Love'],
+    ['A_B', 'AXB'], ["' OR 1=1 --", '重庆森林'], ['\\', '重庆森林']]) await excludes(kw, title);
+  assert.deepEqual((await titles('森林')).slice(0, 1), ['森林']);
+  assert.equal((await titles('重庆'))[0], '重庆');
+  assert.deepEqual(await titles('qyn', { mediaType: 'tv' }), ['庆余年', '庆余年第二季']);
+  assert.deepEqual(await titles('qyn', { mediaType: 'movie' }), []);
+  assert.equal((await titles('cq', { limit: 1 })).length, 1);
+  assert.equal((await titles('senlin'))[0], '森林');
+  assert.deepEqual((await titles('cqsl')).slice(0, 2), ['虫情森林', '重庆森林']);
+  assert.ok((await titles('cqsl', { sortBy: 'title' })).includes('重庆森林'));
+  assert.ok((await titles('cqsl', { sortBy: 'year' })).includes('重庆森林'));
+  assert.deepEqual(await titles('cqsl'), await titles('cqsl'));
+
+  assert.deepEqual(await titles('cq', { minRating: 10 }), []);
+  // All four production insertion/update paths keep search indexes in sync.
+  for (const type of ['movie', 'tv']) {
+    const { mediaId, entity } = await add('旧片名', type);
+    entity.title = '重庆森林新篇';
+    if (type === 'movie') await content.upsertMovie(entity); else await content.upsertTvSeries(entity);
+    const row = store.db.prepare(`SELECT * FROM ${type === 'movie' ? 'movies' : 'tv_series'} WHERE id = ?`).get(mediaId);
+    assert.equal(row.title_initials, 'cqslxp');
+    assert.ok(row.title_pinyin_segments.includes('|senlinxinpian|'));
+  }
+  assert.equal(store.openCursors, 0);
+  // Upgrade a v12 database, backfill > one batch, and prove restart does no writes.
+  const legacy = new Store();
+  legacy.db.exec('CREATE TABLE movies (id INTEGER PRIMARY KEY, title TEXT, title_pinyin TEXT, title_initials TEXT); CREATE TABLE tv_series (id INTEGER PRIMARY KEY, title TEXT, title_pinyin TEXT, title_initials TEXT)');
+  for (let id = 1; id <= 205; id++) legacy.db.prepare('INSERT INTO movies VALUES (?, ?, ?, ?)').run(id, '重庆森林', 'chongqingsenlin', 'chqsl');
+  legacy.db.exec("INSERT INTO tv_series VALUES (1, '长安三万里', '', '')");
+  await core.onUpgrade(legacy, 12, 13);
+  await core.backfillPinyinFields(legacy);
+  assert.equal(legacy.db.prepare("SELECT COUNT(*) n FROM movies WHERE title_initials = 'cqsl' AND title_pinyin_segments IS NOT NULL").get().n, 205);
+  assert.equal(legacy.db.prepare('SELECT title_initials FROM tv_series').get().title_initials, 'caswl');
+  legacy.calls = [];
+  await core.backfillPinyinFields(legacy);
+  assert.equal(legacy.calls.filter(sql => sql.startsWith('UPDATE')).length, 0);
+  assert.equal(legacy.openCursors, 0);
+  await core.onUpgrade(legacy, 12, 13); // Idempotent schema recovery after interruption.
+  // Failed backfill is surfaced, retains NULL on unfinished rows, and resumes next time.
+  await legacy.executeSql('UPDATE movies SET title_pinyin_segments = NULL');
+  const execute = legacy.executeSql.bind(legacy);
+  let writes = 0;
+  legacy.executeSql = async (sql, params) => {
+    if (sql.startsWith('UPDATE') && ++writes === 102) throw new Error('simulated interruption');
+    return execute(sql, params);
+  };
+  await assert.rejects(core.backfillPinyinFields(legacy), /simulated interruption/);
+  assert.equal(legacy.openCursors, 0);
+  legacy.executeSql = execute;
+  await core.backfillPinyinFields(legacy);
+  assert.equal(legacy.db.prepare('SELECT COUNT(*) n FROM movies WHERE title_pinyin_segments IS NULL').get().n, 0);
+  const missing = new Store();
+  await core.onUpgrade(missing, 12, 13);
+  assert.ok(missing.db.prepare('PRAGMA table_info(movies)').all().some(c => c.name === 'title_pinyin_segments'));
+  if (process.argv.includes('--benchmark')) {
+    const oldLog = console.info;
+    console.info = () => {};
+    store.db.exec('BEGIN');
+    const start = performance.now();
+    for (let i = 0; i < 10000; i++) await add(`测试电影${i}重庆森林`);
+    store.db.exec('COMMIT');
+    const indexingMs = performance.now() - start;
+    const timings = [];
+    for (const kw of ['重庆', 'chongqing', 'cqsl', 'ceshi', '森林', 'missing']) {
+      const before = performance.now();
+      await titles(kw);
+      timings.push({ keyword: kw, ms: Math.round(performance.now() - before) });
+    }
+    console.info = oldLog;
+    console.log(JSON.stringify({ syntheticRows: 10000, indexingMs: Math.round(indexingMs), timings }));
+  }
+  console.log('Local pinyin: utility, real SQLite search/ranking, insert/update, v12 migration and restart checks passed.');
+}
+main().catch(error => { console.error(error); process.exitCode = 1; });

--- a/entry/src/test/local_pinyin_search_test.cjs
+++ b/entry/src/test/local_pinyin_search_test.cjs
@@ -1,5 +1,5 @@
-// Executes production ArkTS query/write/migration code against real SQLite (Node >= 22.13).
-// TYPESCRIPT_PATH may point to DevEco's installed TypeScript module.
+// 使用真实 SQLite 执行生产 ArkTS 查询、写入及迁移代码（Node >= 22.13）。
+// TYPESCRIPT_PATH 可指向 DevEco 已安装的 TypeScript 模块。
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -124,31 +124,79 @@ async function main() {
   assert.deepEqual(await titles('cqsl'), await titles('cqsl'));
 
   assert.deepEqual(await titles('cq', { minRating: 10 }), []);
-  // All four production insertion/update paths keep search indexes in sync.
+  // 电影与电视剧的四条生产插入、更新路径均需同步搜索字段。
   for (const type of ['movie', 'tv']) {
     const { mediaId, entity } = await add('旧片名', type);
-    entity.title = '重庆森林新篇';
+    assert.equal(store.db.prepare(`SELECT title_normalized FROM ${type === 'movie' ? 'movies' : 'tv_series'} WHERE id = ?`).get(mediaId).title_normalized, '旧片名');
+    entity.title = '重庆·森林 新篇';
     if (type === 'movie') await content.upsertMovie(entity); else await content.upsertTvSeries(entity);
     const row = store.db.prepare(`SELECT * FROM ${type === 'movie' ? 'movies' : 'tv_series'} WHERE id = ?`).get(mediaId);
+    assert.equal(row.title_normalized, '重庆森林新篇');
     assert.equal(row.title_initials, 'cqslxp');
+    assert.ok((await titles('重庆森林新篇', { mediaType: type })).includes(entity.title));
     assert.ok(row.title_pinyin_segments.includes('|senlinxinpian|'));
   }
+  // 原始标题含分隔符时，两端规范化仍应保留真实汉字，不能召回同音标题。
+  for (const type of ['movie', 'tv']) {
+    await add('长安·三万里', type);
+    await add('常安·三万里', type);
+    for (const keyword of ['长安 三万里', '长安三万里', '长安·三万里']) {
+      assert.ok((await titles(keyword, { mediaType: type })).includes('长安·三万里'));
+      assert.ok(!(await titles(keyword, { mediaType: type })).includes('常安·三万里'));
+    }
+  }
   assert.equal(store.openCursors, 0);
-  // Upgrade a v12 database, backfill > one batch, and prove restart does no writes.
+  // 模拟已完成 v13 回填的完整数据库，验证新增列回填后真实搜索与重启行为。
+  const { DB_VERSION } = source('db/files/DbConstants.ets');
+  assert.equal(DB_VERSION, 14);
+  for (const table of ['movies', 'tv_series']) {
+    await store.executeSql(`ALTER TABLE ${table} DROP COLUMN title_normalized`);
+    assert.equal(store.db.prepare(`SELECT COUNT(*) n FROM ${table} WHERE title_pinyin_segments IS NULL`).get().n, 0);
+  }
+  await core.onUpgrade(store, 13, DB_VERSION);
+  // 故障发生在新增字段回填期间，重启不得因 v13 拼音字段非空而漏掉未完成行。
+  const v13Execute = store.executeSql.bind(store);
+  let normalizedWrites = 0;
+  store.executeSql = async (sql, params) => {
+    if (sql.startsWith('UPDATE') && ++normalizedWrites === 3) throw new Error('v14 回填中断');
+    return v13Execute(sql, params);
+  };
+  await assert.rejects(core.backfillPinyinFields(store), /v14 回填中断/);
+  assert.ok(store.db.prepare('SELECT COUNT(*) n FROM movies WHERE title_normalized IS NULL').get().n > 0);
+  assert.equal(store.openCursors, 0);
+  store.executeSql = v13Execute;
+  await core.onUpgrade(store, 13, DB_VERSION);
+  await core.backfillPinyinFields(store);
+  for (const type of ['movie', 'tv']) {
+    const table = type === 'movie' ? 'movies' : 'tv_series';
+    assert.equal(store.db.prepare(`SELECT COUNT(*) n FROM ${table} WHERE title_normalized IS NULL`).get().n, 0);
+    for (const keyword of ['长安 三万里', '长安三万里', '长安·三万里', '三万里', '长安 三万', '长安sanwanli']) {
+      const results = await titles(keyword, { mediaType: type });
+      assert.ok(results.includes('长安·三万里'));
+      if (keyword.startsWith('长安')) assert.ok(!results.includes('常安·三万里'));
+    }
+  }
+  for (const keyword of ['---', '（）']) assert.deepEqual(await titles(keyword), []);
+  store.calls = [];
+  await core.backfillPinyinFields(store);
+  assert.equal(store.calls.filter(sql => sql.startsWith('UPDATE')).length, 0);
+  assert.equal(store.openCursors, 0);
+  // v12 升级到 v14，跨批次回填，并验证重启不重复写入。
   const legacy = new Store();
   legacy.db.exec('CREATE TABLE movies (id INTEGER PRIMARY KEY, title TEXT, title_pinyin TEXT, title_initials TEXT); CREATE TABLE tv_series (id INTEGER PRIMARY KEY, title TEXT, title_pinyin TEXT, title_initials TEXT)');
   for (let id = 1; id <= 205; id++) legacy.db.prepare('INSERT INTO movies VALUES (?, ?, ?, ?)').run(id, '重庆森林', 'chongqingsenlin', 'chqsl');
   legacy.db.exec("INSERT INTO tv_series VALUES (1, '长安三万里', '', '')");
-  await core.onUpgrade(legacy, 12, 13);
+  await core.onUpgrade(legacy, 12, 14);
   await core.backfillPinyinFields(legacy);
-  assert.equal(legacy.db.prepare("SELECT COUNT(*) n FROM movies WHERE title_initials = 'cqsl' AND title_pinyin_segments IS NOT NULL").get().n, 205);
+  assert.equal(legacy.db.prepare("SELECT COUNT(*) n FROM movies WHERE title_initials = 'cqsl' AND title_pinyin_segments IS NOT NULL AND title_normalized = '重庆森林'").get().n, 205);
   assert.equal(legacy.db.prepare('SELECT title_initials FROM tv_series').get().title_initials, 'caswl');
+  assert.equal(legacy.db.prepare('SELECT title_normalized FROM tv_series').get().title_normalized, '长安三万里');
   legacy.calls = [];
   await core.backfillPinyinFields(legacy);
   assert.equal(legacy.calls.filter(sql => sql.startsWith('UPDATE')).length, 0);
   assert.equal(legacy.openCursors, 0);
-  await core.onUpgrade(legacy, 12, 13); // Idempotent schema recovery after interruption.
-  // Failed backfill is surfaced, retains NULL on unfinished rows, and resumes next time.
+  await core.onUpgrade(legacy, 12, 14); // 中断后的结构恢复必须幂等。
+  // 回填失败需向上传播，未完成行保留 NULL，下次启动继续回填。
   await legacy.executeSql('UPDATE movies SET title_pinyin_segments = NULL');
   const execute = legacy.executeSql.bind(legacy);
   let writes = 0;
@@ -162,7 +210,7 @@ async function main() {
   await core.backfillPinyinFields(legacy);
   assert.equal(legacy.db.prepare('SELECT COUNT(*) n FROM movies WHERE title_pinyin_segments IS NULL').get().n, 0);
   const missing = new Store();
-  await core.onUpgrade(missing, 12, 13);
+  await core.onUpgrade(missing, 12, 14);
   assert.ok(missing.db.prepare('PRAGMA table_info(movies)').all().some(c => c.name === 'title_pinyin_segments'));
   if (process.argv.includes('--benchmark')) {
     const oldLog = console.info;
@@ -181,6 +229,6 @@ async function main() {
     console.info = oldLog;
     console.log(JSON.stringify({ syntheticRows: 10000, indexingMs: Math.round(indexingMs), timings }));
   }
-  console.log('Local pinyin: utility, real SQLite search/ranking, insert/update, v12 migration and restart checks passed.');
+  console.log('本地搜索：工具函数、真实 SQLite 搜索排序、电影及电视剧插入更新、v12/v13 至 v14 迁移和中断恢复检查全部通过。');
 }
 main().catch(error => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
## 背景
本地文件源搜索需要更准确地处理拼音、首字母和混合输入，并将更相关的标题优先展示，减少不相关结果对查找体验的影响。

Fixes: #319

## 实现
- 统一拼音规范化和查询构造，改进词组读音、首字母及音节匹配，约束中文与混合输入的召回范围。
- 为本地查询增加相关度排序，统一 WHERE 与排序参数绑定及 LIKE 转义。
- 同步电影和电视剧写入路径的拼音索引，将数据库版本升级至 v13，分批回填已有索引并支持中断恢复。
- 增加聚焦搜索、排序及索引迁移的回归测试与运行说明。

## 验证
- 已通过 `node entry/src/test/local_pinyin_search_test.cjs`，运行时通过 `TYPESCRIPT_PATH` 指向 DevEco 内置 TypeScript。
- 覆盖真实内存 SQLite 查询与排序、四条插入/更新路径、205 行跨批回填、中断续做、重复迁移及重启不重写。
- 已通过 `git diff --check 45b6b8a17^ 45b6b8a17`。
- 只读审查未发现高置信度未解决问题。

## 风险与待验证
未执行 ArkTS 构建或真机验证。Node 转译与 SQLite 替身测试不能替代 HarmonyOS relationalStore 的设备验证；API 19 兼容性、大媒体库首次升级耗时和回填期间的搜索行为仍需设备确认。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化本地媒体搜索，支持原文、拼音全拼及拼音首字母匹配。
  * 改进中文、多音字、大小写、声调及特殊字符的搜索处理。
  * 优化搜索结果排序，并提升匹配稳定性。

* **改进**
  * 升级数据库结构，自动为现有数据补充拼音搜索信息。
  * 优化数据导入和更新时的拼音索引同步，提升搜索准确性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->