### PR TITLE
Fix movie scraping to prefer localized directory titles

### DIFF
--- a/entry/src/main/ets/lib/MediaTypeClassifier.ets
+++ b/entry/src/main/ets/lib/MediaTypeClassifier.ets
@@ -591,6 +591,21 @@ export function classifyMediaType(input: MediaTypeClassificationInput): MediaTyp
     return createMediaTypeClassificationResult('tv', signals, 'path-tv-semantics');
   }
 
+  // 英文发行名与中文目录名并存时，优先用中文目录片名；排除合集、季目录和通用目录。
+  if (movieScore > tvScore && !hasWeakSemanticTitle &&
+    !/[\u3400-\u9fff]/.test(fileNameInfo?.title ?? '')) {
+    const pathSignalValues = new Set<string>();
+    pathMatches.forEach((match: PathSemanticSignalMatch) => pathSignalValues.add(match.signal.value));
+    const parentTitle = resolveParentDirectoryFallbackTitle(input, pathSignalValues);
+    if (parentTitle !== undefined && /[\u3400-\u9fff]/.test(parentTitle) &&
+      !/合集|系列|收藏|精选/.test(parentTitle)) {
+      appendSignal(signals, 'parent-directory', parentTitle, 'localized-movie-title', 60);
+      const result = createMediaTypeClassificationResult('movie', signals, 'localized-parent-directory-title');
+      result.fallbackTitle = parentTitle;
+      return result;
+    }
+  }
+
   if (movieScore >= 70 && movieScore > tvScore && !hasWeakSemanticTitle) {
     return createMediaTypeClassificationResult('movie', signals, 'movie-title-or-path');
   }

--- a/entry/src/main/ets/lib/ScrapeClient.ets
+++ b/entry/src/main/ets/lib/ScrapeClient.ets
@@ -240,17 +240,44 @@ export function resolveMovieSearchTerms(parsed: ParsedFileName, overrideTitle?: 
   let year = parsed.year;
   if (overrideTitle !== undefined && overrideTitle.trim().length > 0) {
     const normalizedOverrideTitle = overrideTitle.trim();
-    const overridden = parseFileName(normalizedOverrideTitle);
+    const overridden = parseFileName(`${normalizedOverrideTitle}.mkv`);
     title = overridden.title.length > 0 ? overridden.title : normalizedOverrideTitle;
-    // parseFileName 会把无扩展名标题末尾的 ".2021" 当扩展名截断导致年份丢失，
-    // 此时改用 extractSearchYear 从原始兜底标题直接提取年份（如 "Dune.2021" → 2021）。
+    // 目录名没有扩展名，补虚拟扩展名保护点分标题，并单独处理末尾年份。
     const overrideYear = overridden.year ?? extractSearchYear(normalizedOverrideTitle);
     if (overrideYear !== undefined) {
       year = overrideYear;
+      title = removeSearchYear(title);
     }
   }
   const terms: MovieSearchTerms = { title, year };
   return terms;
+}
+
+/** 自动关联仅接受规范化后相同的标题/原名；年份冲突和同名歧义留给人工确认。 */
+export function selectMovieSearchResult(
+  results: MovieScrapeResult[], title: string, year?: number
+): MovieScrapeResult | null {
+  const normalize = (value: string): string => value.toLowerCase().replace(/[^a-z0-9\u3400-\u9fff]/g, '');
+  const query = normalize(title);
+  if (query.length === 0) { return null; }
+  let selected: MovieScrapeResult | null = null;
+  let bestScore = -1;
+  let ambiguous = false;
+  for (const result of results) {
+    if (normalize(result.title) !== query && normalize(result.originalTitle ?? '') !== query) { continue; }
+    const resultYear = extractSearchYear(result.releaseDate ?? '');
+    if (year !== undefined && resultYear !== undefined && resultYear !== year) { continue; }
+    const score = year !== undefined && resultYear === year ? 2 : 1;
+    if (score > bestScore) {
+      selected = result;
+      bestScore = score;
+      ambiguous = false;
+    } else if (score === bestScore && selected !== null &&
+      (selected.provider !== result.provider || selected.providerId !== result.providerId)) {
+      ambiguous = true;
+    }
+  }
+  return ambiguous ? null : selected;
 }
 
 /**
@@ -957,7 +984,7 @@ export class ScrapeClient {
     }
   }
 
-  /** 搜索电影，返回第一个命中的详情
+  /** 搜索电影，返回标题和年份校验通过的唯一候选详情
    * @param overrideTitle 可选，兜底搜索标题。弱语义文件名（如"4K.mp4"）场景下由分类器提供的父目录片名，
    * 传入后以该标题（可含年份）替代文件名解析结果发起 TMDB 搜索。
    */
