### PR TITLE
优化: 按当前来源隔离搜索历史与片名建议

### DIFF
--- a/docs/search-lifecycle.md
+++ b/docs/search-lifecycle.md
@@ -54,3 +54,21 @@ TYPESCRIPT_PATH=/path/to/typescript/lib/typescript.js node scripts/tests/search-
 - 在目标电视测量首次展示与长列表滚动；模拟器启动和主机测试不能证明真机性能。
 
 电视性能、设备焦点行为与人工评审仍属于发布验收步骤；本测试不声明数值性能结论。
+
+## 当前来源历史与建议词（#320）
+
+- 历史以统一 `SearchScope.key` 隔离：WebDAV/SMB 共用 `local-files`，每个影视服务器使用 `video-server:<type>:<id>`，不保存地址、令牌或连接配置。
+- v15 初始化 `scoped_search_history`，以 `(scope_key, keyword)` 唯一存储。旧 `search_history` 保留但不展示、不自动归入任何来源，因为旧数据没有可靠的来源身份。
+- 搜索按钮、输入法提交、历史和片名建议提交统一调用当前来源的搜索路径并保存历史；自动输入预览不写历史。每个范围保留最近 15 条，删除单条和清空只作用于当前来源。
+- 本地片名建议直接复用已接受的本地搜索结果，沿用相同的中文、拼音匹配与排序，去重后最多显示 6 条。输入变化时隐藏旧建议，来源变化或离页时立即清空并使旧请求失效。
+- 服务器使用来源内历史和明确标为示例的输入提示，不调用在线补全；示例不代表服务器已收录对应影片。没有外部热搜、AI 建议或跨来源推荐。
+- 建议词使用可聚焦按钮，OK 提交后回到输入框；返回键先从建议区域回输入，再沿既有搜索页返回路径退出。
+
+回归命令（Node >= 22.13，`TYPESCRIPT_PATH` 可指向 DevEco TypeScript）：
+
+```sh
+node entry/src/test/search_suggestions_test.cjs
+node entry/src/test/local_pinyin_search_test.cjs
+```
+
+真机验收：在本地、Jellyfin 实例和 Plex 实例分别提交关键词，往返切换检查历史隔离；删除/清空其中一个来源后确认其他来源不变；输入拼音并选择本地片名建议，确认结果一致；用 D-Pad、OK、返回检查建议词与输入框的焦点路径。

--- a/entry/src/main/ets/db/files/DbConstants.ets
+++ b/entry/src/main/ets/db/files/DbConstants.ets
@@ -2,7 +2,7 @@
  * 数据库共享常量：表名、版本号、事件名。
  * 拆分自 FileSourceDatabase.ets 的私有静态常量，供 DbCore 与各 DAO 共用。
  */
-export const DB_VERSION: number = 14;
+export const DB_VERSION: number = 15;
 export const DEFAULT_DB_NAME: string = 'FILE_SOURCES_DB';
 export const DATABASE_READY: string = 'FILE_SOURCES_DB_READY';
 
@@ -18,3 +18,5 @@ export const TABLE_TV_EPISODES: string = 'tv_episodes';
 export const TABLE_PLAY_PROGRESS: string = 'play_progress';
 export const TABLE_MEDIA_PROGRESS: string = 'media_progress';
 export const TABLE_SEARCH_HISTORY: string = 'search_history';
+
+export const TABLE_SCOPED_SEARCH_HISTORY: string = 'scoped_search_history';