@@ -971,9 +998,11 @@ export class ScrapeClient {
           const searchTitles = buildSearchTitles(searchTerms.title);
           for (const candidate of searchTitles) {
             const results = await provider.searchMovie(candidate, searchTerms.year, 'zh-CN');
-            if (results.length > 0) {
-              console.info(`[ScrapeClient] autoScrapeMovie 命中候选标题="${candidate}" providerId=${results[0].providerId}`);
-              return await provider.fetchMovieDetail(results[0].providerId, 'zh-CN');
+            const selected = selectMovieSearchResult(results, candidate, searchTerms.year);
+            if (selected !== null) {
+              console.info(`[ScrapeClient] autoScrapeMovie 命中候选标题="${candidate}" providerId=${selected.providerId}`);
+              const detail = await provider.fetchMovieDetail(selected.providerId, 'zh-CN');
+              if (detail !== null) { return detail; }
             }
           }
         } catch (e) {

--- a/entry/src/main/ets/utils/VideoScrapeProcessor.ets
+++ b/entry/src/main/ets/utils/VideoScrapeProcessor.ets
@@ -224,7 +224,7 @@ export async function processVideoScrape(
   if (classification.mediaType === 'movie') {
     try {
       if (classification.fallbackTitle !== undefined) {
-        console.info(`${logPrefix} 文件名弱语义，使用父目录片名兜底搜索 fallbackTitle="${classification.fallbackTitle}"`);
+        console.info(`${logPrefix} 使用父目录片名搜索 fallbackTitle="${classification.fallbackTitle}"`);
       }
       const movie = await scrapeClient.autoScrapeMovie(fileName, classification.fallbackTitle);
       if (!movie) {

--- a/entry/src/test/MediaTypeClassifierContract.test.ets
+++ b/entry/src/test/MediaTypeClassifierContract.test.ets
@@ -55,6 +55,20 @@ const weakSemanticRegressionSamples: WeakSemanticRegressionSample[] = [
 
 export default function mediaTypeClassifierContractTest() {
   describe('MediaTypeClassifier contract', () => {
+    it('should prefer a localized movie directory over the English release name', 0, () => {
+      const fileName = 'Dear.You.2026.1080p.H264.mkv';
+      const result = classifyVideoScrapeTarget(fileName, `/volume1/Videos/Movies/给阿嬷的情书/${fileName}`);
+      expect(result.mediaType).assertEqual('movie');
+      expect(result.fallbackTitle).assertEqual('给阿嬷的情书');
+      const terms = resolveMovieSearchTerms(parseFileName(fileName), result.fallbackTitle);
+      expect(terms.title).assertEqual('给阿嬷的情书');
+      expect(terms.year).assertEqual(2026);
+      for (const directory of ['Movies', '电影合集', '我的收藏']) {
+        expect(classifyVideoScrapeTarget(fileName, `/Movies/${directory}/${fileName}`).fallbackTitle).assertUndefined();
+      }
+      expect(resolveMovieSearchTerms(parseFileName(fileName), 'Dear.You').title).assertEqual('Dear You');
+    });
+
     it('should capture filename and ancestor path context for classification input', 0, () => {
       const fileNameInfo: FileNameSemanticInfo = {
         title: '19',

--- a/entry/src/test/ScrapeClient.test.ets
+++ b/entry/src/test/ScrapeClient.test.ets
@@ -1,5 +1,5 @@
 import { describe, beforeAll, beforeEach, afterEach, afterAll, it, expect } from '@ohos/hypium';
-import { ScrapeClient, TmdbProvider, parseFileName, buildSearchTitles, ParsedFileName, MovieScrapeResult } from '../main/ets/lib/ScrapeClient';
+import { ScrapeClient, TmdbProvider, parseFileName, buildSearchTitles, ParsedFileName, MovieScrapeResult, selectMovieSearchResult } from '../main/ets/lib/ScrapeClient';
 import {
   ScriptedFakeScrapeProvider,
   createDeferred,
@@ -17,6 +17,35 @@ async function flushMicrotasksUntil(predicate: () => boolean, rounds: number = 1
 
 export default function scrapeClientTest() {
   describe('ScrapeClient', () => {
+    it('should reject unrelated and conflicting movie results and select exact original title', 0, () => {
+      const wrong: MovieScrapeResult = { provider: 'fake', providerId: 'wrong',
+        title: 'Where Are You, Dear General?', releaseDate: '2025-01-01' };
+      const right: MovieScrapeResult = { provider: 'fake', providerId: 'right',
+        title: '给阿嬷的情书', originalTitle: 'Dear You', releaseDate: '2026-01-01' };
+      expect(selectMovieSearchResult([wrong], 'Dear You', 2026)).assertEqual(null);
+      expect(selectMovieSearchResult([wrong], 'Dear You', 2025)).assertEqual(null);
+      expect(selectMovieSearchResult([wrong, right], 'Dear.You', 2026)?.providerId).assertEqual('right');
+      expect(selectMovieSearchResult([right], '给阿嬷的情书', 2025)).assertEqual(null);
+      const duplicate: MovieScrapeResult = { provider: 'fake', providerId: 'duplicate',
+        title: '给阿嬷的情书', releaseDate: '2026-02-01' };
+      expect(selectMovieSearchResult([right, duplicate], '给阿嬷的情书', 2026)).assertEqual(null);
+    });
+
+    it('should fetch the validated movie instead of the first search result', 0, async () => {
+      const fake = new ScriptedFakeScrapeProvider('movie-match');
+      const right = createMovieScrapeResult('movie-match', '给阿嬷的情书', 'right');
+      fake.enqueueSearchMovieResults([
+        createMovieScrapeResult('movie-match', 'Where Are You, Dear General?', 'wrong'), right
+      ]);
+      fake.enqueueFetchMovieDetailResult(right);
+      const client = new ScrapeClient({ scrapeConcurrency: 1 });
+      client.registerProvider(fake);
+      expect((await client.autoScrapeMovie('Dear.You.2026.1080p.H264.mkv', '给阿嬷的情书'))?.providerId).assertEqual('right');
+      expect(fake.getLastCall('searchMovie')?.title).assertEqual('给阿嬷的情书');
+      expect(fake.getLastCall('searchMovie')?.year).assertEqual(2026);
+      expect(fake.getLastCall('fetchMovieDetail')?.providerId).assertEqual('right');
+    });
+
     /**
      * 测试用例 1：测试文件名解析功能 - 电影格式
      */
@@ -229,7 +258,7 @@ export default function scrapeClientTest() {
       expect(fake.getCallCount('searchMovie')).assertEqual(2);
       expect(fake.getCallCount('fetchMovieDetail')).assertEqual(0);
 
-      deferred1.resolve([createMovieScrapeResult('fake-concurrency', 'First Movie Result', 'movie-1')]);
+      deferred1.resolve([createMovieScrapeResult('fake-concurrency', 'First Movie', 'movie-1')]);
       const result1 = await p1;
       expect(result1 !== null).assertTrue();
       if (result1 !== null) {
@@ -248,8 +277,8 @@ export default function scrapeClientTest() {
         expect(thirdSearchCall.language).assertEqual('zh-CN');
       }
 
-      deferred2.resolve([createMovieScrapeResult('fake-concurrency', 'Second Movie Result', 'movie-2')]);
-      deferred3.resolve([createMovieScrapeResult('fake-concurrency', 'Third Movie Result', 'movie-3')]);
+      deferred2.resolve([createMovieScrapeResult('fake-concurrency', 'Second Movie', 'movie-2')]);
+      deferred3.resolve([createMovieScrapeResult('fake-concurrency', 'Third Movie', 'movie-3')]);
 
       const results = await Promise.all([p1, p2, p3]);
       expect(results.length).assertEqual(3);

--- a/entry/src/test/movie_scrape_test.cjs
+++ b/entry/src/test/movie_scrape_test.cjs
@@ -1,0 +1,47 @@
+// Run with TYPESCRIPT_PATH pointing to the DevEco bundled TypeScript package.
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+const ts = require(process.env.TYPESCRIPT_PATH || 'typescript');
+const tests = [];
+const cache = new Map();
+const hypium = {
+  describe: (_, fn) => fn(), it: (name, _, fn) => tests.push({name, fn}),
+  beforeAll() {}, beforeEach() {}, afterEach() {}, afterAll() {},
+  expect: value => ({
+    assertEqual: expected => assert.equal(value, expected),
+    assertTrue: () => assert.equal(value, true), assertFalse: () => assert.equal(value, false),
+    assertUndefined: () => assert.equal(value, undefined), assertLarger: expected => assert.ok(value > expected)
+  })
+};
+function load(file) {
+  file = path.resolve(file);
+  if (cache.has(file)) return cache.get(file);
+  const exports = {};
+  cache.set(file, exports);
+  const source = fs.readFileSync(file, 'utf8');
+  const js = ts.transpileModule(source, {compilerOptions: {
+    target: ts.ScriptTarget.ES2021, module: ts.ModuleKind.CommonJS
+  }}).outputText;
+  const req = name => {
+    if (name === '@ohos/hypium') return hypium;
+    if (name.endsWith('AppPreferences')) return {AppPreferences: {getNumber: async () => 2}, PrefKey: {}};
+    if (name.startsWith('@') || name.includes('/db/')) return {};
+    return load(path.resolve(path.dirname(file), name + '.ets'));
+  };
+  vm.runInNewContext(js, {exports, require: req, setTimeout, clearTimeout, Promise,
+    console: {info() {}, warn() {}, error() {}, log() {}}}, {filename: file});
+  return exports;
+}
+load('entry/src/test/ScrapeClient.test.ets').default();
+load('entry/src/test/MediaTypeClassifierContract.test.ets').default();
+(async () => {
+  let failed = 0;
+  for (const test of tests) {
+    try { await test.fn(); }
+    catch (error) { failed++; console.error('FAIL:', test.name, error); }
+  }
+  console.log(`${tests.length - failed}/${tests.length} scrape regression tests passed`);
+  process.exitCode = failed ? 1 : 0;
+})();


### PR DESCRIPTION
## Summary

- Prefer Chinese parent-directory titles when English release names are ambiguous.
- Exclude generic collection, season, and library directories from fallback titles.
- Validate movie search results by normalized title, original title, and release year before fetching details.
- Add regression coverage for localized titles, conflicting results, duplicate matches, and fallback parsing.

## Testing

- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化电影识别：可从符合条件的中文父目录中提取片名作为兜底标题。
  - 优化电影搜索结果匹配，结合标题与年份选择更准确的详情；结果存在歧义时不再盲选。
  - 兜底标题的年份解析和搜索词处理更加准确。

- **测试**
  - 新增电影目录识别、搜索结果筛选及自动刮削流程的回归测试。
  - 增加测试运行工具，支持执行相关 ArkTS 测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->