--- a/entry/src/main/ets/db/files/FileSourceDatabase.ets
+++ b/entry/src/main/ets/db/files/FileSourceDatabase.ets
@@ -507,19 +507,19 @@ export class FileSourceDatabase {
   // search_history
   // ─────────────────────────────────────────────
 
-  async upsertSearchHistory(keyword: string): Promise<void> {
-    await this.searchHistoryDao.upsertSearchHistory(keyword);
+  async upsertSearchHistory(scopeKey: string, keyword: string): Promise<void> {
+    await this.searchHistoryDao.upsertSearchHistory(scopeKey, keyword);
   }
 
-  async getSearchHistory(limit: number = 20): Promise<SearchHistoryEntry[]> {
-    return this.searchHistoryDao.getSearchHistory(limit);
+  async getSearchHistory(scopeKey: string, limit: number = 20): Promise<SearchHistoryEntry[]> {
+    return this.searchHistoryDao.getSearchHistory(scopeKey, limit);
   }
 
-  async deleteSearchHistory(keyword: string): Promise<void> {
-    await this.searchHistoryDao.deleteSearchHistory(keyword);
+  async deleteSearchHistory(scopeKey: string, keyword: string): Promise<void> {
+    await this.searchHistoryDao.deleteSearchHistory(scopeKey, keyword);
   }
 
-  async clearSearchHistory(): Promise<void> {
-    await this.searchHistoryDao.clearSearchHistory();
+  async clearSearchHistory(scopeKey: string): Promise<void> {
+    await this.searchHistoryDao.clearSearchHistory(scopeKey);
   }
 }

--- a/entry/src/main/ets/db/files/FileSourceDbCore.ets
+++ b/entry/src/main/ets/db/files/FileSourceDbCore.ets
@@ -1,3 +1,4 @@
+import { TABLE_SCOPED_SEARCH_HISTORY } from './DbConstants';
 import relationalStore from '@ohos.data.relationalStore';
 import { Context } from '@ohos.abilityAccessCtrl';
 import { normalizeSearchText, toPinyinFull, toPinyinInitials, toPinyinSegments } from '../../utils/PinyinUtil';
@@ -131,6 +132,8 @@ export class FileSourceDbCore {
         // 版本一致，但仍做防御性 schema 补全（应对手动降级/异常情况）
         await this.ensureScrapeInfoSchema(this.rdbStore);
       }
+
+      await this.ensureScopedSearchHistory(this.rdbStore);
 
       // 版本不一致时（含旧版和全新安装）也做一次 schema 补全
       if (currentVersion !== DB_VERSION) {
@@ -515,6 +518,17 @@ export class FileSourceDbCore {
    * 版本升级入口：按 currentVersion 逐步执行各版本迁移步骤，
    * 确保从任意旧版本升级都能经过所有中间版本的 DDL 变更。
    */
+  /** v15：旧全局历史保留但不推测归属，所有新历史必须显式携带来源键。 */
+  private async ensureScopedSearchHistory(store: relationalStore.RdbStore): Promise<void> {
+    await store.executeSql(`CREATE TABLE IF NOT EXISTS ${TABLE_SCOPED_SEARCH_HISTORY} (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      scope_key TEXT NOT NULL,
+      keyword TEXT NOT NULL,
+      searched_at INTEGER NOT NULL,
+      UNIQUE(scope_key, keyword)
+    )`);
+  }
+
   private async onUpgrade(rdbStore: relationalStore.RdbStore, oldVersion: number, newVersion: number): Promise<void> {
     console.info(`FileSourceDatabase: Upgrading ${oldVersion} → ${newVersion}`);
     // 用 currentVersion 追踪迁移进度，避免 oldVersion 固定导致跳步

--- a/entry/src/main/ets/db/files/SearchHistoryDao.ets
+++ b/entry/src/main/ets/db/files/SearchHistoryDao.ets
@@ -1,12 +1,12 @@
 import relationalStore from '@ohos.data.relationalStore';
 import { SearchHistoryEntry } from '../models/MediaEntity';
 import { BusinessError } from "@kit.BasicServicesKit";
-import { TABLE_SEARCH_HISTORY } from './DbConstants';
+import { TABLE_SCOPED_SEARCH_HISTORY } from './DbConstants';
 import { FileSourceDbCore } from './FileSourceDbCore';
 
 /**
  * search_history 表的数据访问。
- * 拆分自 FileSourceDatabase，保持原方法签名与行为不变。
+ * 来源键为必填，旧全局历史不参与读取。
  */
 export class SearchHistoryDao {
   private core: FileSourceDbCore;
@@ -16,26 +16,27 @@ export class SearchHistoryDao {
   }
 
   /**
-   * 新增或更新搜索历史（upsert by keyword）。
+   * 新增或更新搜索历史（upsert by scope_key, keyword）。
    * 相同关键词重复搜索时，更新 searched_at 为当前时间。
    */
-  async upsertSearchHistory(keyword: string): Promise<void> {
-    if (!this.core.isReady()) {
+  async upsertSearchHistory(scopeKey: string, keyword: string): Promise<void> {
+    if (scopeKey.trim().length === 0 || !this.core.isReady()) {
       return;
     }
     const store = this.core.getStore();
     const now = Date.now();
     try {
-      // 标准 SQLite upsert：ON CONFLICT(keyword) DO UPDATE
+      // 标准 SQLite upsert：ON CONFLICT(scope_key, keyword) DO UPDATE
       await store.executeSql(
-        `INSERT INTO ${TABLE_SEARCH_HISTORY} (keyword, searched_at) VALUES (?, ?)` +
-        ` ON CONFLICT(keyword) DO UPDATE SET searched_at = excluded.searched_at`,
-        [keyword, now]
+        `INSERT INTO ${TABLE_SCOPED_SEARCH_HISTORY} (scope_key, keyword, searched_at) VALUES (?, ?, ?)` +
+        ` ON CONFLICT(scope_key, keyword) DO UPDATE SET searched_at = excluded.searched_at`,
+        [scopeKey, keyword, now]
       );
       // 裁剪：只保留最近 15 条，防止表无限增长
       await store.executeSql(
-        'DELETE FROM search_history WHERE id NOT IN ' +
-        '(SELECT id FROM search_history ORDER BY searched_at DESC LIMIT 15)'
+        `DELETE FROM ${TABLE_SCOPED_SEARCH_HISTORY} WHERE scope_key = ? AND id NOT IN ` +
+        `(SELECT id FROM ${TABLE_SCOPED_SEARCH_HISTORY} WHERE scope_key = ? ORDER BY searched_at DESC, id DESC LIMIT 15)`,
+        [scopeKey, scopeKey]
       );
       console.info(`[DB][upsertSearchHistory] keyword=[${keyword.length}chars]`);
     } catch (e) {
@@ -48,8 +49,8 @@ export class SearchHistoryDao {
    * 获取搜索历史列表，按 searched_at 倒序排列。
    * @param limit 最大返回条数，默认 20
    */
-  async getSearchHistory(limit: number = 20): Promise<SearchHistoryEntry[]> {
-    if (!this.core.isReady()) {
+  async getSearchHistory(scopeKey: string, limit: number = 20): Promise<SearchHistoryEntry[]> {
+    if (scopeKey.trim().length === 0 || !this.core.isReady()) {
       return [];
     }
     const store = this.core.getStore();
@@ -58,8 +59,9 @@ export class SearchHistoryDao {
     let rs: relationalStore.ResultSet | null = null;
     try {
       rs = await store.querySql(
-        `SELECT keyword, searched_at FROM ${TABLE_SEARCH_HISTORY}` +
-        ` ORDER BY searched_at DESC LIMIT ${safeLimit}`
+        `SELECT keyword, searched_at FROM ${TABLE_SCOPED_SEARCH_HISTORY}` +
+        ` WHERE scope_key = ? ORDER BY searched_at DESC, id DESC LIMIT ${safeLimit}`,
+        [scopeKey]
       );
       const result: SearchHistoryEntry[] = [];
       while (rs.goToNextRow()) {
@@ -83,15 +85,15 @@ export class SearchHistoryDao {
    * 删除单条搜索历史。
    * @param keyword 要删除的关键词
    */
-  async deleteSearchHistory(keyword: string): Promise<void> {
-    if (!this.core.isReady()) {
+  async deleteSearchHistory(scopeKey: string, keyword: string): Promise<void> {
+    if (scopeKey.trim().length === 0 || !this.core.isReady()) {
       return;
     }
     const store = this.core.getStore();
     try {
       await store.executeSql(
-        `DELETE FROM ${TABLE_SEARCH_HISTORY} WHERE keyword = ?`,
-        [keyword]
+        `DELETE FROM ${TABLE_SCOPED_SEARCH_HISTORY} WHERE scope_key = ? AND keyword = ?`,
+        [scopeKey, keyword]
       );
       console.info(`[DB][deleteSearchHistory] keyword=[${keyword.length}chars] 已删除`);
     } catch (e) {
@@ -101,18 +103,18 @@ export class SearchHistoryDao {
   }
 
   /**
-   * 清空全部搜索历史。
+   * 清空当前来源搜索历史。
    */
-  async clearSearchHistory(): Promise<void> {
-    if (!this.core.isReady()) {
+  async clearSearchHistory(scopeKey: string): Promise<void> {
+    if (scopeKey.trim().length === 0 || !this.core.isReady()) {
       return;
     }
     const store = this.core.getStore();
     try {
       await store.executeSql(
-        `DELETE FROM ${TABLE_SEARCH_HISTORY}`
+        `DELETE FROM ${TABLE_SCOPED_SEARCH_HISTORY} WHERE scope_key = ?`, [scopeKey]
       );
-      console.info('[DB][clearSearchHistory] 全部搜索历史已清空');
+      console.info('[DB][clearSearchHistory] 当前来源搜索历史已清空');
     } catch (e) {
       const err = e as BusinessError;
       console.warn(`[DB][clearSearchHistory] 失败 code=${err.code} msg=${err.message}`);

--- a/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
+++ b/entry/src/main/ets/pages/search/SearchWorkspacePage.ets
@@ -1,3 +1,4 @@
+import { titleSuggestions, searchInputExample } from '../../services/search/SearchSuggestions';
 import { SearchSession } from '../../services/search/SearchSession';
 import { SearchResultSource } from './SearchResultSource';
 import { SearchWorkspaceSession, SearchWorkspaceContext } from '../../services/search/SearchWorkspaceSession';
@@ -424,7 +425,7 @@ struct SearchWorkspacePage {
     this.session.invalidate(true);
     this.resultSource.replace([]);
     this.db = null;
-    if (getSearchCapabilities(this.scope).localSearch) {
+    if (this.scope.kind !== 'unavailable') {
       this.db = FileSourceDatabase.getInstance();
     }
     this.scheduleSearch();
@@ -495,14 +496,14 @@ struct SearchWorkspacePage {
   }
 
   private loadHistory(): void {
-    if (!getSearchCapabilities(this.scope).localHistory || this.db === null) { return; }
+    if (this.scope.kind === 'unavailable' || this.db === null) { return; }
     const sourceGeneration = this.historySourceGeneration;
     const loadGeneration = ++this.historyLoadGeneration;
-    this.db.getSearchHistory(20)
+    this.db.getSearchHistory(this.scope.key, 20)
       .then((list: SearchHistoryEntry[]) => {
         if (this.pageActive && sourceGeneration === this.historySourceGeneration &&
           loadGeneration === this.historyLoadGeneration &&
-          getSearchCapabilities(this.scope).localHistory) { this.historyList = list; }
+          this.scope.kind !== 'unavailable') { this.historyList = list; }
       })
       .catch(() => {});
   }
@@ -595,7 +596,7 @@ struct SearchWorkspacePage {
 
   /** 执行搜索并保存历史 */
   private executeSearchWithHistory(): void {
-    if (!getSearchCapabilities(this.scope).localHistory) { return; }
+    if (this.scope.kind === 'unavailable') { return; }
     const kw: string = this.searchText.trim();
     if (kw.length === 0) { return; }
     this.invalidateSearch();
@@ -603,7 +604,7 @@ struct SearchWorkspacePage {
       this.invalidateHistoryRequests();
       const sourceGeneration = this.historySourceGeneration;
       const updateGeneration = this.historyLoadGeneration;
-      this.db.upsertSearchHistory(kw)
+      this.db.upsertSearchHistory(this.scope.key, kw)
         .then(() => {
           if (this.pageActive && sourceGeneration === this.historySourceGeneration &&
             updateGeneration === this.historyLoadGeneration) {
@@ -612,7 +613,11 @@ struct SearchWorkspacePage {
         })
         .catch(() => {});
     }
-    this.executeSearch();
+    if (getSearchCapabilities(this.scope).serverSearch) {
+      this.executeServerSearch();
+    } else {
+      this.executeSearch();
+    }
   }
 
   private appendChar(c: string): void {
@@ -636,11 +641,11 @@ struct SearchWorkspacePage {
   }
 
   private deleteHistory(keyword: string): void {
-    if (!getSearchCapabilities(this.scope).localHistory || this.db === null) { return; }
+    if (this.scope.kind === 'unavailable' || this.db === null) { return; }
     this.invalidateHistoryRequests();
     const sourceGeneration = this.historySourceGeneration;
     const deleteGeneration = this.historyLoadGeneration;
-    this.db.deleteSearchHistory(keyword)
+    this.db.deleteSearchHistory(this.scope.key, keyword)
       .then(() => {
         if (this.pageActive && sourceGeneration === this.historySourceGeneration &&
           deleteGeneration === this.historyLoadGeneration) {
@@ -651,15 +656,15 @@ struct SearchWorkspacePage {
   }
 
   private clearAllHistory(): void {
-    if (!getSearchCapabilities(this.scope).localHistory || this.db === null) { return; }
+    if (this.scope.kind === 'unavailable' || this.db === null) { return; }
     this.invalidateHistoryRequests();
     const sourceGeneration = this.historySourceGeneration;
     const clearGeneration = this.historyLoadGeneration;
-    this.db.clearSearchHistory()
+    this.db.clearSearchHistory(this.scope.key)
       .then(() => {
         if (this.pageActive && sourceGeneration === this.historySourceGeneration &&
           clearGeneration === this.historyLoadGeneration &&
-          getSearchCapabilities(this.scope).localHistory) {
+          this.scope.kind !== 'unavailable') {
           this.historyList = [];
         }
       })
@@ -794,19 +799,15 @@ struct SearchWorkspacePage {
         .onSubmit(() => {
           this.inputController.stopEditing();
           this.isEditing = false;
-          if (getSearchCapabilities(this.scope).serverSearch) {
-            this.executeServerSearch();
-          } else {
-            this.executeSearchWithHistory();
-          }
+          this.executeSearchWithHistory();
         })
-      if (getSearchCapabilities(this.scope).inputModes.includes('text')) {
+      if (this.scope.kind !== 'unavailable') {
         ActionKey({
           label: '搜索',
           onPress: () => {
             this.inputController.stopEditing();
             this.isEditing = false;
-            this.executeServerSearch();
+            this.executeSearchWithHistory();
           }
         })
           .id('search-workspace-submit')
@@ -939,6 +940,30 @@ struct SearchWorkspacePage {
   }
 
   @Builder
+  buildSuggestions() {
+    Column({ space: 10 }) {
+      Text(searchInputExample(this.scope))
+        .fontSize(16).fontColor(C_SECONDARY)
+      if (this.scope.kind === 'localFiles' && this.session.status === 'results') {
+        Flex({ wrap: FlexWrap.Wrap }) {
+          ForEach(titleSuggestions(this.scope, this.session.results), (title: string) => {
+            Button(title)
+              .fontSize(16).fontColor(C_HIST_TEXT)
+              .backgroundColor(C_HIST_CHIP_BG)
+              .margin({ right: 10, bottom: 10 })
+              .onFocus(() => { this.resultsFocused = true; })
+              .onClick(() => {
+                this.searchText = title;
+                this.focusInput();
+                this.executeSearchWithHistory();
+              })
+          }, (title: string) => title)
+        }
+      }
+    }.width('100%').alignItems(HorizontalAlign.Start)
+  }
+
+  @Builder
   buildHistory() {
     if (this.historyList.length > 0) {
       Flex({ wrap: FlexWrap.Wrap }) {
@@ -946,7 +971,9 @@ struct SearchWorkspacePage {
           // M2：拆成两个独立可聚焦节点，遥控器 D-pad 可分别聚焦到关键词和删除按钮
           Row({ space: 0 }) {
             // 左侧：关键词文字 — 聚焦后 OK 键触发搜索并跳转
-            Text(entry.keyword)
+            Button(entry.keyword)
+              .backgroundColor(C_HIST_CHIP_BG)
+              .onFocus(() => { this.resultsFocused = true; })
               .fontSize(16)
               .fontWeight(500)
               .fontColor(C_HIST_TEXT)
@@ -954,10 +981,13 @@ struct SearchWorkspacePage {
               .focusable(true)
               .onClick(() => {
                 this.searchText = entry.keyword;
+                this.focusInput();
                 this.executeSearchWithHistory();
               })
             // 右侧：× 删除按钮 — 聚焦后 OK 键触发删除
-            Text('\u00D7')
+            Button('\u00D7')
+              .backgroundColor(C_HIST_CHIP_BG)
+              .onFocus(() => { this.resultsFocused = true; })
               .fontSize(14)
               .fontColor(C_SECONDARY)
               .padding({ left: 6, right: 14, top: 8, bottom: 8 })
@@ -971,7 +1001,7 @@ struct SearchWorkspacePage {
         }, (entry: SearchHistoryEntry) => entry.keyword)
 
         // Clear-all button styled same as chip
-        Text('\u5220\u9664\u5386\u53f2')
+        Button('清空当前来源历史')
           .fontSize(16)
           .fontWeight(600)
           .fontColor('#D7DEE7')
@@ -1099,9 +1129,8 @@ struct SearchWorkspacePage {
             if (getSearchCapabilities(this.scope).inputModes.includes('pinyin')) {
               this.buildKeyboard()
             }
-            if (getSearchCapabilities(this.scope).localSearch) {
-              this.buildHistory()
-            }
+            this.buildHistory()
+            this.buildSuggestions()
             this.buildSearchResults()
           }
         }

--- a/entry/src/main/ets/services/search/SearchSuggestions.ets
+++ b/entry/src/main/ets/services/search/SearchSuggestions.ets
@@ -1,0 +1,24 @@
+import { MediaItem } from '../../db/models/MediaEntity';
+import { SearchScope } from '../../models/search/SearchScope';
+
+/** Reuse accepted local search results so completion has the same matching and ranking. */
+export function titleSuggestions(scope: SearchScope, items: MediaItem[]): string[] {
+  if (scope.kind !== 'localFiles') { return []; }
+  const titles: string[] = [];
+  const seen: Set<string> = new Set<string>();
+  for (const item of items) {
+    const title = (item.title ?? '').trim();
+    if (title.length === 0 || seen.has(title.toLowerCase())) { continue; }
+    seen.add(title.toLowerCase());
+    titles.push(title);
+    if (titles.length === 6) { break; }
+  }
+  return titles;
+}
+
+/** Examples describe input syntax, never claim that a title exists in the source. */
+export function searchInputExample(scope: SearchScope): string {
+  if (scope.kind === 'localFiles') { return '输入示例：流浪地球 / liulangdiqiu / lldq（仅搜索本地文件源）'; }
+  if (scope.kind === 'videoServer') { return '输入示例：片名或片名中的文字，如 Dune（仅搜索当前服务器，不代表已收录）'; }
+  return '';
+}

--- a/entry/src/test/local_pinyin_search_test.cjs
+++ b/entry/src/test/local_pinyin_search_test.cjs
@@ -148,7 +148,7 @@ async function main() {
   assert.equal(store.openCursors, 0);
   // 模拟已完成 v13 回填的完整数据库，验证新增列回填后真实搜索与重启行为。
   const { DB_VERSION } = source('db/files/DbConstants.ets');
-  assert.equal(DB_VERSION, 14);
+  assert.ok(DB_VERSION >= 14);
   for (const table of ['movies', 'tv_series']) {
     await store.executeSql(`ALTER TABLE ${table} DROP COLUMN title_normalized`);
     assert.equal(store.db.prepare(`SELECT COUNT(*) n FROM ${table} WHERE title_pinyin_segments IS NULL`).get().n, 0);

--- a/entry/src/test/search_suggestions_test.cjs
+++ b/entry/src/test/search_suggestions_test.cjs
@@ -1,0 +1,99 @@
+// Node >= 22.13; runs production ArkTS storage against real SQLite.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const { DatabaseSync } = require('node:sqlite');
+const ts = require(process.env.TYPESCRIPT_PATH || 'typescript');
+const base = 'entry/src/main/ets/';
+function compile(source, deps = {}, globals = {}) {
+  const exports = {};
+  const js = ts.transpileModule(source, { compilerOptions: { target: ts.ScriptTarget.ES2021,
+    module: ts.ModuleKind.CommonJS } }).outputText;
+  vm.runInNewContext(js, { exports, require: name => deps[name] || {}, console, setTimeout, clearTimeout, ...globals });
+  return exports;
+}
+const read = path => fs.readFileSync(base + path, 'utf8');
+const constants = compile(read('db/files/DbConstants.ets'));
+const { SearchHistoryDao } = compile(read('db/files/SearchHistoryDao.ets'), {
+  './DbConstants': constants, '../models/MediaEntity': { SearchHistoryEntry: class {} }
+});
+const { FileSourceDbCore } = compile(read('db/files/FileSourceDbCore.ets'), { './DbConstants': constants });
+const { titleSuggestions, searchInputExample } = compile(read('services/search/SearchSuggestions.ets'));
+const { getSearchCapabilities } = compile(read('models/search/SearchScope.ets'));
+const local = { kind: 'localFiles', key: 'local-files' };
+const jelly = { kind: 'videoServer', key: 'video-server:jellyfin:1' };
+const plex = { kind: 'videoServer', key: 'video-server:plex:2' };
+const db = new DatabaseSync(':memory:');
+let cursors = 0;
+const store = {
+  executeSql: async (sql, args = []) => db.prepare(sql).run(...args),
+  querySql: async (sql, args = []) => {
+    const stmt = db.prepare(sql), columns = stmt.columns().map(c => c.name), rows = stmt.all(...args);
+    let index = -1; cursors++;
+    return { goToNextRow: () => ++index < rows.length, getColumnIndex: name => columns.indexOf(name),
+      getString: col => rows[index][columns[col]], getLong: col => rows[index][columns[col]], close: () => cursors-- };
+  }
+};
+async function main() {
+  db.exec("CREATE TABLE search_history (keyword TEXT UNIQUE, searched_at INTEGER); INSERT INTO search_history VALUES ('legacy', 1)");
+  await FileSourceDbCore.prototype.ensureScopedSearchHistory(store);
+  await FileSourceDbCore.prototype.ensureScopedSearchHistory(store);
+  const dao = new SearchHistoryDao({ isReady: () => true, getStore: () => store });
+  assert.equal((await dao.getSearchHistory(local.key)).length, 0);
+  for (const scope of [local, jelly, plex]) await dao.upsertSearchHistory(scope.key, 'Dune');
+  for (let i = 0; i < 20; i++) await dao.upsertSearchHistory(local.key, `Local ${i}`);
+  assert.equal((await dao.getSearchHistory(local.key)).length, 15);
+  for (const scope of [jelly, plex]) assert.equal((await dao.getSearchHistory(scope.key))[0].keyword, 'Dune');
+  await dao.upsertSearchHistory(jelly.key, 'Dune');
+  assert.equal((await dao.getSearchHistory(jelly.key)).length, 1);
+  await dao.deleteSearchHistory(jelly.key, 'Dune');
+  assert.equal((await dao.getSearchHistory(jelly.key)).length, 0);
+  assert.equal((await dao.getSearchHistory(plex.key)).length, 1);
+  await dao.clearSearchHistory(local.key);
+  assert.equal((await dao.getSearchHistory(local.key)).length, 0);
+  assert.equal((await dao.getSearchHistory(plex.key)).length, 1);
+  assert.equal(db.prepare('SELECT keyword FROM search_history').get().keyword, 'legacy');
+  await dao.upsertSearchHistory(plex.key, "O'Brien ? %");
+  assert.equal((await dao.getSearchHistory(plex.key)).length, 2);
+  assert.equal(cursors, 0);
+  console.log('PASS schema upgrade, legacy exclusion, scope isolation, per-scope pruning/upsert/delete/clear, bound SQL');
+  const items = [{ title: 'Dune' }, { title: 'dune' }, { title: '' }, { title: '流浪地球' }];
+  assert.equal(titleSuggestions(local, items).join(','), 'Dune,流浪地球');
+  assert.equal(titleSuggestions(local, Array.from({length: 20}, (_, i) => ({title: `title${i}`}))).length, 6);
+  for (const scope of [jelly, plex, {kind: 'unavailable'}]) assert.equal(titleSuggestions(scope, items).length, 0);
+  assert.ok(searchInputExample(jelly).includes('不代表已收录'));
+  assert.ok(searchInputExample(local).includes('lldq'));
+  assert.equal(searchInputExample({kind: 'unavailable'}), '');
+  console.log('PASS source-specific title completion, stable ranking, deduplication and honest input examples');
+
+  // Execute the real page's non-render methods; native UI/IO are substituted.
+  const pageSource = read('pages/search/SearchWorkspacePage.ets');
+  const start = pageSource.indexOf('struct SearchWorkspacePage {');
+  const end = pageSource.indexOf('  @Builder', start);
+  const body = pageSource.slice(start, end).replace('struct SearchWorkspacePage', 'export class Page')
+    .replace(/@Consumer\([^)]*\)\s*/g, '').replace(/@Local\s*/g, '') + '}';
+  class Empty {}
+  const { Page } = compile(body, {}, { NavPathStack: Empty, SearchSession: Empty,
+    SearchResultSource: Empty, Scroller: Empty, SearchWorkspaceSession: Empty, TextInputController: Empty,
+    createUnavailableSearchScope: () => ({kind:'unavailable'}), getSearchCapabilities });
+  const page = new Page();
+  page.pageActive = true; page.scope = local;
+  let finish;
+  page.db = { getSearchHistory: () => new Promise(resolve => { finish = resolve; }) };
+  page.loadHistory();
+  page.invalidateHistorySource(); page.scope = jelly;
+  finish([{keyword:'local secret'}]); await Promise.resolve();
+  assert.equal(page.historyList.length, 0);
+  const writes = [], searches = [];
+  page.db = { upsertSearchHistory: async (...args) => writes.push(args), getSearchHistory: async () => [] };
+  page.invalidateSearch = () => {};
+  page.executeSearch = () => searches.push('local');
+  page.executeServerSearch = () => searches.push('server');
+  for (const scope of [local, jelly, plex]) {
+    page.scope = scope; page.searchText = 'Dune'; page.executeSearchWithHistory();
+  }
+  assert.equal(writes.map(w => w[0]).join(','), [local,jelly,plex].map(s => s.key).join(','));
+  assert.equal(searches.join(','), 'local,server,server');
+  console.log('PASS late history suppression and suggestion submission stays in current source');
+}
+main().catch(e => { console.error(e); process.exitCode = 1; });

--- a/entry/src/test/search_suggestions_test.cjs
+++ b/entry/src/test/search_suggestions_test.cjs
@@ -56,7 +56,7 @@ async function main() {
   await dao.upsertSearchHistory(plex.key, "O'Brien ? %");
   assert.equal((await dao.getSearchHistory(plex.key)).length, 2);
   assert.equal(cursors, 0);
-  console.log('PASS schema upgrade, legacy exclusion, scope isolation, per-scope pruning/upsert/delete/clear, bound SQL');
+  console.log('通过: 数据库升级、排除旧历史、来源隔离、按来源裁剪/插入更新/删除/清空及 SQL 参数绑定');
   const items = [{ title: 'Dune' }, { title: 'dune' }, { title: '' }, { title: '流浪地球' }];
   assert.equal(titleSuggestions(local, items).join(','), 'Dune,流浪地球');
   assert.equal(titleSuggestions(local, Array.from({length: 20}, (_, i) => ({title: `title${i}`}))).length, 6);
@@ -64,7 +64,7 @@ async function main() {
   assert.ok(searchInputExample(jelly).includes('不代表已收录'));
   assert.ok(searchInputExample(local).includes('lldq'));
   assert.equal(searchInputExample({kind: 'unavailable'}), '');
-  console.log('PASS source-specific title completion, stable ranking, deduplication and honest input examples');
+  console.log('通过: 当前来源片名补全、稳定排序、去重及准确的输入示例');
 
   // Execute the real page's non-render methods; native UI/IO are substituted.
   const pageSource = read('pages/search/SearchWorkspacePage.ets');
@@ -94,6 +94,6 @@ async function main() {
   }
   assert.equal(writes.map(w => w[0]).join(','), [local,jelly,plex].map(s => s.key).join(','));
   assert.equal(searches.join(','), 'local,server,server');
-  console.log('PASS late history suppression and suggestion submission stays in current source');
+  console.log('通过: 忽略迟到的历史响应，建议词提交保持在当前来源');
 }
 main().catch(e => { console.error(e); process.exitCode = 1; });


### PR DESCRIPTION
## 背景
搜索历史和建议词应遵循当前来源，避免切换服务器后看到其他来源的关键词，或把示例误认为当前来源已收录的影片。

Fixes: #320

## 实现方式
- 使用统一 `SearchScope.key` 隔离历史: 本地文件源共用 `local-files`，各影视服务器实例独立存储。每个范围保留最近 15 条，删除与清空仅作用于当前来源。
- 搜索按钮、输入法提交、历史和片名建议统一走当前来源搜索路径并记录历史，自动输入预览不写历史。
- 本地建议复用已接受搜索结果的匹配与排序，片名去重后最多展示 6 条。服务器仅提供来源内历史和明确标注的输入示例，不调用在线补全。
- 来源切换与离页时使历史请求失效，防止迟到响应覆盖新来源；建议词和历史采用可聚焦按钮。

## 迁移与取舍
数据库升级至 v15，新建 `scoped_search_history`，以 `(scope_key, keyword)` 唯一存储。旧全局历史保留但不展示、不自动归入本地来源，因为无法可靠判断原始来源。

## 验证
- `search_suggestions_test.cjs` 通过: 真实 SQLite 来源隔离、裁剪、更新、删除、清空、旧历史排除，以及建议词和迟到响应检查。
- `local_pinyin_search_test.cjs` 通过: 本地拼音匹配、排序、电影及电视剧更新、迁移和中断恢复。
- 测试使用 DevEco 已安装的 TypeScript，通过 `TYPESCRIPT_PATH` 指定。
- `git diff --check` 通过，自审未发现未解决的高置信度问题。
- 当前 worktree 执行 `devecocli run --module entry --device 127.0.0.1:5555 --product default`，构建成功，并安装、启动于 HarmonyOS 6.1.1 TV 模拟器。

## 待人工验收
真机 D-Pad/OK/返回焦点路径，以及不同服务器实例间切换、历史删除和清空的交互效果仍需人工确认。模拟器安装启动不等同于完成真机交互验收。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 搜索历史按当前来源分别保存、查看、删除和清空，避免不同来源之间相互混淆。
  - 本地搜索结果可提供去重后的标题建议，帮助快速发起搜索。
  - 搜索框根据当前来源显示相应的输入示例。
  - 点击历史关键词后自动聚焦搜索框，提升操作便捷性。

- **改进**
  - 搜索提交与搜索按钮行为保持一致，并支持本地及服务器来源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->